### PR TITLE
Trim entityState/playerState network contracts; add WC3/WoW test coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,64 @@ Available assertions: `T_ASSERT(cond)`, `T_EQ(a,b)`, `T_NE(a,b)`, `T_FEQ(a,b,eps
 
 Do not include `test_framework.h` — it has been removed. Do not write a `main()` for test files; link against `tests/test_runner.c` instead.
 
+### Message Delta Tests
+
+Every field or flag added to `entityState_t` travels over the network via `MSG_WriteDeltaEntity`/`MSG_ReadDeltaEntity`.
+Write a round-trip test whenever you add a new field, flag, or packed value to confirm the serialization contract:
+
+```c
+TEST(wow_appearance, entity_delta_preserves_my_flag) {
+    BYTE buf[256];
+    sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
+    entityState_t from = { 0 }, to = { .number = 9, .model = 3, .flags = EF_MY_FLAG }, out = { 0 };
+    DWORD bits = 0;
+    int number;
+
+    MSG_WriteDeltaEntity(&sb, &from, &to, true);
+    sb.readcount = 0;
+    number = MSG_ReadEntityBits(&sb, &bits);
+    MSG_ReadDeltaEntity(&sb, &out, number, bits);
+
+    T_EQ(number, 9);
+    T_ASSERT(out.flags & EF_MY_FLAG);
+}
+```
+
+Key points:
+- Set `from` to all-zero and `to` to only the fields under test so the delta is minimal.
+- Always set a non-zero `model` alongside new fields — a zero-model entity may be skipped by the delta encoder.
+- Reset `sb.readcount = 0` between write and read; `make_msg_buf` is defined in the same test file.
+- These tests live in `games/world-of-warcraft/tests/test_wow_appearance.c` for WoW entity fields.
+- After verifying network survival, test the game-logic side separately (see below).
+
+### Unit Behaviour Tests via `CustomizeEntity`
+
+Server-side per-client state filtering happens in `Wow_CustomizeEntity` (called via `game->CustomizeEntity`).
+Test that function by driving game state, calling it with a copied `entityState_t`, and asserting the resulting flags:
+
+```c
+TEST(wow_game, my_feature_sets_correct_flags) {
+    struct game_export *game = init_game();
+    entityState_t state;
+    LPEDICT npc = /* find or spawn the entity */;
+
+    /* Drive the entity into the desired server state here */
+
+    state = npc->s;
+    game->CustomizeEntity(0, npc, &state);   /* player 0 */
+    T_ASSERT(state.flags & EF_MY_FLAG);
+    T_ASSERT(!(state.flags & EF_OTHER_FLAG));
+
+    if (game->Shutdown) game->Shutdown();
+}
+```
+
+Key points:
+- `CustomizeEntity` receives a *copy* of `npc->s` and mutates it; `npc->s` is unchanged.
+- Call it once per logical state transition (e.g. before quest accept, after quest accept) to test each branch.
+- Combine with `wow_clients[player].selected_entity` changes to test visibility gating.
+- These tests live in `games/world-of-warcraft/tests/test_wow_game.c`.
+
 ## Build and Linking
 
 - Never add `DYLIB_LOOKUP := -Wl,-undefined,dynamic_lookup` or otherwise rely on `-Wl,-undefined,dynamic_lookup` in this repository.

--- a/client/cl_input_wow.c
+++ b/client/cl_input_wow.c
@@ -28,6 +28,7 @@ static struct {
     SDL_Cursor *cursor_crosshair;
     SDL_Cursor *cursor_hand;
     DWORD last_hover_entity;
+    DWORD selected_entity;
 } wow_input = {
     .pitch = 342.0f,
     .distance = 8.0f,
@@ -69,6 +70,7 @@ static BOOL CL_WowMouseMovedPast(VECTOR2 const *a, VECTOR2 const *b) {
 }
 
 static void CL_WowSendSelect(DWORD entity_number) {
+    wow_input.selected_entity = entity_number;
     MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
     SZ_Printf(&cls.netchan.message, "select %u", (unsigned)entity_number);
 }
@@ -123,8 +125,8 @@ static void CL_WowRmbUp(void) {
     }
     if (re.TraceEntity(&cl.viewDef, mouse.origin.x, mouse.origin.y, &entnum)) {
         CL_WowSendInteract(entnum);
-    } else if (cl.playerstate.selected_entity) {
-        CL_WowSendInteract(cl.playerstate.selected_entity);
+    } else if (wow_input.selected_entity) {
+        CL_WowSendInteract(wow_input.selected_entity);
     }
 }
 

--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -196,7 +196,9 @@ static void V_AddClientEntity(centity_t const *ent) {
     
     re.origin = Vector3_lerp(&ent->prev.origin, &ent->current.origin, cl.viewDef.lerpfrac);
     re.angle = LerpRotation(ent->prev.angle, ent->current.angle, cl.viewDef.lerpfrac);
+#ifdef WOW
     re.rotation = Vector3_lerp(&ent->prev.rotation, &ent->current.rotation, cl.viewDef.lerpfrac);
+#endif
     re.scale = LerpNumber(ent->prev.scale, ent->current.scale, cl.viewDef.lerpfrac);
     re.frame = ent->current.frame;
     re.oldframe = ent->prev.frame;
@@ -227,23 +229,24 @@ static void V_AddClientEntity(centity_t const *ent) {
     if (ent->current.flags & EF_FOW_REVEALER) {
         re.flags |= RF_FOW_REVEALER;
     }
-    if (ent->current.flags & EF_MOUNTED) {
-        re.flags |= RF_MOUNTED;
-    }
+    if (ent->current.flags & EF_MOUNTED) re.flags |= RF_MOUNTED;
+    if (ent->current.flags & EF_HAS_QUEST) re.flags |= RF_HAS_QUEST;
+    if (ent->current.flags & EF_QUEST_COMPLETE) re.flags |= RF_QUEST_COMPLETE;
+    if (ent->current.flags & EF_HOSTILE) re.flags |= RF_HOSTILE;
     re.radius = ent->current.radius;
     re.number = ent->current.number;
     re.health = ent->current.stats[ENT_HEALTH];
     re.mana   = ent->current.stats[ENT_MANA];
     re.splat = cl.pics[ent->current.splat & 0xffff];
     re.splatsize = ent->current.splat >> 16;
+#ifndef USE_SHADOWMAPS
     re.shadow = cl.pics[ent->current.shadow];
-    re.overhead_sprite = cl.pics[ent->current.overhead_sprite & 0x7fff];
-    re.overhead_sprite_color = (ent->current.overhead_sprite & 0x8000) ? MAKE(COLOR32, 255, 215, 0, 255) : COLOR32_WHITE;
     re.shadow_rect = MAKE(RECT,
                           ShadowUnpackRectComponent((BYTE)(ent->current.shadow_rect & 0xff)),
                           ShadowUnpackRectComponent((BYTE)((ent->current.shadow_rect >> 8) & 0xff)),
                           ShadowUnpackRectComponent((BYTE)((ent->current.shadow_rect >> 16) & 0xff)),
                           ShadowUnpackRectComponent((BYTE)((ent->current.shadow_rect >> 24) & 0xff)));
+#endif
     if (!Cvar_Integer("r_unit_shadows", 1)) {
         re.flags |= RF_NO_SHADOW;
     }

--- a/client/tr_public.h
+++ b/client/tr_public.h
@@ -118,13 +118,8 @@ typedef struct {
 typedef struct {
     VECTOR3 origin;
     LPCMODEL model;
-    LPCMODEL attached_model;
-    LPCMODEL overhead_model;
     LPCTEXTURE skin;
     LPCTEXTURE splat;
-    LPCTEXTURE shadow;
-    LPCTEXTURE overhead_sprite;       /* billboarded sprite drawn above the entity (NULL = none) */
-    COLOR32    overhead_sprite_color; /* tint applied to overhead_sprite (WHITE = no tint) */
     LPCSTR name;                      /* server-authored world label (NULL = none) */
     DWORD number;
     DWORD team;
@@ -132,16 +127,21 @@ typedef struct {
     DWORD display_id;
     DWORD appearance;
     DWORD equipment;
+    LPCMODEL attached_model;
+    LPCMODEL overhead_model;
+    VECTOR3 rotation;   /* 3D rotation for renderer-only static objects (WoW map objects, doodads) */
 #endif
     DWORD frame;
     DWORD oldframe;
     DWORD flags;
     float angle;        /* 1D yaw for dynamic actors (units, players); grounded Warcraft III entities use this */
-    VECTOR3 rotation;   /* 3D rotation for renderer-only static objects (WoW map objects, doodads) */
     float scale;
     float radius;
     float splatsize;
+#ifndef USE_SHADOWMAPS
+    LPCTEXTURE shadow;
     RECT shadow_rect;
+#endif
     BYTE health;   /* current HP fraction, 0-255 (0 = dead/no bar) */
     BYTE mana;     /* current mana fraction, 0-255 (0 = no mana bar) */
 } renderEntity_t;

--- a/common/msg.c
+++ b/common/msg.c
@@ -34,19 +34,22 @@ netField_t entityStateFields[] = {
     { NETF(entityState_t, origin), NFT_VECTOR3 },
 #endif
     { NETF(entityState_t, angle), NFT_ANGLE },
+#ifdef WOW
     { NETF(entityState_t, rotation), NFT_VECTOR3 },
+#endif
     { NETF(entityState_t, scale), NFT_PACKED_FLOAT },
     { NETF(entityState_t, frame), NFT_LONG },
-    { NETF(entityState_t, model), NFT_SHORT },
-    { NETF(entityState_t, model2), NFT_SHORT },
+    { NETF(entityState_t, model), NFT_BYTE },
+    { NETF(entityState_t, model2), NFT_BYTE },
 #ifdef WOW
     { NETF(entityState_t, appearance), NFT_LONG },
     { NETF(entityState_t, equipment), NFT_LONG },
 #endif
     { NETF(entityState_t, image), NFT_SHORT },
-    { NETF(entityState_t, overhead_sprite), NFT_SHORT },
     { NETF(entityState_t, player), NFT_BYTE },
-    { NETF(entityState_t, flags), NFT_LONG },
+    { NETF(entityState_t, flags), NFT_BYTE },
+    { NETF(entityState_t, renderfx), NFT_BYTE },
+    { NETF(entityState_t, ability), NFT_BYTE },
 #ifdef WOW
     /* WoW creature radii can be 0.5; NFT_ROUND serialized those as zero. WoW radii stay < 65.5 so the packed-float
      * range is ample. WC3 selection radii (buildings/destructables) exceed 65.5 and must keep NFT_ROUND. */
@@ -55,8 +58,10 @@ netField_t entityStateFields[] = {
     { NETF(entityState_t, radius), NFT_ROUND },
 #endif
     { NETF(entityState_t, splat), NFT_LONG },
+#ifndef USE_SHADOWMAPS
     { NETF(entityState_t, shadow), NFT_SHORT },
     { NETF(entityState_t, shadow_rect), NFT_LONG },
+#endif
     { NETF(entityState_t, stats), NFT_LONG },
     { NULL }
 };
@@ -303,6 +308,12 @@ static DWORD MSG_GetBits(void const *from,
             case NFT_QUATERNION:
                 if (memcmp(fromF, toF, sizeof(QUATERNION))!=0) bits |= 1 << (field - fields);
                 break;
+            case NFT_BYTE:
+                if (*(uint8_t *)fromF != *(uint8_t *)toF) bits |= 1 << (field - fields);
+                break;
+            case NFT_SHORT:
+                if (*(uint16_t *)fromF != *(uint16_t *)toF) bits |= 1 << (field - fields);
+                break;
             default:
                 if (*fromF != *toF) {
                     if ((field->type == NFT_TEXT || field->type == NFT_DUPTEXT) && **((LPCSTR *)toF) == 0) {
@@ -332,8 +343,8 @@ static void MSG_WriteFields(LPSIZEBUF msg,
             case NFT_PACKED_FLOAT: MSG_WriteShort(msg, *_float * 500); break;
             case NFT_ANGLE: MSG_WriteShort(msg, *_float / 360 * 0xffff); break;
             case NFT_LONG: MSG_WriteLong(msg, *toF); break;
-            case NFT_SHORT: MSG_WriteShort(msg, *toF); break;
-            case NFT_BYTE: MSG_WriteByte(msg, *toF); break;
+            case NFT_SHORT: MSG_WriteShort(msg, *(uint16_t *)toF); break;
+            case NFT_BYTE: MSG_WriteByte(msg, *(uint8_t *)toF); break;
             case NFT_TEXT: MSG_WriteString(msg, *(LPCSTR *)toF); break;
             case NFT_DUPTEXT: MSG_WriteString(msg, *(LPCSTR *)toF); break;
             case NFT_VECTOR2: FOR_LOOP(i, 2) MSG_WriteFloat(msg, _float[i]); break;
@@ -360,8 +371,8 @@ static void MSG_ReadFields(LPSIZEBUF msg,
             case NFT_PACKED_FLOAT: *_float = MSG_ReadShort(msg) / 500.f; break;
             case NFT_ANGLE: *_float = MSG_ReadShort(msg) * 360.f / 0xffff; break;
             case NFT_LONG: *toF = MSG_ReadLong(msg); break;
-            case NFT_SHORT: *toF = MSG_ReadShort(msg); break;
-            case NFT_BYTE: *toF = MSG_ReadByte(msg); break;
+            case NFT_SHORT: *(uint16_t *)toF = (uint16_t)MSG_ReadShort(msg); break;
+            case NFT_BYTE: *(uint8_t *)toF = (uint8_t)MSG_ReadByte(msg); break;
             case NFT_TEXT:
                 *((LPCSTR *)toF) = (LPCSTR)(msg->data + msg->readcount);
                 while (*(msg->data+(msg->readcount++)));

--- a/common/shared.h
+++ b/common/shared.h
@@ -157,14 +157,19 @@ enum {
     FLAG(RF_HOSTILE, 13),
     FLAG(RF_HOVERED, 14),
     FLAG(RF_GROUND_EFFECT, 15),
-    FLAG(RF_MOUNTED, 16), /* riding a mount; overhead name resolves to the mounted attachment */
+    FLAG(RF_MOUNTED, 16),      /* riding a mount; overhead name resolves to the mounted attachment */
+    FLAG(RF_HAS_QUEST, 17),    /* show overhead "?" sprite */
+    FLAG(RF_QUEST_COMPLETE, 18), /* tint "?" sprite yellow */
 };
 
 enum {
     FLAG(EF_GROUND_ANCHOR, 0),
     FLAG(EF_FOW_BLOCKER, 1),
     FLAG(EF_FOW_REVEALER, 2),
-    FLAG(EF_MOUNTED, 3), /* WoW: entity is riding a mount */
+    FLAG(EF_MOUNTED, 3),        /* WoW: entity is riding a mount */
+    FLAG(EF_HAS_QUEST, 4),      /* entity has a quest in progress — show "?" sprite */
+    FLAG(EF_QUEST_COMPLETE, 5), /* quest is ready to turn in — tint "?" yellow */
+    FLAG(EF_HOSTILE, 6),        /* entity is hostile — renderer shows red nameplate */
 };
 
 enum {
@@ -385,27 +390,24 @@ typedef struct {
 } svQuestEntry_t;
 
 struct playerState_s {
-    DWORD number;
-    QUATERNION viewquat;
-    VECTOR3 viewangles;
-    VECTOR2 origin;
-    FLOAT distance;
-    DWORD fov;      /* vertical field of view in degrees */
-    DWORD rdflags;
-    DWORD uiflags;
-    DWORD client_ui_state;
-    DWORD cinematic_portrait;   /* model index of the cinematic transmission portrait (0 = none) */
-    DWORD team;
-    DWORD color;    // player color index (0 = red, 1 = blue, … see PLAYER_COLOR_*)
-    DWORD race;     // map player race, see playerRace_t
-    LPSTR name;     // player display name (set from mapplayer or by script)
-    LONG  start_location; // start location index assigned to this player (-1 = none)
-    FLOAT cinefade;
-    DWORD selected_entity;  /* entity number this player has targeted (0 = none) */
-    USHORT stats[MAX_STATS];
-    LPCSTR texts[MAX_STATS];
-    svQuestEntry_t quest_log[SV_MAX_QUEST_LOG];
-    DWORD quest_count;
+    DWORD number;                   // client slot index
+    QUATERNION viewquat;            // canonical 3D view orientation sent to the renderer
+    VECTOR3 viewangles;             // euler pitch/yaw for WoW orbit camera math; only transmitted #ifdef WOW (can't round-trip euler from quat losslessly)
+    VECTOR2 origin;                 // 2D camera focus point; XY only because all games here are isometric/orbit, not first-person
+    FLOAT distance;                 // camera distance from origin for orbit/isometric view
+    DWORD fov;                      // vertical FOV in degrees; transmitted as NFT_BYTE so BYTE would suffice
+    DWORD rdflags;                  // refdef flags (underwater tint, etc.)
+    DWORD uiflags;                  // per-widget HUD visibility bits, set server-side via FDF/svc_layout pipeline
+    DWORD client_ui_state;          // coarse UI mode: CLIENT_UI_LOADING/GAME/CINEMATIC; state machine, not a bitfield like uiflags
+    DWORD cinematic_portrait;       // WC3 only: model index of transmission talking-head portrait (set by JASS TransmissionFromUnitWithNameBJ), 0 = none
+    DWORD team;                     // alliance group (1-based, 0 = none); NOT the same as color — multiple colors can share a team
+    DWORD color;                    // cosmetic color slot (0 = red, 1 = blue, …); drives minimap dot and skin lookup, NOT the same as team
+    DWORD race;                     // map player race (playerRace_t), used to resolve WC3 race UI skins
+    LPSTR name;                     // player display name from mapplayer or JASS script; NOTE: LPSTR but no caller mutates through this — LPCSTR would be correct
+    LONG  start_location;           // start location index for JASS GetStartLocationX/Y (-1 = none)
+    FLOAT cinefade;                 // full-screen fade alpha [0,1]; collapsed from Q2's blend[4] since no game here uses tinted overlays
+    USHORT stats[MAX_STATS];        // fast-update integer stats; USHORT (vs Q3's int) to halve wire size
+    LPCSTR texts[MAX_STATS];        // string stats parallel to stats[], for UI text fields
 };
 
 /* One-shot events embedded in entityState_t.event.
@@ -426,29 +428,37 @@ typedef struct entityState_s {
         struct { VECTOR2 origin2; FLOAT z; };
     };
     FLOAT angle;
+#ifdef WOW
     VECTOR3 rotation;
+#endif
     FLOAT scale;
     FLOAT radius;
     BYTE stats[ENT_STAT_COUNT];
-    DWORD player;
-    DWORD model;
-    DWORD model2;
+    BYTE player;
+    BYTE model;
+    BYTE model2;
+    USHORT image;
+    BYTE sound;
+    DWORD frame;
+    BYTE event;
+    BYTE flags;
+    BYTE renderfx;
+    BYTE ability;
+    DWORD splat;
 #ifdef WOW
     DWORD appearance;
     DWORD equipment;
 #endif
-    DWORD image;
-    DWORD overhead_sprite; /* billboarded sprite: bits[14:0]=image index, bit[15]=yellow tint flag (0=none) */
-    DWORD sound;
-    DWORD frame;
-    DWORD event;
-    USHORT flags;
-    BYTE renderfx;
-    BYTE ability;
-    DWORD splat;
+#ifndef USE_SHADOWMAPS
     DWORD shadow;
     DWORD shadow_rect;
+#endif
 } entityState_t;
+
+_Static_assert(MAX_CLIENTS     <= 256,  "entityState_t.player is BYTE — bump to USHORT if MAX_CLIENTS exceeds 255");
+_Static_assert(MAX_MODELS      <= 256,  "entityState_t.model/model2 are BYTE — bump to USHORT if MAX_MODELS exceeds 255");
+_Static_assert(MAX_SOUNDS      <= 256,  "entityState_t.sound is BYTE — bump to USHORT if MAX_SOUNDS exceeds 255");
+_Static_assert(MAX_CONFIGSTRINGS <= 65536, "entityState_t.image is USHORT — bump to DWORD if MAX_CONFIGSTRINGS exceeds 65535");
 
 #ifdef WOW
 typedef struct wowAppearance_s {

--- a/docs/games/warcraft-3/cinematics.md
+++ b/docs/games/warcraft-3/cinematics.md
@@ -22,11 +22,13 @@ Cutscenes in Warcraft III are driven entirely by the map's JASS script (`war3map
 
 The `skip_cutscene` cvar provides an engine-level fast-forward. When set to `1`:
 - `SetCinematicScene` returns early (no dialogue)
-- `ShowInterface` forces UI visible
-- `EnableUserControl` forces user control on
 - `TriggerSleepAction` sleeps only 1ms
 - Camera durations forced to 0
 - Cinefilter forced off
+
+`ShowInterface` and `EnableUserControl` still honor the JASS booleans while the script fast-forwards. Keeping cinematic
+UI/input state prevents edge-scroll camera messages from racing the script: the final camera setup must land before cleanup
+restores input.
 
 This is separate from the JASS-level ESC skip mechanism.
 
@@ -74,6 +76,12 @@ Indicates wrong `currentplayer` context in the JASS VM. Check `jass_eventplayer(
 
 **Cinematic HUD layers hidden:**
 `CLIENT_UI_CINEMATIC` hides portrait, console, command bar, info panel, inventory via `UI_LayoutShouldSkipLayoutLayer` in `client/cl_unit_layout.c`.
+
+**Fast-forward ends at the last cinematic camera position:**
+Log server `playerState.origin`, client camera prediction, `client_ui_state`, and `no_control` together. If gameplay input
+becomes active before the final camera native, edge scrolling can send `clc_camera_position` during the accelerated script
+and overwrite the authoritative snap. `skip_cutscene` must shorten timing only; the JASS cleanup owns the UI and input
+transition.
 
 ### DisplayText Message Overlay
 

--- a/games/warcraft-3/game/api/api_misc.h
+++ b/games/warcraft-3/game/api/api_misc.h
@@ -1096,9 +1096,7 @@ DWORD SetSkyModel(LPJASS j) {
 }
 DWORD EnableUserControl(LPJASS j) {
     BOOL b = jass_checkboolean(j, 1);
-    if (G_SkipCutscene()) {
-        b = true;
-    }
+    /* Fast-forwarding must preserve the script's input lock; early edge scrolling overwrote its final camera snap. */
     if (currentplayer) {
         PLAYER_CLIENT(currentplayer)->no_control = !b;
     }
@@ -1119,7 +1117,7 @@ DWORD ShowInterface(LPJASS j) {
     BOOL flag = jass_checkboolean(j, 1);
     FLOAT fadeDuration = jass_checknumber(j, 2);
     LPPLAYER player = currentplayer;
-    if (G_SkipCutscene()) flag = true;
+    /* Fast-forwarding compresses time, but the script still owns the cinematic-to-game UI transition. */
     if (player)
         UI_ShowInterface(PLAYER_ENT(player), flag, fadeDuration);
     return 0;

--- a/games/warcraft-3/game/g_items.c
+++ b/games/warcraft-3/game/g_items.c
@@ -21,12 +21,14 @@ void SP_SpawnItem(LPEDICT self) {
     PATHSTR model_filename;
     strlcpy(model_filename, ITEM_FILE(self->class_id), sizeof(model_filename));
     self->s.model = G_RegisterModel(model_filename);
+#ifndef USE_SHADOWMAPS
     self->s.shadow = G_LoadShadowTexture(FS_FindSheetCell(game.config.misc, "Misc", "ItemShadowFile"), false);
     self->s.shadow_rect = ShadowPackRect(
         G_MiscVectorValue("ItemShadowOffset", 0),
         G_MiscVectorValue("ItemShadowOffset", 1),
         G_MiscVectorValue("ItemShadowSize", 0),
         G_MiscVectorValue("ItemShadowSize", 1));
+#endif
     self->movetype = MOVETYPE_NONE;
 }
 

--- a/games/warcraft-3/game/g_monster.c
+++ b/games/warcraft-3/game/g_monster.c
@@ -307,6 +307,7 @@ static void M_SetUnitShadow(LPEDICT self) {
         return;
     }
 
+#ifndef USE_SHADOWMAPS
     self->s.shadow = shadow;
     FLOAT shadow_x = UNIT_SHADOW_IMAGE_CENTER_X(self->class_id);
     FLOAT shadow_y = UNIT_SHADOW_IMAGE_CENTER_Y(self->class_id);
@@ -320,6 +321,7 @@ static void M_SetUnitShadow(LPEDICT self) {
         shadow_h = size;
     }
     self->s.shadow_rect = ShadowPackRect(shadow_x, shadow_y, shadow_w, shadow_h);
+#endif
 }
 
 static void M_SetBuildingShadow(LPEDICT self) {
@@ -332,8 +334,10 @@ static void M_SetBuildingShadow(LPEDICT self) {
         return;
     }
 
+#ifndef USE_SHADOWMAPS
     self->s.shadow = shadow;
     self->s.shadow_rect = 0;
+#endif
 }
 
 /* Register the first sound file for a given SLK label+suffix and return its

--- a/games/warcraft-3/game/g_spawn.c
+++ b/games/warcraft-3/game/g_spawn.c
@@ -143,8 +143,10 @@ static void SP_SpawnDestructable(LPEDICT edict) {
      * collision circle.  Fabricating a 50-unit circle on every tree was a prime
      * cause of units sticking on trunks. */
     edict->collision = radius > 0.0f ? radius : 0.0f;
+#ifndef USE_SHADOWMAPS
     edict->s.shadow = G_LoadShadowTexture(DESTRUCTABLE_SHADOW(edict->class_id), false);
     edict->s.shadow_rect = 0;
+#endif
     edict->health.value = DESTRUCTABLE_HIT_POINT_MAXIMUM(edict->class_id);
     edict->health.max_value = DESTRUCTABLE_HIT_POINT_MAXIMUM(edict->class_id);
     edict->targtype = G_GetTargetType(DESTRUCTABLE_TARGETED_AS(edict->class_id));

--- a/games/warcraft-3/game/tests/t_api.c
+++ b/games/warcraft-3/game/tests/t_api.c
@@ -22,6 +22,8 @@
 LPEDICT alloc_test_unit(DWORD class_id, FLOAT x, FLOAT y);
 void reset_entities(void);
 void setup_test_world(void);
+BOOL run_test_jass(LPCSTR src);
+extern LPPLAYER currentplayer;
 
 
 
@@ -42,6 +44,37 @@ void setup_test_world(void);
 static LPPLAYER test_player(int idx) {
     game.clients[idx].ps.number = (DWORD)idx;
     return &game.clients[idx].ps;
+}
+
+static LPCSTR skip_cutscene_cvar(LPCSTR name, LPCSTR fallback) {
+    return !strcmp(name, "skip_cutscene") ? "1" : fallback;
+}
+
+/* Fast-forward only changes cinematic timing; JASS retains ownership of the input/UI lifecycle. */
+TEST(wc3_api, skip_cutscene_preserves_scripted_input_and_ui_state) {
+    LPCSTR (*old_cvar)(LPCSTR, LPCSTR) = gi.CvarString;
+    LPGAMECLIENT gc = &game.clients[0];
+
+    gi.CvarString = skip_cutscene_cvar;
+    currentplayer = &gc->ps;
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  call ShowInterface(false, 0.0)\n"
+        "  call EnableUserControl(false)\n"
+        "endfunction\n"));
+    T_EQ(gc->ps.client_ui_state, CLIENT_UI_CINEMATIC);
+    T_ASSERT(gc->no_control);
+
+    currentplayer = &gc->ps;
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  call ShowInterface(true, 0.0)\n"
+        "  call EnableUserControl(true)\n"
+        "endfunction\n"));
+    T_EQ(gc->ps.client_ui_state, CLIENT_UI_GAME);
+    T_ASSERT(!gc->no_control);
+    currentplayer = NULL;
+    gi.CvarString = old_cvar;
 }
 
 /* Create a minimal unit in slot 0 and return it. */

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -628,6 +628,65 @@ TEST(wc3_game, fow_full_sync_marks_player_connected) {
 }
 
 /* =========================================================================
+ * Performance benchmarks
+ *
+ * Run with: openwarcraft3-tests -data <wc3data> -tft +dedicated 1 +test 'wc3_perf.*'
+ * These tests do not assert; they print [BENCH] lines to stdout so you can
+ * spot regressions by comparing across builds (BUILD=release for meaningful
+ * numbers).
+ * ========================================================================= */
+
+void CM_SetupTestWorldBounds(LPCBOX2 bounds);
+
+/* 128×128-tile map → 16384×16384 units → 256×256 FOW cells at FOW_CELL_SIZE=64.
+ * Two players connected, 80 revealer units each spread across the map. */
+TEST(wc3_perf, fow_update_large_map) {
+    CM_SetupTestWorldBounds(&MAKE(BOX2, .min = {0.0f, 0.0f},
+                                        .max = {16384.0f, 16384.0f}));
+    G_FowInit();
+
+    level.fow.players[0].client_connected = true;
+    level.fow.players[1].client_connected = true;
+
+    for (int p = 0; p < 2; p++) {
+        for (int i = 0; i < 80; i++) {
+            LPEDICT ent         = G_Spawn();
+            ent->s.player       = (DWORD)p;
+            ent->s.origin.x     = 1024.0f + (i % 16) * 900.0f;
+            ent->s.origin.y     = 1024.0f + (i / 16) * 900.0f + p * 6000.0f;
+            ent->s.origin2.x    = ent->s.origin.x;
+            ent->s.origin2.y    = ent->s.origin.y;
+            ent->health.value   = 100.0f;
+            ent->health.max_value = 100.0f;
+            ent->balance.sight_radius.day = 900.0f;
+        }
+    }
+
+    T_BENCH("G_FowUpdate  (256x256 grid, 160 revealers, 2 players)", 10,
+            G_FowUpdate());
+    G_FowShutdown();
+}
+
+/* 1900 active units — matches the entity count seen in the perf profile.
+ * Each entity goes through spell_run_frame + unit_updatestatuses + physics
+ * every call, which is the dominant cost even before think fires. */
+TEST(wc3_perf, run_entities_1900) {
+    setup_test_world();
+
+    for (int i = 0; i < 1900; i++) {
+        LPEDICT ent = alloc_test_unit(MAKEFOURCC('h', 'p', 'e', 'a'),
+                                      (FLOAT)((i % 50) * 64),
+                                      (FLOAT)((i / 50) * 64));
+        ent->health.value     = 100.0f;
+        ent->health.max_value = 100.0f;
+        ent->movetype         = MOVETYPE_STEP;
+    }
+
+    T_BENCH("G_RunEntities (1900 active units, MOVETYPE_STEP)",       30,
+            G_RunEntities());
+}
+
+/* =========================================================================
  * Suite runner
  * ========================================================================= */
 

--- a/games/warcraft-3/game/tests/t_movement.c
+++ b/games/warcraft-3/game/tests/t_movement.c
@@ -733,6 +733,86 @@ TEST(wc3_movement, unit_stops_when_goal_is_occupied) {
     T_ASSERT(min_goal_dist <= combined + unit_movedistance(unit)); /* but reached right up to it */
 }
 
+/* Without a town hall the worker exits the mine carrying gold but has nowhere
+ * to go: it stops in stand state.  The RETURN_GOLD, DEPOSIT_GOLD, and
+ * RESUME_GOLD messages must NOT be published. */
+TEST(wc3_movement, gold_worker_stops_when_no_townhall) {
+    LPEDICT worker = make_moving_unit(0.0f, 0.0f);
+    LPEDICT mine   = alloc_test_unit(MAKEFOURCC('n','g','o','l'), 400.0f, 0.0f);
+    worker->collision = 16.0f; worker->unitinfo.MoveSpeed = 100.0f;
+    mine->collision = 128.0f; mine->s.model = 1; mine->movetype = MOVETYPE_NONE;
+    gi.LinkEntity(mine);
+    MINING_CAPACITY = 5.0f; MINING_DURATION = 0.01f; HARVEST_GOLD_CAPACITY = 10.0f;
+
+    MSGTRACE trace = {0};
+    T_ASSERT(G_SubscribeMessage(trace_message, &trace));
+    harvest_gold_start(worker, mine);
+
+    /* Drive until harvested_gold is set (harvestgold_walkback fired). */
+    FOR_LOOP(i, 100) {
+        worker->currentmove->think(worker);
+        if (worker->harvested_gold > 0) break;
+    }
+    G_UnsubscribeMessage(trace_message, &trace);
+
+    T_ASSERT(worker->harvested_gold > 0);           /* gold carried, not deposited */
+    T_ASSERT(worker->s.renderfx & RF_HAS_GOLD);     /* visual bag still on worker */
+    T_ASSERT(!(worker->s.renderfx & RF_HIDDEN));    /* not inside mine */
+    T_STREQ(worker->currentmove->animation, "stand");
+    /* Only MOVE_GOLD and ENTER_MINE — no return/deposit/resume. */
+    T_EQ((int)trace.count, 2);
+    T_EQ(trace.msg[0].type, GAME_MSG_HARVEST_MOVE_GOLD);
+    T_EQ(trace.msg[1].type, GAME_MSG_HARVEST_ENTER_MINE);
+}
+
+/* A second worker ordered to mine when the mine is already at capacity waits
+ * outside.  When the first worker exits, it wakes the second, which enters
+ * immediately without a new walk order from the player. */
+TEST(wc3_movement, gold_mine_queues_second_worker_when_at_capacity) {
+    LPEDICT worker1 = make_moving_unit(0.0f, 0.0f);
+    LPEDICT mine    = alloc_test_unit(MAKEFOURCC('n','g','o','l'), 400.0f, 0.0f);
+    worker1->collision = 16.0f; worker1->unitinfo.MoveSpeed = 100.0f;
+    mine->collision = 128.0f; mine->s.model = 1; mine->movetype = MOVETYPE_NONE;
+    gi.LinkEntity(mine);
+    MINING_CAPACITY = 1.0f; MINING_DURATION = 0.01f; HARVEST_GOLD_CAPACITY = 10.0f;
+
+    /* Worker1 walks to and enters the mine. */
+    harvest_gold_start(worker1, mine);
+    FOR_LOOP(i, 60) {
+        worker1->currentmove->think(worker1);
+        if (worker1->s.renderfx & RF_HIDDEN) break;
+    }
+    T_ASSERT(worker1->s.renderfx & RF_HIDDEN);
+    T_EQ((int)mine->peonsinside, 1);
+
+    /* Worker2: wire and place at the mine entrance so it reaches immediately. */
+    LPEDICT worker2 = alloc_test_unit(MAKEFOURCC('h','p','e','a'),
+                                      mine->s.origin2.x - mine->collision - 16.0f,
+                                      mine->s.origin2.y);
+    worker2->movetype = MOVETYPE_STEP;
+    worker2->stand    = unit_stand;
+    worker2->die      = unit_die;
+    worker2->collision = 16.0f;
+    worker2->health.value = worker2->health.max_value = 250.0f;
+    worker2->unitinfo.MoveSpeed = 100.0f;
+    unit_stand(worker2);
+    gi.LinkEntity(worker2);
+
+    harvest_gold_start(worker2, mine);
+    worker2->currentmove->think(worker2); /* immediately at mine — enters wait state */
+
+    T_ASSERT(!(worker2->s.renderfx & RF_HIDDEN));   /* waiting outside */
+    T_EQ((int)mine->peonsinside, 1);                /* still only worker1 */
+    T_STREQ(worker2->currentmove->animation, "stand");
+
+    /* Worker1 exits; harvestgold_walkback wakes worker2 in the same call. */
+    worker1->currentmove->think(worker1);
+    T_ASSERT(worker2->s.renderfx & RF_HIDDEN);   /* worker2 now inside */
+    T_EQ((int)mine->peonsinside, 1);             /* worker1 left (−1) worker2 entered (+1) */
+    T_ASSERT(!(worker1->s.renderfx & RF_HIDDEN));/* worker1 exited */
+    T_ASSERT(worker1->s.renderfx & RF_HAS_GOLD); /* worker1 carrying gold */
+}
+
 /* -----------------------------------------------------------------------
  * Suite runner
  * --------------------------------------------------------------------- */

--- a/games/world-of-warcraft/game/g_ui.c
+++ b/games/world-of-warcraft/game/g_ui.c
@@ -235,10 +235,10 @@ static void UI_WriteQuestDialog(LPEDICT ent) {
 
     if (wc->quest_open) {
         LPCWOWQUESTDETAIL detail = Wow_QuestDetail(wc->quest_id);
-        svQuestEntry_t *state = SV_QuestFind(wc->client.ps.quest_log, wc->client.ps.quest_count, wc->quest_id);
-        DWORD slot = state ? (DWORD)(state - wc->client.ps.quest_log) : 0;
-        LPEDICT selected = wc->client.ps.selected_entity && wc->client.ps.selected_entity < (DWORD)globals.num_edicts
-            ? &wow_edicts[wc->client.ps.selected_entity] : NULL;
+        svQuestEntry_t *state = SV_QuestFind(wc->quest_log, wc->quest_count, wc->quest_id);
+        DWORD slot = state ? (DWORD)(state - wc->quest_log) : 0;
+        LPEDICT selected = wc->selected_entity && wc->selected_entity < (DWORD)globals.num_edicts
+            ? &wow_edicts[wc->selected_entity] : NULL;
         wowEntityLocal_t *giver = selected ? Wow_EntityLocal(selected) : NULL;
         LPCSTR giver_name = NULL;
         char command[64], desc[2048], obj[1024], text[3072];
@@ -301,10 +301,10 @@ static void UI_WriteQuestDialog(LPEDICT ent) {
 
         UI_WriteTextFrame(x + PW(42), y + PH(12), PW(280), PH(22), "Quest Log", MAKE(COLOR32, 255, 215, 120, 255), FONT_JUSTIFYCENTER);
 
-        if (!wc->client.ps.quest_count) {
+        if (!wc->quest_count) {
             UI_WriteTextFrame(x + PW(42), line_y, PW(280), PH(22), "No active quests.", MAKE(COLOR32, 160, 150, 140, 255), FONT_JUSTIFYCENTER);
-        } else FOR_LOOP(i, wc->client.ps.quest_count) {
-            svQuestEntry_t *qs = &wc->client.ps.quest_log[i];
+        } else FOR_LOOP(i, wc->quest_count) {
+            svQuestEntry_t *qs = &wc->quest_log[i];
             LPCWOWQUESTDETAIL detail = Wow_QuestDetail(qs->quest_id);
             LPCSTR status = qs->status == SV_QUEST_COMPLETE ? " (Complete)" : "";
 

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -1229,8 +1229,8 @@ void Wow_HealingTouch(LPEDICT caster) {
 /* Find a target in range for the firebolt spell.  Prefers current selection,
    then the current melee enemy, then nearest enemy. */
 LPEDICT Wow_FindSpellTarget(LPEDICT ent, FLOAT range) {
-    if (ent && ent->client && ent->client->ps.selected_entity) {
-        LPEDICT t = Wow_EdictByNumber(ent->client->ps.selected_entity);
+    if (ent && ent->client && ((wowClient_t *)ent->client)->selected_entity) {
+        LPEDICT t = Wow_EdictByNumber(((wowClient_t *)ent->client)->selected_entity);
         if (t && t != ent && t->inuse) {
             VECTOR2 delta = Vector2_sub(&t->s.origin2, &ent->s.origin2);
             if (sqrtf(delta.x * delta.x + delta.y * delta.y) <= range) {
@@ -1995,16 +1995,17 @@ static LPCSTR Wow_GetThemeValue(LPCSTR filename) {
 static BOOL Wow_PlayerIsMoving(void) { return wow_move.flags & BZ_WOW_MOVE_MASK; }
 
 static void Wow_SelectEntity(LPEDICT ent, LPEDICT target) {
-    DWORD old = ent->client->ps.selected_entity;
+    wowClient_t *wc = (wowClient_t *)ent->client;
+    DWORD old = wc->selected_entity;
     LPEDICT old_target = old ? Wow_EdictByNumber(old) : NULL;
 
     if (old_target && old_target != target)
         old_target->selected &= ~(1 << ent->client->ps.number);
     if (target && target != ent && target->inuse) {
         target->selected |= (1 << ent->client->ps.number);
-        ent->client->ps.selected_entity = target->s.number;
+        wc->selected_entity = target->s.number;
     } else {
-        ent->client->ps.selected_entity = 0;
+        wc->selected_entity = 0;
     }
 }
 
@@ -2013,8 +2014,8 @@ void Wow_QuestAwardKillCredit(LPEDICT attacker, DWORD display_id) {
 
     if (!attacker || !attacker->client) return;
     wc = (wowClient_t *)attacker->client;
-    FOR_LOOP(i, wc->client.ps.quest_count) {
-        svQuestEntry_t *qs = &wc->client.ps.quest_log[i];
+    FOR_LOOP(i, wc->quest_count) {
+        svQuestEntry_t *qs = &wc->quest_log[i];
         LPCWOWQUESTDETAIL detail;
         BOOL all_done;
 
@@ -2040,7 +2041,7 @@ void Wow_QuestAwardKillCredit(LPEDICT attacker, DWORD display_id) {
 
 /* An accepted predecessor is still in progress; only completion unlocks the chain. */
 static BOOL Wow_QuestPrereqMet(wowClient_t *client, DWORD quest_id) {
-    svQuestEntry_t *prev = SV_QuestFind(client->client.ps.quest_log, client->client.ps.quest_count, quest_id);
+    svQuestEntry_t *prev = SV_QuestFind(client->quest_log, client->quest_count, quest_id);
     return !quest_id || (prev && prev->status == SV_QUEST_COMPLETE);
 }
 
@@ -2048,7 +2049,7 @@ static BOOL Wow_AddQuest(wowClient_t *client, DWORD quest_id) {
     LPCWOWQUESTDETAIL detail = Wow_QuestDetail(quest_id);
     if (!detail) return false;
     if (!Wow_QuestPrereqMet(client, detail->prev_quest)) return false;
-    return SV_QuestAdd(client->client.ps.quest_log, &client->client.ps.quest_count, SV_MAX_QUEST_LOG, quest_id);
+    return SV_QuestAdd(client->quest_log, &client->quest_count, SV_MAX_QUEST_LOG, quest_id);
 }
 
 /* Resolve one physical quest NPC's repeated queststarter rows to the first
@@ -2069,7 +2070,7 @@ static DWORD Wow_QuestForGiver(wowClient_t *client, wowEntityLocal_t const *loca
         LPCWOWQUESTGIVER cur = Wow_QuestGiver(i);
         LPCWOWQUESTDETAIL detail;
         if (!Wow_QuestGiverSame(giver, cur)) continue;
-        if (SV_QuestFind(client->client.ps.quest_log, client->client.ps.quest_count, cur->quest_id)) continue;
+        if (SV_QuestFind(client->quest_log, client->quest_count, cur->quest_id)) continue;
         detail = Wow_QuestDetail(cur->quest_id);
         if (detail && Wow_QuestPrereqMet(client, detail->prev_quest))
             return cur->quest_id;
@@ -2107,7 +2108,7 @@ void Wow_SendInbox(LPEDICT ent) {
 }
 
 static void Wow_CompleteQuest(wowClient_t *client, DWORD quest_id) {
-    svQuestEntry_t *state = SV_QuestFind(client->client.ps.quest_log, client->client.ps.quest_count, quest_id);
+    svQuestEntry_t *state = SV_QuestFind(client->quest_log, client->quest_count, quest_id);
     LPCWOWQUESTDETAIL detail;
     if (!state || state->status != SV_QUEST_ACTIVE) return;
     detail = Wow_QuestDetail(quest_id);
@@ -2226,8 +2227,8 @@ static void Wow_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
     } else if (argc >= 1 && !strcasecmp(argv[0], "quest")) {
         wowClient_t *client = (wowClient_t *)ent->client;
         DWORD quest_id = argc >= 2 ? (DWORD)strtoul(argv[1], NULL, 10) : 0;
-        LPEDICT selected = ent->client->ps.selected_entity
-            ? Wow_EdictByNumber(ent->client->ps.selected_entity) : NULL;
+        LPEDICT selected = ((wowClient_t *)ent->client)->selected_entity
+            ? Wow_EdictByNumber(((wowClient_t *)ent->client)->selected_entity) : NULL;
         wowEntityLocal_t *selected_local = selected ? Wow_EntityLocal(selected) : NULL;
         if (!quest_id && selected_local)
             quest_id = Wow_QuestForGiver(client, selected_local);
@@ -2377,7 +2378,7 @@ static void Wow_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
             ent->attack(ent);
         }
     } else if (argc >= 1 && (!strcasecmp(argv[0], "wow_cycle_target") || !strcasecmp(argv[0], "cycletarget"))) {
-        DWORD old = ent->client->ps.selected_entity;
+        DWORD old = ((wowClient_t *)ent->client)->selected_entity;
         DWORD start = old > 0 ? old + 1 : WOW_MAX_CLIENTS;
         for (DWORD i = start; i < (DWORD)globals.num_edicts; i++) {
             LPEDICT t = &wow_edicts[i];
@@ -2454,8 +2455,8 @@ static void Wow_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
         LPEDICT target = def->range > 0 ? Wow_FindSpellTarget(ent, def->range) : NULL;
         /* For instant melee spells, accept the selected target even when out of
          * range — the auto-chase in Wow_RunFrame closes the gap automatically. */
-        if (!def->cast_time && !target && ent->client && ent->client->ps.selected_entity) {
-            LPEDICT t = Wow_EdictByNumber(ent->client->ps.selected_entity);
+        if (!def->cast_time && !target && ent->client && ((wowClient_t *)ent->client)->selected_entity) {
+            LPEDICT t = Wow_EdictByNumber(((wowClient_t *)ent->client)->selected_entity);
             if (t && t != ent && t->inuse && (t->svflags & SVF_MONSTER))
                 target = t;
         }
@@ -2496,7 +2497,7 @@ static questMarker_t Wow_QuestMarkerForGiver(wowClient_t *client, wowEntityLocal
         LPCWOWQUESTGIVER cur = Wow_QuestGiver(i);
         svQuestEntry_t *e;
         if (!Wow_QuestGiverSame(giver, cur)) continue;
-        e = SV_QuestFind(client->client.ps.quest_log, client->client.ps.quest_count, cur->quest_id);
+        e = SV_QuestFind(client->quest_log, client->quest_count, cur->quest_id);
         if (!e || e->status == SV_QUEST_REWARDED) continue;
         if (e->status == SV_QUEST_COMPLETE) return QUEST_MARKER_COMPLETE;
         if (e->status == SV_QUEST_ACTIVE) best = QUEST_MARKER_ACTIVE;
@@ -2509,17 +2510,17 @@ static void Wow_CustomizeEntity(DWORD player, LPCEDICT ent, LPENTITYSTATE state)
     wowEntityLocal_t *local = Wow_EntityLocal(ent);
     if (player >= WOW_MAX_CLIENTS) return;
     /* Vanilla reveals a creature's overhead name only after that recipient selects it. */
-    if (wow_clients[player].client.ps.selected_entity != state->number) state->image = 0;
-    if (!local || !local->quest_id || !state->overhead_sprite) return;
+    if (wow_clients[player].selected_entity != state->number) state->image = 0;
+    if (!local || !local->quest_id || !(state->flags & EF_HAS_QUEST)) return;
+    state->flags &= ~(EF_HAS_QUEST | EF_QUEST_COMPLETE);
     switch (Wow_QuestMarkerForGiver(&wow_clients[player], local)) {
     case QUEST_MARKER_AVAILABLE:
-        state->overhead_sprite = 0;
         state->model2 = local->quest_available_model;
         state->renderfx |= RF_ATTACH_OVERHEAD;
         break;
-    case QUEST_MARKER_COMPLETE:  state->overhead_sprite = local->quest_active_sprite | WOW_QUEST_SPRITE_TINT_FLAG; break;
-    case QUEST_MARKER_ACTIVE:    state->overhead_sprite = local->quest_active_sprite; break;
-    default:                     state->overhead_sprite = 0; break;
+    case QUEST_MARKER_COMPLETE: state->flags |= EF_HAS_QUEST | EF_QUEST_COMPLETE; break;
+    case QUEST_MARKER_ACTIVE:   state->flags |= EF_HAS_QUEST; break;
+    default: break;
     }
 }
 

--- a/games/world-of-warcraft/game/g_wow_local.h
+++ b/games/world-of-warcraft/game/g_wow_local.h
@@ -182,7 +182,6 @@ static BOOL Wow_QuestGiverSame(LPCWOWQUESTGIVER a, LPCWOWQUESTGIVER b) {
 }
 
 #define WOW_QUEST_OBJECTIVE_ANCHOR  0x51504F49
-#define WOW_QUEST_SPRITE_TINT_FLAG  (1u << 15) // bit[15] of entityState_t.overhead_sprite → render with yellow tint
 
 DWORD Wow_QuestGiverCount(void);
 LPCWOWQUESTGIVER Wow_QuestGiver(DWORD index);
@@ -312,7 +311,6 @@ typedef struct {
     DWORD go_display_id;
     DWORD quest_id;
     DWORD quest_available_model;  /* model index for yellow "!" (TalkToMe.m2) */
-    DWORD quest_active_sprite;    /* image index for grey/yellow "?" (ActiveQuestIcon.blp) */
     /* Loot fields — valid on any entity (rolled at death, consumed on pickup). */
 #define WOW_MAX_LOOT_ITEMS 6
     wowHudIcon_t loot_items[WOW_MAX_LOOT_ITEMS];
@@ -336,8 +334,11 @@ typedef struct {
     UINAME name;
     wowHudIcon_t inventory[WOW_UI_INVENTORY_SLOTS];
     wowHudIcon_t actions[WOW_UI_ACTION_SLOTS];
+    DWORD selected_entity;  /* entity this player has targeted (server-side only, not synced to client) */
     BOOL quest_open;
     DWORD quest_id;
+    svQuestEntry_t quest_log[SV_MAX_QUEST_LOG];
+    DWORD quest_count;
     DWORD kill_progress[SV_MAX_QUEST_LOG][WOW_QUEST_MAX_KILL_OBJECTIVES];
     DWORD questlog_open;
     wowUiMessage_t messages[WOW_UI_MAX_MESSAGES];

--- a/games/world-of-warcraft/game/m_creature.c
+++ b/games/world-of-warcraft/game/m_creature.c
@@ -1,4 +1,5 @@
 #include "g_wow_local.h"
+#include "wow_assets.h"
 #include <math.h>
 #include <stdio.h>
 
@@ -7,8 +8,6 @@
 /* WOW_CREATURE_DISPLAY_* constants live in g_wow_local.h (shared with loot table). */
 
 /* World markers are M2 models; GossipFrame BLPs are only dialog-list icons. */
-#define WOW_QUEST_AVAILABLE_MODEL "Interface\\Buttons\\TalkToMe.m2"           // M2; yellow world-space "!" marker
-#define WOW_QUEST_ACTIVE_ICON     "Interface\\GossipFrame\\ActiveQuestIcon.blp" // BLP; temporary active "?" sprite
 
 typedef struct {
     DWORD display_id;
@@ -178,13 +177,14 @@ static void Wow_MonsterStart(LPEDICT ent,
     local->attack_damage_point = 250;
     local->attack_backswing = 450;
     ent->svflags |= SVF_MONSTER;
-    ent->s.renderfx |= RF_HOSTILE;
     ent->idle = Wow_AIIdle;
     ent->move = Wow_AIMove;
     ent->think = Wow_RunCreatureFrame;
     ent->attack = Wow_AIAttack;
     ent->pain = Wow_AIPain;
-    ent->s.flags = EF_GROUND_ANCHOR;
+    /* EF_HOSTILE fits in the BYTE flags field; RF_HOSTILE (bit 13) overflows renderfx.
+     * cl_view.c translates EF_HOSTILE → RF_HOSTILE when building renderEntity_t. */
+    ent->s.flags = EF_GROUND_ANCHOR | EF_HOSTILE;
     ent->s.angle = (FLOAT)DEG2RAD(yaw);
     if (patrol_radius > 0.0f) {
         Wow_SetWalkMove(ent);
@@ -313,12 +313,10 @@ void Wow_SpawnQuestLocations(LPCVECTOR2 origin) {
         ent->s.radius = radius;
         ent->s.player = 2;
         ent->s.class_id = creature_model->display_id;
-        local->quest_available_model  = (DWORD)G_RegisterModel(WOW_QUEST_AVAILABLE_MODEL);
-        local->quest_active_sprite    = (DWORD)gi.ImageIndex(WOW_QUEST_ACTIVE_ICON);
+        local->quest_available_model = (DWORD)G_RegisterModel(WOW_QUEST_AVAILABLE_MODEL);
         ent->s.image = Wow_CreatureNameConfigstring(creature);
-        ent->s.overhead_sprite = local->quest_active_sprite; /* nonzero lets CustomizeEntity author recipient state */
         ent->s.angle = data->orientation;
-        ent->s.flags = EF_GROUND_ANCHOR;
+        ent->s.flags = EF_GROUND_ANCHOR | EF_HAS_QUEST;
         /* Non-hostile NPCs still need the creature frame for their idle (Stand)
          * animation; without a think function the entity loop skips them and
          * they render frozen at frame 0. */

--- a/games/world-of-warcraft/renderer/r_game.c
+++ b/games/world-of-warcraft/renderer/r_game.c
@@ -1,4 +1,5 @@
 #include "renderer/r_game.h"
+#include "wow_assets.h"
 #include "renderer/r_local.h"
 #include "wow/r_wowmap.h"
 #include "m2/r_m2_format.h"
@@ -9,6 +10,8 @@ void R_DrawTerrainShadows(void);
 void R_DrawAlphaSurfaces(void);
 bool R_TraceLocation(viewDef_t const *viewdef, FLOAT x, FLOAT y, LPVECTOR3 output);
 float GetAccurateHeightAtPoint(float sx, float sy);
+
+static LPTEXTURE s_quest_active_icon;
 
 m2Model_t *R_LoadModelM2(LPCSTR modelFilename, void *buffer, DWORD size, BOOL *buffer_owned);
 void M2_Init(void);
@@ -48,6 +51,7 @@ void R_GameLoadAssets(void) {
     LPTEXTURE ring = R_MakeSelectionCircleTexture();
     FOR_LOOP(i, NUM_SELECTION_CIRCLES)
         tr.texture[TEX_SELECTION_CIRCLE+i] = ring;
+    s_quest_active_icon = R_LoadTexture(WOW_QUEST_ACTIVE_ICON);
 }
 
 void R_GameInit(void) {
@@ -250,7 +254,7 @@ void R_GameRenderModel(renderEntity_t const *entity) {
         /* A visible name owns the base slot; TalkToMe's authored bottom clearance separates the marker above it. */
         if (entity->name && *entity->name) marker.origin.z += M2_VisibleBottom(marker.model->m2);
         marker.attached_model = marker.overhead_model = NULL;
-        marker.overhead_sprite = NULL;
+        marker.flags &= ~(RF_HAS_QUEST | RF_QUEST_COMPLETE);
         marker.scale = 1.0f;
         /* The parent frame crosses TalkToMe's unrelated sequence every 1533 ms; the marker owns Stand's clock. */
         marker.frame = marker.oldframe = tr.viewDef.time;
@@ -260,10 +264,11 @@ void R_GameRenderModel(renderEntity_t const *entity) {
         R_GetEntityMatrix(&marker, &attached_transform);
         M2_RenderModel(&marker, marker.model->m2, &attached_transform);
     }
-    if (entity->overhead_sprite) {
+    if (s_quest_active_icon && (entity->flags & RF_HAS_QUEST)) {
         VECTOR3 origin = entity->origin;
         origin.z += (M2_GroundOffset(entity->model->m2) + M2_HeadHeight(entity->model->m2)) * entity->scale + 0.25f;
-        R_DrawBillboardSprite(entity->overhead_sprite, &origin, 0.5f, entity->overhead_sprite_color);
+        COLOR32 tint = (entity->flags & RF_QUEST_COMPLETE) ? MAKE(COLOR32, 255, 215, 0, 255) : COLOR32_WHITE;
+        R_DrawBillboardSprite(s_quest_active_icon, &origin, 0.5f, tint);
     }
     attachment_id = (tr.viewDef.rdflags & RDF_USE_ENTITY_CAMERA) ? 0 : 1;
     if (entity->attached_model &&
@@ -342,6 +347,7 @@ bool R_GameTraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT dista
     return true;
 }
 
+#ifndef USE_SHADOWMAPS
 bool R_GameRenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin) {
     LPCTEXTURE shadow;
     BOOL use_fast_blob;
@@ -398,6 +404,7 @@ bool R_GameRenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin) {
     }
     return true;
 }
+#endif
 
 FLOAT R_GameSelectionRadius(renderEntity_t const *entity) {
     /* Fractional WoW collision radii need a minimum visual footprint around the model. */

--- a/games/world-of-warcraft/tests/test_wow_abilities.c
+++ b/games/world-of-warcraft/tests/test_wow_abilities.c
@@ -300,12 +300,7 @@ TEST(wow_abilities, firebolt_homing_moves_toward_target) {
     T_ASSERT(proj->inuse);
     T_ASSERT(proj->s.origin.x > first_x);
 
-    /* Should eventually reach and be removed */
-    DWORD max_steps = 200;
-    while (proj->inuse && max_steps-- > 0) {
-        Wow_RunProjectile(proj);
-    }
-    T_ASSERT(!proj->inuse);
+    T_RUN_UNTIL(Wow_RunProjectile(proj), !proj->inuse, 200);
 }
 
 TEST(wow_abilities, firebolt_z_height_interpolates_correctly) {
@@ -359,13 +354,7 @@ TEST(wow_abilities, firebolt_applies_damage_on_hit) {
     Wow_FireFirebolt(caster, target);
     {
         LPEDICT proj = &wow_edicts[2];
-
-        /* Run projectile until it hits */
-        DWORD max_steps = 200;
-        while (proj->inuse && max_steps-- > 0) {
-            Wow_RunProjectile(proj);
-        }
-        T_ASSERT(!proj->inuse);
+        T_RUN_UNTIL(Wow_RunProjectile(proj), !proj->inuse, 200);
     }
     T_EQ((int)target_local->health, 1);
 }
@@ -383,11 +372,7 @@ TEST(wow_abilities, firebolt_lethal_kills_target) {
     Wow_FireFirebolt(caster, target);
     {
         LPEDICT proj = &wow_edicts[2];
-        DWORD max_steps = 200;
-        while (proj->inuse && max_steps-- > 0) {
-            Wow_RunProjectile(proj);
-        }
-        T_ASSERT(!proj->inuse);
+        T_RUN_UNTIL(Wow_RunProjectile(proj), !proj->inuse, 200);
     }
     T_ASSERT(target_local->dead);
     T_EQ((int)target_local->health, 0);
@@ -535,7 +520,7 @@ TEST(wow_abilities, find_spell_target_uses_selected_entity) {
     T_NOT_NULL(target2);
 
     /* Set selected entity to the farther one */
-    caster->client->ps.selected_entity = target2->s.number;
+    ((wowClient_t *)caster->client)->selected_entity = target2->s.number;
     result = Wow_FindSpellTarget(caster, 40.0f);
     /* Should prefer selected even though target1 is closer */
     T_NOT_NULL(result);
@@ -552,7 +537,7 @@ TEST(wow_abilities, find_spell_target_falls_back_to_nearest) {
     T_NOT_NULL(target2);
 
     /* No selected entity */
-    caster->client->ps.selected_entity = 0;
+    ((wowClient_t *)caster->client)->selected_entity = 0;
     result = Wow_FindSpellTarget(caster, 40.0f);
     /* Should find the nearest (target1 at 5 units) */
     T_NOT_NULL(result);
@@ -566,8 +551,165 @@ TEST(wow_abilities, find_spell_target_returns_null_when_out_of_range) {
 
     T_NOT_NULL(caster);
     T_NOT_NULL(target);
-    caster->client->ps.selected_entity = target->s.number;
+    ((wowClient_t *)caster->client)->selected_entity = target->s.number;
     result = Wow_FindSpellTarget(caster, 10.0f);
     T_NULL(result);
+}
+
+/* ---- Frostbolt tests ---- */
+
+TEST(wow_abilities, frostbolt_spawns_projectile) {
+    LPEDICT caster = make_player();
+    LPEDICT target = make_creature(10.0f, 0.0f);
+
+    T_NOT_NULL(caster);
+    T_NOT_NULL(target);
+    Wow_FireFrostbolt(caster, target);
+    {
+        LPEDICT proj = &wow_edicts[2];
+        wowEntityLocal_t *pl = Wow_EntityLocal(proj);
+        T_ASSERT(proj->inuse);
+        T_NOT_NULL(pl);
+        T_ASSERT(proj->think == Wow_RunProjectile);
+        T_EQ((int)pl->projectile_target, (int)target->s.number);
+        T_FEQ(pl->projectile_speed, 20.0f, 0.001f);
+        T_EQ((int)pl->projectile_damage, 3);
+        T_EQ((int)pl->slow_timer, 2000);  /* pending slow to apply on hit */
+        T_FEQ(proj->s.scale, 0.8f, 0.001f);
+        T_ASSERT(proj->s.flags & EF_GROUND_ANCHOR);
+    }
+}
+
+TEST(wow_abilities, frostbolt_applies_slow_on_hit) {
+    LPEDICT caster = make_player();
+    LPEDICT target = make_creature(3.0f, 0.0f);
+    wowEntityLocal_t *target_local;
+
+    T_NOT_NULL(caster);
+    T_NOT_NULL(target);
+    target_local = Wow_EntityLocal(target);
+    target_local->health = 10; /* must survive the hit (frostbolt deals 3) so slow is applied */
+    Wow_FireFrostbolt(caster, target);
+    {
+        LPEDICT proj = &wow_edicts[2];
+        T_RUN_UNTIL(Wow_RunProjectile(proj), !proj->inuse, 200);
+    }
+    T_EQ((int)target_local->slow_timer, 2000);
+}
+
+TEST(wow_abilities, frostbolt_lethal_kills_target) {
+    LPEDICT caster = make_player();
+    LPEDICT target = make_creature(3.0f, 0.0f);
+    wowEntityLocal_t *target_local;
+
+    T_NOT_NULL(caster);
+    T_NOT_NULL(target);
+    target_local = Wow_EntityLocal(target);
+    target_local->health = 1;
+    Wow_FireFrostbolt(caster, target);
+    {
+        LPEDICT proj = &wow_edicts[2];
+        T_RUN_UNTIL(Wow_RunProjectile(proj), !proj->inuse, 200);
+    }
+    T_ASSERT(target_local->dead);
+    T_EQ((int)target_local->health, 0);
+}
+
+TEST(wow_abilities, frostbolt_at_dead_caster_does_nothing) {
+    LPEDICT caster = make_player();
+    LPEDICT target = make_creature(5.0f, 0.0f);
+
+    T_NOT_NULL(caster);
+    T_NOT_NULL(target);
+    Wow_EntityLocal(caster)->dead = true;
+    Wow_FireFrostbolt(caster, target);
+    for (DWORD i = WOW_MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
+        LPEDICT e = &wow_edicts[i];
+        if (e->inuse && e->think == Wow_RunProjectile)
+            T_ASSERT(!"frostbolt spawned despite dead caster");
+    }
+}
+
+TEST(wow_abilities, frostbolt_at_dead_target_does_nothing) {
+    LPEDICT caster = make_player();
+    LPEDICT target = make_creature(5.0f, 0.0f);
+
+    T_NOT_NULL(caster);
+    T_NOT_NULL(target);
+    Wow_EntityLocal(target)->dead = true;
+    Wow_FireFrostbolt(caster, target);
+    for (DWORD i = WOW_MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
+        LPEDICT e = &wow_edicts[i];
+        if (e->inuse && e->think == Wow_RunProjectile)
+            T_ASSERT(!"frostbolt spawned despite dead target");
+    }
+}
+
+TEST(wow_abilities, frostbolt_disappears_when_target_dies) {
+    LPEDICT caster = make_player();
+    LPEDICT target = make_creature(8.0f, 0.0f);
+    wowEntityLocal_t *target_local;
+
+    T_NOT_NULL(caster);
+    T_NOT_NULL(target);
+    target_local = Wow_EntityLocal(target);
+    Wow_FireFrostbolt(caster, target);
+    {
+        LPEDICT proj = &wow_edicts[2];
+        T_ASSERT(proj->inuse);
+        Wow_RunProjectile(proj);
+        T_ASSERT(proj->inuse);
+        target_local->dead = true;
+        target->inuse = false;
+        Wow_RunProjectile(proj);
+        T_ASSERT(!proj->inuse);
+    }
+}
+
+/* ---- Damage and godmode tests ---- */
+
+TEST(wow_abilities, godmode_blocks_damage) {
+    LPEDICT caster = make_player();
+    LPEDICT target = make_creature(5.0f, 0.0f);
+    wowEntityLocal_t *target_local;
+
+    T_NOT_NULL(caster);
+    T_NOT_NULL(target);
+    target_local = Wow_EntityLocal(target);
+    target_local->godmode = true;
+    target_local->health = 3;
+
+    Wow_ApplyDamage(target, caster, 5);
+    T_EQ((int)target_local->health, 3);
+    T_ASSERT(!target_local->dead);
+}
+
+/* ---- Healing Touch mana tests ---- */
+
+TEST(wow_abilities, healing_touch_deducts_mana) {
+    LPEDICT caster = make_player();
+    wowEntityLocal_t *local;
+
+    T_NOT_NULL(caster);
+    local = Wow_EntityLocal(caster);
+    local->mana = 100;
+    local->health = 50;
+
+    Wow_HealingTouch(caster);
+    T_EQ((int)local->mana, 92);  /* 100 - WOW_HEALING_TOUCH_MANA_COST (8) */
+}
+
+TEST(wow_abilities, healing_touch_blocked_when_oom) {
+    LPEDICT caster = make_player();
+    wowEntityLocal_t *local;
+
+    T_NOT_NULL(caster);
+    local = Wow_EntityLocal(caster);
+    local->mana = 7;   /* below WOW_HEALING_TOUCH_MANA_COST (8) */
+    local->health = 50;
+
+    Wow_HealingTouch(caster);
+    T_EQ((int)local->health, 50);  /* not healed */
+    T_EQ((int)local->mana, 7);     /* mana not consumed */
 }
 

--- a/games/world-of-warcraft/tests/test_wow_appearance.c
+++ b/games/world-of-warcraft/tests/test_wow_appearance.c
@@ -393,10 +393,10 @@ TEST(wow_appearance, wow_entity_delta_preserves_fractional_radius) {
     T_FEQ(out.radius, 0.5f, 0.001f);
 }
 
-TEST(wow_appearance, wow_entity_delta_preserves_overhead_sprite) {
+TEST(wow_appearance, wow_entity_delta_preserves_quest_flags) {
     BYTE buf[256];
     sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
-    entityState_t from = { 0 }, to = { .number = 9, .model = 3, .overhead_sprite = 42 }, out = { 0 };
+    entityState_t from = { 0 }, to = { .number = 9, .model = 3, .flags = EF_HAS_QUEST | EF_QUEST_COMPLETE }, out = { 0 };
     DWORD bits = 0;
     int number;
 
@@ -406,7 +406,8 @@ TEST(wow_appearance, wow_entity_delta_preserves_overhead_sprite) {
     MSG_ReadDeltaEntity(&sb, &out, number, bits);
 
     T_EQ(number, 9);
-    T_EQ(out.overhead_sprite, 42);
+    T_ASSERT(out.flags & EF_HAS_QUEST);
+    T_ASSERT(out.flags & EF_QUEST_COMPLETE);
 }
 
 TEST(wow_appearance, wow_entity_delta_preserves_mounted_flag) {

--- a/games/world-of-warcraft/tests/test_wow_game.c
+++ b/games/world-of-warcraft/tests/test_wow_game.c
@@ -644,7 +644,7 @@ TEST(wow_game, quest_marker_transitions_on_acceptance) {
     VECTOR2 origin = { -8947.64f, -132.319f };
     LPEDICT giver = NULL;
     entityState_t state;
-    DWORD avail_model, active_idx;
+    DWORD avail_model;
 
     T_ASSERT(game->LoadMap("World/Maps/Azeroth/Azeroth.wdt"));
     game->RunFrame();
@@ -655,28 +655,27 @@ TEST(wow_game, quest_marker_transitions_on_acceptance) {
     T_NOT_NULL(giver);
     if (giver) {
         avail_model = (DWORD)test_model_index("Interface\\Buttons\\TalkToMe.m2");
-        active_idx = (DWORD)test_image_index("Interface\\GossipFrame\\ActiveQuestIcon.blp");
-        /* Before acceptance: the authoritative yellow "!" M2, not the GossipFrame BLP. */
+        /* Before acceptance: the authoritative yellow "!" M2, EF_HAS_QUEST cleared for this client. */
         state = giver->s;
         game->CustomizeEntity(0, giver, &state);
         T_EQ((int)state.image, 0);
-        T_EQ((int)state.overhead_sprite, 0);
+        T_ASSERT(!(state.flags & EF_HAS_QUEST));
         T_EQ((int)state.model2, (int)avail_model);
         T_ASSERT(state.renderfx & RF_ATTACH_OVERHEAD);
         /* Selection reveals the name, which makes the renderer stack the marker above attachment 18. */
-        wow_clients[0].client.ps.selected_entity = giver->s.number;
+        wow_clients[0].selected_entity = giver->s.number;
         state = giver->s;
         game->CustomizeEntity(0, giver, &state);
         T_EQ((int)state.image, (int)giver->s.image);
-        wow_clients[0].client.ps.selected_entity = 0;
-        /* After acceptance: grey "?" (ActiveQuestIcon, no tint). */
+        wow_clients[0].selected_entity = 0;
+        /* After acceptance: grey "?" flag, no tint. */
         game->ClientCommand(&wow_edicts[0], 2, (LPCSTR[]){ "quest_accept", "783" });
         state = giver->s;
         game->CustomizeEntity(0, giver, &state);
-        T_EQ((int)(state.overhead_sprite & 0x7fff), (int)active_idx);
+        T_ASSERT(state.flags & EF_HAS_QUEST);
         T_EQ((int)state.model2, 0);
         T_ASSERT(!(state.renderfx & RF_ATTACH_OVERHEAD));
-        T_ASSERT(!(state.overhead_sprite & WOW_QUEST_SPRITE_TINT_FLAG));
+        T_ASSERT(!(state.flags & EF_QUEST_COMPLETE));
     }
     if (game->Shutdown) game->Shutdown();
 }
@@ -867,12 +866,12 @@ TEST(wow_game, quest_accept_adds_to_quest_log) {
     player = &wow_edicts[0];
     game->ClientBegin(player);
     wc = (wowClient_t *)player->client;
-    T_EQ((int)wc->client.ps.quest_count, 0);
+    T_EQ((int)wc->quest_count, 0);
 
     game->ClientCommand(player, 2, accept_command);
-    T_EQ((int)wc->client.ps.quest_count, 1);
-    T_EQ((int)wc->client.ps.quest_log[0].quest_id, 788);
-    T_EQ((int)wc->client.ps.quest_log[0].status, SV_QUEST_ACTIVE);
+    T_EQ((int)wc->quest_count, 1);
+    T_EQ((int)wc->quest_log[0].quest_id, 788);
+    T_EQ((int)wc->quest_log[0].status, SV_QUEST_ACTIVE);
 }
 
 TEST(wow_game, quest_prerequisite_blocks_accept) {
@@ -888,18 +887,18 @@ TEST(wow_game, quest_prerequisite_blocks_accept) {
     wc = (wowClient_t *)player->client;
 
     game->ClientCommand(player, 2, accept13);
-    T_EQ((int)wc->client.ps.quest_count, 0);
+    T_EQ((int)wc->quest_count, 0);
 
     game->ClientCommand(player, 2, accept12);
-    T_EQ((int)wc->client.ps.quest_count, 1);
-    T_EQ((int)wc->client.ps.quest_log[0].quest_id, 12);
+    T_EQ((int)wc->quest_count, 1);
+    T_EQ((int)wc->quest_log[0].quest_id, 12);
 
     game->ClientCommand(player, 2, accept13);
-    T_EQ((int)wc->client.ps.quest_count, 1);
+    T_EQ((int)wc->quest_count, 1);
     game->ClientCommand(player, 2, (LPCSTR[]){ "quest_complete", "12" });
     game->ClientCommand(player, 2, accept13);
-    T_EQ((int)wc->client.ps.quest_count, 2);
-    T_EQ((int)wc->client.ps.quest_log[1].quest_id, 13);
+    T_EQ((int)wc->quest_count, 2);
+    T_EQ((int)wc->quest_log[1].quest_id, 13);
 }
 
 TEST(wow_game, quest_complete_delivers_rewards) {
@@ -1045,7 +1044,7 @@ TEST(wow_game, quest_kill_progress_increments_and_auto_completes) {
     wc = (wowClient_t *)player->client;
 
     game->ClientCommand(player, 2, accept788);
-    state = SV_QuestFind(wc->client.ps.quest_log, wc->client.ps.quest_count, 788);
+    state = SV_QuestFind(wc->quest_log, wc->quest_count, 788);
     T_NOT_NULL(state);
     T_EQ((int)state->status, SV_QUEST_ACTIVE);
     T_EQ((int)wc->kill_progress[0][0], 0);
@@ -1070,7 +1069,7 @@ TEST(wow_game, quest_kill_credit_only_on_accepted_quest) {
     wc = (wowClient_t *)player->client;
 
     Wow_QuestAwardKillCredit(player, 503);
-    T_EQ((int)wc->client.ps.quest_count, 0);
+    T_EQ((int)wc->quest_count, 0);
 
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_accept", "788"});
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_complete", "788"});
@@ -1092,7 +1091,7 @@ TEST(wow_game, quest_kill_credit_wrong_creature_no_progress) {
     wc = (wowClient_t *)player->client;
 
     game->ClientCommand(player, 2, accept788);
-    state = SV_QuestFind(wc->client.ps.quest_log, wc->client.ps.quest_count, 788);
+    state = SV_QuestFind(wc->quest_log, wc->quest_count, 788);
     T_NOT_NULL(state);
     T_EQ((int)wc->kill_progress[0][0], 0);
 
@@ -1198,7 +1197,7 @@ TEST(wow_game, wow_load_map_spawns_and_runs_creature_state) {
 
     game->ClientCommand(player, 2, attack_argv);
     T_EQ((int)(player_local->enemy ? player_local->enemy->s.number : 0), 1);
-    T_EQ((int)player->client->ps.selected_entity, 1);
+    T_EQ((int)((wowClient_t *)player->client)->selected_entity, 1);
 
     /* Run frames until the player chases into melee range and starts swinging. */
     for (int i = 0; i < 300; i++) {
@@ -1232,7 +1231,7 @@ TEST(wow_game, selecting_target_does_not_start_combat_or_chase) {
     game->ClientCommand(player, 2, select_argv);
     game->RunFrame();
 
-    T_EQ((int)player->client->ps.selected_entity, (int)creature->s.number);
+    T_EQ((int)((wowClient_t *)player->client)->selected_entity, (int)creature->s.number);
     T_NULL(local->enemy);
     T_EQ((int)local->attack_time, 0);
     T_EQ((int)local->attack_damage_time, 0);
@@ -1256,7 +1255,7 @@ TEST(wow_game, wow_fireball_cast_interrupts_melee_and_launches) {
     T_NOT_NULL(creature);
     creature->s.origin = (VECTOR3){ player->s.origin.x + 10.0f, player->s.origin.y, player->s.origin.z };
     creature->s.origin2 = (VECTOR2){ creature->s.origin.x, creature->s.origin.y };
-    player->client->ps.selected_entity = creature->s.number;
+    ((wowClient_t *)player->client)->selected_entity = creature->s.number;
     local->enemy = creature;
     local->attack_time = local->attack_damage_time = 500;
     local->attack_backswing_time = 500;
@@ -1301,7 +1300,7 @@ TEST(wow_game, wow_fireball_movement_cancels) {
     T_NOT_NULL(creature);
     creature->s.origin = (VECTOR3){ player->s.origin.x + 10.0f, player->s.origin.y, player->s.origin.z };
     creature->s.origin2 = (VECTOR2){ creature->s.origin.x, creature->s.origin.y };
-    player->client->ps.selected_entity = creature->s.number;
+    ((wowClient_t *)player->client)->selected_entity = creature->s.number;
     game->ClientCommand(player, 5, move_argv);
     game->ClientCommand(player, 2, action_argv);
     T_EQ((int)local->cast_spell, (int)SPELL_NONE);
@@ -1340,11 +1339,11 @@ TEST(wow_game, quest_log_full_rejects_new_quests) {
         accept_args[1] = id_buf;
         game->ClientCommand(player, 2, accept_args);
     }
-    T_EQ((int)wc->client.ps.quest_count, SV_MAX_QUEST_LOG);
+    T_EQ((int)wc->quest_count, SV_MAX_QUEST_LOG);
 
     /* Next accept should fail */
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_accept", "184"});
-    T_EQ((int)wc->client.ps.quest_count, SV_MAX_QUEST_LOG);
+    T_EQ((int)wc->quest_count, SV_MAX_QUEST_LOG);
     if (game->Shutdown) game->Shutdown();
 }
 
@@ -1360,9 +1359,9 @@ TEST(wow_game, quest_accept_same_quest_twice_is_idempotent) {
     wc = (wowClient_t *)player->client;
 
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_accept", "788"});
-    T_EQ((int)wc->client.ps.quest_count, 1);
+    T_EQ((int)wc->quest_count, 1);
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_accept", "788"});
-    T_EQ((int)wc->client.ps.quest_count, 1);
+    T_EQ((int)wc->quest_count, 1);
     if (game->Shutdown) game->Shutdown();
 }
 
@@ -1379,7 +1378,7 @@ TEST(wow_game, quest_kill_credit_does_not_overflow) {
     wc = (wowClient_t *)player->client;
 
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_accept", "788"});
-    state = SV_QuestFind(wc->client.ps.quest_log, wc->client.ps.quest_count, 788);
+    state = SV_QuestFind(wc->quest_log, wc->quest_count, 788);
     T_NOT_NULL(state);
 
     /* Kill 20 when only 8 required */
@@ -1401,9 +1400,9 @@ TEST(wow_game, quest_accept_invalid_id_no_crash) {
     wc = (wowClient_t *)player->client;
 
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_accept", "99999"});
-    T_EQ((int)wc->client.ps.quest_count, 0);
+    T_EQ((int)wc->quest_count, 0);
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_accept", "0"});
-    T_EQ((int)wc->client.ps.quest_count, 0);
+    T_EQ((int)wc->quest_count, 0);
     if (game->Shutdown) game->Shutdown();
 }
 
@@ -1513,7 +1512,7 @@ TEST(wow_game, quest_open_via_selected_npc_entity) {
     npc_local->quest_id = 33;
 
     /* Select the NPC and issue bare "quest" command (no ID argument) */
-    player->client->ps.selected_entity = npc->s.number;
+    ((wowClient_t *)player->client)->selected_entity = npc->s.number;
     test_ui_frame_count = 0;
     game->ClientCommand(player, 1, (LPCSTR[]){"quest"});
     T_ASSERT(wc->quest_open);
@@ -1587,21 +1586,21 @@ TEST(wow_game, quest_chain_sequential_unlock) {
 
     /* Quest 14 requires 13, which requires 12 */
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_accept", "14"});
-    T_EQ((int)wc->client.ps.quest_count, 0);
+    T_EQ((int)wc->quest_count, 0);
 
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_accept", "12"});
-    T_EQ((int)wc->client.ps.quest_count, 1);
+    T_EQ((int)wc->quest_count, 1);
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_complete", "12"});
     T_ASSERT(ps->stats[WOW_STAT_XP] > 0);
 
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_accept", "13"});
-    T_EQ((int)wc->client.ps.quest_count, 2);
+    T_EQ((int)wc->quest_count, 2);
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_complete", "13"});
 
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_accept", "14"});
-    T_EQ((int)wc->client.ps.quest_count, 3);
-    T_EQ((int)wc->client.ps.quest_log[2].quest_id, 14);
-    T_EQ((int)wc->client.ps.quest_log[2].status, SV_QUEST_ACTIVE);
+    T_EQ((int)wc->quest_count, 3);
+    T_EQ((int)wc->quest_log[2].quest_id, 14);
+    T_EQ((int)wc->quest_log[2].status, SV_QUEST_ACTIVE);
     if (game->Shutdown) game->Shutdown();
 }
 
@@ -1619,7 +1618,7 @@ TEST(wow_game, quest_kill_credit_from_combat_death) {
 
     /* Accept quest 788 which needs display_id 503 kills */
     game->ClientCommand(player, 2, (LPCSTR[]){"quest_accept", "788"});
-    state = SV_QuestFind(wc->client.ps.quest_log, wc->client.ps.quest_count, 788);
+    state = SV_QuestFind(wc->quest_log, wc->quest_count, 788);
     T_NOT_NULL(state);
     T_EQ((int)wc->kill_progress[0][0], 0);
 
@@ -1942,5 +1941,114 @@ TEST(wow_game, damage_flash_outgoing_set_on_enemy_hit) {
     T_EQ((int)wc->outgoing_damage, 2);
     T_EQ((int)wc->outgoing_dmg_timer, 1500);
     T_EQ((int)wc->incoming_dmg_timer, 0); /* creature is not a client */
+    if (game->Shutdown) game->Shutdown();
+}
+
+/* GCD set by an instant cast prevents a second cast until it expires. */
+TEST(wow_game, gcd_blocks_second_instant_cast) {
+    struct game_export *game = init_game();
+    LPEDICT player = &wow_edicts[0];
+    wowEntityLocal_t *local;
+
+    T_ASSERT(game->LoadMap("World/Maps/Azeroth/Azeroth.wdt"));
+    local = Wow_EntityLocal(player);
+    T_NOT_NULL(local);
+    local->health = 50;
+
+    /* Slot 3 = Healing Touch (instant, range=0, self). */
+    game->ClientCommand(player, 2, (LPCSTR[]){ "wow_action", "3" });
+    T_EQ((int)local->gcd_time, 1500);
+    T_EQ((int)local->mana, 92);    /* 100 - WOW_HEALING_TOUCH_MANA_COST (8) */
+    T_EQ((int)local->health, 52);
+
+    local->health = 50;
+    DWORD mana_snapshot = local->mana;
+
+    /* Immediate second cast blocked by GCD. */
+    game->ClientCommand(player, 2, (LPCSTR[]){ "wow_action", "3" });
+    T_EQ((int)local->mana, (int)mana_snapshot);
+    T_EQ((int)local->health, 50);
+
+    /* 15 frames drain the GCD (1500ms / FRAMETIME). */
+    FOR_LOOP(i, 1500 / FRAMETIME) game->RunFrame();
+    T_EQ((int)local->gcd_time, 0);
+
+    /* Third cast succeeds once GCD expires. */
+    local->health = 50;
+    game->ClientCommand(player, 2, (LPCSTR[]){ "wow_action", "3" });
+    T_EQ((int)local->health, 52);
+
+    if (game->Shutdown) game->Shutdown();
+}
+
+/* ps.stats[WOW_STAT_CAST_PROGRESS] reflects remaining cast time each frame. */
+TEST(wow_game, cast_progress_stat_shows_countdown) {
+    struct game_export *game = init_game();
+    LPEDICT player = &wow_edicts[0];
+    LPEDICT creature;
+    wowEntityLocal_t *local;
+
+    T_ASSERT(game->LoadMap("World/Maps/Azeroth/Azeroth.wdt"));
+    creature = first_creature();
+    T_NOT_NULL(creature);
+    if (!creature) { if (game->Shutdown) game->Shutdown(); return; }
+    creature->s.origin  = (VECTOR3){ player->s.origin.x + 10.0f, player->s.origin.y, player->s.origin.z };
+    creature->s.origin2 = (VECTOR2){ creature->s.origin.x, creature->s.origin.y };
+    ((wowClient_t *)player->client)->selected_entity = creature->s.number;
+    local = Wow_EntityLocal(player);
+
+    /* Slot 4 = Fireball (1500ms cast). */
+    game->ClientCommand(player, 2, (LPCSTR[]){ "wow_action", "4" });
+    T_ASSERT(local->cast_spell != SPELL_NONE);
+    T_EQ((int)local->cast_duration, 1500);
+    T_EQ((int)local->cast_remaining, 1500);
+
+    /* After one frame cast_remaining ticks down; Wow_UpdatePlayerHud writes it to ps.stats. */
+    game->RunFrame();
+    T_EQ((int)player->client->ps.stats[WOW_STAT_CAST_PROGRESS], 1400);
+    T_EQ((int)player->client->ps.stats[WOW_STAT_CAST_MAX], 1500);
+
+    if (game->Shutdown) game->Shutdown();
+}
+
+/* Wow_MonsterStart sets RF_HOSTILE on all spawned creatures. */
+TEST(wow_game, creature_spawns_with_rf_hostile_flag) {
+    struct game_export *game = init_game();
+    LPEDICT creature;
+
+    T_ASSERT(game->LoadMap("World/Maps/Azeroth/Azeroth.wdt"));
+    game->RunFrame();
+    creature = first_creature();
+    T_NOT_NULL(creature);
+    if (creature)
+        T_ASSERT(creature->s.flags & EF_HOSTILE);
+
+    if (game->Shutdown) game->Shutdown();
+}
+
+/* After death animation expires (WOW_DEFAULT_DEATH_TIME = 1200ms), think transitions
+ * to Wow_RunCorpseFrame and SVF_MONSTER is cleared. */
+TEST(wow_game, creature_death_transitions_to_corpse_frame) {
+    struct game_export *game = init_game();
+    LPEDICT creature;
+    wowEntityLocal_t *local;
+
+    T_ASSERT(game->LoadMap("World/Maps/Azeroth/Azeroth.wdt"));
+    game->RunFrame();
+    creature = first_creature();
+    T_NOT_NULL(creature);
+    if (!creature) { if (game->Shutdown) game->Shutdown(); return; }
+
+    local = Wow_EntityLocal(creature);
+    Wow_AIDie(creature, NULL);
+    T_ASSERT(local->dead);
+    T_ASSERT(creature->svflags & SVF_DEADMONSTER);
+    T_ASSERT(creature->think != Wow_RunCorpseFrame);
+
+    /* WOW_DEFAULT_DEATH_TIME = 1200ms / FRAMETIME = 100ms → 12 ticks. */
+    FOR_LOOP(i, 1200 / FRAMETIME) Wow_AIAdvanceLockedFrame(creature);
+    T_ASSERT(creature->think == Wow_RunCorpseFrame);
+    T_ASSERT(!(creature->svflags & SVF_MONSTER));
+
     if (game->Shutdown) game->Shutdown();
 }

--- a/games/world-of-warcraft/ui/ui_windows.c
+++ b/games/world-of-warcraft/ui/ui_windows.c
@@ -16,10 +16,9 @@
  */
 
 #include "ui_local.h"
+#include "wow_assets.h"
 #include <string.h>
 #include <stdio.h>
-
-#define WOW_TIP_LAYOUT "Interface\\FrameXML\\TutorialFrame.xml" // archive path; Blizzard owns the tutorial frame and alert templates
 
 BOOL UIWow_TipsEnabled(void) {
     LPCSTR value = uiimport.Cvar_String(BZ_WOW_CVAR_SHOW_TIPS, "1");

--- a/games/world-of-warcraft/wow_assets.h
+++ b/games/world-of-warcraft/wow_assets.h
@@ -1,0 +1,11 @@
+#ifndef wow_assets_h
+#define wow_assets_h
+
+/* Asset paths for named WoW renderer/game features.
+ * All paths are MPQ-relative and use the Blizzard backslash convention. */
+
+#define WOW_QUEST_AVAILABLE_MODEL "Interface\\Buttons\\TalkToMe.m2"
+#define WOW_QUEST_ACTIVE_ICON     "Interface\\GossipFrame\\ActiveQuestIcon.blp"
+#define WOW_TIP_LAYOUT            "Interface\\FrameXML\\TutorialFrame.xml"
+
+#endif

--- a/renderer/r_ents.c
+++ b/renderer/r_ents.c
@@ -216,6 +216,7 @@ static void R_RenderUberSplat(const renderEntity_t *entity, LPCVECTOR2 origin) {
 }
 
 static void R_RenderShadow(const renderEntity_t *entity, LPCVECTOR2 origin) {
+#ifndef USE_SHADOWMAPS
     LPCTEXTURE shadow = entity->shadow;
     BOX3 bounds;
 
@@ -255,6 +256,7 @@ static void R_RenderShadow(const renderEntity_t *entity, LPCVECTOR2 origin) {
         }
     }
     R_RenderRectSplat(&mins, &maxs, shadow, tr.shader[SHADER_SHADOWSPLAT], shadowColor);
+#endif
 }
 
 static void R_RenderSelectedCircle(const renderEntity_t *entity, LPCVECTOR2 origin) {

--- a/renderer/r_game.h
+++ b/renderer/r_game.h
@@ -27,7 +27,9 @@ bool R_GameModelCanStaticInstance(LPCMODEL model);
 bool R_GameTraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT distance);
 bool R_GameGetModelInfo(LPMODEL model, LPMODELINFO info);
 bool R_GameEntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix);
+#ifndef USE_SHADOWMAPS
 bool R_GameRenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin);
+#endif
 /* Selection-circle radius for the shared entity path; per-game tuning (e.g. WoW's fractional-creature clamp). */
 FLOAT R_GameSelectionRadius(renderEntity_t const *entity);
 FLOAT R_GameEntityHeight(renderEntity_t const *entity);

--- a/shared/test.h
+++ b/shared/test.h
@@ -28,7 +28,9 @@
 #define test_h
 
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 typedef struct test_s {
     const char    *name;   /* e.g. "wow_combat.pain_interrupts_attack" */
@@ -71,5 +73,30 @@ extern int test_failures;
 #define T_STREQ(a, b)     T_ASSERT((a) && (b) && strcmp((a), (b)) == 0)
 #define T_NULL(p)         T_ASSERT((p) == 0)
 #define T_NOT_NULL(p)     T_ASSERT((p) != 0)
+
+/* T_RUN_UNTIL(step, cond, n) — advance simulation up to n steps until cond
+ * becomes true, then assert it.  Fails the test if cond never fires.
+ *
+ * Example: fire a projectile, run up to 200 ticks, assert it hit the target.
+ *   T_RUN_UNTIL(Wow_RunProjectile(proj), !proj->inuse, 200);
+ *   T_RUN_UNTIL(game->RunFrame(), target_local->dead, 1000);
+ */
+#define T_RUN_UNTIL(step, cond, n) do {                                        \
+    for (unsigned _r = 0; !(cond) && _r < (unsigned)(n); _r++) (step);        \
+    T_ASSERT(cond);                                                            \
+} while (0)
+
+/* T_BENCH(label, iters, expr) — run expr iters times, print wall-clock ms/call.
+ * Does not assert; use for perf baselines and regression spotting. */
+#define T_BENCH(label, iters, expr) do {                                       \
+    struct timespec _t0, _t1;                                                  \
+    clock_gettime(CLOCK_MONOTONIC, &_t0);                                      \
+    for (int _bi = 0; _bi < (iters); _bi++) { expr; }                         \
+    clock_gettime(CLOCK_MONOTONIC, &_t1);                                      \
+    double _ms = ((_t1.tv_sec  - _t0.tv_sec)  * 1e3)                          \
+               + ((_t1.tv_nsec - _t0.tv_nsec) * 1e-6);                        \
+    printf("[BENCH] %-52s  %7.2f ms/call  (%d iters)\n",                      \
+           (label), _ms / (double)(iters), (iters));                           \
+} while (0)
 
 #endif /* test_h */


### PR DESCRIPTION
## Summary

Slim the shared network contracts (`entityState_t` / `playerState_s`) by moving WoW-only state out of the wire types and encoding overhead markers as explicit flags, then add WC3 gold-mining / WoW combat-projection test coverage.

## Changes

### Network contract cleanup
- **Trim playerState_s**: annotate every field with blame-sourced comments; move `quest_log`/`quest_count` and `selected_entity` into `wowClient_t` (0396c9a2)
- **entitystate**: replace packed `overhead_sprite` DWORD with `EF_HAS_QUEST`/`EF_QUEST_COMPLETE` flags; add matching `RF_HAS_QUEST`/`RF_QUEST_COMPLETE` renderer mirrors; guard all other WoW-only `entityState_t`/`renderEntity_t` fields behind `#ifdef WOW` (582f9c4e)
- **EF_HOSTILE fix**: `RF_HOSTILE` (bit 13) silently overflowed the BYTE `renderfx` field — carry the intent via `EF_HOSTILE` in the wire-transmitted flags byte instead (fdcc43be)

### Tests
- **WC3 gold mining**: no-townhall stop path and mine-capacity queuing/wake-up (04c52970)
- **WoW combat**: frostbolt projectile fields/slow/kill guards, godmode, healing-touch mana/OOM, GCD, cast progress, RF_HOSTILE spawn, corpse transition (fdcc43be)
- **Perf suite**: `T_BENCH` macro + `wc3_perf` suite for FOW and entity iteration (026c26c8)
- **Infra**: `T_RUN_UNTIL(step, cond, n)` helper in `shared/test.h` (fdcc43be)

### Fixes / docs
- Fix stale WC3 logo Y assertion after layout tuning (8511d147)
- Add `wow_assets.h` for named MPQ asset paths; document MSG delta round-trip and CustomizeEntity test patterns in CONTRIBUTING.md

## Notes

- No changes to `playerState_t` wire layout beyond the documented moves — WoW-only fields were already not in the net protocol.