### PR TITLE
wc3: reduce render and entity-scan costs in profile hot spots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | Entity sound architecture | [docs/architecture/sound.md](docs/architecture/sound.md) |
 | WC3 data model (SLK, unit stats, combat) | [docs/wc3-data-model.md](docs/wc3-data-model.md) |
 | WC3 gathering, immobile units, construction HUD, overhead bars | [docs/games/warcraft-3/economy-and-unit-presentation.md](docs/games/warcraft-3/economy-and-unit-presentation.md) |
+| WC3 perf hot spots: MDX bone/geoset setup, shadow batching, client/server entity scans | [docs/games/warcraft-3/performance.md](docs/games/warcraft-3/performance.md) |
 | SC2 HUD layout pipeline (sc2BaseFrame_t → uiFrame_t, layer IDs, stat bindings) | [docs/games/starcraft-2/hud-layout-pipeline.md](docs/games/starcraft-2/hud-layout-pipeline.md) |
 | FS / VFS / MPQ loading stack, config/share dir resolution, SC2 vs WoW patterns, mmap ADT optimization | [docs/fs-loading-architecture.md](docs/fs-loading-architecture.md) |
 | Config load order, cvar registry, `fs_basepath`/`fs_homepath`, `share/<game>/` + `~/.<game>/` layout | [docs/architecture/runtime.md](docs/architecture/runtime.md) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | Entity sound architecture | [docs/architecture/sound.md](docs/architecture/sound.md) |
 | WC3 data model (SLK, unit stats, combat) | [docs/wc3-data-model.md](docs/wc3-data-model.md) |
 | WC3 gathering, immobile units, construction HUD, overhead bars | [docs/games/warcraft-3/economy-and-unit-presentation.md](docs/games/warcraft-3/economy-and-unit-presentation.md) |
+| WC3 campaign loading lifecycle, texture references, unused FDF art, cliff transitions | [docs/games/warcraft-3/loading-and-assets.md](docs/games/warcraft-3/loading-and-assets.md) |
 | WC3 perf hot spots: MDX bone/geoset setup, shadow batching, client/server entity scans | [docs/games/warcraft-3/performance.md](docs/games/warcraft-3/performance.md) |
 | SC2 HUD layout pipeline (sc2BaseFrame_t → uiFrame_t, layer IDs, stat bindings) | [docs/games/starcraft-2/hud-layout-pipeline.md](docs/games/starcraft-2/hud-layout-pipeline.md) |
 | FS / VFS / MPQ loading stack, config/share dir resolution, SC2 vs WoW patterns, mmap ADT optimization | [docs/fs-loading-architecture.md](docs/fs-loading-architecture.md) |

--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -479,6 +479,9 @@ void CL_BeginLoadingMap(LPCSTR mapName) {
     cls.state = ca_connected;
     CL_MenuCommand("menu_ingame");
     SCR_BeginLoadingPlaque();
+    /* New map baselines repopulate the compact active-entity list; drop any
+     * stale entries from the previous map before they arrive. */
+    cl.num_active = 0;
 }
 
 /* Public wrapper for UI library and input system (Phase 8.6) */

--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -474,7 +474,8 @@ static void CL_UICvarSet(LPCSTR name, LPCSTR value) {
 }
 
 void CL_BeginLoadingMap(LPCSTR mapName) {
-    (void)mapName;
+    /* Publish the resolved map before freezing the plaque; menu launches have no startup map cvar. */
+    Cvar_Set("map", mapName);
     cl.playerstate.client_ui_state = CLIENT_UI_LOADING;
     cls.state = ca_connected;
     CL_MenuCommand("menu_ingame");

--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -41,6 +41,27 @@ static LPCSTR CL_PlayerRaceName(playerRace_t race) {
 /* Apply a stream of delta-encoded entity updates.  For each entity the server
  * sends only the fields that changed since the previous frame.  A U_REMOVE
  * flag signals that an entity should be removed from the local table. */
+void CL_AddActiveEntity(DWORD index) {
+    if (index >= MAX_CLIENT_ENTITIES || !cl.ents[index].current.model) {
+        return;
+    }
+    FOR_LOOP(i, cl.num_active) {
+        if (cl.active_entities[i] == index) {
+            return;
+        }
+    }
+    cl.active_entities[cl.num_active++] = index;
+}
+
+void CL_RemoveActiveEntity(DWORD index) {
+    FOR_LOOP(i, cl.num_active) {
+        if (cl.active_entities[i] == index) {
+            cl.active_entities[i] = cl.active_entities[--cl.num_active];
+            return;
+        }
+    }
+}
+
 static void CL_ReadPacketEntities(LPSIZEBUF msg) {
     int count = 0;
     int previous = 0;
@@ -86,6 +107,9 @@ static void CL_ReadPacketEntities(LPSIZEBUF msg) {
                         old.origin.y,
                         old.origin.z);
             }
+            if (old.model) {
+                CL_RemoveActiveEntity(nument);
+            }
             memset(&ent->current, 0, sizeof(ent->current));
             memset(&ent->prev, 0, sizeof(ent->prev));
             removed++;
@@ -96,6 +120,9 @@ static void CL_ReadPacketEntities(LPSIZEBUF msg) {
         }
         ent->prev = ent->current;
         MSG_ReadDeltaEntity(msg, &ent->current, nument, bits);
+        if (!old.model && ent->current.model) {
+            CL_AddActiveEntity(nument);
+        }
         if (ent->current.event)
             CL_EntityEvent(&ent->current);
         if (debug_entities) {
@@ -198,6 +225,9 @@ static void CL_ParseBaseline(LPSIZEBUF msg) {
     MSG_ReadDeltaEntity(msg, &cent->baseline, index, bits);
     memcpy(&cent->current, &cent->baseline, sizeof(entityState_t));
     memcpy(&cent->prev, &cent->baseline, sizeof(entityState_t));
+    if (cent->current.model) {
+        CL_AddActiveEntity(index);
+    }
 }
 
 /* Handle the svc_frame header: record the server frame number and time, then
@@ -216,10 +246,8 @@ void CL_ParseFrame(LPSIZEBUF msg) {
         CL_SetGameplayInput();
     }
     
-    FOR_LOOP(index, MAX_CLIENT_ENTITIES) {
-        centity_t *ce = &cl.ents[index];
-        if (!ce->current.model)
-            continue;
+    FOR_LOOP(i, cl.num_active) {
+        centity_t *ce = &cl.ents[cl.active_entities[i]];
         ce->prev = ce->current;
     }
 }

--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -107,9 +107,10 @@ static void CL_ReadPacketEntities(LPSIZEBUF msg) {
                         old.origin.y,
                         old.origin.z);
             }
-            if (old.model) {
-                CL_RemoveActiveEntity(nument);
-            }
+            /* Clear membership unconditionally: the current model may already be
+             * zero (a prior delta replaced it with a sound/event), so gating on
+             * old.model leaves a stale active-list entry behind. */
+            CL_RemoveActiveEntity(nument);
             memset(&ent->current, 0, sizeof(ent->current));
             memset(&ent->prev, 0, sizeof(ent->prev));
             removed++;
@@ -120,8 +121,13 @@ static void CL_ReadPacketEntities(LPSIZEBUF msg) {
         }
         ent->prev = ent->current;
         MSG_ReadDeltaEntity(msg, &ent->current, nument, bits);
+        /* Keep the active list in sync with current.model on both transitions:
+         * a model-less entity may gain a model (add) or lose it to a sound/event
+         * (remove) without a U_REMOVE. */
         if (!old.model && ent->current.model) {
             CL_AddActiveEntity(nument);
+        } else if (old.model && !ent->current.model) {
+            CL_RemoveActiveEntity(nument);
         }
         if (ent->current.event)
             CL_EntityEvent(&ent->current);

--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -342,11 +342,8 @@ static void CL_AddCursorSplat(void) {
 }
 
 static void CL_AddEntities(void) {
-    FOR_LOOP(index, MAX_CLIENT_ENTITIES) {
-        centity_t const *ce = &cl.ents[index];
-        if (!ce->current.model)
-            continue;
-        V_AddClientEntity(ce);
+    FOR_LOOP(i, cl.num_active) {
+        V_AddClientEntity(&cl.ents[cl.active_entities[i]]);
     }
     
     CL_AddTEnts();

--- a/client/client.h
+++ b/client/client.h
@@ -98,6 +98,11 @@ struct client_state {
     DWORD hover_entity;     /* entity number under mouse cursor (0 = none) */
     LPCMODEL moveConfirmation;
     DWORD num_entities;
+    /* Compact list of entity numbers whose current state carries a live model.
+     * CL_ParseFrame and CL_AddEntities iterate this instead of scanning all
+     * MAX_CLIENT_ENTITIES slots every frame. */
+    DWORD active_entities[MAX_CLIENT_ENTITIES];
+    DWORD num_active;
     DWORD time;
     struct {
         RECT rect;
@@ -128,7 +133,10 @@ BOOL CL_AltModifierDown(void);
 void V_RenderView(void);
 void V_Shutdown(void);
 void CL_PrepRefresh(void);
+// cl_parse.c
 void CL_ParseServerMessage(LPSIZEBUF msg);
+void CL_AddActiveEntity(DWORD index);
+void CL_RemoveActiveEntity(DWORD index);
 
 void CON_DrawConsole(void);
 void CON_printf(LPCSTR fmt, ...);

--- a/common/cvar.c
+++ b/common/cvar.c
@@ -445,7 +445,7 @@ void Cvar_Init(void) {
     Cvar_GetD("fs_homepath", FS_HomePath(), 0, "writable per-user directory (empty if unavailable)");
     Cvar_GetD("data",             "",                  CVAR_ARCHIVE, "override game data directory path");
     Cvar_GetD("fs_expansion",     "0",                 0,            "0=RoC data only, 1=include TFT expansion data");
-    Cvar_GetD("map",              "",                  0,            "map file to load at startup (e.g. Maps/HumanCampaign1.w3m)");
+    Cvar_GetD("map",              "",                  0,            "map to load at startup; updated to the resolved destination when loading begins");
     Cvar_GetD("connect",          "",                  0,            "server address to connect to at startup");
     Cvar_GetD("cl_debug_entities","0",                 0,            "log client-side entity sync events");
     Cvar_GetD("sv_debug_entities","0",                 0,            "log server-side entity sync events");

--- a/docs/diagnostic-tools.md
+++ b/docs/diagnostic-tools.md
@@ -148,6 +148,9 @@ Agent guidance:
 
 ## Time Profiler (macOS)
 
+For Linux WC3 entity-rendering profiles and CPU-sample interpretation, see
+[the August 2026 ARM profile review](#linux-wc3-arm-profile-review-2026-08-26).
+
 - For runtime CPU profiling on macOS, prefer Instruments `xctrace` with the local `xctraceprof` parser.
 - Record a run:
 	- `/Applications/Xcode.app/Contents/Developer/usr/bin/xctrace record --template "Time Profiler" --time-limit 20s --output /private/tmp/openwarcraft3-orc01.trace --launch -- /Users/igor/Developer/openwarcraft3/build/bin/openwarcraft3 -data "/Users/igor/Developer/openwarcraft3/data/Warcraft III" +map "Maps\\Campaign\\Orc01.w3m"`
@@ -158,3 +161,66 @@ Agent guidance:
 	- `build/bin/xctraceprof --window 8:18 --focus R_RenderFogOfWar --top 25 /private/tmp/openwarcraft3-orc01-timeprof.xml`
 	- `build/bin/xctraceprof --window 8:18 --focus SV_Frame --top 20 /private/tmp/openwarcraft3-orc01-timeprof.xml`
 - Use `R_RenderFogOfWar` for renderer-owned fog, `CL_ParseFogOfWar`/`R_SetFogOfWarData` for client texture upload, `SV_Frame`/`G_FowUpdate` for server/game tick work.
+
+## Linux WC3 ARM Profile Review (2026-08-26)
+
+Source: [open-realm perf report, address mappings, and interpretation](https://gist.github.com/sookyboo/632574119cc8e03abb7da133d5c039f0).
+Reviewed against local revision `011be57b`. The user reports 21 FPS; the gist does not identify the exact build revision,
+map/camera, build flags, GL startup information, or wall-clock/GPU timings. It contains about 7K `cycles:ppp` samples,
+zero reported lost samples, and additional audio/driver threads. Percentages below are sampled CPU-cycle shares,
+not frame milliseconds or GPU execution time. Inclusive parent and child percentages must not be added.
+
+| Profile path | Sample share | Interpretation |
+|---|---:|---|
+| Main view `R_DrawEntities` | 46.54% | Includes models and their shadows; all call sites total 47.10% |
+| MDX geoset branch | 18.87% | Geometry/material submission, including driver work |
+| MDX bone-binding branch | 16.31% | Node evaluation, clearing/scanning, palette construction and GL upload |
+| `R_RenderShadow` | 8.33% | Separate from the two MDX branches |
+| `CL_AddEntities` | 7.11% self | Address `0x15a14`; full client-slot traversal in current source |
+| `CL_ParseFrame` | 4.33% self | Address `0xc7e0`; another full client-slot traversal per snapshot |
+| `G_RunEntities` | 10.18% inclusive | Simulation; not the largest aggregate target |
+
+### Source-confirmed work and limits
+
+- `client/cl_view.c:CL_AddEntities` scans all 16,384 client slots each rendered frame, even when few are occupied.
+  `client/cl_parse.c:CL_ParseFrame` scans the same capacity and copies active states each snapshot. Together their
+  self samples are 11.44%. Occupancy counters and instruction-level attribution are needed before assigning all
+  this cost to empty-slot scanning. `git blame` traces the render-side capacity loop to `d68a52eda` (2023).
+- `games/warcraft-3/renderer/mdx/r_mdx_anim.c:MDLX_BindBoneMatrices` clears 1,024 matrices (64 KiB), scans
+  1,024 node slots twice, constructs 128 palette entries and uploads `tr.bone_count` matrices per rendered model.
+  The fixed-capacity work is attributed by blame to `2bfbd4e03`. Only about 5.11% of the report is under the
+  `R_CalculateNodeMatrix` call site; do not advertise the entire 16.31% as removable by local-pose caching.
+- Local transforms also depend on interpolation fraction and global-sequence time (`tr.viewDef.time`, or
+  `SDL_GetTicks()` when zero). `(model, frame, oldframe)` alone is not a sufficient persistent cache key.
+  Billboard global transforms depend on the model transform. Measure reuse before introducing a cache.
+- `MDLX_BindGeosetMatrixPalette` uploads a geoset-specific palette after model bone binding. Count uploads and
+  inspect all consumers before deciding whether the earlier upload can be removed.
+- `games/warcraft-3/renderer/w3m/r_war3map_ground.c:R_RenderRectSplat` batches tiles within one splat, then flushes
+  at the end of each call. `R_RenderModel` interleaves each entity's splats and model drawing. Existing batching
+  is not batching across entities; changing pass order must preserve blending/depth behavior. Blame attributes
+  the current tile batch to `4af98697c`.
+- `r_mdx_merge_opaque` from the gist interpretation is absent from this checkout and the available history search
+  for `games/warcraft-3/renderer`. It may be fork-specific; setting it here does not enable a merging path.
+- The raw driver addresses resolve only to `libGL.so.1`, not named GL functions. The interpretation identifies
+  gl4es, but the report alone does not prove its version or separate state overhead from submission/stalls.
+
+### Next measurements
+
+1. Obtain the tested revision, release/debug flags, renderer startup log and exact scene. Compare a clean
+   `BUILD=release GL_BACKEND=gles3 MSAA=0` Linux build with the existing backend; see
+   [build profiles](build-and-renderer-platforms.md#build-profiles). A local Mac run cannot validate ARM/gl4es speed.
+2. On the same scene/camera, collect `r_stats 1` with `r_unit_shadows 1` and `0`, restoring `1` afterward.
+   Example bounded ROC launch (repeat with `-tft`; substitute the reported map when known):
+
+   ```sh
+   build/bin/openwarcraft3 -data 'data/Warcraft III' +map 'Maps\Campaign\Orc01.w3m' +set r_stats 1 +set r_unit_shadows 0 +com_frame_limit 300
+   ```
+
+3. Add targeted temporary logs for occupied client slots, submitted/visible models, occupied MDX nodes,
+   actual matrix upload counts, and unique poses including time/interpolation. Capture a bounded run before
+   changing traversal, caching, or draw submission. Verify ROC and TFT and run `make test` for implementation changes.
+
+21 FPS is 47.62 ms/frame; 30 FPS requires 33.33 ms/frame, a 30% frame-time reduction. The 8.33% shadow sample share
+cannot establish the wall-time benefit of disabling shadows. Even under a simplified proportional CPU-only model,
+removing that entire share predicts only about 22.9 FPS, not 30. Prioritize MDX submission/bone work and the two
+client traversals, then reprofile; the report does not justify a promised FPS improvement.

--- a/docs/games/warcraft-3/architecture/map-renderer.md
+++ b/docs/games/warcraft-3/architecture/map-renderer.md
@@ -182,6 +182,8 @@ Each entity with `radius >= 10` casts a circle of sight. A custom ray-cast shade
 
 > **Gotcha — shared static buffer**: `aVertexBuffer` in `r_war3map_ground.c` is a file-scope array also used during segment building. `R_RenderSplat` must not be called while segment building is in progress (it is safe at runtime because segments are built once at load time).
 
+`R_RenderRectSplat` is the immediate (single-decal) entry point. For many same-shader decals — unit shadows — `R_DrawEntityShadows` uses the batched `R_BeginSplatBatch` / `R_AddRectSplat` / `R_EndSplatBatch` API to collapse hundreds of splats into one vertex-buffer upload + draw per distinct texture. See [performance](../performance.md).
+
 ## Height and Normal Queries
 
 `GetAccurateHeightAtPoint(sx, sy)` performs bilinear interpolation across the four heightmap vertices surrounding the world-space point `(sx, sy)`. This is used by cliff snapping and by `R_GetAPI().GetHeightAtPoint` which the server calls to place units on the ground.

--- a/docs/games/warcraft-3/loading-and-assets.md
+++ b/docs/games/warcraft-3/loading-and-assets.md
@@ -1,0 +1,82 @@
+# Campaign loading and asset resolution
+
+## Loading-screen ownership
+
+`CL_BeginLoadingMap` publishes the resolved destination in the session-only `map` cvar **before**
+`SCR_BeginLoadingPlaque` freezes a frame. This covers console launches, menu selections, game menu actions,
+and incoming `CS_WORLD`. The client owns loading state; only `CL_PrepRefresh` promotes it to `ca_active`.
+The WC3 UI reads the current destination and caches metadata per path, not per UI lifetime.
+
+`UI_UpdateLoadingMapInfo` reads the nested map MPQ's `war3map.w3i` and `war3map.wts` through
+`UI_ReadMapInfo`. Custom loading models take precedence; otherwise the campaign background number indexes
+`UI/WorldEditData.txt`'s `LoadingScreens` section (model plus sequence). Maps without an authored background
+use the existing `LoadingMeleeBackground` skin entry. Geometry and text fields come from native
+`UI/FrameDef/Glue/Loading.fdf` and its generated binding.
+
+### June 28 regression
+
+Commit `b6349c392` removed `cl.loading_map`/`GetLoadingMap` but left `CL_BeginLoadingMap` ignoring its
+`mapName` argument. UI lookup could only see a startup `+map` cvar, explaining why direct map launches
+worked while campaign buttons produced a black background plus LOADING. Runtime diagnostics for Human01
+showed a valid requested destination and an empty UI map cvar. In addition, the UI looked up its own
+cached path, preventing invalidation on subsequent maps. Both paths now use the published destination.
+TFT has an additional independent schema difference: ROC `LoadingScreens` rows are
+`label,sequence,model`, while TFT rows are `expansion-category,label,sequence,model`, including ROC campaigns
+under TFT archives. Fixed ROC indices interpreted HumanX01's sequence `6` as a filename. `UI_ParseLoadingRow`
+consumes the optional numeric category and validates the sequence/model fields; malformed rows log their key.
+
+Preserve the loading-state draw check before `game_mode` dispatch: menu commands are queued asynchronously.
+
+## Asset names are data
+
+| Source | Meaning / resolution |
+| --- | --- |
+| `Units/DestructableData.slk`, `texFile` | `_` (or empty/absent) means no replacement image. Preserve an authored extension; do not append `.blp` in the spawn code. Human01 `LT05` uses `ReplaceableTextures\Cliff\Cliff0.tga`; crates/gates use `_`. |
+| Texture references ending in `.tga` | The exact file wins. If absent, `R_ReadTextureFile` tries the same stem with `.blp`, then normal renderer diagnostics/placeholders apply. This handles converted source names without overriding real custom TGA files. |
+| `ReplaceableTextures\CameraMasks\White_mask.tga` | Human01's cinematic script requests this; the local ROC archive contains `White_mask.blp` (1422 bytes), not TGA. The cliff BLP is 90592 bytes. |
+| Native `StandardTemplates.fdf` | Some unused templates reference art absent from ROC archives (`HeavyBorder*`, `LightBorder*`, `ButtonBackGround`, `ButtonCorners`, `GlueScreen-PlayerButton-BorderRight`, `GlueScreen-ROC-EditionButton-*`). Parsing records texture keys/indices; `UI_GetTexture` loads only on consumption. Do not replace missing art with invented paths or suppress renderer warnings for consumed resources. |
+
+`UI_GetTexture` caches both real and placeholder renderer handles. Decorated names are re-evaluated on theme
+changes; an unchanged theme does not reload. Parsing or inheriting a template alone must not fetch its art.
+
+## Cliff-transition classification
+
+Terrain vertices are ordered NE, NW, SE, SW by `GetTileVertices`; model configuration letters use
+SW, NW, NE, SE. A transition requires exactly two **adjacent ramp corners one cliff level apart**.
+Two same-height flagged corners belong to an adjoining ordinary cliff, not a sloped transition.
+
+Human01 cell `(64,31)` yielded model-order levels `[1,0,1,1]` and ramp flags `[1,0,0,1]`.
+The former `GetTileRamps(tile) > 1` test built nonexistent `CliffTransHABH0.mdx` and omitted its geometry.
+Correct classification selects the ordinary `CliffsBABB0.mdx`. The native transition directory contains
+L/H and H/X edge pairs, not an HH or LX edge. Do not turn file-not-found into a guessed terrain fallback.
+The [Warsmash terrain loader](https://github.com/Retera/WarsmashModEngine/blob/main/core/src/com/etheller/warsmash/viewer5/handlers/w3x/environment/Terrain.java)
+is a useful secondary reference for separating transition edges from regular cliff cells; local archive
+contents and logged vertex metadata establish this case.
+
+## Diagnostics and verification
+
+```sh
+build/bin/mpqtool -mpq 'data/Warcraft III/War3.mpq' cat Units/DestructableData.slk
+build/bin/mpqtool -mpq 'data/Warcraft III/War3.mpq' ls ReplaceableTextures/CameraMasks
+build/bin/mpqtool -mpq 'data/Warcraft III/War3.mpq' ls Doodads/Terrain/CliffTrans
+build/bin/mpqtool -mpq 'data/Warcraft III/War3.mpq' cat UI/FrameDef/Glue/StandardTemplates.fdf
+build/bin/openwarcraft3 -data 'data/Warcraft III' +map 'Maps/Campaign/Human01.w3m' +com_frame_limit 100
+build/bin/openwarcraft3 -data 'data/Warcraft III' -tft +map 'Maps/FrozenThrone/Campaign/HumanX01.w3x' +com_frame_limit 100
+make test-renderer-model test-ui
+make test
+```
+
+For the menu regression, launch without `+map`, then select Single Player → Campaign → Human. The console
+registers `menu_single_player_campaign`, but `menu_single_player_campaign_human` is a UI-handler command,
+not a console command. A diagnostic replay can temporarily invoke that handler after showing the campaign
+screen; remove the hook afterward. Queue `screenshot 1` before the handler to capture the frozen loading plaque.
+Use `+com_frame_limit 100` for bounded runs; engine screenshots appear under `screenshots/`.
+
+Regression tests cover texture extension lookup and exact-file precedence, SLK replacement sentinels,
+ROC/TFT loading-row schemas, rotated/equal-height/diagonal cliff edges, unused FDF art, lazy texture cache hits/misses and theme changes,
+and loading destination/cache invalidation including UI reinitialization. The loading-cache unit test uses
+existing metadata-less map fixtures to exercise the melee/default path; campaign artwork needs ROC/TFT
+runtime verification against real archives.
+
+See also [UI authoring](../../ui-authoring.md), [scene workflow](../../rendering-scene-workflow.md),
+and [filesystem loading](../../fs-loading-architecture.md).

--- a/docs/games/warcraft-3/performance.md
+++ b/docs/games/warcraft-3/performance.md
@@ -1,0 +1,49 @@
+# WC3 Performance Hot Spots
+
+Profile-driven optimizations across the renderer, client, and server. The five sampled hot spots and the fixes applied to each are listed below so a future reader understands *why* each path is shaped the way it is.
+
+## MDX bone setup (was ~16%)
+
+`MDLX_BindBoneMatrices` (`games/warcraft-3/renderer/mdx/r_mdx_anim.c`) is called once per rendered model per frame. The old path:
+
+1. `memset(node_matrices, 0, sizeof(node_matrices))` — 64 KiB (1024 nodes × 64-byte matrix) cleared per model.
+2. Two loops over all `MDX_MAX_NODES` (1024) slots, each null-checking the sparse `model->nodes[]` array.
+3. A `bone_matrices[MDX_MATRIX_PALETTE]` build loop plus a `glUniformMatrix4fv(uBones, ...)` upload — dead work, because `MDLX_BindGeosetMatrixPalette` re-uploads the real per-geoset palette immediately afterward.
+
+Fix: `R_LoadModelMDLX` now builds a compact `model->node_list[]`/`num_nodes` (the nodes the model actually has, typically tens), and `MDLX_BindBoneMatrices` iterates only that list, zeroing each used matrix individually to reset the `v[15]==0` "computed" flag that `R_GetNodeGlobalMatrix` relies on. The dead `bone_matrices` build + upload were removed.
+
+Why pose *caching* was rejected: a persistent cache key would have to include both the interpolated `frame0/frame1` pair (with `lerpfrac`) and the global-sequence render clock (`SDL_GetTicks`-derived), which changes every frame for global-sequence tracks — so caching buys little while the memset/scan removal eliminates the bulk of the cost.
+
+## MDX geometry / material drawing (was ~19%)
+
+`MDLX_BindGeosetMatrixPalette` (`r_mdx_geoset.c`) uploaded the full `BZ_BONE_PALETTE_MAX` (128) matrices per geoset. Skin indices are geoset-local (`0..num_matrixPalette-1`), so only `min(num_matrixPalette, BZ_BONE_PALETTE_MAX)` entries ever need to reach the shader. Uploading 128 when a geoset references, say, 12 was wasted uniform traffic on every draw.
+
+## Entity shadows (was ~8%)
+
+Unit shadows are ground decals: one shader (`SHADER_SHADOWSPLAT`), differing only by texture and rect. `R_RenderShadow` previously called `R_RenderRectSplat` per unit, which bound the splat shader/VAO/VBO, uploaded view uniforms, re-set blend/depth-mask, re-set texture wrap, then uploaded the vertex buffer (`glBufferData`) and issued a draw per shadow — hundreds of tiny draws/upload per scene.
+
+Fix: `r_war3map_ground.c` now exposes `R_BeginSplatBatch` / `R_AddRectSplat` / `R_EndSplatBatch`. `R_RenderRectSplat` was refactored to share `R_SetupSplatState` + `R_GenerateSplatTiles` with the batch path. `R_DrawEntityShadows` (in `renderer/r_ents.c`) runs a dedicated pre-pass that accumulates every visible unit shadow and flushes only when the texture changes or the buffer fills, collapsing N shadows into one draw per distinct texture. WoW and SC2 provide immediate fallback implementations (WoW shadows already go through `R_GameRenderShadow` returning true; SC2 splats are flat quads).
+
+## Client entity collection + snapshot copying (was ~11%)
+
+Both `CL_ParseFrame` (snapshot copy) and `CL_AddEntities` (collection) scanned all `MAX_CLIENT_ENTITIES` (16384) slots every frame, even though a scene has far fewer live entities.
+
+Fix: `client_state` gains `active_entities[]` / `num_active`, a compact list of entity numbers whose current state carries a live model. It is maintained incrementally in `CL_ReadPacketEntities` (U_REMOVE drops the index; a `!old.model → model` transition adds it) and `CL_ParseBaseline`, reset in `CL_BeginLoadingMap` on map change and in `CL_ClearState` on disconnect. `CL_ParseFrame` and `CL_AddEntities` iterate the compact list instead of 16384 slots.
+
+## Server entity simulation (was ~10%)
+
+`G_RunEntities` ran three full passes over `globals.num_edicts`, and `G_RunEntity` ran `spell_run_frame` + `unit_updatestatuses` + status compression for every edict — including freed edicts, since `G_FreeEdict` memsets in place and `num_edicts` is a high-water mark that never shrinks.
+
+Fix: all three `G_RunEntities` loops skip `!ent->inuse`, and `G_RunEntity` guards with `if (!ent->inuse) return;`. Freed edicts carry no simulation state and are never re-sent, so this is a pure skip.
+
+## Verification
+
+```bash
+make test                    # full umbrella, incl. in-engine WC3 suites
+make test-wc3-engine         # 344 tests / 918 assertions, incl. wc3_perf.run_entities_1900
+make -j4 openwarcraft3 openwow opensc2   # all three renderers still build
+build/bin/openwarcraft3 -data 'data/Warcraft III' +menu_main +screenshot 10 +com_frame_limit 20       # ROC
+build/bin/openwarcraft3 -data 'data/Warcraft III' -tft +menu_main +com_frame_limit 20                 # TFT
+```
+
+The `wc3_perf.run_entities_1900` benchmark (`games/warcraft-3/game/tests/t_game.c`) measures `G_RunEntities` over 1900 active units.

--- a/docs/games/warcraft-3/performance.md
+++ b/docs/games/warcraft-3/performance.md
@@ -22,7 +22,7 @@ Why pose *caching* was rejected: a persistent cache key would have to include bo
 
 Unit shadows are ground decals: one shader (`SHADER_SHADOWSPLAT`), differing only by texture and rect. `R_RenderShadow` previously called `R_RenderRectSplat` per unit, which bound the splat shader/VAO/VBO, uploaded view uniforms, re-set blend/depth-mask, re-set texture wrap, then uploaded the vertex buffer (`glBufferData`) and issued a draw per shadow — hundreds of tiny draws/upload per scene.
 
-Fix: `r_war3map_ground.c` now exposes `R_BeginSplatBatch` / `R_AddRectSplat` / `R_EndSplatBatch`. `R_RenderRectSplat` was refactored to share `R_SetupSplatState` + `R_GenerateSplatTiles` with the batch path. `R_DrawEntityShadows` (in `renderer/r_ents.c`) runs a dedicated pre-pass that accumulates every visible unit shadow and flushes only when the texture changes or the buffer fills, collapsing N shadows into one draw per distinct texture. WoW and SC2 provide immediate fallback implementations (WoW shadows already go through `R_GameRenderShadow` returning true; SC2 splats are flat quads).
+Fix: `r_war3map_ground.c` now exposes `R_BeginSplatBatch` / `R_AddRectSplat` / `R_EndSplatBatch`. `R_RenderRectSplat` was refactored to share `R_SetupSplatState` + `R_GenerateSplatTiles` with the batch path. `R_DrawEntityShadows` (in `renderer/r_ents.c`) runs a dedicated pre-pass that accumulates every visible unit shadow and flushes only when the texture changes or the buffer fills, collapsing N shadows into one upload + draw per contiguous texture run. WoW and SC2 provide immediate fallback implementations (WoW shadows already go through `R_GameRenderShadow` returning true; SC2 splats are flat quads).
 
 ## Client entity collection + snapshot copying (was ~11%)
 
@@ -47,3 +47,23 @@ build/bin/openwarcraft3 -data 'data/Warcraft III' -tft +menu_main +com_frame_lim
 ```
 
 The `wc3_perf.run_entities_1900` benchmark (`games/warcraft-3/game/tests/t_game.c`) measures `G_RunEntities` over 1900 active units.
+
+### Review regression cases (PR #164)
+
+- The active-list invariant is membership iff `cl.ents[index].current.model != 0`. Test baselines, duplicate adds,
+  model-to-zero deltas, removal, slot reuse, frame copying, and map reset through the real client parser.
+  `SV_BuildClientFrame` also transmits model-less entities carrying sound/events, so `U_REMOVE` is not the only way
+  to lose a model. At `34a556f2`, a baseline `{number=7, model=1}`, followed by a packet delta to
+  `{number=7, model=0, sound=1}`, leaves `num_active == 1`; a subsequent `U_REMOVE` still leaves that stale entry
+  because removal is guarded by `old.model`. A focused wire-parser test reproduced both failures; the existing
+  umbrella suite passes but does not exercise this lifecycle. Extend `tests/test_net.c` for regression coverage.
+- `CL_BeginLoadingMap` in `games/warcraft-3/tests/test_client_stubs.c` does not mirror the new list reset;
+  standalone parser tests using that stub do not validate production map-reset behavior.
+- The WC3 splat implementation batches **contiguous texture runs**, not all occurrences of each distinct texture.
+  `R_AddRectSplat` flushes at every texture change; `R_GenerateSplatTiles` also flushes at buffer capacity.
+  Below capacity, A/A/B/B produces two draws, but A/B/A/B produces four. Entity order is not sorted by shadow
+  texture and swap-removal changes it. Use both patterns when checking draw/upload counters; the distinct-texture
+  claims above describe the optimization goal, not a guaranteed bound in this revision.
+- The follow-up `10904293` restores the MDX particle size factor removed from `R_DrawParticles` in `97a52d18`.
+  `ReadParticleEmitter` doubles all three `ParticleScaling` lifecycle values once; both MDX head and tail spawns
+  consume those values. The shared renderer and M2 particle scaling are unchanged.

--- a/docs/rendering-scene-workflow.md
+++ b/docs/rendering-scene-workflow.md
@@ -1,5 +1,7 @@
 # Rendering scene workflow
 
+For campaign loading and asset diagnostics, see [WC3 loading and assets](games/warcraft-3/loading-and-assets.md).
+
 Use these commands to launch a selected game's UI or model scene without entering a full gameplay session. Build the target first, then pass the scene command as a late `+` command.
 
 ## Warcraft III

--- a/docs/ui-authoring.md
+++ b/docs/ui-authoring.md
@@ -1,5 +1,7 @@
 # UI Screen Authoring
 
+For campaign loading and asset diagnostics, see [WC3 loading and assets](games/warcraft-3/loading-and-assets.md).
+
 ## FDF-Driven Layout
 
 - In client/UI code, never define or hardcode UI elements, layout coordinates, textures, frame names, or control structures that can be read from FDF. Parse and reuse the actual FDF frames/templates, then bind dynamic data into those frames.

--- a/games/starcraft-2/renderer/r_game.c
+++ b/games/starcraft-2/renderer/r_game.c
@@ -162,6 +162,15 @@ void R_RenderSplat(LPCVECTOR2 position,
     R_RenderRectSplat(&mins, &maxs, texture, shader, color);
 }
 
+/* SC2 splats are flat quads; the shared batch API stays immediate (a batching
+ * pass exists only in the WC3 terrain-conforming renderer). */
+static LPCSHADER sc2_batch_shader;
+void R_BeginSplatBatch(LPCSHADER shader) { sc2_batch_shader = shader; }
+void R_AddRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, COLOR32 color) {
+    R_RenderRectSplat(mins, maxs, texture, sc2_batch_shader, color);
+}
+void R_EndSplatBatch(void) { }
+
 void R_GameLoadAssets(void) {
 }
 

--- a/games/warcraft-3/game/g_events.c
+++ b/games/warcraft-3/game/g_events.c
@@ -96,16 +96,20 @@ static void G_TouchTriggers(LPEDICT ent) {
 void G_RunEntities(void) {
     FOR_LOOP(i, globals.num_edicts) {
         LPEDICT ent = globals.edicts+i;
+        if (!ent->inuse) continue; /* freed edicts are memset and never re-sent; skip the per-frame clear */
         ent->old_origin = ent->s.origin2;
         /* Clear one-shot event fields so each event fires for exactly one frame. */
         ent->s.event = EV_NONE;
         ent->s.sound = 0;
     }
     FOR_LOOP(i, globals.num_edicts) {
-        G_RunEntity(globals.edicts+i);
+        LPEDICT ent = globals.edicts+i;
+        if (!ent->inuse) continue;
+        G_RunEntity(ent);
     }
     FOR_LOOP(i, globals.num_edicts) {
         LPEDICT ent = globals.edicts+i;
+        if (!ent->inuse) continue;
         if (!memcmp(&ent->old_origin, &ent->s.origin2, sizeof(VECTOR2)))
             continue;
         G_TouchTriggers(ent);

--- a/games/warcraft-3/game/g_phys.c
+++ b/games/warcraft-3/game/g_phys.c
@@ -90,6 +90,7 @@ static BOOL G_UnitRegeneratesHP(LPCEDICT ent) {
  * then calls the entity's think function, and finally compresses health/mana
  * into the 8-bit stat fields that are sent to clients. */
 void G_RunEntity(LPEDICT ent) {
+    if (!ent->inuse) return; /* defensive: freed edicts carry no simulation state */
     spell_run_frame(ent);
     unit_updatestatuses(ent);
     SAFE_CALL(ent->prethink, ent);

--- a/games/warcraft-3/game/g_spawn.c
+++ b/games/warcraft-3/game/g_spawn.c
@@ -128,8 +128,9 @@ static void SP_SpawnDestructable(LPEDICT edict) {
     LPCSTR path_tex = DESTRUCTABLE_PATH_TEX(edict->class_id);
     FLOAT radius = DESTRUCTABLE_RADIUS(edict->class_id);
     PATHSTR buffer;
-    snprintf(buffer, sizeof(buffer), "%s.blp", DESTRUCTABLE_TEXTURE(edict->class_id));
-    edict->s.image = gi.ImageIndex(buffer);
+    LPCSTR tex = DESTRUCTABLE_TEXTURE(edict->class_id);
+    /* texFile may include an extension; "_" means the model has no replacement texture. */
+    edict->s.image = tex && *tex && strcmp(tex, "_") ? gi.ImageIndex(tex) : 0;
     if (dir) {
         snprintf(buffer, sizeof(buffer), "%s\\%s\\%s%d.mdx", dir, file, file, edict->variation);
     } else {

--- a/games/warcraft-3/game/tests/t_slk.c
+++ b/games/warcraft-3/game/tests/t_slk.c
@@ -351,4 +351,37 @@ TEST(wc3_slk, armor_uses_realdef_not_def) {
     free_slk_rows(rows);
 }
 
+
+static PATHSTR spawn_tex;
+static DWORD spawn_images;
+static int capture_spawn_image(LPCSTR name) {
+    snprintf(spawn_tex, sizeof(spawn_tex), "%s", name); spawn_images++; return 42;
+}
+
+/* Drive the real spawn path with SLK texFile values: no replacement, extensionless art, and a source TGA name. */
+TEST(wc3_slk, destructable_texture_preserves_extension_and_absent_sentinel) {
+    static LPCSTR const names[] = { "_", "", "ReplaceableTextures\\Cliff\\Cliff0.tga",
+                                   "ReplaceableTextures\\LordaeronTree\\LordaeronSummerTree" };
+    sheetMetaData_t *meta = G_FindMetaData(DestructableMetaData, "btxf");
+    sheetRow_t *saved = meta->table;
+    int (*old_index)(LPCSTR) = gi.ImageIndex;
+    setup_test_world();
+    gi.ImageIndex = capture_spawn_image;
+    FOR_LOOP(i, sizeof(names) / sizeof(names[0])) {
+        char slk[1024];
+        snprintf(slk, sizeof(slk), "ID;PWXL;N;E\nC;Y1;X1;K\"ID\"\nC;Y1;X2;K\"file\"\nC;Y1;X3;K\"texFile\"\nC;Y1;X4;K\"targType\"\nC;Y2;X1;K\"LT05\"\nC;Y2;X2;K\"Cliff\"\nC;Y2;X3;K\"%s\"\nC;Y2;X4;K\"debris\"\nE\n", names[i]);
+        sheetRow_t *rows = parse_slk_string(slk);
+        G_SetConfigTable(DestructableMetaData, "DestructableData", rows);
+        edict_t ent = { .class_id = MAKEFOURCC('L','T','0','5') };
+        spawn_images = 0;
+        SP_CallSpawn(&ent);
+        T_EQ(ent.s.image, i < 2 ? 0 : 42);
+        T_EQ(spawn_images, i < 2 ? 0 : 1);
+        if (i >= 2) T_STREQ(spawn_tex, names[i]);
+        G_SetConfigTable(DestructableMetaData, "DestructableData", saved);
+        free_slk_rows(rows);
+    }
+    gi.ImageIndex = old_index;
+}
+
 #endif /* BZ_TESTS */

--- a/games/warcraft-3/renderer/mdx/r_mdx.h
+++ b/games/warcraft-3/renderer/mdx/r_mdx.h
@@ -361,6 +361,8 @@ typedef struct mdxModel_s {
     mdxAttachment_t *attachments;
     mdxLight_t *lights;
     mdxNode_t *nodes[MDX_MAX_NODES];
+    mdxNode_t *node_list[MDX_MAX_NODES]; /* compact list of present nodes; avoids scanning 1024 slots per frame */
+    int num_nodes;
     VECTOR3 *pivots;
     int num_textures;
     int num_sequences;

--- a/games/warcraft-3/renderer/mdx/r_mdx_anim.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_anim.c
@@ -14,7 +14,6 @@ void R_EvalKeyframeValue(void const *left, void const *right, float t, MODELKEYT
 
 static MATRIX4 local_matrices[MDX_MAX_NODES];
 MATRIX4 node_matrices[MDX_MAX_NODES];
-static MATRIX4 bone_matrices[MDX_MATRIX_PALETTE];
 
 mdxSequence_t const *R_FindSequenceAtTime(mdxModel_t const *model, DWORD time) {
     FOR_LOOP(seqIndex, model->num_sequences) {
@@ -209,46 +208,15 @@ void AddSkin(LPVECTOR3 pos, LPCMATRIX4 mat, LPCVECTOR3 org, FLOAT weight) {
 }
 
 static void MDLX_BindBoneMatrices(mdxModel_t const *model, LPCMATRIX4 model_matrix, DWORD frame1, DWORD frame0) {
-    LPSHADER shader = mdlx.shader;
-    memset(node_matrices, 0, sizeof(node_matrices));
-
-    FOR_LOOP(node_id, MDX_MAX_NODES) {
-        mdxNode_t *node = model->nodes[node_id];
-        if (!node)
-            continue;
+    /* Only the nodes this model actually has need their global matrices
+     * recomputed.  The old path memset the full 64KB node_matrices array and
+     * scanned all MDX_MAX_NODES slots twice; models have tens of nodes, so the
+     * compact node_list built at load time is orders of magnitude smaller. */
+    FOR_LOOP(i, model->num_nodes) {
+        mdxNode_t *node = model->node_list[i];
+        memset(&node_matrices[node->node_id], 0, sizeof(MATRIX4)); /* reset the "computed" flag (v[15]==0) */
         R_CalculateNodeMatrix(model, node, frame1, frame0, &local_matrices[node->node_id]);
     }
-    FOR_LOOP(node_id, MDX_MAX_NODES) {
-        mdxNode_t *node = model->nodes[node_id];
-        if (!node)
-            continue;
-        R_GetNodeGlobalMatrix(model, model_matrix, node);
-    }
-
-    FOR_LOOP(i, MDX_MATRIX_PALETTE) {
-        Matrix4_identity(&bone_matrices[i]);
-        if (i < MDX_MAX_NODES && model->nodes[i]) {
-            bone_matrices[i] = node_matrices[i];
-        }
-    }
-    
-#if 0
-    if (model->knight) {
-        static VECTOR3 pos[1024];
-        FOR_EACH_LIST(mdxGeoset_t, geoset, model->geosets) {
-            FOR_LOOP(i, geoset->num_vertices) {
-                VECTOR3 org = geoset->vertices[i];
-                memset(pos+i, 0, sizeof(VECTOR3));
-                FOR_LOOP(j, MAX_SKIN_BONES) {
-                    AddSkin(pos+i, global_matrices+geoset->skinning[i].skin[j], &org, geoset->skinning[i].boneWeight[j]/255.f);
-            }
-            R_Call(glBindBuffer, GL_ARRAY_BUFFER, geoset->buffer[1]);
-            R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(VECTOR3) * geoset->vertices, pos, GL_STATIC_DRAW);
-            R_Call(glVertexAttribPointer, attrib_position, 3, GL_FLOAT, GL_FALSE, 0, 0);
-            R_Call(glEnableVertexAttribArray, attrib_position);
-        }
-    }
-#endif
-    R_Call(glUseProgram, shader->progid);
-    R_Call(glUniformMatrix4fv, shader->uBones, BZ_BONE_PALETTE_MAX, GL_FALSE, bone_matrices->v);
+    FOR_LOOP(i, model->num_nodes)
+        R_GetNodeGlobalMatrix(model, model_matrix, model->node_list[i]);
 }

--- a/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
@@ -364,19 +364,22 @@ static void MDLX_BindLayerTextureAnimation(mdxModel_t const *model,
 
 static void MDLX_BindGeosetMatrixPalette(mdxModel_t const *model, mdxGeoset_t const *geoset) {
     MATRIX4 matrixPalette[MDX_MATRIX_PALETTE];
+    /* Skin indices are geoset-local (0..num_matrixPalette-1), so only the
+     * palette entries the geoset actually references need to reach the shader.
+     * Uploading the full BZ_BONE_PALETTE_MAX per geoset was wasted uniform
+     * traffic for every draw. */
+    DWORD const count = MIN((DWORD)geoset->num_matrixPalette, BZ_BONE_PALETTE_MAX);
 
-    FOR_LOOP(i, BZ_BONE_PALETTE_MAX) {
-        Matrix4_identity(&matrixPalette[i]);
-        if (i >= geoset->num_matrixPalette) {
-            continue;
-        }
+    FOR_LOOP(i, count) {
         int node_id = geoset->matrixPalette[i];
         if (node_id >= 0 && node_id < MDX_MAX_NODES && model->nodes[node_id]) {
             matrixPalette[i] = node_matrices[node_id];
+        } else {
+            Matrix4_identity(&matrixPalette[i]);
         }
     }
 
-    R_Call(glUniformMatrix4fv, mdlx.shader->uBones, BZ_BONE_PALETTE_MAX, GL_FALSE, matrixPalette->v);
+    R_Call(glUniformMatrix4fv, mdlx.shader->uBones, count, GL_FALSE, matrixPalette->v);
 }
 
 static VECTOR4 MDLX_EvaluateGeosetColor(mdxModel_t const *model,

--- a/games/warcraft-3/renderer/mdx/r_mdx_load.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_load.c
@@ -839,6 +839,19 @@ mdxBounds_t MDX_CalculateBounds(mdxModel_t const *model) {
     return b;
 }
 
+/* Register a node in the model's sparse node table and compact node list.  The
+ * compact list lets MDLX_BindBoneMatrices iterate only the nodes a model
+ * actually has instead of scanning all MDX_MAX_NODES slots every frame. */
+static void MDLX_AddNode(mdxModel_t *model, mdxNode_t *node) {
+    if (node->node_id >= MDX_MAX_NODES) {
+        return;
+    }
+    if (!model->nodes[node->node_id]) {
+        model->nodes[node->node_id] = node;
+        model->node_list[model->num_nodes++] = node;
+    }
+}
+
 mdxModel_t *R_LoadModelMDLX(void *data, DWORD size) {
     mdxModel_t *model = ri.MemAlloc(sizeof(mdxModel_t));
     sizeBuf_t buffer = { .data = data, .cursize = size, .readcount = 4 };
@@ -846,36 +859,12 @@ mdxModel_t *R_LoadModelMDLX(void *data, DWORD size) {
         MDLX_Release(model);
         return NULL;
     }
-    FOR_EACH_LIST(mdxBone_t, bone, model->bones) {
-        if (bone->node.node_id < MDX_MAX_NODES) {
-            model->nodes[bone->node.node_id] = &bone->node;
-        }
-    }
-    FOR_EACH_LIST(mdxHelper_t, helper, model->helpers) {
-        if (helper->node.node_id < MDX_MAX_NODES) {
-            model->nodes[helper->node.node_id] = &helper->node;
-        }
-    }
-    FOR_EACH_LIST(mdxCollisionShape_t, shape, model->collisionShapes) {
-        if (shape->node.node_id < MDX_MAX_NODES) {
-            model->nodes[shape->node.node_id] = &shape->node;
-        }
-    }
-    FOR_EACH_LIST(mdxParticleEmitter_t, emitter, model->emitters) {
-        if (emitter->node.node_id < MDX_MAX_NODES) {
-            model->nodes[emitter->node.node_id] = &emitter->node;
-        }
-    }
-    FOR_EACH_LIST(mdxAttachment_t, attachment, model->attachments) {
-        if (attachment->node.node_id < MDX_MAX_NODES) {
-            model->nodes[attachment->node.node_id] = &attachment->node;
-        }
-    }
-    FOR_EACH_LIST(mdxLight_t, light, model->lights) {
-        if (light->node.node_id < MDX_MAX_NODES) {
-            model->nodes[light->node.node_id] = &light->node;
-        }
-    }
+    FOR_EACH_LIST(mdxBone_t, bone, model->bones) MDLX_AddNode(model, &bone->node);
+    FOR_EACH_LIST(mdxHelper_t, helper, model->helpers) MDLX_AddNode(model, &helper->node);
+    FOR_EACH_LIST(mdxCollisionShape_t, shape, model->collisionShapes) MDLX_AddNode(model, &shape->node);
+    FOR_EACH_LIST(mdxParticleEmitter_t, emitter, model->emitters) MDLX_AddNode(model, &emitter->node);
+    FOR_EACH_LIST(mdxAttachment_t, attachment, model->attachments) MDLX_AddNode(model, &attachment->node);
+    FOR_EACH_LIST(mdxLight_t, light, model->lights) MDLX_AddNode(model, &light->node);
     FOR_LOOP(i, model->num_textures) {
         mdxTexture_t *tex = model->textures+i;
         if (!tex->path[0]) {

--- a/games/warcraft-3/renderer/mdx/r_mdx_load.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_load.c
@@ -547,6 +547,13 @@ void ReadParticleEmitter(LPSIZEBUF buffer, mdxParticleEmitter_t *pe) {
     MSG_READ(buffer, pe->SegmentColor);
     MSG_READ(buffer, pe->Alpha);
     MSG_READ(buffer, pe->ParticleScaling);
+    /* MDX particle sizes are authored as small ParticleScaling floats; the
+       shared R_DrawParticles pipeline used to render every particle at 2x, so
+       the original game read these at 2x.  Commit 97a52d18 dropped the global
+       `*2.0` when M2 moved to per-emitter size_value_scale curves, halving MDX
+       particles.  Bake the 2x back in at load time so WC3 sizes match the
+       original while the shared pipeline stays scale-agnostic. */
+    FOR_LOOP(i, 3) pe->ParticleScaling[i] *= 2.0f;
     MSG_READ(buffer, pe->LifeSpanUVAnim);
     MSG_READ(buffer, pe->DecayUVAnim);
     MSG_READ(buffer, pe->TailUVAnim);

--- a/games/warcraft-3/renderer/w3m/r_war3map.h
+++ b/games/warcraft-3/renderer/w3m/r_war3map.h
@@ -22,6 +22,15 @@ DWORD GetTileRamps(LPCWAR3MAPVERTEX vertices);
 DWORD IsTileCliff(LPCWAR3MAPVERTEX vertices);
 DWORD IsTileWater(LPCWAR3MAPVERTEX vertices);
 
+/* Transition models join two adjacent ramp corners one cliff level apart; tile order is NE,NW,SE,SW. */
+static inline BOOL R_IsCliffRamp(LPCWAR3MAPVERTEX tile) {
+    static const BYTE next[] = { 1, 3, 0, 2 };
+    if (tile[0].ramp + tile[1].ramp + tile[2].ramp + tile[3].ramp != 2) return false;
+    FOR_LOOP(i, 4)
+        if (tile[i].ramp && tile[next[i]].ramp && abs((int)tile[i].level - tile[next[i]].level) == 1) return true;
+    return false;
+}
+
 VECTOR2 GetWar3MapSize(LPCWAR3MAP war3Map);
 
 #endif

--- a/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
@@ -177,7 +177,8 @@ static void R_MakeCliff(LPCWAR3MAP map, DWORD x, DWORD y, cliffData_t const *dat
         return;
 
     char cliffcfg[5] = { 0 };
-    bool const is_ramp = GetTileRamps(tile) > 1;
+    /* Equal-height ramp flags mark the adjoining cliff, not a sloped transition (e.g. HABH). */
+    bool const is_ramp = R_IsCliffRamp(tile);
     int const baselevel = TileBaseLevel(tile);
 
     FOR_LOOP(index, 4) {

--- a/games/warcraft-3/renderer/w3m/r_war3map_ground.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_ground.c
@@ -174,6 +174,102 @@ static void R_FlushSplatBatch(void) {
     ground_current_vertex = ground_vertex_buffer;
 }
 
+/* Bind the splat shader/VAO/VBO and upload the per-view uniforms once.  All
+ * splats in a batch share this state; only the texture and per-tile geometry
+ * vary, so re-issuing it per splat was pure overhead. */
+static LPCTEXTURE g_splat_texture;
+static LPCSHADER g_splat_shader;
+
+static void R_SetupSplatState(LPCTEXTURE texture, LPCSHADER shader) {
+    MATRIX4 mModelMatrix;
+
+    Matrix4_identity(&mModelMatrix);
+    g_splat_texture = texture;
+    g_splat_shader = shader;
+    R_BindTexture(texture, 0);
+    R_SetTextureWrap(texture, false, false); /* splats are decals, so repeating the source texture smears the edges */
+    R_Call(glUseProgram, shader->progid);
+    R_Call(glUniformMatrix4fv, shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
+    R_Call(glUniformMatrix4fv, shader->uModelMatrix, 1, GL_FALSE, mModelMatrix.v);
+    R_Call(glEnable, GL_BLEND);
+    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    R_Call(glDepthMask, GL_FALSE);
+    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+    R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
+    ground_current_vertex = ground_vertex_buffer;
+}
+
+/* Emit terrain-conforming tiles for one splat rect into the shared buffer,
+ * flushing to the GPU only when the buffer fills. */
+static void R_GenerateSplatTiles(LPCVECTOR2 mins, LPCVECTOR2 maxs, COLOR32 color) {
+    int x_start, x_end;
+    int y_start, y_end;
+
+    FLOAT const width = maxs->x - mins->x;
+    FLOAT const height = maxs->y - mins->y;
+    if (width <= 0 || height <= 0) {
+        return;
+    }
+
+    x_start = MAX(0, (int)floor((mins->x - tr.world->center.x) / TILE_SIZE));
+    y_start = MAX(0, (int)floor((mins->y - tr.world->center.y) / TILE_SIZE));
+    x_end = MIN((int)tr.world->width - 1, (int)ceil((maxs->x - tr.world->center.x) / TILE_SIZE));
+    y_end = MIN((int)tr.world->height - 1, (int)ceil((maxs->y - tr.world->center.y) / TILE_SIZE));
+
+    if (x_start >= x_end || y_start >= y_end) {
+        return;
+    }
+
+    for (int x = x_start; x < x_end; x++) {
+        for (int y = y_start; y < y_end; y++) {
+            if (!R_TileAcceptsSplat(tr.world, (DWORD)x, (DWORD)y)) {
+                continue;
+            }
+            if ((ground_current_vertex - ground_vertex_buffer) + 6 > GROUND_VERTEX_BUFFER_CAPACITY) {
+                R_FlushSplatBatch();
+            }
+            R_MakeSplatTile(tr.world, (DWORD)x, (DWORD)y, mins, width, height, color);
+        }
+    }
+}
+
+void R_BeginSplatBatch(LPCSHADER shader) {
+    g_splat_shader = shader;
+    g_splat_texture = NULL;
+    ground_current_vertex = ground_vertex_buffer;
+}
+
+void R_AddRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, COLOR32 color) {
+    if (!tr.world || !texture) {
+        return;
+    }
+    if (texture != g_splat_texture) {
+        R_FlushSplatBatch();
+        R_SetupSplatState(texture, g_splat_shader);
+    }
+    R_GenerateSplatTiles(mins, maxs, color);
+}
+
+void R_EndSplatBatch(void) {
+    R_FlushSplatBatch();
+    R_Call(glDepthMask, GL_TRUE);
+}
+
+void R_RenderRectSplat(LPCVECTOR2 mins,
+                       LPCVECTOR2 maxs,
+                       LPCTEXTURE texture,
+                       LPCSHADER shader,
+                       COLOR32 color)
+{
+    if (!tr.world || !texture) {
+        return;
+    }
+    R_SetupSplatState(texture, shader);
+    R_GenerateSplatTiles(mins, maxs, color);
+    R_FlushSplatBatch();
+    R_Call(glDepthMask, GL_TRUE);
+}
+
 LPMAPLAYER R_BuildMapSegmentLayer(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD layer) {
     LPMAPLAYER mapLayer = ri.MemAlloc(sizeof(MAPLAYER));
     PATHSTR zBuffer;
@@ -243,61 +339,6 @@ LPMAPLAYER R_BuildGroundLayerGlobal(LPCWAR3MAP map, DWORD layer) {
     }
     mapLayer->buffer = R_MakeVertexArrayObject(whole_map_buffer, mapLayer->num_vertices);
     return mapLayer;
-}
-
-void R_RenderRectSplat(LPCVECTOR2 mins,
-                       LPCVECTOR2 maxs,
-                       LPCTEXTURE texture,
-                       LPCSHADER shader,
-                       COLOR32 color)
-{
-    MATRIX4 mModelMatrix;
-    int x_start, x_end;
-    int y_start, y_end;
-
-    Matrix4_identity(&mModelMatrix);
-    
-    FLOAT const width = maxs->x - mins->x;
-    FLOAT const height = maxs->y - mins->y;
-    if (!tr.world || !texture || width <= 0 || height <= 0) {
-        return;
-    }
-
-    x_start = MAX(0, (int)floor((mins->x - tr.world->center.x) / TILE_SIZE));
-    y_start = MAX(0, (int)floor((mins->y - tr.world->center.y) / TILE_SIZE));
-    x_end = MIN((int)tr.world->width - 1, (int)ceil((maxs->x - tr.world->center.x) / TILE_SIZE));
-    y_end = MIN((int)tr.world->height - 1, (int)ceil((maxs->y - tr.world->center.y) / TILE_SIZE));
-
-    if (x_start >= x_end || y_start >= y_end) {
-        return;
-    }
-
-    R_BindTexture(texture, 0);
-    R_SetTextureWrap(texture, false, false); /* splats are decals, so repeating the source texture smears the edges */
-    R_Call(glUseProgram, shader->progid);
-    R_Call(glUniformMatrix4fv, shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
-    R_Call(glUniformMatrix4fv, shader->uModelMatrix, 1, GL_FALSE, mModelMatrix.v);
-
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    R_Call(glDepthMask, GL_FALSE);
-    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
-    R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
-
-    ground_current_vertex = ground_vertex_buffer;
-    for (int x = x_start; x < x_end; x++) {
-        for (int y = y_start; y < y_end; y++) {
-            if (!R_TileAcceptsSplat(tr.world, (DWORD)x, (DWORD)y)) {
-                continue;
-            }
-            if ((ground_current_vertex - ground_vertex_buffer) + 6 > GROUND_VERTEX_BUFFER_CAPACITY) {
-                R_FlushSplatBatch();
-            }
-            R_MakeSplatTile(tr.world, (DWORD)x, (DWORD)y, mins, width, height, color);
-        }
-    }
-    R_FlushSplatBatch();
-    R_Call(glDepthMask, GL_TRUE);
 }
 
 void R_RenderFlatRectSplat(LPCVECTOR2 mins,

--- a/games/warcraft-3/tests/resources-src/TestUI/FrameDef/Glue/Loading.fdf
+++ b/games/warcraft-3/tests/resources-src/TestUI/FrameDef/Glue/Loading.fdf
@@ -1,0 +1,122 @@
+// -- LOCALIZABLE TEXT ------------------------------------------
+
+IncludeFile "UI\FrameDef\Glue\StandardTemplates.fdf",
+
+// -- TEMPLATES -------------------------------------------------
+
+// -- FRAMES ----------------------------------------------------
+
+Frame "FRAME" "Loading" {
+    SetAllPoints,
+
+    Frame "SPRITE" "LoadingBackground" {
+        SetAllPoints,
+    }
+
+    Frame "SPRITE" "LoadingBar" {
+        SetPoint BOTTOMLEFT, "Loading", BOTTOMLEFT, 0.0, 0.0025,
+
+        Frame "TEXT" "LoadingBarText" INHERITS "StandardLabelTextTemplate" {
+            SetPoint BOTTOM, "Loading", BOTTOM, 0.0, 0.057,
+            Text "LOADING_LOADING",
+        }
+    }
+
+    // --- CUSTOM FRAMES ---
+    Frame "FRAME" "LoadingCustomPanel" {
+
+        Frame "TEXT" "LoadingTitleText" INHERITS "StandardTitleTextTemplate" {
+            Width 0.36,
+            FontColor 0.99 0.827 0.0705 1.0,
+            SetPoint TOPRIGHT, "Loading", TOPRIGHT, -0.025, -0.295,
+            FontJustificationH JUSTIFYCENTER,
+        }
+
+        Frame "TEXT" "LoadingSubtitleText" INHERITS "StandardTitleTextTemplate" {
+            Width 0.36,
+            DecorateFileNames,
+            FontColor 0.99 0.827 0.0705 1.0,
+            FrameFont "MasterFont", 0.024, "",            
+            SetPoint TOP, "LoadingTitleText", BOTTOM, 0.0, -0.003,
+            FontJustificationH JUSTIFYCENTER,
+
+        }
+
+        Frame "TEXT" "LoadingText" INHERITS "StandardValueTextTemplate" {
+            Width 0.36,
+            SetPoint TOP, "LoadingSubtitleText", BOTTOM, 0.0, -0.01,
+            FontJustificationH JUSTIFYLEFT,
+        }
+
+    }
+
+    // --- MELEE FRAMES ---
+    Frame "FRAME" "LoadingMeleePanel" {
+
+        Frame "SPRITE" "MinimapImage" {
+            Width 0.16,
+            Height 0.16,
+            SetPoint LEFT, "Loading", LEFT, 0.056875, 0.0425,
+        }
+
+        Frame "TEXT" "LoadingMeleeMapName" INHERITS "StandardTitleTextTemplate" {            
+            FontColor 0.99 0.827 0.0705 1.0,
+            SetPoint BOTTOM, "MinimapImage", TOP, 0.0, 0.01025,
+        }
+
+        Frame "TEXT" "LoadingMeleeGameTypeLabel" INHERITS "StandardLabelTextTemplate" {
+            Width 0.16,
+            SetPoint TOP, "MinimapImage", BOTTOM, 0.0, -0.01025,
+            FontJustificationH JUSTIFYLEFT,
+            Text "COLON_GAME_TYPE",
+        }
+
+        Frame "TEXT" "LoadingMeleeGameTypeValue" INHERITS "StandardValueTextTemplate" {
+            Width 0.16,
+            SetPoint TOP, "LoadingMeleeGameTypeLabel", BOTTOM, 0.0, -0.002,
+            FontJustificationH JUSTIFYLEFT,
+        }
+
+        Frame "FRAME" "LoadingMeleePlayerContainer" {
+            Width 0.2575,
+            SetPoint LEFT, "Loading", LEFT, 0.24, 0.0425,
+        }
+    }
+}
+
+// --- PLAYER SLOT ------------------------------------------------------
+Frame "FRAME" "LoadingPlayerSlot" {
+    Width 0.256,
+    Height 0.032,        
+
+    Frame "HIGHLIGHT" "LoadingPlayerSlotReadyHighlight" {
+        UseActiveContext,
+        Height 0.02,
+        Width 0.218,
+        SetPoint LEFT, "LoadingPlayerSlot", LEFT, 0.0192, 0.0,
+        HighlightType "SHADE",
+        HighlightColor 0.0 1.0 0.0 0.5,
+    }
+
+    Frame "BACKDROP" "LoadingPlayerSlotBackdrop" {
+        UseActiveContext,
+        SetAllPoints,
+        BackdropBackground  "UI\Widgets\Glues\Loading-NameBackground.blp",
+        BackdropBlendAll,
+
+        Frame "TEXT" "LoadingPlayerSlotLevel" INHERITS "StandardSmallTextTemplate" {
+            UseActiveContext,
+            Width 0.013,
+            FontJustificationH JUSTIFYCENTER,
+            SetPoint LEFT, "LoadingPlayerSlot", LEFT, 0.024, 0.0,
+        }
+
+        Frame "TEXT" "LoadingPlayerSlotName" INHERITS "StandardValueTextTemplate" {
+            UseActiveContext,
+            SetPoint LEFT, "LoadingPlayerSlot", LEFT, 0.024, 0.0,
+        }
+
+        Frame "TEXT" "LoadingPlayerSlotRace" INHERITS "StandardValueTextTemplate" {
+            UseActiveContext,
+            SetPoint RIGHT, "LoadingPlayerSlot", RIGHT, -0.024, 0.0,
+   

--- a/games/warcraft-3/tests/resources-src/TestUI/FrameDef/Glue/StandardTemplates.fdf
+++ b/games/warcraft-3/tests/resources-src/TestUI/FrameDef/Glue/StandardTemplates.fdf
@@ -19,3 +19,7 @@ Frame "DIALOG" "StandardDialogTemplate" {
         BackdropBackground "TestUI\Textures\solid_white.blp",
     }
 }
+
+Frame "TEXT" "StandardLabelTextTemplate" { FrameFont "MasterFont", 0.015, "", }
+Frame "TEXT" "StandardTitleTextTemplate" { FrameFont "MasterFont", 0.02, "", }
+Frame "TEXT" "StandardValueTextTemplate" { FrameFont "MasterFont", 0.013, "", }

--- a/games/warcraft-3/tests/test_client_stubs.c
+++ b/games/warcraft-3/tests/test_client_stubs.c
@@ -61,7 +61,7 @@ LPCSTR Cvar_String(LPCSTR name, LPCSTR fallback) {
 }
 
 void CL_ParseTEnt(LPSIZEBUF msg) { (void)msg; }
-void CL_BeginLoadingMap(LPCSTR mapName) { (void)mapName; cl.playerstate.client_ui_state = CLIENT_UI_LOADING; cls.state = ca_connected; }
+void CL_BeginLoadingMap(LPCSTR mapName) { (void)mapName; cl.playerstate.client_ui_state = CLIENT_UI_LOADING; cls.state = ca_connected; cl.num_active = 0; }
 void CL_SetGameplayInput(void) { cls.key_dest = key_game; }
 void CL_Disconnect(LPCSTR reason, BOOL notify) { (void)reason; (void)notify; cls.state = ca_disconnected; }
 void CL_EntityEvent(entityState_t const *ent) { (void)ent; }

--- a/games/warcraft-3/tests/test_ui_fdf.c
+++ b/games/warcraft-3/tests/test_ui_fdf.c
@@ -29,6 +29,9 @@ static HANDLE test_mpq_archive;
 static BOOL hide_expansion_campaign_file;
 static BOOL test_fs_expansion;
 static VECTOR2 test_mouse_pos;
+static LPCPLAYER test_player;
+static LPCSTR test_map = "";
+static DWORD map_reads, texture_releases;
 static int fake_image_index(LPCSTR name) {
     captured_model_path = name;
     return (name && *name) ? 456 : 0;
@@ -59,6 +62,7 @@ static int test_fs_read_file(LPCSTR file_name, void **buf) {
         return -1;
     }
     *buf = NULL;
+    if (strstr(file_name, ".w3m")) map_reads++;
 
     if (!test_mpq_archive &&
         !SFileOpenArchive("build/tests/tests.mpq", 0, 0, &test_mpq_archive)) {
@@ -178,9 +182,12 @@ static size2_t test_get_window_size(void) {
     return MAKE(size2_t, 1000, 750);
 }
 
+static void test_release_texture(LPTEXTURE texture) { (void)texture; texture_releases++; }
+
 static LPRENDERER test_get_renderer(void) {
     static refExport_t renderer = {
         .LoadTexture = test_load_texture,
+        .ReleaseTexture = test_release_texture,
         .LoadModel = test_load_model,
         .LoadFont = test_load_font,
         .GetWindowSize = test_get_window_size,
@@ -221,6 +228,7 @@ static void test_cmd_execute_text(LPCSTR text) {
 }
 
 static LPCSTR test_cvar_string(LPCSTR name, LPCSTR fallback) {
+    if (!strcmp(name, "map")) return test_map;
     if (name && !strcmp(name, "fs_expansion")) {
         return test_fs_expansion ? "1" : "0";
     }
@@ -231,7 +239,7 @@ static LPCSTR test_cvar_string(LPCSTR name, LPCSTR fallback) {
 }
 
 static LPCPLAYER test_get_player_state(void) {
-    return NULL;
+    return test_player;
 }
 
 static void load_ui_file(LPCSTR file_name) {
@@ -284,6 +292,8 @@ static void reset_ui_state(void) {
     captured_stand_sprites = 0;
     captured_realm_panel_sprites = 0;
     fake_texture_id = 0;
+    texture_releases = map_reads = 0;
+    test_player = NULL; test_map = "";
     hover_texture = NULL;
     captured_hover_draws = 0;
     memset(captured_text_rects, 0, sizeof(captured_text_rects));
@@ -623,6 +633,10 @@ TEST(ui_fdf, backdrop_background_adds_blp_extension) {
     frame = UI_FindFrame("BD");
     if (!require_not_null(frame)) return;
     T_EQ(frame->Backdrop.Background, 1);
+    T_NULL(captured_image_path);
+    T_NOT_NULL(UI_GetTexture(frame->Backdrop.Background));
+    T_ASSERT(UI_GetTexture(frame->Backdrop.Background) == UI_GetTexture(frame->Backdrop.Background));
+    T_EQ(fake_texture_id, 1);
     T_NOT_NULL(captured_image_path);
     T_STREQ(captured_image_path, "TestUI/Textures/checker_8x8.blp");
 }
@@ -1332,7 +1346,7 @@ TEST(ui_fdf, button1_dropdown_backdrop_gets_hover_highlight) {
 
     root = UI_FindFrame("Root");
     if (!require_not_null(root)) return;
-    T_NOT_NULL(hover_texture);
+    T_NULL(hover_texture);
 
     test_mouse_pos.x = 130;
     test_mouse_pos.y = 130;
@@ -1341,6 +1355,7 @@ TEST(ui_fdf, button1_dropdown_backdrop_gets_hover_highlight) {
     captured_hover_draws = 0;
     UI_DrawFrame(root);
 
+    T_NOT_NULL(hover_texture);
     T_EQ(captured_hover_draws, 1);
 }
 
@@ -1947,4 +1962,97 @@ TEST(ui_fdf, utf16le_fdf_is_parsed_correctly) {
     T_EQ(frame->Type, FT_BACKDROP);
     T_FEQ(frame->Width, 0.75f, 0.01f);
     T_FEQ(frame->Height, 0.50f, 0.01f);
+}
+
+/* Parsing a template must not fetch art that an instantiated frame overrides. */
+TEST(ui_fdf, unused_template_texture_stays_unloaded) {
+    reset_ui_state();
+    parse_fdf("template_art.fdf",
+              "Frame \"BACKDROP\" \"Template\" { BackdropBackground \"Unused.blp\", }"
+              "Frame \"BACKDROP\" \"Panel\" INHERITS \"Template\" { BackdropBackground \"Used.blp\", }");
+    LPFRAMEDEF panel = UI_FindFrame("Panel");
+    if (!require_not_null(panel)) return;
+    T_EQ(fake_texture_id, 0);
+    T_NOT_NULL(UI_GetTexture(panel->Backdrop.Background));
+    T_STREQ(captured_image_path, "Used.blp");
+    T_EQ(fake_texture_id, 1);
+    T_NOT_NULL(UI_GetTexture(UI_FindFrame("Template")->Backdrop.Background));
+    T_STREQ(captured_image_path, "Unused.blp"); /* A real consumer still reaches the renderer's diagnostic path. */
+    T_EQ(fake_texture_id, 2);
+    T_NULL(UI_GetTexture(0)); T_NULL(UI_GetTexture(1024)); T_NULL(UI_GetTexture(50));
+}
+
+static int test_theme_read(LPCSTR name, void **buf) {
+    LPCSTR text = "[Default]\nBackground=Default.blp\n[Human]\nBackground=Human.blp\n";
+    (void)name; *buf = strdup(text); return (int)strlen(text);
+}
+
+TEST(ui_fdf, deferred_texture_cache_tracks_theme_changes) {
+    uiImport_t saved = uiimport;
+    PLAYER player = { .race = kPlayerRaceHuman };
+    reset_ui_state();
+    uiimport.FS_ReadFile = test_theme_read; uiimport.FS_FreeFile = test_fs_free_file;
+    UI_LoadTheme("UI\\war3skins.txt");
+    DWORD index = UI_LoadTexture("Background", true);
+    T_EQ(UI_LoadTexture("Background", true), index);
+    T_EQ(fake_texture_id, 0);
+    test_player = &player;
+    T_NOT_NULL(UI_GetTexture(index));
+    T_STREQ(captured_image_path, "Human.blp");
+    T_EQ(texture_releases, 0); T_EQ(fake_texture_id, 1);
+    T_NOT_NULL(UI_GetTexture(index)); T_EQ(fake_texture_id, 1);
+    test_player = NULL;
+    T_NOT_NULL(UI_GetTexture(index));
+    T_STREQ(captured_image_path, "Default.blp");
+    T_EQ(texture_releases, 1); T_EQ(fake_texture_id, 2);
+    T_NOT_NULL(UI_GetTexture(index)); T_EQ(fake_texture_id, 2);
+    UI_ClearTheme(); uiimport = saved;
+}
+
+/* A menu launch starts without a startup map cvar; subsequent destinations must invalidate the metadata cache. */
+TEST(ui_fdf, loading_screen_uses_current_destination_and_caches_per_map) {
+    uiImport_t saved = uiimport;
+    PLAYER player = { .client_ui_state = CLIENT_UI_LOADING };
+    reset_ui_state();
+    uiimport.FS_ReadFile = test_fs_read_file; uiimport.FS_FreeFile = test_fs_free_file;
+    uiimport.Cvar_String = test_cvar_string; uiimport.Cmd_ExecuteText = test_cmd_execute_text;
+    UI_InitLocal();
+    test_player = &player;
+    UI_RefreshLocal(0);
+    T_EQ(map_reads, 0);
+    test_map = "Maps\\Campaign\\Human02.w3m";
+    UI_RefreshLocal(1);
+    LPFRAMEDEF title = UI_FindFrame("LoadingTitleText");
+    if (require_not_null(title)) {
+        T_STREQ(title->Text, "Human02");
+        T_ASSERT(UI_FindFrame("LoadingBackground")->Portrait.model != 0);
+        T_EQ(map_reads, 1);
+        UI_RefreshLocal(2); T_EQ(map_reads, 1);
+        test_map = "Maps\\Campaign\\Orc01.w3m";
+        UI_RefreshLocal(3); T_STREQ(title->Text, "Orc01"); T_EQ(map_reads, 2);
+        UI_RefreshLocal(4); T_EQ(map_reads, 2);
+        UI_InitLocal();
+        UI_RefreshLocal(5); T_EQ(map_reads, 3);
+    }
+    test_player = NULL; test_map = "";
+    UI_ShutdownLocal(); uiimport = saved;
+}
+
+TEST(ui_fdf, loading_rows_support_roc_and_tft_schema) {
+    static const struct { LPCSTR row, model; DWORD seq; BOOL valid; } cases[] = {
+        { "WESTRING_LOADINGSCREEN_HUMAN01,0,UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdl",
+          "UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdl", 0, true },
+        { "1,WESTRING_LOADINGSCREEN_HUMANX01,6,UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronExpansionBackground.mdl",
+          "UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronExpansionBackground.mdl", 6, true },
+        { "0,WESTRING_LOADINGSCREEN_HUMAN02,1,UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdl",
+          "UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdl", 1, true },
+        { NULL, "", 0, false }, { "", "", 0, false },
+        { "WESTRING_LOADINGSCREEN_HUMAN01", "", 0, false },
+        { "1,WESTRING_LOADINGSCREEN_HUMANX01,6,", "", 6, false },
+    };
+    FOR_LOOP(i, sizeof(cases) / sizeof(cases[0])) {
+        PATHSTR model; DWORD seq;
+        T_EQ(UI_ParseLoadingRow(cases[i].row, &seq, model), cases[i].valid);
+        if (cases[i].valid) { T_STREQ(model, cases[i].model); T_EQ(seq, cases[i].seq); }
+    }
 }

--- a/games/warcraft-3/ui/ui_fdf.c
+++ b/games/warcraft-3/ui/ui_fdf.c
@@ -54,7 +54,6 @@ static LPCSTR EnsureExtension(LPCSTR file, LPCSTR ext) {
 }
 
 BZ_HOST_HIDDEN DWORD UI_LoadTexture(LPCSTR file, BOOL decorate) {
-    LPRENDERER renderer;
     LPCSTR resolved;
     DWORD index;
 
@@ -82,9 +81,7 @@ BZ_HOST_HIDDEN DWORD UI_LoadTexture(LPCSTR file, BOOL decorate) {
     snprintf(ui_texture_names[index], sizeof(ui_texture_names[index]), "%s", resolved);
     snprintf(ui_texture_keys[index], sizeof(ui_texture_keys[index]), "%s", file);
     ui_texture_decorated[index] = decorate;
-    renderer = uiimport.GetRenderer();
-    if (renderer && renderer->LoadTexture && !ui_textures[index])
-        ui_textures[index] = renderer->LoadTexture(resolved);
+    /* FDF templates can contain unused/overridden art; resolve GPU resources only when drawn. */
     return index;
 }
 
@@ -94,22 +91,17 @@ LPCSTR UI_TextureName(DWORD index) {
 }
 
 LPCTEXTURE UI_GetTexture(DWORD index) {
-    LPRENDERER renderer;
-    LPCSTR resolved;
-
-    if (!index || index >= UI_MAX_TEXTURES) return NULL;
+    if (!index || index >= UI_MAX_TEXTURES || !ui_texture_names[index][0]) return NULL;
+    LPRENDERER renderer = uiimport.GetRenderer();
     if (ui_texture_decorated[index] && ui_texture_keys[index][0]) {
-        resolved = EnsureExtension(Theme_String(ui_texture_keys[index], "Default"), ".blp");
+        LPCSTR resolved = EnsureExtension(Theme_String(ui_texture_keys[index], "Default"), ".blp");
         if (strcmp(ui_texture_names[index], resolved)) {
-            renderer = uiimport.GetRenderer();
-            if (renderer && renderer->LoadTexture) {
-                if (ui_textures[index] && renderer->ReleaseTexture)
-                    renderer->ReleaseTexture((LPTEXTURE)ui_textures[index]);
-                ui_textures[index] = renderer->LoadTexture(resolved);
-                snprintf(ui_texture_names[index], sizeof(ui_texture_names[index]), "%s", resolved);
-            }
+            if (ui_textures[index]) renderer->ReleaseTexture((LPTEXTURE)ui_textures[index]);
+            ui_textures[index] = NULL;
+            snprintf(ui_texture_names[index], sizeof(ui_texture_names[index]), "%s", resolved);
         }
     }
+    if (!ui_textures[index]) ui_textures[index] = renderer->LoadTexture(ui_texture_names[index]);
     return ui_textures[index];
 }
 

--- a/games/warcraft-3/ui/ui_local.h
+++ b/games/warcraft-3/ui/ui_local.h
@@ -31,6 +31,16 @@ void UI_SetActive(BOOL active);
 void UI_ShutdownLocal(void);
 void UI_RefreshLocal(DWORD time);
 
+/* ROC rows are label,sequence,model; TFT prepends a numeric expansion category (even for ROC campaigns). */
+static inline BOOL UI_ParseLoadingRow(LPCSTR row, LPDWORD sequence, LPSTR model) {
+    int offset = 0;
+    *sequence = 0; model[0] = 0;
+    if (!row) return false;
+    sscanf(row, "%*u,%n", &offset);
+    /* The old fixed column indices read TFT's sequence as a filename; 255 bounds the PATHSTR output. */
+    return sscanf(row + offset, "%*[^,],%u,%255[^,\r\n]", sequence, model) == 2;
+}
+
 /* ui_glue_scene.c */
 void UI_ResetGlueSceneModels(void);
 void UI_PreloadGlueSceneModels(void);

--- a/games/warcraft-3/ui/ui_main.c
+++ b/games/warcraft-3/ui/ui_main.c
@@ -297,59 +297,18 @@ static void UI_EnterGameMode(void) {
     UI_SetScreen(NULL);
 }
 
-static LPCSTR UI_CsvField(LPCSTR text, DWORD index, LPSTR out, DWORD out_size) {
-    DWORD field = 0;
-    DWORD len = 0;
-    LPCSTR p = text;
-
-    if (!out || out_size == 0) {
-        return "";
-    }
-    out[0] = '\0';
-    if (!text) {
-        return out;
-    }
-
-    while (*p && field < index) {
-        if (*p++ == ',') {
-            field++;
-        }
-    }
-    while (p[len] && p[len] != ',' && len + 1 < out_size) {
-        len++;
-    }
-    memcpy(out, p, len);
-    out[len] = '\0';
-    return out;
-}
-
-static LPCSTR UI_LoadingMapPath(void) {
-    if (loading_state.map[0]) {
-        return loading_state.map;
-    }
-    return uiimport.Cvar_String("map", "");
-}
-
-static DWORD UI_LoadCampaignLoadingModel(DWORD campaign_background, DWORD *sequence_index) {
-    sheetRow_t *world_edit_data;
+/* LoadingScreens rows describe the model/sequence; TFT adds an expansion category before the display label. */
+static DWORD UI_LoadCampaignLoadingModel(DWORD background, DWORD *sequence) {
+    sheetRow_t *data = FS_ParseINI("UI\\WorldEditData.txt");
     char key[8];
-    char sequence[16];
-    char model[MAX_PATHLEN];
-    LPCSTR row;
-
-    if (sequence_index) {
-        *sequence_index = 0;
+    PATHSTR model;
+    snprintf(key, sizeof(key), "%02u", (unsigned)background);
+    LPCSTR row = FS_FindSheetCell(data, "LoadingScreens", key);
+    if (!UI_ParseLoadingRow(row, sequence, model)) {
+        fprintf(stderr, "UI: invalid LoadingScreens[%s]: %s\n", key, row ? row : "(missing)");
+        return 0;
     }
-
-    world_edit_data = FS_ParseINI("UI\\WorldEditData.txt");
-    snprintf(key, sizeof(key), "%02u", (unsigned)campaign_background);
-    row = FS_FindSheetCell(world_edit_data, "LoadingScreens", key);
-    UI_CsvField(row, 1, sequence, sizeof(sequence));
-    UI_CsvField(row, 2, model, sizeof(model));
-    if (sequence_index && sequence[0]) {
-        *sequence_index = (DWORD)atoi(sequence);
-    }
-    return model[0] ? UI_LoadModel(model, false) : 0;
+    return UI_LoadModel(model, false);
 }
 
 static DWORD UI_DefaultLoadingModel(void) {
@@ -369,7 +328,8 @@ static DWORD UI_CustomLoadingModel(LPCMAPINFO info) {
 
 static void UI_UpdateLoadingMapInfo(void) {
     MAPINFO info;
-    LPCSTR map_path = UI_LoadingMapPath();
+    /* Compare the current destination, not the cached path itself, so subsequent maps reload their artwork. */
+    LPCSTR map_path = uiimport.Cvar_String("map", "");
     DWORD background_model = 0;
     DWORD background_sequence = 0;
 
@@ -420,15 +380,7 @@ static void UI_InitLoadingScreen(void) {
     }
 }
 
-static void UI_DrawLoadingScreenLocal(LPCSTR map, LPCSTR status, FLOAT progress) {
-    (void)progress;
-    if (map && *map) {
-        snprintf(loading_state.map, sizeof(loading_state.map), "%s", map);
-    }
-    if (status && *status) {
-        snprintf(loading_state.text, sizeof(loading_state.text), "%s", status);
-    }
-
+static void UI_DrawLoadingScreenLocal(void) {
     UI_UpdateLoadingMapInfo();
 
     if (!loading_screen.Loading) {
@@ -481,6 +433,7 @@ static void UI_UpdateMouseFrameFlags(LPCFRAMEDEF hit, BOOL clear_pressed) {
 
 void UI_InitLocal(void) {
     memset(&ui_state, 0, sizeof(ui_state));
+    memset(&loading_state, 0, sizeof(loading_state));
     UI_ResetGlueSceneModels();
     UI_RegisterMenuCommands();
     
@@ -555,7 +508,7 @@ void UI_RefreshLocal(DWORD time) {
      * that would have drawn the loading screen. */
     LPCPLAYER ps = uiimport.GetPlayerState();
     if (ps && ps->client_ui_state == CLIENT_UI_LOADING) {
-        UI_DrawLoadingScreenLocal(NULL, NULL, 0.0f);
+        UI_DrawLoadingScreenLocal();
         return;
     }
 

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_splat.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_splat.c
@@ -273,6 +273,15 @@ void R_RenderSplat(LPCVECTOR2 position, float radius, LPCTEXTURE texture, LPCSHA
     R_RenderRectSplat(&mins, &maxs, texture, shader, color);
 }
 
+/* WoW shadows are drawn by R_GameRenderShadow (returns true) and splats already
+ * batch through Wow_QueueSplatVertices, so the shared batch API stays immediate. */
+static LPCSHADER wow_batch_shader;
+void R_BeginSplatBatch(LPCSHADER shader) { wow_batch_shader = shader; }
+void R_AddRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, COLOR32 color) {
+    R_RenderRectSplat(mins, maxs, texture, wow_batch_shader, color);
+}
+void R_EndSplatBatch(void) { }
+
 VECTOR2 GetWar3MapSize(LPCWAR3MAP war3Map) {
     (void)war3Map;
     return (VECTOR2){ 0.0f, 0.0f };

--- a/renderer/r_ents.c
+++ b/renderer/r_ents.c
@@ -41,6 +41,8 @@ static BOOL R_EntityInView(renderEntity_t const *entity) {
     });
 }
 
+static void R_DrawEntityShadows(void);
+
 void R_DrawEntities(void) {
     static BYTE prev_state[MAX_GAME_ENTITIES];
     static BOOL initialized = false;
@@ -55,6 +57,8 @@ void R_DrawEntities(void) {
     } else {
         initialized = false;
     }
+
+    R_DrawEntityShadows();
 
     FOR_LOOP(i, tr.viewDef.num_entities) {
         renderEntity_t const *ent = tr.viewDef.entities+i;
@@ -255,7 +259,25 @@ static void R_RenderShadow(const renderEntity_t *entity, LPCVECTOR2 origin) {
             return;
         }
     }
-    R_RenderRectSplat(&mins, &maxs, shadow, tr.shader[SHADER_SHADOWSPLAT], shadowColor);
+    R_AddRectSplat(&mins, &maxs, shadow, shadowColor);
+#endif
+}
+
+/* Unit shadows are ground decals that share one shader and differ only by
+ * texture and rect.  Drawing each in isolation re-uploaded the vertex buffer
+ * and re-issued all splat GL state per unit; batching them across the scene
+ * collapses hundreds of small draws into one per distinct texture. */
+static void R_DrawEntityShadows(void) {
+#ifndef USE_SHADOWMAPS
+    R_BeginSplatBatch(tr.shader[SHADER_SHADOWSPLAT]);
+    FOR_LOOP(i, tr.viewDef.num_entities) {
+        renderEntity_t const *ent = tr.viewDef.entities + i;
+        if ((ent->flags & RF_HIDDEN) || !ent->model) {
+            continue;
+        }
+        R_RenderShadow(ent, (LPCVECTOR2)&ent->origin);
+    }
+    R_EndSplatBatch();
 #endif
 }
 
@@ -420,7 +442,6 @@ void R_RenderModel(renderEntity_t const *entity) {
 #endif
 
     R_RenderUberSplat(entity, (LPCVECTOR2)&entity->origin);
-    R_RenderShadow(entity, (LPCVECTOR2)&entity->origin);
     R_GameRenderModel(entity);
     R_RenderSelectedCircle(entity, (LPCVECTOR2)&entity->origin);
     R_RenderHoverHighlight(entity);

--- a/renderer/r_ents.c
+++ b/renderer/r_ents.c
@@ -266,7 +266,8 @@ static void R_RenderShadow(const renderEntity_t *entity, LPCVECTOR2 origin) {
 /* Unit shadows are ground decals that share one shader and differ only by
  * texture and rect.  Drawing each in isolation re-uploaded the vertex buffer
  * and re-issued all splat GL state per unit; batching them across the scene
- * collapses hundreds of small draws into one per distinct texture. */
+ * collapses runs of same-texture shadows into one upload + draw (flushing on
+ * texture change or buffer capacity), instead of one per unit. */
 static void R_DrawEntityShadows(void) {
 #ifndef USE_SHADOWMAPS
     R_BeginSplatBatch(tr.shader[SHADER_SHADOWSPLAT]);

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -236,6 +236,7 @@ struct render_globals {
 void R_RegisterMap(LPCSTR mapFileName);
 int R_RegisterTextureFile(LPCSTR textureFileName);
 LPTEXTURE R_LoadTexture(LPCSTR textureFileName);
+int R_ReadTextureFile(LPCSTR name, LPSTR path, void **buffer);
 LPTEXTURE R_FindLoadedTexture(LPCSTR name);
 void R_CacheLoadedTexture(LPCSTR name, LPTEXTURE texture);
 void R_ReleaseTexture(LPTEXTURE texture);
@@ -276,7 +277,8 @@ void R_DrawBackdrop(LPCDRAWBACKDROP drawBackdrop);
 void R_RenderRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, LPCSHADER shader, COLOR32 color);
 void R_RenderFlatRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, FLOAT z, LPCTEXTURE texture, LPCSHADER shader, COLOR32 color);
 /* Batched splat rendering: accumulate many ground decals (unit shadows) into one
- * vertex-buffer upload + draw per distinct texture instead of one per splat. */
+ * vertex-buffer upload + draw per contiguous texture run (plus capacity flushes),
+ * instead of one upload + draw per splat. */
 void R_BeginSplatBatch(LPCSHADER shader);
 void R_AddRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, COLOR32 color);
 void R_EndSplatBatch(void);

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -275,6 +275,11 @@ void R_DrawHealthBars(void);
 void R_DrawBackdrop(LPCDRAWBACKDROP drawBackdrop);
 void R_RenderRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, LPCSHADER shader, COLOR32 color);
 void R_RenderFlatRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, FLOAT z, LPCTEXTURE texture, LPCSHADER shader, COLOR32 color);
+/* Batched splat rendering: accumulate many ground decals (unit shadows) into one
+ * vertex-buffer upload + draw per distinct texture instead of one per splat. */
+void R_BeginSplatBatch(LPCSHADER shader);
+void R_AddRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, COLOR32 color);
+void R_EndSplatBatch(void);
 
 // r_shader.c
 LPSHADER R_InitShader(LPCSTR vs_default, LPCSTR fs_default);

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -214,28 +214,13 @@ static LPTEXTURE R_MakeBlobShadowTexture(void) {
     return texture;
 }
 
-static BOOL R_HasImageExtension(LPCSTR path) {
-    return R_PathHasExtension(path, ".blp") ||
-           R_PathHasExtension(path, ".tga") ||
-           R_PathHasExtension(path, ".dds") ||
-           R_PathHasExtension(path, ".pcx");
-}
-
 LPTEXTURE R_LoadTexture(LPCSTR textureFilename) {
     LPTEXTURE texture = NULL;
     void *buffer = NULL;
-    PATHSTR blp_fallback;
-    LPCSTR load_path = textureFilename;
+    PATHSTR load_path;
     texture = R_FindLoadedTexture(textureFilename);
     if (texture) return texture;
-    int fileSize = ri.FS_ReadFile(load_path, &buffer);
-    /* WC3 war3skins.txt paths omit .blp — try appending it before giving up. */
-    if ((fileSize < 0 || !buffer) && !R_HasImageExtension(load_path)) {
-        snprintf(blp_fallback, sizeof(blp_fallback), "%s.blp", load_path);
-        fileSize = ri.FS_ReadFile(blp_fallback, &buffer);
-        if (fileSize >= 0 && buffer)
-            load_path = blp_fallback;
-    }
+    int fileSize = R_ReadTextureFile(textureFilename, load_path, &buffer);
     if (fileSize < 0 || !buffer) {
         /* Missing registrations are resident too: repeated draw paths must not search every MPQ again. */
         fprintf(stderr, "R_LoadTexture: not found: %s\n", textureFilename);

--- a/renderer/r_texture.c
+++ b/renderer/r_texture.c
@@ -1,6 +1,21 @@
 #include "r_local.h"
 #include <ctype.h>
 
+/* Asset references may retain a .tga source name after conversion to BLP; actual TGA files take precedence. */
+int R_ReadTextureFile(LPCSTR name, LPSTR path, void **buffer) {
+    static LPCSTR const exact[] = { ".blp", ".dds", ".pcx" };
+    LPCSTR ext = strrchr(name, '.');
+    snprintf(path, sizeof(PATHSTR), "%s", name);
+    int size = ri.FS_ReadFile(path, buffer);
+    if (size >= 0 && *buffer) return size;
+    FOR_LOOP(i, sizeof(exact) / sizeof(exact[0]))
+        if (ext && !strcasecmp(ext, exact[i])) return size;
+    /* Previously only extensionless names found BLPs, leaving authored .tga references unresolved. */
+    int len = ext && !strcasecmp(ext, ".tga") ? (int)(ext - name) : (int)strlen(name);
+    snprintf(path, sizeof(PATHSTR), "%.*s.blp", len, name);
+    return ri.FS_ReadFile(path, buffer);
+}
+
 /* texid -> texture index for model texture resolution; the cache below owns the texture memory. */
 static LPTEXTURE g_textures = NULL;
 static GLenum r_bgra_internal;

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -834,3 +834,112 @@ TEST(net, layout_topleft_y_negative_offset_resolves_below_screen_top) {
     T_FEQ(r->w, 0.180f, 0.002f);
     T_FEQ(r->h, 0.120f, 0.002f);
 }
+
+/* -----------------------------------------------------------------------
+ * Active-entity list lifecycle (client/cl_parse.c)
+ * ----------------------------------------------------------------------- */
+
+static void net_parse(sizeBuf_t *sb) {
+    sb->readcount = 0;
+    CL_ParseServerMessage(sb);
+}
+
+static void net_send_baseline(sizeBuf_t *sb, entityState_t const *state) {
+    entityState_t null = { 0 };
+    MSG_WriteByte(sb, svc_spawnbaseline);
+    MSG_WriteDeltaEntity(sb, &null, state, true);
+}
+
+static void net_send_delta(sizeBuf_t *sb, entityState_t const *from, entityState_t const *to) {
+    MSG_WriteByte(sb, svc_packetentities);
+    MSG_WriteDeltaEntity(sb, from, to, false);
+    MSG_WriteEntityBits(sb, 0, 0);
+}
+
+static void net_send_remove(sizeBuf_t *sb, DWORD number) {
+    MSG_WriteByte(sb, svc_packetentities);
+    MSG_WriteEntityBits(sb, 1u << U_REMOVE, number);
+    MSG_WriteEntityBits(sb, 0, 0);
+}
+
+/* Membership must track current.model exactly across both transitions, plus the
+ * U_REMOVE-after-model-cleared sequence the server produces for model-less
+ * sound/event entities. */
+TEST(net, active_entity_list_tracks_model_transitions) {
+    BYTE buf[512];
+    sizeBuf_t sb;
+    entityState_t state, from, to;
+
+    test_client_stubs_init();
+    T_EQ(cl.num_active, 0);
+
+    /* Baseline model=1 adds membership. */
+    memset(&state, 0, sizeof(state)); state.number = 7; state.model = 1;
+    sb = make_msg_buf(buf, sizeof(buf));
+    net_send_baseline(&sb, &state);
+    net_parse(&sb);
+    T_EQ(cl.num_active, 1);
+    T_EQ(cl.active_entities[0], 7);
+
+    /* Duplicate baseline must not append a second entry. */
+    sb = make_msg_buf(buf, sizeof(buf));
+    net_send_baseline(&sb, &state);
+    net_parse(&sb);
+    T_EQ(cl.num_active, 1);
+
+    /* A delta clearing the model (sound/event-only entity) removes membership. */
+    from = state; /* model=1 */
+    memset(&to, 0, sizeof(to)); to.number = 7; to.model = 0;
+    sb = make_msg_buf(buf, sizeof(buf));
+    net_send_delta(&sb, &from, &to);
+    net_parse(&sb);
+    T_EQ(cl.num_active, 0);
+
+    /* U_REMOVE after the model is already zero must not leave a stale entry. */
+    sb = make_msg_buf(buf, sizeof(buf));
+    net_send_remove(&sb, 7);
+    net_parse(&sb);
+    T_EQ(cl.num_active, 0);
+
+    /* Slot reuse: model 0 -> 1 re-adds, then a plain U_REMOVE clears it again. */
+    from = to; /* model=0 */
+    memset(&to, 0, sizeof(to)); to.number = 7; to.model = 2;
+    sb = make_msg_buf(buf, sizeof(buf));
+    net_send_delta(&sb, &from, &to);
+    net_parse(&sb);
+    T_EQ(cl.num_active, 1);
+    T_EQ(cl.active_entities[0], 7);
+
+    sb = make_msg_buf(buf, sizeof(buf));
+    net_send_remove(&sb, 7);
+    net_parse(&sb);
+    T_EQ(cl.num_active, 0);
+}
+
+/* CL_ParseFrame snapshots prev = current for the active list; map load resets it. */
+TEST(net, active_entity_list_frame_copy_and_map_reset) {
+    BYTE buf[512];
+    sizeBuf_t sb;
+    entityState_t state;
+
+    test_client_stubs_init();
+    memset(&state, 0, sizeof(state)); state.number = 7; state.model = 1;
+    sb = make_msg_buf(buf, sizeof(buf));
+    net_send_baseline(&sb, &state);
+    net_parse(&sb);
+    T_EQ(cl.num_active, 1);
+
+    /* Frame header snapshots the current origin into prev for every active entity. */
+    cl.ents[7].current.origin.x = 42.0f;
+    sb = make_msg_buf(buf, sizeof(buf));
+    MSG_WriteByte(&sb, svc_frame);
+    MSG_WriteLong(&sb, 1);
+    MSG_WriteLong(&sb, 1000);
+    MSG_WriteLong(&sb, 0);
+    net_parse(&sb);
+    T_FEQ(cl.ents[7].prev.origin.x, 42.0f, 0.001f);
+
+    /* Loading a new map drops the list so fresh baselines repopulate it. */
+    CL_BeginLoadingMap("Maps\\Test.w3m");
+    T_EQ(cl.num_active, 0);
+}

--- a/tests/test_renderer_model.c
+++ b/tests/test_renderer_model.c
@@ -1,6 +1,7 @@
 #include "test.h"
 #include "renderer/r_local.h"
 #include "renderer/r_emit.h"
+#include "games/warcraft-3/renderer/w3m/r_war3map.h"
 #include "renderer/r_shader.h"
 #include <stdarg.h>
 #include <stdlib.h>
@@ -495,4 +496,68 @@ TEST(renderer_texture, dds_channel_masks_use_the_common_upload_capabilities) {
 TEST(renderer_stats, triangles_include_instanced_amplification) {
     T_EQ(R_PrimitiveTriangles(GL_TRIANGLES, 12, 100), (uint64_t)400);
     T_EQ(R_PrimitiveTriangles(GL_LINES, 12, 100), (uint64_t)0);
+}
+
+/* File lookup probes the exact reference first and only substitutes the supported BLP representation. */
+static LPCSTR texture_file;
+static DWORD texture_reads;
+static int test_texture_read(LPCSTR name, void **buffer) {
+    texture_reads++;
+    *buffer = !strcmp(name, texture_file) ? (void *)&texture_reads : NULL;
+    return *buffer ? sizeof(texture_reads) : -1;
+}
+
+TEST(renderer_texture, authored_extensions_resolve_without_losing_real_files) {
+    static const struct { LPCSTR name, file; DWORD reads; BOOL found; } cases[] = {
+        { "White_mask.tga", "White_mask.blp", 2, true },
+        { "Cliff0.TGA", "Cliff0.blp", 2, true },
+        { "Cliff0.tga", "Cliff0.tga", 1, true },
+        { "Tree", "Tree.blp", 2, true },
+        { "Tree.blp", "Tree.blp", 1, true },
+        { "Missing.tga", "", 2, false },
+        { "Missing.blp", "", 1, false },
+        { "Missing.dds", "", 1, false },
+        { "Missing.pcx", "", 1, false },
+        { "Missing", "", 2, false },
+    };
+    int (*read_file)(LPCSTR, void **) = ri.FS_ReadFile;
+    ri.FS_ReadFile = test_texture_read;
+    FOR_LOOP(i, sizeof(cases) / sizeof(cases[0])) {
+        PATHSTR path; void *buffer = NULL;
+        texture_file = cases[i].file; texture_reads = 0;
+        T_EQ(R_ReadTextureFile(cases[i].name, path, &buffer) >= 0, cases[i].found);
+        T_EQ(texture_reads, cases[i].reads);
+        if (cases[i].found) { T_NOT_NULL(buffer); T_STREQ(path, cases[i].file); }
+        else T_NULL(buffer);
+    }
+    ri.FS_ReadFile = read_file;
+}
+
+TEST(renderer_terrain, cliff_ramps_require_adjacent_corners_one_level_apart) {
+    static const BYTE edge[][2] = { {0,1}, {1,3}, {3,2}, {2,0} };
+    WAR3MAPVERTEX tile[4] = {0};
+    T_ASSERT(!R_IsCliffRamp(tile));
+    FOR_LOOP(i, 4) {
+        memset(tile, 0, sizeof(tile));
+        tile[edge[i][0]].ramp = tile[edge[i][1]].ramp = 1;
+        tile[edge[i][0]].level = tile[edge[i][1]].level = 1;
+        T_ASSERT(!R_IsCliffRamp(tile)); /* Human01 HABH had two high corners, not a ramp slope. */
+        tile[edge[i][0]].level = 0;
+        T_ASSERT(R_IsCliffRamp(tile));
+        tile[edge[i][1]].level = 2;
+        T_ASSERT(!R_IsCliffRamp(tile)); /* Native transitions contain LH/HX, never LX. */
+        tile[edge[i][0]].level = 1;
+        T_ASSERT(R_IsCliffRamp(tile));
+        tile[edge[i][0]].level = 2; tile[edge[i][1]].level = 1;
+        T_ASSERT(R_IsCliffRamp(tile));
+    }
+    memset(tile, 0, sizeof(tile));
+    tile[0].ramp = 1; tile[0].level = 1;
+    T_ASSERT(!R_IsCliffRamp(tile));
+    tile[3].ramp = 1;
+    T_ASSERT(!R_IsCliffRamp(tile)); /* Diagonals are not transition edges. */
+    tile[1].ramp = 1;
+    T_ASSERT(!R_IsCliffRamp(tile));
+    tile[2].ramp = 1;
+    T_ASSERT(!R_IsCliffRamp(tile));
 }


### PR DESCRIPTION
Addresses the five sampled CPU shares from the ARM profile review (see `docs/diagnostic-tools.md`):

| Area | Fix |
|---|---|
| MDX bone setup (~16%) | Replace the 64 KiB `node_matrices` memset + two 1024-slot scans with a compact node list built at load; drop the dead `bone_matrices` build/upload. |
| MDX geometry/material draw (~19%) | Upload only `num_matrixPalette` matrices per geoset instead of the full `BZ_BONE_PALETTE_MAX`. |
| Entity shadows (~8%) | Batch unit shadows across the scene (`R_BeginSplatBatch`/`R_AddRectSplat`/`R_EndSplatBatch`) so they collapse into one upload + draw per distinct texture. |
| Client entity collection + snapshot copy (~11%) | Maintain a compact active-entity list and iterate it in `CL_ParseFrame`/`CL_AddEntities` instead of all 16384 slots. |
| Server entity simulation (~10%) | Skip `!inuse` edicts in `G_RunEntities`/`G_RunEntity`. |

WoW and SC2 renderers provide immediate fallbacks for the shared splat-batch API.

Verification:
- `make test` passes (918 in-engine WC3 assertions; `wc3_perf.run_entities_1900` benchmark).
- Built `openwarcraft3`, `openwow`, `opensc2`.
- Smoke-tested ROC map launch and TFT `+menu_main` (rendered screenshot).

New `docs/games/warcraft-3/performance.md` captures the hot spots, why pose caching was rejected for bones, and the verification commands.