### PR TITLE
renderer: redesign shader_desc — typed structs + UNIFORM() offsetof binding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | Config load order, cvar registry, `fs_basepath`/`fs_homepath`, `share/<game>/` + `~/.<game>/` layout | [docs/architecture/runtime.md](docs/architecture/runtime.md) |
 | Code patterns that work well (file-shaped structs, table-driven parsing, pointer-walk parsers) | [docs/code-patterns-that-work.md](docs/code-patterns-that-work.md) |
 | Launching UI/model scenes and maps from the command line; `make run-wow`, `make build-run-wow-*`, `make run-sc2` shortcuts | [docs/rendering-scene-workflow.md](docs/rendering-scene-workflow.md) |
-| Release/debug builds, MSAA, GL/GLES backends, fixed bone palette and shader validation, video modes | [docs/build-and-renderer-platforms.md](docs/build-and-renderer-platforms.md) |
+| Release/debug builds, MSAA, GL/GLES backends, GLSL version (`GLSL=120/140/150`), shader dialect tokens, bone palette, video modes | [docs/build-and-renderer-platforms.md](docs/build-and-renderer-platforms.md) |
 | Shared model shader lighting and packed grass uniform contracts | [docs/architecture/model-shader.md](docs/architecture/model-shader.md) |
 
 ## Coding Style

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CFLAGS  := -Wall -Wmisleading-indentation -fno-common -I. -Ishared -Ishared/type
 BUILD   ?= debug
 MSAA    ?= 0
 GL_BACKEND ?= gl
+GLSL      ?= 140
 
 ifeq ($(BUILD),release)
 	CFLAGS += -O2
@@ -17,9 +18,18 @@ endif
 ifeq ($(filter $(MSAA),0 2 4 8),)
 	$(error MSAA must be 0, 2, 4, or 8)
 endif
+ifeq ($(filter $(GLSL),120 140 150),)
+	$(error GLSL must be 120, 140, or 150)
+endif
 ifeq ($(GL_BACKEND),gles3)
 	CFLAGS += -DBZ_GL_ES3
-else ifneq ($(GL_BACKEND),gl)
+else ifeq ($(GL_BACKEND),gl)
+	ifeq ($(GLSL),120)
+		CFLAGS += -DBZ_GLSL_120
+	else ifeq ($(GLSL),150)
+		CFLAGS += -DBZ_GLSL_150
+	endif
+else
 	$(error GL_BACKEND must be gl or gles3)
 endif
 CFLAGS += -DBZ_MSAA_SAMPLES=$(MSAA)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,21 @@ make clean
 make BUILD=release GL_BACKEND=gles3 MSAA=0 openwarcraft3
 ```
 
-Build configurations share `build/`; always run `make clean` when changing `BUILD`, `GL_BACKEND`, or `MSAA`. See [Build And Renderer Platforms](docs/build-and-renderer-platforms.md) for the API and alpha-coverage contracts.
+Build configurations share `build/`; always run `make clean` when changing `BUILD`, `GL_BACKEND`, `MSAA`, or `GLSL`.
+
+| Variable | Default | Other values | Notes |
+|----------|---------|--------------|-------|
+| `BUILD` | `debug` | `release` | `release` adds `-O2` |
+| `GL_BACKEND` | `gl` | `gles3` | GLES3 is Linux-only |
+| `MSAA` | `0` | `2`, `4`, `8` | Coverage sample count |
+| `GLSL` | `140` | `120`, `150` | GLSL version for descriptor shaders; ignored when `GL_BACKEND=gles3` |
+
+```bash
+make clean && make GLSL=120 openwarcraft3          # legacy GLSL 120
+make clean && make GLSL=150 openwarcraft3          # macOS Core Profile
+```
+
+See [Build And Renderer Platforms](docs/build-and-renderer-platforms.md) for the full dialect token reference, shader body conventions, and alpha-coverage contracts.
 
 Compiles the engine and game libraries (`shared`, `jass`, `sheet`, `renderer`, `game`, `ui`) and the `open-realm` executable into `build/`.
 

--- a/docs/architecture/model-shader.md
+++ b/docs/architecture/model-shader.md
@@ -121,3 +121,43 @@ separately from accumulated lighting. The fragment shader removes only the occlu
 so scene ambient and other lights remain. `BZ_SHADOW_GLSL` also serves SC2 terrain/cliffs; see
 [SC2 shadow diagnostics](../games/starcraft-2/map-model-unit-data.md#shadow-and-catalog-diagnostics).
 The umbrella suite runs the model shader tests with shadows both enabled and disabled.
+
+## Descriptor programs and typed state
+
+All renderer shaders (sprites, ground, MDX/M2/M3, particles, FOW raycast, SC2 terrain/cliffs,
+WoW terrain/grass) use `shader_desc_t`. A typed program has `SHADERPROG prog` plus a typed `state`.
+`SHADERPROG` owns the linked handle and location table; `UNIFORM` offsets address **state values**,
+not locations. `R_LoadShader` resolves inputs once and assigns sampler units in descriptor order.
+Draw paths fill values and call `R_ApplyShader(&shader)` immediately before the draw (or once when
+setting up an unchanged splat batch). `R_UploadShader(&shader.prog, &state)` also accepts a separate
+state value. Only `renderer/r_shader.c` calls `glGetUniformLocation` or `glUniform*`.
+
+- State booleans are C `bool` and GLSL `bool`, including WoW `useWeightedBlend`, `singleTexture`,
+  `wmoIndoor`, model alpha-key/unshaded/fog flags. The backend converts to GLint for GL; never read
+  a bool through a GLint pointer. WMO blend mode remains an integer, since it is not a boolean.
+- Matrices/vectors are native shared math types. Arrays are contiguous inline storage and submit
+  with one count-based GL call. Model bones remain the full 128-matrix contract, lights eight slots;
+  `lightCount` selects active entries. Instanced bones initialize to identity once at program creation.
+- `UNIFORM_TRANSPOSE` describes row-major CPU normal matrices; UV matrices remain column-major.
+- One renderer API submission is **not** one GL call or a UBO. The GL backend walks the descriptor
+  and submits active fields, preserving the existing supported dialects without std140 assumptions.
+- Samplers use descriptor declaration order, not linker location order. Shared models/default ground
+  use diffuse=0, shadow=1, FOW=2. WoW terrain uses layers=0..3, alpha=4; camera grass explicitly
+  assigns its height/control samplers to 5/6 to match existing bindings.
+- Inactive locations (`-1`) mean GLSL optimized out a declared input; the upload skips those.
+  Shader compile/link failure still terminates, never substitutes another shader.
+- Release each `SHADERPROG` with `R_DeleteShader` before its GL context is destroyed.
+
+`make test-renderer-model` exercises generation for 120/140/150/ES3, program cache hit/miss,
+compile/link failures, typed offsets, preserved non-sampler values, all upload types, arrays,
+boolean true/false, transpose, and inactive inputs. `make test` additionally needs local UDP socket
+permissions. On macOS, graphical smoke tests need display access (sandboxed SDL can report no displays).
+Use `+screenshot 5 +com_frame_limit 10`; `com_framelimit` is not the registered cvar.
+If `+map playercreate` reports missing spawn-map data, use the authoritative explicit WDT path for
+renderer verification: `+map World/Maps/Azeroth/Azeroth.wdt` (do not add a runtime map fallback).
+
+SC2 shader shutdown must only delete its programs: `R_Shutdown` currently calls `R_ShutdownModels`
+before `R_GameShutdown`. Reusing terrain/map cleanup there attempts to release cliff-model pointers
+already removed from the model registry. A bounded TRaynor01 run with targeted shutdown logs confirmed
+an abort at the first cliff-model release. Keep map cleanup at its registration boundary; do not
+fold it into `R_SC2ShutdownShaders`.

--- a/docs/build-and-renderer-platforms.md
+++ b/docs/build-and-renderer-platforms.md
@@ -2,13 +2,14 @@
 
 ## Build Profiles
 
-The Makefile has three independent build choices:
+The Makefile has four independent build choices:
 
 | Variable | Values | Default | Contract |
 |---|---|---|---|
 | `BUILD` | `debug`, `release` | `debug` | `release` adds `-O2`; debug adds `-O0 -g` |
 | `GL_BACKEND` | `gl`, `gles3` | `gl` | Desktop OpenGL 3.1, or Linux OpenGL ES 3.0 |
 | `MSAA` | `0`, `2`, `4`, `8` | `0` | Compile-time default framebuffer sample count |
+| `GLSL` | `120`, `140`, `150` | `140` | GLSL version for descriptor-based shaders (ignored when `GL_BACKEND=gles3`) |
 
 All configurations currently share `build/`, so clean before changing any build variable:
 
@@ -38,6 +39,47 @@ For an optimized desktop build with 4x coverage:
 make clean
 make BUILD=release MSAA=4 openwarcraft3
 ```
+
+## GLSL Version Selection
+
+The `GLSL` variable sets which GLSL version string the descriptor-based shader system emits.  It has no effect when `GL_BACKEND=gles3` — that path always generates `#version 300 es`.
+
+| `GLSL=` | Preprocessor define | `#version` emitted | Keyword style |
+|---------|--------------------|--------------------|---------------|
+| `120` | `-DBZ_GLSL_120` | `#version 120` | `attribute` / `varying` / `texture2D` / `gl_FragColor` |
+| `140` *(default)* | *(none)* | `#version 140` | `in` / `out` / `texture` / `o_color` |
+| `150` | `-DBZ_GLSL_150` | `#version 150` | same as 140 |
+| *(when `gles3`)* | `-DBZ_GL_ES3` | `#version 300 es` | same as 140 + `precision highp float/int` prologue |
+
+GLSL 140 and 150 use identical declaration keywords; the `GLSL=150` choice only changes the `#version` line.  Use it when targeting a core profile context that requires at least 150 (e.g. macOS Core Profile which dropped the compatibility profile and requires ≥ 150).
+
+**Switching versions requires a clean build** because the version define bakes into compiled `.o` files:
+
+```bash
+make clean
+make GLSL=120 openwarcraft3        # legacy hardware / older drivers
+make clean
+make GLSL=150 openwarcraft3        # macOS Core Profile
+make clean
+make GL_BACKEND=gles3 openwarcraft3  # GLES3 (ignores GLSL=)
+```
+
+### How dialect tokens work in shader bodies
+
+Shader bodies in `shader_desc_t` must not hardcode version-specific spellings.  Use the compile-time macros from `renderer/shader_desc.h` instead:
+
+| Macro | GLSL 120 | GLSL 140/150/ES3 |
+|-------|----------|-----------------|
+| `GLSL_ATTR` | `attribute` | `in` |
+| `GLSL_VS_OUT` | `varying` | `out` |
+| `GLSL_FS_IN` | `varying` | `in` |
+| `GLSL_FRAGCOLOR` | `gl_FragColor` | `o_color` |
+| `GLSL_TEX` | `texture2D` | `texture` |
+| `GLSL_TEXFETCH` | `texture2D` | `texelFetch` |
+
+The `uniform`, `in`, and `out` declarations for each stage are generated automatically by `R_BuildShaderDeclarations()` from the descriptor tables — shader bodies only contain the logic inside `void main()`.
+
+`make test-renderer-model` verifies that each dialect produces the correct declarations.
 
 ## JASS Header Dependencies
 

--- a/docs/build-and-renderer-platforms.md
+++ b/docs/build-and-renderer-platforms.md
@@ -64,22 +64,17 @@ make clean
 make GL_BACKEND=gles3 openwarcraft3  # GLES3 (ignores GLSL=)
 ```
 
-### How dialect tokens work in shader bodies
+### Descriptor shader bodies and state
 
-Shader bodies in `shader_desc_t` must not hardcode version-specific spellings.  Use the compile-time macros from `renderer/shader_desc.h` instead:
+Shader descriptors provide `vec4 vert()` and `vec4 frag()` bodies and call `texture()`.
+`R_BuildShaderDeclarations` generates uniform/attribute/varying declarations. `R_BuildShaderMain`
+wraps the bodies with the dialect's output variables; GLSL 120 gets the `texture2D` alias.
+Bodies do not need `GLSL_ATTR`, `GLSL_FRAGCOLOR`, or other dialect-token macros.
 
-| Macro | GLSL 120 | GLSL 140/150/ES3 |
-|-------|----------|-----------------|
-| `GLSL_ATTR` | `attribute` | `in` |
-| `GLSL_VS_OUT` | `varying` | `out` |
-| `GLSL_FS_IN` | `varying` | `in` |
-| `GLSL_FRAGCOLOR` | `gl_FragColor` | `o_color` |
-| `GLSL_TEX` | `texture2D` | `texture` |
-| `GLSL_TEXFETCH` | `texture2D` | `texelFetch` |
-
-The `uniform`, `in`, and `out` declarations for each stage are generated automatically by `R_BuildShaderDeclarations()` from the descriptor tables — shader bodies only contain the logic inside `void main()`.
-
-`make test-renderer-model` verifies that each dialect produces the correct declarations.
+`UNIFORM` entries address fields in a typed CPU value state; GL locations stay inside `SHADERPROG`.
+Populate the state, then call `R_ApplyShader` at the draw boundary. See
+[descriptor programs and typed state](architecture/model-shader.md#descriptor-programs-and-typed-state).
+`make test-renderer-model` verifies declaration generation and upload dispatch.
 
 ## JASS Header Dependencies
 

--- a/games/starcraft-2/renderer/m3/r_m3_load.c
+++ b/games/starcraft-2/renderer/m3/r_m3_load.c
@@ -39,7 +39,6 @@ M3_READER(TYPE##SequenceData) { \
     M3_REFR(sb, data->values, TYPE, 0); \
 }
 
-
 static MATRIX4 bonemats[BZ_BONE_PALETTE_MAX];
 static MATRIX4 tmp[M3_MAX_NODES];
 
@@ -50,7 +49,7 @@ extern bool is_rendering_lights;
 #endif
 
 static struct {
-    LPSHADER shader;
+    MODELPROG * shader;
     DWORD uDiffuseMap;
 } m3 = { 0 };
 
@@ -71,7 +70,7 @@ R_EvalKeyframeValue(void const *left,
                     HANDLE out);
 
 /* M3 models consume the same authored key/fill/back rig as SC2 terrain. */
-static void M3_SetLighting(LPSHADER shader) {
+static void M3_SetLighting(MODELPROG * shader) {
     sc2Map_t const *map = SC2_MapCurrent();
     sc2MapLighting_t const *src = map ? &map->lighting : NULL;
     bool const lit = src && src->enabled;
@@ -684,19 +683,15 @@ static void M3_DrawRegionMaterial(m3Region_t const *region, m3Material_t const *
     if (!M3_SetMaterialBlendMode(material)) {
         return;
     }
-    R_Call(glUniform4f, m3.shader->uGeosetColor,
-           diffuse_color.r / 255.0f,
-           diffuse_color.g / 255.0f,
-           diffuse_color.b / 255.0f,
-           diffuse_color.a / 255.0f * alpha);
+    m3.shader->state.geosetColor = (VECTOR4){ diffuse_color.r / 255.0f, diffuse_color.g / 255.0f, diffuse_color.b / 255.0f, diffuse_color.a / 255.0f * alpha };
     {
         FLOAT cutoff = M3_MaterialAlphaCutoff(material);
         BOOL alpha_key = cutoff >= 0.0f;
-        R_Call(glUniform1i, m3.shader->uAlphaKey, alpha_key);
-        R_Call(glUniform1f, m3.shader->uAlphaCutoff, cutoff >= 0.0f ? cutoff : 0.5f);
+        m3.shader->state.alphaKey = alpha_key;
+        m3.shader->state.alphaCutoff = cutoff >= 0.0f ? cutoff : 0.5f;
         if (alpha_key && !M3_MaterialIsBlended(material)) R_SetAlphaKeyState(true);
     }
-    R_Call(glUniform1f, m3.shader->uFirstBoneLookupIndex, (FLOAT)region->firstBoneLookupIndex);
+    m3.shader->state.firstBoneLookupIndex = (FLOAT)region->firstBoneLookupIndex;
 
     R_Call(glActiveTexture, GL_TEXTURE0);
     R_Call(glBindTexture, GL_TEXTURE_2D, diffuse->texid);
@@ -706,6 +701,7 @@ static void M3_DrawRegionMaterial(m3Region_t const *region, m3Material_t const *
             continue;
 #ifndef __linux__
         R_StatsDraw(GL_TRIANGLES, num_indices, 1);
+        R_ApplyShader(m3.shader);
         R_Call(glDrawElementsBaseVertex, GL_TRIANGLES, num_indices, GL_UNSIGNED_SHORT, indices, first_vertex);
 #endif
     }
@@ -872,33 +868,33 @@ void M3_RenderModel(renderEntity_t const *entity, m3Model_t const *model, LPCMAT
     R_Call(glDisable, GL_BLEND);
     R_Call(glEnable, GL_DEPTH_TEST);
     R_Call(glDepthMask, GL_TRUE);
-    R_Call(glUseProgram, m3.shader->progid);
+
 #ifdef USE_SHADOWMAPS
     extern bool is_rendering_lights;
     if (is_rendering_lights) {
-        R_Call(glUniformMatrix4fv, m3.shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.lightMatrix.v);
+        m3.shader->state.viewProjection = tr.viewDef.lightMatrix;
     } else {
-        R_Call(glUniformMatrix4fv, m3.shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
+        m3.shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
     }
 #else
-    R_Call(glUniformMatrix4fv, m3.shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
+    m3.shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
 #endif
-    R_Call(glUniformMatrix4fv, m3.shader->uLightMatrix, 1, GL_FALSE, tr.viewDef.lightMatrix.v);
-    R_Call(glUniformMatrix4fv, m3.shader->uTextureMatrix, 1, GL_FALSE, tr.viewDef.textureMatrix.v);
-    R_Call(glUniformMatrix4fv, m3.shader->uModelMatrix, 1, GL_FALSE, mScaledMatrix.v);
-    R_Call(glUniformMatrix3fv, m3.shader->uNormalMatrix, 1, GL_TRUE, mNormalMatrix.v);
-    R_Call(glUniformMatrix4fv, m3.shader->uBones, MIN(model->boneLookupNum, BZ_BONE_PALETTE_MAX), GL_FALSE, bonemats->v);
+    m3.shader->state.lightMatrix = tr.viewDef.lightMatrix;
+    m3.shader->state.textureMatrix = tr.viewDef.textureMatrix;
+    m3.shader->state.model = mScaledMatrix;
+    m3.shader->state.normalMatrix = mNormalMatrix;
+    memcpy(&m3.shader->state.bones, bonemats->v, (MIN(model->boneLookupNum, BZ_BONE_PALETTE_MAX)) * sizeof(MATRIX4));
     M3_SetLighting(m3.shader);
     /* The unified model shader requires identity defaults for uniforms that
        M3 does not animate (texture UV transform, layer alpha, geoset colour). */
-    R_Call(glUniform4f, m3.shader->uGeosetColor, 1.0f, 1.0f, 1.0f, 1.0f);
-    R_Call(glUniform1f, m3.shader->uLayerAlpha, 1.0f);
-    { GLfloat m[9] = { 1,0,0, 0,1,0, 0,0,1 }; R_Call(glUniformMatrix3fv, m3.shader->uUvMatrix, 1, GL_FALSE, m); }
-    R_Call(glUniform1i, m3.shader->uAlphaKey, 0);
-    R_Call(glUniform1f, m3.shader->uAlphaCutoff, 0.5f);
-    R_Call(glUniform1i, m3.shader->uUnshaded, 0);
-    R_Call(glUniform1f, m3.shader->uFogEnable, 0);
-    R_Call(glUniform1f, m3.shader->uFirstBoneLookupIndex, 0.0f);
+    m3.shader->state.geosetColor = (VECTOR4){ 1.0f, 1.0f, 1.0f, 1.0f };
+    m3.shader->state.layerAlpha = 1.0f;
+    { GLfloat m[9] = { 1,0,0, 0,1,0, 0,0,1 }; memcpy(&m3.shader->state.uvMatrix, m, (1) * sizeof(MATRIX3)); }
+    m3.shader->state.alphaKey = 0;
+    m3.shader->state.alphaCutoff = 0.5f;
+    m3.shader->state.unshaded = 0;
+    m3.shader->state.fogEnable = 0;
+    m3.shader->state.firstBoneLookupIndex = 0.0f;
     R_Call(glBindVertexArray, model->renbuf->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, model->renbuf->vbo);
     

--- a/games/starcraft-2/renderer/m3/r_m3_load.c
+++ b/games/starcraft-2/renderer/m3/r_m3_load.c
@@ -45,7 +45,7 @@ static MATRIX4 tmp[M3_MAX_NODES];
 m3Model_t *currentmodel;
 
 #ifdef USE_SHADOWMAPS
-extern bool is_rendering_lights;
+extern render_phase_t render_phase;
 #endif
 
 static struct {
@@ -592,7 +592,7 @@ static COLOR32 M3_LayerColor(m3Layer_t const *layer) {
 static BOOL M3_SetMaterialBlendMode(m3Material_t const *material) {
     R_SetAlphaKeyState(false);
 #ifdef USE_SHADOWMAPS
-    switch (is_rendering_lights ? (int)(material ? material->blendMode : BLEND_MODE_NONE) : -1) {
+    switch (render_phase == RENDER_PHASE_LIGHTS ? (int)(material ? material->blendMode : BLEND_MODE_NONE) : -1) {
         case BLEND_MODE_BLEND:
         case BLEND_MODE_ADD:
         case BLEND_MODE_ADDALPHA:
@@ -870,8 +870,8 @@ void M3_RenderModel(renderEntity_t const *entity, m3Model_t const *model, LPCMAT
     R_Call(glDepthMask, GL_TRUE);
 
 #ifdef USE_SHADOWMAPS
-    extern bool is_rendering_lights;
-    if (is_rendering_lights) {
+    extern render_phase_t render_phase;
+    if (render_phase == RENDER_PHASE_LIGHTS) {
         m3.shader->state.viewProjection = tr.viewDef.lightMatrix;
     } else {
         m3.shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
@@ -901,7 +901,7 @@ void M3_RenderModel(renderEntity_t const *entity, m3Model_t const *model, LPCMAT
     R_BindTexture(tr.texture[TEX_WHITE], 0);
     /* Terrain owns units 0..4; restore the model's shadow binding and avoid depth-target feedback. */
     R_Call(glActiveTexture, GL_TEXTURE1);
-    R_Call(glBindTexture, GL_TEXTURE_2D, is_rendering_lights || (tr.viewDef.rdflags & RDF_NOWORLDMODEL) ? tr.texture[TEX_WHITE]->texid : tr.rt[RT_DEPTHMAP]->texture);
+    R_Call(glBindTexture, GL_TEXTURE_2D, render_phase == RENDER_PHASE_LIGHTS || (tr.viewDef.rdflags & RDF_NOWORLDMODEL) ? tr.texture[TEX_WHITE]->texid : tr.rt[RT_DEPTHMAP]->texture);
     
     R_Call(glDisable, GL_CULL_FACE);
     

--- a/games/starcraft-2/renderer/r_game.c
+++ b/games/starcraft-2/renderer/r_game.c
@@ -101,7 +101,7 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins,
                            LPCVECTOR2 maxs,
                            FLOAT z,
                            LPCTEXTURE texture,
-                           LPCSHADER shader,
+                           splat_shader_t *shader,
                            COLOR32 color)
 {
     MATRIX4 model_matrix;
@@ -122,9 +122,9 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins,
 
     Matrix4_identity(&model_matrix);
     R_BindTexture(texture, 0);
-    R_Call(glUseProgram, shader->progid);
-    R_Call(glUniformMatrix4fv, shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
-    R_Call(glUniformMatrix4fv, shader->uModelMatrix, 1, GL_FALSE, model_matrix.v);
+
+    shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
+    shader->state.model = model_matrix;
     R_Call(glEnable, GL_BLEND);
     R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     R_Call(glDepthMask, GL_FALSE);
@@ -132,6 +132,7 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins,
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STREAM_DRAW);
     R_StatsDraw(GL_TRIANGLES, sizeof(vertices) / sizeof(vertices[0]), 1);
+    R_ApplyShader(shader);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, sizeof(vertices) / sizeof(vertices[0]));
     R_Call(glDepthMask, GL_TRUE);
 }
@@ -139,7 +140,7 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins,
 void R_RenderRectSplat(LPCVECTOR2 mins,
                        LPCVECTOR2 maxs,
                        LPCTEXTURE texture,
-                       LPCSHADER shader,
+                       splat_shader_t *shader,
                        COLOR32 color)
 {
     R_RenderFlatRectSplat(mins, maxs, 0.0f, texture, shader, color);
@@ -148,7 +149,7 @@ void R_RenderRectSplat(LPCVECTOR2 mins,
 void R_RenderSplat(LPCVECTOR2 position,
                    FLOAT radius,
                    LPCTEXTURE texture,
-                   LPCSHADER shader,
+                   splat_shader_t *shader,
                    COLOR32 color)
 {
     VECTOR2 mins = {
@@ -165,8 +166,8 @@ void R_RenderSplat(LPCVECTOR2 position,
 
 /* SC2 splats are flat quads; the shared batch API stays immediate (a batching
  * pass exists only in the WC3 terrain-conforming renderer). */
-static LPCSHADER sc2_batch_shader;
-void R_BeginSplatBatch(LPCSHADER shader) { sc2_batch_shader = shader; }
+static splat_shader_t *sc2_batch_shader;
+void R_BeginSplatBatch(splat_shader_t *shader) { sc2_batch_shader = shader; }
 void R_AddRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, COLOR32 color) {
     R_RenderRectSplat(mins, maxs, texture, sc2_batch_shader, color);
 }
@@ -180,6 +181,7 @@ void R_GameInit(void) {
 }
 
 void R_GameShutdown(void) {
+    R_SC2ShutdownShaders();
     M3_Shutdown();
 }
 

--- a/games/starcraft-2/renderer/sc2/r_sc2map.c
+++ b/games/starcraft-2/renderer/sc2/r_sc2map.c
@@ -42,8 +42,7 @@ do { \
     (LEVEL)[3] = r_sc2_cliff_level_at_grid((MAP), (X),                          (Y) + SC2_CLIFF_BLOCK_SPAN); \
 } while (0)
 
-/* extern LPCSTR vs_default; SC2 terrain uses its own vertex shader for blend UVs. */
-extern LPCSTR fs_ui;
+/* SC2 terrain uses its own vertex shader for blend UVs. */
 extern m3SequenceTimeline_t const *M3_FindAnimationAtTime(m3Model_t const *model, DWORD time, DWORD *localtime);
 extern VECTOR3 M3_GetVector3AnimValue(m3Model_t const *model,
                                       m3SequenceTimeline_t const *timeline,
@@ -55,16 +54,8 @@ extern VECTOR4 M3_GetVector4AnimValue(m3Model_t const *model,
                                       DWORD time);
 
 static LPMAPSEGMENT sc2_terrain_segment;
-static LPSHADER sc2_terrain_shader;
-static LPSHADER sc2_cliff_shader;
-static GLint sc2_u_layer[SC2_TERRAIN_PASS_LAYERS];
-static GLint sc2_u_mask = -1;
-static GLint sc2_u_world_uv_offset = -1;
-static GLint sc2_u_world_uv_scale = -1;
-static GLint sc2_u_fog_color = -1;
-static GLint sc2_u_fog_params = -1;
-static GLint sc2_u_cliff_fog_color = -1;
-static GLint sc2_u_cliff_fog_params = -1;
+static BOOL sc2_terrain_shader_loaded;
+static BOOL sc2_cliff_shader_loaded;
 static LPTEXTURE sc2_terrain_textures[SC2_TERRAIN_BLEND_LAYERS];
 static LPTEXTURE sc2_terrain_masks[SC2_TERRAIN_BLEND_GROUPS];
 static DWORD sc2_num_terrain_layers;
@@ -81,229 +72,230 @@ typedef struct rSc2CliffPlacement_s {
     FLOAT z_scale;
 } rSc2CliffPlacement_t;
 
-typedef struct rSc2LightUniforms_s {
-    GLint ambient;
-    GLint direction[SC2_MAX_DIRECTIONAL_LIGHTS];
-    GLint color[SC2_MAX_DIRECTIONAL_LIGHTS];
-} rSc2LightUniforms_t;
-
 static sc2CliffModel_t *sc2_cliff_models;
-static rSc2LightUniforms_t sc2_u_terrain_light;
-static rSc2LightUniforms_t sc2_u_cliff_light;
 
 static void r_sc2_release_cliff_models(void);
 static sc2CliffCell_t const *r_sc2_find_cliff_cell(sc2Map_t const *map, DWORD index);
 
-static LPCSTR sc2_vs_terrain =
-"#version 140\n"
-"in vec3 i_position;\n"
-"in vec3 i_normal;\n"
-"in vec4 i_color;\n"
-"out vec2 v_texcoord2;\n"
-"out vec3 v_worldpos;\n"
-"out vec3 v_light;\n"
-"out vec3 v_key;\n"
-"out vec4 v_color;\n"
-"uniform mat4 uViewProjectionMatrix;\n"
-"uniform mat4 uTextureMatrix;\n"
-"uniform mat4 uModelMatrix;\n"
-"uniform mat4 uLightMatrix;\n"
-"out vec4 v_shadow;\n"
-"uniform vec3 uLightAmbient;\n"
-"uniform vec3 uLightDir[3];\n"
-"uniform vec3 uLightColor[3];\n"
-"vec3 vertex_lighting(vec3 normal) {\n"
-"    vec3 n = normalize(normal);\n"
-"    vec3 light = uLightAmbient;\n"
-"    v_key = vec3(0.0);\n"
-"    for (int i = 0; i < 3; i++) {\n"
-"        vec3 l = normalize(uLightDir[i]);\n"
-"        vec3 contribution = uLightColor[i] * max(dot(n, l), 0.0);\n"
-"        light += contribution;\n"
-"        if (i == 0) v_key = contribution;\n"
-"    }\n"
-"    return max(light, vec3(0.0));\n"
-"}\n"
-"void main() {\n"
-"    vec4 pos = uModelMatrix * vec4(i_position, 1.0);\n"
-"    v_texcoord2 = (uTextureMatrix * pos).xy;\n"
-"    v_worldpos = pos.xyz;\n"
-"    v_shadow = uLightMatrix * pos;\n"
-"    v_light = vertex_lighting(mat3(uModelMatrix) * i_normal);\n"
-"    v_color = i_color;\n"
-"    gl_Position = uViewProjectionMatrix * pos;\n"
-"}\n";
+typedef struct SC2TERRAINSTATE {
+    MATRIX4 viewProjection;
+    MATRIX4 textureMatrix;
+    MATRIX4 model;
+    MATRIX4 lightMatrix;
+    VECTOR3 lightAmbient;
+    VECTOR3 lightDir[SC2_MAX_DIRECTIONAL_LIGHTS];
+    VECTOR3 lightColor[SC2_MAX_DIRECTIONAL_LIGHTS];
+    int layer0;
+    int layer1;
+    int layer2;
+    int layer3;
+    int mask;
+    int shadowmap;
+    VECTOR2 worldUVOffset;
+    VECTOR2 worldUVScale;
+    VECTOR4 fogColor;
+    VECTOR4 fogParams;
+} SC2TERRAINSTATE;
+typedef struct SC2TERRAINSTATE *LPSC2TERRAINSTATE;
+typedef const struct SC2TERRAINSTATE *LPCSC2TERRAINSTATE;
+typedef struct SC2TERRAINPROG {
+    SHADERPROG prog;
+    SC2TERRAINSTATE state;
+} SC2TERRAINPROG;
+typedef struct SC2TERRAINPROG *LPSC2TERRAINPROG;
+typedef const struct SC2TERRAINPROG *LPCSC2TERRAINPROG;
 
-static LPCSTR sc2_vs_cliff_texture =
-"#version 140\n"
-"in vec3 i_position;\n"
-"in vec2 i_texcoord;\n"
-"in vec3 i_normal;\n"
-"in vec4 i_color;\n"
-"out vec2 v_texcoord;\n"
-"out vec3 v_worldpos;\n"
-"out vec3 v_light;\n"
-"out vec3 v_key;\n"
-"out vec4 v_color;\n"
-"uniform mat4 uViewProjectionMatrix;\n"
-"uniform mat4 uModelMatrix;\n"
-"uniform mat4 uLightMatrix;\n"
-"out vec4 v_shadow;\n"
-"uniform vec3 uLightAmbient;\n"
-"uniform vec3 uLightDir[3];\n"
-"uniform vec3 uLightColor[3];\n"
-"vec3 vertex_lighting(vec3 normal) {\n"
-"    vec3 n = normalize(normal);\n"
-"    vec3 light = uLightAmbient;\n"
-"    v_key = vec3(0.0);\n"
-"    for (int i = 0; i < 3; i++) {\n"
-"        vec3 l = normalize(uLightDir[i]);\n"
-"        vec3 contribution = uLightColor[i] * max(dot(n, l), 0.0);\n"
-"        light += contribution;\n"
-"        if (i == 0) v_key = contribution;\n"
-"    }\n"
-"    return max(light, vec3(0.0));\n"
-"}\n"
-"void main() {\n"
-"    vec4 pos = uModelMatrix * vec4(i_position, 1.0);\n"
-"    v_texcoord = i_texcoord;\n"
-"    v_worldpos = pos.xyz;\n"
-"    v_shadow = uLightMatrix * pos;\n"
-"    v_light = vertex_lighting(mat3(uModelMatrix) * i_normal);\n"
-"    v_color = i_color;\n"
-"    gl_Position = uViewProjectionMatrix * pos;\n"
-"}\n";
+typedef struct SC2CLIFFSTATE {
+    MATRIX4 viewProjection;
+    MATRIX4 model;
+    MATRIX4 lightMatrix;
+    VECTOR3 lightAmbient;
+    VECTOR3 lightDir[SC2_MAX_DIRECTIONAL_LIGHTS];
+    VECTOR3 lightColor[SC2_MAX_DIRECTIONAL_LIGHTS];
+    int texture;
+    int shadowmap;
+    VECTOR4 fogColor;
+    VECTOR4 fogParams;
+} SC2CLIFFSTATE;
+typedef struct SC2CLIFFSTATE *LPSC2CLIFFSTATE;
+typedef const struct SC2CLIFFSTATE *LPCSC2CLIFFSTATE;
+typedef struct SC2CLIFFPROG {
+    SHADERPROG prog;
+    SC2CLIFFSTATE state;
+} SC2CLIFFPROG;
+typedef struct SC2CLIFFPROG *LPSC2CLIFFPROG;
+typedef const struct SC2CLIFFPROG *LPCSC2CLIFFPROG;
 
-static LPCSTR sc2_fs_terrain =
-"#version 140\n"
-"in vec2 v_texcoord2;\n"
-"in vec3 v_worldpos;\n"
-"in vec3 v_light;\n"
-"in vec3 v_key;\n"
-"in vec4 v_color;\n"
-"out vec4 o_color;\n"
-"in vec4 v_shadow;\n"
-"uniform sampler2D uShadowmap;\n"
-"uniform vec3 uLightAmbient;\n"
-"uniform sampler2D uLayer0;\n"
-"uniform sampler2D uLayer1;\n"
-"uniform sampler2D uLayer2;\n"
-"uniform sampler2D uLayer3;\n"
-"uniform sampler2D uMask;\n"
-"uniform vec2 uWorldUVOffset;\n"
-"uniform vec2 uWorldUVScale;\n"
-"uniform vec4 uFogColor;\n"
-"uniform vec4 uFogParams;\n"
-"vec2 get_mask_coord() {\n"
-"    return clamp(v_texcoord2 * 0.5 + vec2(0.5), vec2(0.0), vec2(1.0));\n"
-"}\n"
-"vec2 get_terrain_coord() {\n"
-"    return (v_texcoord2 * 0.5 + vec2(0.5)) * uWorldUVScale + uWorldUVOffset;\n"
-"}\n"
-"float get_height_fog() {\n"
-"    if (uFogParams.w <= 0.0) return 0.0;\n"
-"    float above = max(v_worldpos.z - uFogParams.x, 0.0);\n"
-"    float vertical = v_worldpos.z <= uFogParams.x ? 1.0 : exp(-above * max(uFogParams.z, 0.0001));\n"
-"    return clamp((uFogParams.y / max(uFogParams.z, 0.0001)) * vertical, 0.0, 1.0) * uFogColor.a;\n"
-"}\n"
-BZ_SHADOW_GLSL
-"void main() {\n"
-"    vec2 mc = get_mask_coord();\n"
-"    vec2 tc = get_terrain_coord();\n"
-"    vec4 w = texture(uMask, mc);\n"
-"    vec4 color = texture(uLayer0, tc) * w.r +\n"
-"                 texture(uLayer1, tc) * w.g +\n"
-"                 texture(uLayer2, tc) * w.b +\n"
-"                 texture(uLayer3, tc) * w.a;\n"
-"    color.rgb *= v_color.rgb;\n"
-"    color.rgb *= (v_light - v_key * (1.0 - shadow_visibility(uShadowmap, v_shadow)));\n"
-"    color.rgb = mix(color.rgb, uFogColor.rgb, get_height_fog());\n"
-"    color.a = 1.0;\n"
-"    o_color = color;\n"
-"}\n";
+static SC2TERRAINPROG sc2_terrain_shader;
+static SC2CLIFFPROG sc2_cliff_shader;
 
-static LPCSTR sc2_fs_cliff =
-"#version 140\n"
-"in vec4 v_color;\n"
-"in vec2 v_texcoord;\n"
-"in vec3 v_worldpos;\n"
-"in vec3 v_light;\n"
-"in vec3 v_key;\n"
-"out vec4 o_color;\n"
-"in vec4 v_shadow;\n"
-"uniform sampler2D uShadowmap;\n"
-"uniform vec3 uLightAmbient;\n"
-"uniform sampler2D uTexture;\n"
-"uniform vec4 uFogColor;\n"
-"uniform vec4 uFogParams;\n"
-"float get_height_fog() {\n"
-"    if (uFogParams.w <= 0.0) return 0.0;\n"
-"    float above = max(v_worldpos.z - uFogParams.x, 0.0);\n"
-"    float vertical = v_worldpos.z <= uFogParams.x ? 1.0 : exp(-above * max(uFogParams.z, 0.0001));\n"
-"    return clamp((uFogParams.y / max(uFogParams.z, 0.0001)) * vertical, 0.0, 1.0) * uFogColor.a;\n"
-"}\n"
-BZ_SHADOW_GLSL
-"void main() {\n"
-"    vec4 color = texture(uTexture, v_texcoord) * v_color;\n"
-"    color.rgb *= (v_light - v_key * (1.0 - shadow_visibility(uShadowmap, v_shadow)));\n"
-"    color.rgb = mix(color.rgb, uFogColor.rgb, get_height_fog());\n"
-"    o_color = color;\n"
-"}\n";
+#define SHADER_TYPE SC2TERRAINSTATE
+static const shader_desc_t sd_sc2_terrain = {
+    .Name = "sc2_terrain",
+    .Uniforms = {
+        UNIFORM(viewProjection, UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(textureMatrix,  UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(model,          UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(lightMatrix,    UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(lightAmbient,   UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM_ARRAY(lightDir,   UT_FLOAT_VEC3, PRECISION_LOW, SC2_MAX_DIRECTIONAL_LIGHTS),
+        UNIFORM_ARRAY(lightColor, UT_FLOAT_VEC3, PRECISION_LOW, SC2_MAX_DIRECTIONAL_LIGHTS),
+        UNIFORM(layer0,         UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(layer1,         UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(layer2,         UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(layer3,         UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(mask,           UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(shadowmap,      UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(worldUVOffset,  UT_FLOAT_VEC2, PRECISION_LOW),
+        UNIFORM(worldUVScale,   UT_FLOAT_VEC2, PRECISION_LOW),
+        UNIFORM(fogColor,       UT_FLOAT_VEC4, PRECISION_LOW),
+        UNIFORM(fogParams,      UT_FLOAT_VEC4, PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(normal,   attrib_normal,   UT_FLOAT_VEC3),
+        ATTRIB(color,    attrib_color,    UT_COLOR),
+    },
+    .Shared = {
+        SHARED(texcoord2, UT_FLOAT_VEC2),
+        SHARED(worldpos,  UT_FLOAT_VEC3),
+        SHARED(light,     UT_FLOAT_VEC3),
+        SHARED(key,       UT_FLOAT_VEC3),
+        SHARED(shadow,    UT_FLOAT_VEC4),
+        SHARED(color,     UT_COLOR),
+    },
+    .VertexBody =
+        "vec3 vertex_lighting(vec3 normal) {\n"
+        "  vec3 n = normalize(normal);\n"
+        "  vec3 light = u_lightAmbient;\n"
+        "  v_key = vec3(0.0);\n"
+        "  for (int i = 0; i < 3; i++) {\n"
+        "    vec3 l = normalize(u_lightDir[i]);\n"
+        "    vec3 contribution = u_lightColor[i] * max(dot(n, l), 0.0);\n"
+        "    light += contribution;\n"
+        "    if (i == 0) v_key = contribution;\n"
+        "  }\n"
+        "  return max(light, vec3(0.0));\n"
+        "}\n"
+        "vec4 vert() {\n"
+        "  vec4 pos = u_model * vec4(a_position, 1.0);\n"
+        "  v_texcoord2 = (u_textureMatrix * pos).xy;\n"
+        "  v_worldpos = pos.xyz;\n"
+        "  v_shadow = u_lightMatrix * pos;\n"
+        "  v_light = vertex_lighting(mat3(u_model) * a_normal);\n"
+        "  v_color = a_color;\n"
+        "  return u_viewProjection * pos;\n"
+        "}\n",
+    .FragmentBody =
+        "vec2 get_mask_coord() {\n"
+        "  return clamp(v_texcoord2 * 0.5 + vec2(0.5), vec2(0.0), vec2(1.0));\n"
+        "}\n"
+        "vec2 get_terrain_coord() {\n"
+        "  return (v_texcoord2 * 0.5 + vec2(0.5)) * u_worldUVScale + u_worldUVOffset;\n"
+        "}\n"
+        "float get_height_fog() {\n"
+        "  if (u_fogParams.w <= 0.0) return 0.0;\n"
+        "  float above = max(v_worldpos.z - u_fogParams.x, 0.0);\n"
+        "  float vertical = v_worldpos.z <= u_fogParams.x ? 1.0 : exp(-above * max(u_fogParams.z, 0.0001));\n"
+        "  return clamp((u_fogParams.y / max(u_fogParams.z, 0.0001)) * vertical, 0.0, 1.0) * u_fogColor.a;\n"
+        "}\n"
+        BZ_SHADOW_GLSL
+        "vec4 frag() {\n"
+        "  vec2 mc = get_mask_coord();\n"
+        "  vec2 tc = get_terrain_coord();\n"
+        "  vec4 w = texture(u_mask, mc);\n"
+        "  vec4 color = texture(u_layer0, tc) * w.r +\n"
+        "               texture(u_layer1, tc) * w.g +\n"
+        "               texture(u_layer2, tc) * w.b +\n"
+        "               texture(u_layer3, tc) * w.a;\n"
+        "  color.rgb *= v_color.rgb;\n"
+        "  color.rgb *= (v_light - v_key * (1.0 - shadow_visibility(u_shadowmap, v_shadow)));\n"
+        "  color.rgb = mix(color.rgb, u_fogColor.rgb, get_height_fog());\n"
+        "  color.a = 1.0;\n"
+        "  return color;\n"
+        "}\n",
+};
+#undef SHADER_TYPE
 
-static void r_sc2_init_light_uniforms(GLuint program, rSc2LightUniforms_t *uniforms) {
-    if (!uniforms)
-        return;
-    uniforms->ambient = glGetUniformLocation(program, "uLightAmbient");
-    FOR_LOOP(i, SC2_MAX_DIRECTIONAL_LIGHTS) {
-        char name[32];
-
-        snprintf(name, sizeof(name), "uLightDir[%u]", (unsigned)i);
-        uniforms->direction[i] = glGetUniformLocation(program, name);
-        snprintf(name, sizeof(name), "uLightColor[%u]", (unsigned)i);
-        uniforms->color[i] = glGetUniformLocation(program, name);
-    }
-}
+#define SHADER_TYPE SC2CLIFFSTATE
+static const shader_desc_t sd_sc2_cliff = {
+    .Name = "sc2_cliff",
+    .Uniforms = {
+        UNIFORM(viewProjection, UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(model,          UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(lightMatrix,    UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(lightAmbient,   UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM_ARRAY(lightDir,   UT_FLOAT_VEC3, PRECISION_LOW, SC2_MAX_DIRECTIONAL_LIGHTS),
+        UNIFORM_ARRAY(lightColor, UT_FLOAT_VEC3, PRECISION_LOW, SC2_MAX_DIRECTIONAL_LIGHTS),
+        UNIFORM(texture,        UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(shadowmap,      UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(fogColor,       UT_FLOAT_VEC4, PRECISION_LOW),
+        UNIFORM(fogParams,      UT_FLOAT_VEC4, PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
+        ATTRIB(normal,   attrib_normal,   UT_FLOAT_VEC3),
+        ATTRIB(color,    attrib_color,    UT_COLOR),
+    },
+    .Shared = {
+        SHARED(texcoord, UT_FLOAT_VEC2),
+        SHARED(worldpos, UT_FLOAT_VEC3),
+        SHARED(light,    UT_FLOAT_VEC3),
+        SHARED(key,      UT_FLOAT_VEC3),
+        SHARED(shadow,   UT_FLOAT_VEC4),
+        SHARED(color,    UT_COLOR),
+    },
+    .VertexBody =
+        "vec3 vertex_lighting(vec3 normal) {\n"
+        "  vec3 n = normalize(normal);\n"
+        "  vec3 light = u_lightAmbient;\n"
+        "  v_key = vec3(0.0);\n"
+        "  for (int i = 0; i < 3; i++) {\n"
+        "    vec3 l = normalize(u_lightDir[i]);\n"
+        "    vec3 contribution = u_lightColor[i] * max(dot(n, l), 0.0);\n"
+        "    light += contribution;\n"
+        "    if (i == 0) v_key = contribution;\n"
+        "  }\n"
+        "  return max(light, vec3(0.0));\n"
+        "}\n"
+        "vec4 vert() {\n"
+        "  vec4 pos = u_model * vec4(a_position, 1.0);\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  v_worldpos = pos.xyz;\n"
+        "  v_shadow = u_lightMatrix * pos;\n"
+        "  v_light = vertex_lighting(mat3(u_model) * a_normal);\n"
+        "  v_color = a_color;\n"
+        "  return u_viewProjection * pos;\n"
+        "}\n",
+    .FragmentBody =
+        "float get_height_fog() {\n"
+        "  if (u_fogParams.w <= 0.0) return 0.0;\n"
+        "  float above = max(v_worldpos.z - u_fogParams.x, 0.0);\n"
+        "  float vertical = v_worldpos.z <= u_fogParams.x ? 1.0 : exp(-above * max(u_fogParams.z, 0.0001));\n"
+        "  return clamp((u_fogParams.y / max(u_fogParams.z, 0.0001)) * vertical, 0.0, 1.0) * u_fogColor.a;\n"
+        "}\n"
+        BZ_SHADOW_GLSL
+        "vec4 frag() {\n"
+        "  vec4 color = texture(u_texture, v_texcoord) * v_color;\n"
+        "  color.rgb *= (v_light - v_key * (1.0 - shadow_visibility(u_shadowmap, v_shadow)));\n"
+        "  color.rgb = mix(color.rgb, u_fogColor.rgb, get_height_fog());\n"
+        "  return color;\n"
+        "}\n",
+};
+#undef SHADER_TYPE
 
 static void r_sc2_init_cliff_shader(void) {
-    if (sc2_cliff_shader) {
-        return;
-    }
-    sc2_cliff_shader = R_InitShader(sc2_vs_cliff_texture, sc2_fs_cliff);
-    if (!sc2_cliff_shader) {
-        return;
-    }
-    R_Call(glUseProgram, sc2_cliff_shader->progid);
-    R_Call(glUniform1i, sc2_cliff_shader->uTexture, 0);
-    sc2_u_cliff_fog_color = glGetUniformLocation(sc2_cliff_shader->progid, "uFogColor");
-    sc2_u_cliff_fog_params = glGetUniformLocation(sc2_cliff_shader->progid, "uFogParams");
-    r_sc2_init_light_uniforms(sc2_cliff_shader->progid, &sc2_u_cliff_light);
+    if (sc2_cliff_shader_loaded) return;
+    R_LoadShader(&sd_sc2_cliff, NULL, &sc2_cliff_shader);
+    sc2_cliff_shader_loaded = true;
 }
 
 static void r_sc2_init_terrain_shader(void) {
-    static LPCSTR layer_names[SC2_TERRAIN_PASS_LAYERS] = {
-        "uLayer0", "uLayer1", "uLayer2", "uLayer3",
-    };
-
-    if (sc2_terrain_shader) {
-        r_sc2_init_cliff_shader();
-        return;
+    if (!sc2_terrain_shader_loaded) {
+        R_LoadShader(&sd_sc2_terrain, NULL, &sc2_terrain_shader);
+        sc2_terrain_shader_loaded = true;
     }
-    sc2_terrain_shader = R_InitShader(sc2_vs_terrain, sc2_fs_terrain);
-    if (!sc2_terrain_shader) {
-        return;
-    }
-    R_Call(glUseProgram, sc2_terrain_shader->progid);
-    FOR_LOOP(i, SC2_TERRAIN_PASS_LAYERS) {
-        sc2_u_layer[i] = glGetUniformLocation(sc2_terrain_shader->progid, layer_names[i]);
-        R_Call(glUniform1i, sc2_u_layer[i], (GLint)i);
-    }
-    sc2_u_mask             = glGetUniformLocation(sc2_terrain_shader->progid, "uMask");
-    sc2_u_world_uv_offset  = glGetUniformLocation(sc2_terrain_shader->progid, "uWorldUVOffset");
-    sc2_u_world_uv_scale   = glGetUniformLocation(sc2_terrain_shader->progid, "uWorldUVScale");
-    sc2_u_fog_color        = glGetUniformLocation(sc2_terrain_shader->progid, "uFogColor");
-    sc2_u_fog_params       = glGetUniformLocation(sc2_terrain_shader->progid, "uFogParams");
-    r_sc2_init_light_uniforms(sc2_terrain_shader->progid, &sc2_u_terrain_light);
-    R_Call(glUniform1i, sc2_u_mask, SC2_TERRAIN_PASS_LAYERS);
     r_sc2_init_cliff_shader();
 }
 
@@ -1300,32 +1292,22 @@ static LPTEXTURE r_sc2_terrain_layer_texture(DWORD index) {
     return sc2_terrain_textures[0];
 }
 
-static void r_sc2_set_fog_uniforms(GLint u_color, GLint u_params) {
+static void r_sc2_set_fog_state(LPVECTOR4 u_color, LPVECTOR4 u_params) {
     sc2Map_t const *map = SC2_MapCurrent();
     sc2MapTerrain_t const *terrain = map ? &map->t3Terrain : NULL;
     COLOR32 color = terrain ? terrain->fog_color : COLOR32_BLACK;
     FLOAT enabled = terrain && terrain->fog_enabled && terrain->fog_density > 0.0f ? 1.0f : 0.0f;
 
-    R_Call(glUniform4f, u_color,
-           color.r / 255.0f,
-           color.g / 255.0f,
-           color.b / 255.0f,
-           color.a / 255.0f);
-    R_Call(glUniform4f, u_params,
-           terrain ? terrain->fog_start_height : 0.0f,
-           terrain ? terrain->fog_density : 0.0f,
-           terrain ? terrain->fog_falloff : 0.0f,
-           enabled);
+    *u_color = (VECTOR4){ color.r / 255.0f, color.g / 255.0f, color.b / 255.0f, color.a / 255.0f };
+    *u_params = (VECTOR4){ terrain ? terrain->fog_start_height : 0.0f, terrain ? terrain->fog_density : 0.0f, terrain ? terrain->fog_falloff : 0.0f, enabled };
 }
 
-static void r_sc2_set_light_uniforms(rSc2LightUniforms_t const *uniforms) {
+static void r_sc2_set_light_state(LPVECTOR3 ambient_out, LPVECTOR3 dirs, LPVECTOR3 colors) {
     sc2Map_t const *map = SC2_MapCurrent();
     sc2MapLighting_t const *lighting = map ? &map->lighting : NULL;
     VECTOR3 ambient = lighting && lighting->enabled ? lighting->ambient_color : (VECTOR3){ 1.0f, 1.0f, 1.0f };
 
-    if (!uniforms)
-        return;
-    R_Call(glUniform3f, uniforms->ambient, ambient.x, ambient.y, ambient.z);
+    *ambient_out = (VECTOR3){ ambient.x, ambient.y, ambient.z };
     FOR_LOOP(i, SC2_MAX_DIRECTIONAL_LIGHTS) {
         sc2DirectionalLight_t const *light = lighting && lighting->enabled ? &lighting->directional[i] : NULL;
         FLOAT enabled = light && light->enabled ? 1.0f : 0.0f;
@@ -1333,23 +1315,22 @@ static void r_sc2_set_light_uniforms(rSc2LightUniforms_t const *uniforms) {
         VECTOR3 color = enabled ? light->color : (VECTOR3){ 0.0f, 0.0f, 0.0f };
         FLOAT multiplier = enabled ? light->color_multiplier : 0.0f;
 
-        R_Call(glUniform3f, uniforms->direction[i], direction.x, direction.y, direction.z);
-        R_Call(glUniform3f, uniforms->color[i], color.x * multiplier, color.y * multiplier, color.z * multiplier);
+        dirs[i] = (VECTOR3){ direction.x, direction.y, direction.z };
+        colors[i] = (VECTOR3){ color.x * multiplier, color.y * multiplier, color.z * multiplier };
     }
 }
 
 static void r_sc2_begin_terrain_shader(MATRIX4 const *model_matrix) {
-    R_Call(glUseProgram, sc2_terrain_shader->progid);
-    /* The depth pass must use the same light projection later sampled by receivers. */
-    R_Call(glUniformMatrix4fv, sc2_terrain_shader->uViewProjectionMatrix, 1, GL_FALSE, is_rendering_lights ? tr.viewDef.lightMatrix.v : tr.viewDef.viewProjectionMatrix.v);
-    R_Call(glUniformMatrix4fv, sc2_terrain_shader->uLightMatrix, 1, GL_FALSE, tr.viewDef.lightMatrix.v);
-    R_Call(glUniform1i, sc2_terrain_shader->uShadowmap, 5);
-    R_Call(glActiveTexture, GL_TEXTURE5);
+
+    sc2_terrain_shader.state.viewProjection = is_rendering_lights ? tr.viewDef.lightMatrix : tr.viewDef.viewProjectionMatrix;
+    sc2_terrain_shader.state.lightMatrix = tr.viewDef.lightMatrix;
+    sc2_terrain_shader.state.model = *model_matrix;
+    sc2_terrain_shader.state.textureMatrix = tr.viewDef.textureMatrix;
+    r_sc2_set_fog_state(&sc2_terrain_shader.state.fogColor, &sc2_terrain_shader.state.fogParams);
+    r_sc2_set_light_state(&sc2_terrain_shader.state.lightAmbient, sc2_terrain_shader.state.lightDir, sc2_terrain_shader.state.lightColor);
+    /* Depth pass samples a white texture; receivers sample the light-space depth map. */
+    R_Call(glActiveTexture, GL_TEXTURE0 + sc2_terrain_shader.state.shadowmap);
     R_Call(glBindTexture, GL_TEXTURE_2D, is_rendering_lights ? tr.texture[TEX_WHITE]->texid : tr.rt[RT_DEPTHMAP]->texture);
-    R_Call(glUniformMatrix4fv, sc2_terrain_shader->uModelMatrix, 1, GL_FALSE, model_matrix->v);
-    R_Call(glUniformMatrix4fv, sc2_terrain_shader->uTextureMatrix, 1, GL_FALSE, tr.viewDef.textureMatrix.v);
-    r_sc2_set_fog_uniforms(sc2_u_fog_color, sc2_u_fog_params);
-    r_sc2_set_light_uniforms(&sc2_u_terrain_light);
 }
 
 static void r_sc2_begin_terrain_pass(DWORD group) {
@@ -1372,14 +1353,15 @@ static void r_sc2_set_terrain_uv(void) {
     FLOAT map_w = bounds.max.x - bounds.min.x;
     FLOAT map_h = bounds.max.y - bounds.min.y;
 
-    R_Call(glUniform2f, sc2_u_world_uv_scale, map_w / SC2_TERRAIN_UV_SCALE, map_h / SC2_TERRAIN_UV_SCALE);
-    R_Call(glUniform2f, sc2_u_world_uv_offset, bounds.min.x / SC2_TERRAIN_UV_SCALE, bounds.min.y / SC2_TERRAIN_UV_SCALE);
+    sc2_terrain_shader.state.worldUVScale = (VECTOR2){ map_w / SC2_TERRAIN_UV_SCALE, map_h / SC2_TERRAIN_UV_SCALE };
+    sc2_terrain_shader.state.worldUVOffset = (VECTOR2){ bounds.min.x / SC2_TERRAIN_UV_SCALE, bounds.min.y / SC2_TERRAIN_UV_SCALE };
 }
 
 static void r_sc2_draw_terrain_indexed(LPCMAPLAYER layer) {
     r_sc2_set_terrain_uv();
     FOR_LOOP(group, SC2_TERRAIN_BLEND_GROUPS) {
         r_sc2_begin_terrain_pass(group);
+        R_ApplyShader(&sc2_terrain_shader);
         R_DrawIndexedBuffer(layer->buffer, layer->num_indices);
     }
     R_Call(glDisable, GL_BLEND);
@@ -1390,6 +1372,7 @@ static void r_sc2_draw_terrain_vertices(LPCMAPLAYER layer) {
     r_sc2_set_terrain_uv();
     FOR_LOOP(group, SC2_TERRAIN_BLEND_GROUPS) {
         r_sc2_begin_terrain_pass(group);
+        R_ApplyShader(&sc2_terrain_shader);
         R_DrawBuffer(layer->buffer, layer->num_vertices);
     }
     R_Call(glDisable, GL_BLEND);
@@ -1400,7 +1383,7 @@ static void r_sc2_draw_ground_layer(LPCMAPSEGMENT segment) {
     LPCMAPLAYER layer;
     MATRIX4 model_matrix;
 
-    if (!sc2_terrain_shader || !segment)
+    if (!sc2_terrain_shader_loaded || !segment)
         return;
     layer = segment->layers;
     while (layer && layer->type != MAPLAYERTYPE_GROUND) {
@@ -1425,6 +1408,14 @@ static void r_sc2_load_minimap(LPCSTR mapFileName) {
     }
 }
 
+/* World shaders survive map changes but must be released with their renderer context. */
+void R_SC2ShutdownShaders(void) {
+    /* Only shader ownership ends here: the renderer has already reclaimed registered models. */
+    R_DeleteShader(&sc2_terrain_shader.prog);
+    R_DeleteShader(&sc2_cliff_shader.prog);
+    sc2_terrain_shader_loaded = sc2_cliff_shader_loaded = false;
+}
+
 void R_SC2RegisterMap(LPCSTR mapFileName) {
     SC2_MapSetHost(&(sc2MapHost_t){
         .read_file = r_sc2_read_file,
@@ -1442,7 +1433,7 @@ static void r_sc2_draw_cliff_layer(LPCMAPSEGMENT segment) {
     LPCMAPLAYER layer;
     MATRIX4 model_matrix;
 
-    if (!sc2_terrain_shader || !sc2_cliff_shader || !segment)
+    if (!sc2_terrain_shader_loaded || !sc2_cliff_shader_loaded || !segment)
         return;
     layer = segment->layers;
     while (layer && layer->type != MAPLAYERTYPE_CLIFF) {
@@ -1461,20 +1452,18 @@ static void r_sc2_draw_cliff_layer(LPCMAPSEGMENT segment) {
     /* Pass 2: cliff M3 texture alpha-blended on top, pulled slightly forward */
     R_Call(glEnable, GL_POLYGON_OFFSET_FILL);
     R_Call(glPolygonOffset, -1.0f, -1.0f);
-    R_Call(glUseProgram, sc2_cliff_shader->progid);
-    /* The depth pass must use the same light projection later sampled by receivers. */
-    R_Call(glUniformMatrix4fv, sc2_cliff_shader->uViewProjectionMatrix, 1, GL_FALSE, is_rendering_lights ? tr.viewDef.lightMatrix.v : tr.viewDef.viewProjectionMatrix.v);
-    R_Call(glUniformMatrix4fv, sc2_cliff_shader->uLightMatrix, 1, GL_FALSE, tr.viewDef.lightMatrix.v);
-    R_Call(glUniform1i, sc2_cliff_shader->uShadowmap, 5);
-    R_Call(glActiveTexture, GL_TEXTURE5);
+
+    sc2_cliff_shader.state.viewProjection = is_rendering_lights ? tr.viewDef.lightMatrix : tr.viewDef.viewProjectionMatrix;
+    sc2_cliff_shader.state.lightMatrix = tr.viewDef.lightMatrix;
+    sc2_cliff_shader.state.model = model_matrix;
+    r_sc2_set_fog_state(&sc2_cliff_shader.state.fogColor, &sc2_cliff_shader.state.fogParams);
+    r_sc2_set_light_state(&sc2_cliff_shader.state.lightAmbient, sc2_cliff_shader.state.lightDir, sc2_cliff_shader.state.lightColor);
+    R_Call(glActiveTexture, GL_TEXTURE0 + sc2_cliff_shader.state.shadowmap);
     R_Call(glBindTexture, GL_TEXTURE_2D, is_rendering_lights ? tr.texture[TEX_WHITE]->texid : tr.rt[RT_DEPTHMAP]->texture);
-    R_Call(glUniformMatrix4fv, sc2_cliff_shader->uModelMatrix, 1, GL_FALSE, model_matrix.v);
-    R_Call(glUniformMatrix4fv, sc2_cliff_shader->uTextureMatrix, 1, GL_FALSE, tr.viewDef.textureMatrix.v);
-    r_sc2_set_fog_uniforms(sc2_u_cliff_fog_color, sc2_u_cliff_fog_params);
-    r_sc2_set_light_uniforms(&sc2_u_cliff_light);
     R_Call(glEnable, GL_BLEND);
     R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     R_BindTexture(layer->texture, 0);
+    R_ApplyShader(&sc2_cliff_shader);
     R_DrawBuffer(layer->buffer, layer->num_vertices);
     R_Call(glDisable, GL_POLYGON_OFFSET_FILL);
     R_Call(glPolygonOffset, 0.0f, 0.0f);
@@ -1500,9 +1489,8 @@ void R_SC2DrawWorld(void) {
     }
     Matrix4_identity(&model_matrix);
 
-    R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uModelMatrix, 1, GL_FALSE, model_matrix.v);
+    tr.shader_ui.state.viewProjection = tr.viewDef.viewProjectionMatrix;
+    tr.shader_ui.state.model = model_matrix;
     R_Call(glDisable, GL_CULL_FACE);
     R_Call(glEnable, GL_DEPTH_TEST);
     R_Call(glDepthMask, GL_TRUE);

--- a/games/starcraft-2/renderer/sc2/r_sc2map.c
+++ b/games/starcraft-2/renderer/sc2/r_sc2map.c
@@ -1,6 +1,6 @@
 #include "r_sc2map.h"
 #include "renderer/r_shader.h"
-extern bool is_rendering_lights;
+extern render_phase_t render_phase;
 
 #include "games/starcraft-2/common/sc2_map.c"
 #include "games/starcraft-2/renderer/m3/r_m3.h"
@@ -1322,7 +1322,7 @@ static void r_sc2_set_light_state(LPVECTOR3 ambient_out, LPVECTOR3 dirs, LPVECTO
 
 static void r_sc2_begin_terrain_shader(MATRIX4 const *model_matrix) {
 
-    sc2_terrain_shader.state.viewProjection = is_rendering_lights ? tr.viewDef.lightMatrix : tr.viewDef.viewProjectionMatrix;
+    sc2_terrain_shader.state.viewProjection = render_phase == RENDER_PHASE_LIGHTS ? tr.viewDef.lightMatrix : tr.viewDef.viewProjectionMatrix;
     sc2_terrain_shader.state.lightMatrix = tr.viewDef.lightMatrix;
     sc2_terrain_shader.state.model = *model_matrix;
     sc2_terrain_shader.state.textureMatrix = tr.viewDef.textureMatrix;
@@ -1330,7 +1330,7 @@ static void r_sc2_begin_terrain_shader(MATRIX4 const *model_matrix) {
     r_sc2_set_light_state(&sc2_terrain_shader.state.lightAmbient, sc2_terrain_shader.state.lightDir, sc2_terrain_shader.state.lightColor);
     /* Depth pass samples a white texture; receivers sample the light-space depth map. */
     R_Call(glActiveTexture, GL_TEXTURE0 + sc2_terrain_shader.state.shadowmap);
-    R_Call(glBindTexture, GL_TEXTURE_2D, is_rendering_lights ? tr.texture[TEX_WHITE]->texid : tr.rt[RT_DEPTHMAP]->texture);
+    R_Call(glBindTexture, GL_TEXTURE_2D, render_phase == RENDER_PHASE_LIGHTS ? tr.texture[TEX_WHITE]->texid : tr.rt[RT_DEPTHMAP]->texture);
 }
 
 static void r_sc2_begin_terrain_pass(DWORD group) {
@@ -1453,13 +1453,13 @@ static void r_sc2_draw_cliff_layer(LPCMAPSEGMENT segment) {
     R_Call(glEnable, GL_POLYGON_OFFSET_FILL);
     R_Call(glPolygonOffset, -1.0f, -1.0f);
 
-    sc2_cliff_shader.state.viewProjection = is_rendering_lights ? tr.viewDef.lightMatrix : tr.viewDef.viewProjectionMatrix;
+    sc2_cliff_shader.state.viewProjection = render_phase == RENDER_PHASE_LIGHTS ? tr.viewDef.lightMatrix : tr.viewDef.viewProjectionMatrix;
     sc2_cliff_shader.state.lightMatrix = tr.viewDef.lightMatrix;
     sc2_cliff_shader.state.model = model_matrix;
     r_sc2_set_fog_state(&sc2_cliff_shader.state.fogColor, &sc2_cliff_shader.state.fogParams);
     r_sc2_set_light_state(&sc2_cliff_shader.state.lightAmbient, sc2_cliff_shader.state.lightDir, sc2_cliff_shader.state.lightColor);
     R_Call(glActiveTexture, GL_TEXTURE0 + sc2_cliff_shader.state.shadowmap);
-    R_Call(glBindTexture, GL_TEXTURE_2D, is_rendering_lights ? tr.texture[TEX_WHITE]->texid : tr.rt[RT_DEPTHMAP]->texture);
+    R_Call(glBindTexture, GL_TEXTURE_2D, render_phase == RENDER_PHASE_LIGHTS ? tr.texture[TEX_WHITE]->texid : tr.rt[RT_DEPTHMAP]->texture);
     R_Call(glEnable, GL_BLEND);
     R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     R_BindTexture(layer->texture, 0);
@@ -1475,7 +1475,7 @@ void R_SC2DrawWorld(void) {
     if (!sc2_terrain_segment || (tr.viewDef.rdflags & RDF_NOWORLDMODEL))
         return;
 
-    if (is_rendering_lights) {
+    if (render_phase == RENDER_PHASE_LIGHTS) {
         sc2Map_t const *map = SC2_MapCurrent();
         SC2SHADOWVIEW input = {
             .camera = tr.viewDef.viewProjectionMatrix,

--- a/games/starcraft-2/renderer/sc2/r_sc2map.h
+++ b/games/starcraft-2/renderer/sc2/r_sc2map.h
@@ -4,6 +4,7 @@
 #include "renderer/r_game.h"
 #include "games/starcraft-2/common/sc2_map.h"
 
+void      R_SC2ShutdownShaders(void);
 void      R_SC2RegisterMap(LPCSTR mapFileName);
 void      R_SC2DrawWorld(void);
 bool      R_SC2TraceLocation(viewDef_t const *viewdef, FLOAT x, FLOAT y, LPVECTOR3 output);

--- a/games/warcraft-3/renderer/mdx/r_mdx.h
+++ b/games/warcraft-3/renderer/mdx/r_mdx.h
@@ -371,7 +371,7 @@ typedef struct mdxModel_s {
 } mdxModel_t;
 
 typedef struct {
-    LPSHADER shader;
+    MODELPROG * shader;
 } mdlx_state_t;
 
 extern mdlx_state_t mdlx;

--- a/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
@@ -6,7 +6,7 @@
 #include <string.h>
 
 #ifdef USE_SHADOWMAPS
-extern bool is_rendering_lights;
+extern render_phase_t render_phase;
 #endif
 
 #define MDLX_STACK_DRAW_ORDER 64
@@ -155,7 +155,7 @@ static void MDLX_RenderTailEmitter(mdxModel_t const *model,
 static bool MDLX_SetBlendMode(const mdxMaterialLayer_t *layer, DWORD layerID) {
     R_SetAlphaKeyState(false);
 #ifdef USE_SHADOWMAPS
-    switch (is_rendering_lights ? (int)layer->blendMode : -1) {
+    switch (render_phase == RENDER_PHASE_LIGHTS ? (int)layer->blendMode : -1) {
         case BLEND_MODE_BLEND:
         case BLEND_MODE_ADD:
         case BLEND_MODE_ADDALPHA:
@@ -807,7 +807,7 @@ void MDX_RenderModel(renderEntity_t const *entity,
     MATRIX3 normalMatrix;
     GLfloat const *viewProjectionMatrix =
 #ifdef USE_SHADOWMAPS
-        is_rendering_lights ? tr.viewDef.lightMatrix.v :
+        render_phase == RENDER_PHASE_LIGHTS ? tr.viewDef.lightMatrix.v :
 #endif
         tr.viewDef.viewProjectionMatrix.v;
     Matrix3_normal(&normalMatrix, transform);

--- a/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
@@ -175,7 +175,7 @@ static bool MDLX_SetBlendMode(const mdxMaterialLayer_t *layer, DWORD layerID) {
             R_Call(glDepthMask, GL_TRUE);
             break;
         case BLEND_MODE_ALPHAKEY:
-            R_Call(glUniform1i, mdlx.shader->uAlphaKey, 1);
+            mdlx.shader->state.alphaKey = 1;
             R_SetAlphaKeyState(true);
             break;
         case BLEND_MODE_BLEND:
@@ -357,10 +357,9 @@ static void MDLX_BindLayerTextureAnimation(mdxModel_t const *model,
         float tx = scale.x * (c * (translation.x - 0.5f) - s * (translation.y - 0.5f)) + 0.5f;
         float ty = scale.y * (s * (translation.x - 0.5f) + c * (translation.y - 0.5f)) + 0.5f;
         GLfloat m[9] = { scale.x*c, scale.y*s, 0, -scale.x*s, scale.y*c, 0, tx, ty, 1 };
-        R_Call(glUniformMatrix3fv, mdlx.shader->uUvMatrix, 1, GL_FALSE, m);
+        memcpy(&mdlx.shader->state.uvMatrix, m, (1) * sizeof(MATRIX3));
     }
 }
-
 
 static void MDLX_BindGeosetMatrixPalette(mdxModel_t const *model, mdxGeoset_t const *geoset) {
     MATRIX4 matrixPalette[MDX_MATRIX_PALETTE];
@@ -379,7 +378,7 @@ static void MDLX_BindGeosetMatrixPalette(mdxModel_t const *model, mdxGeoset_t co
         }
     }
 
-    R_Call(glUniformMatrix4fv, mdlx.shader->uBones, count, GL_FALSE, matrixPalette->v);
+    memcpy(&mdlx.shader->state.bones, matrixPalette->v, (count) * sizeof(MATRIX4));
 }
 
 static VECTOR4 MDLX_EvaluateGeosetColor(mdxModel_t const *model,
@@ -456,7 +455,7 @@ static void MDLX_RenderGeoset(mdxModel_t const *model,
                              bool blendedPass)
 {
     BOOL force_two_sided = model && !model->cameras;
-    LPSHADER shader = mdlx.shader;
+    MODELPROG * shader = mdlx.shader;
     VECTOR4 geosetColor;
 
     if (!MDLX_MaterialHasPass(material, blendedPass)) {
@@ -465,8 +464,8 @@ static void MDLX_RenderGeoset(mdxModel_t const *model,
 
     geosetColor = MDLX_EvaluateGeosetColor(model, geoset, frame);
     MDLX_BindGeosetMatrixPalette(model, geoset);
-    R_Call(glUniform1f, shader->uLayerAlpha, 1.0f);
-    R_Call(glUniform4f, shader->uGeosetColor, geosetColor.x, geosetColor.y, geosetColor.z, geosetColor.w);
+    shader->state.layerAlpha = 1.0f;
+    shader->state.geosetColor = (VECTOR4){ geosetColor.x, geosetColor.y, geosetColor.z, geosetColor.w };
 
     FOR_LOOP(layerID, material->num_layers) {
         mdxMaterialLayer_t const *layer = &material->layers[layerID];
@@ -476,7 +475,7 @@ static void MDLX_RenderGeoset(mdxModel_t const *model,
             continue;
         }
         R_Call(glEnable, GL_DEPTH_TEST);
-        R_Call(glUniform1i, shader->uAlphaKey, 0);
+        shader->state.alphaKey = 0;
         if (force_two_sided) {
             R_Call(glDisable, GL_CULL_FACE);
         } else {
@@ -488,7 +487,7 @@ static void MDLX_RenderGeoset(mdxModel_t const *model,
             continue;
         MDLX_ApplyLayerFlags(layer);
         BOOL unshaded = forceUnshaded || (layer->flags & MODEL_GEO_UNSHADED);
-        R_Call(glUniform1i, shader->uUnshaded, unshaded);
+        shader->state.unshaded = unshaded;
         /* Fog only affects opaque/alpha-blended geometry.  Additive and
          * modulate layers (glows, the blue spire flare) must NOT mix toward
          * the fog colour or they turn into solid fog-coloured quads. */
@@ -497,12 +496,12 @@ static void MDLX_RenderGeoset(mdxModel_t const *model,
                 (layer->blendMode == BLEND_MODE_NONE ||
                  layer->blendMode == BLEND_MODE_ALPHAKEY ||
                  layer->blendMode == BLEND_MODE_BLEND);
-            R_Call(glUniform1i, shader->uFogEnable, layerFog ? 1 : 0);
+            shader->state.fogEnable = layerFog ? 1 : 0;
         }
         alpha = MDLX_EvaluateLayerAlpha(model, material, layer, frame);
         if (alpha < EPSILON)
             continue;
-        R_Call(glUniform1f, shader->uLayerAlpha, alpha);
+        shader->state.layerAlpha = alpha;
         MDLX_BindLayerTextureAnimation(model, layer, frame);
         DWORD textureId = MDLX_EvaluateLayerTextureId(model, layer, frame);
         mdxTexture_t const *modeltex = &model->textures[textureId];
@@ -511,6 +510,7 @@ static void MDLX_RenderGeoset(mdxModel_t const *model,
         R_Call(glBindVertexArray, geoset->vertexArrayBuffer);
         R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, *geoset->buffer);
         R_StatsDraw(GL_TRIANGLES, geoset->num_triangles, 1);
+        R_ApplyShader(shader);
         R_Call(glDrawElements, GL_TRIANGLES, geoset->num_triangles, GL_UNSIGNED_SHORT, NULL);
     }
 
@@ -519,9 +519,9 @@ static void MDLX_RenderGeoset(mdxModel_t const *model,
     R_SetAlphaKeyState(false);
     R_Call(glCullFace, GL_BACK);
     R_Call(glDepthMask, GL_TRUE);
-    R_Call(glUniform1i, shader->uUnshaded, forceUnshaded);
-    R_Call(glUniform1f, shader->uLayerAlpha, 1.0f);
-    R_Call(glUniform4f, shader->uGeosetColor, 1.0f, 1.0f, 1.0f, 1.0f);
+    shader->state.unshaded = forceUnshaded;
+    shader->state.layerAlpha = 1.0f;
+    shader->state.geosetColor = (VECTOR4){ 1.0f, 1.0f, 1.0f, 1.0f };
 }
 
 mdxSequence_t const *MDLX_FindSequenceByName(mdxModel_t const *model, LPCSTR name) {
@@ -803,7 +803,7 @@ void MDX_RenderModel(renderEntity_t const *entity,
         entity = &ent;
     }
     
-    LPSHADER shader = mdlx.shader;
+    MODELPROG * shader = mdlx.shader;
     MATRIX3 normalMatrix;
     GLfloat const *viewProjectionMatrix =
 #ifdef USE_SHADOWMAPS
@@ -811,10 +811,10 @@ void MDX_RenderModel(renderEntity_t const *entity,
 #endif
         tr.viewDef.viewProjectionMatrix.v;
     Matrix3_normal(&normalMatrix, transform);
-    R_Call(glUseProgram, shader->progid);
-    R_Call(glUniformMatrix4fv, shader->uModelMatrix, 1, GL_FALSE, transform->v);
-    R_Call(glUniformMatrix3fv, shader->uNormalMatrix, 1, GL_TRUE, normalMatrix.v);
-    R_Call(glUniform1i, shader->uUnshaded, (entity->flags & RF_NO_LIGHTING) != 0);
+
+    shader->state.model = *transform;
+    shader->state.normalMatrix = normalMatrix;
+    shader->state.unshaded = (entity->flags & RF_NO_LIGHTING) != 0;
 
     /* uViewProjectionMatrix/uTextureMatrix/uLightMatrix/fog uniforms are the
        same for every entity drawn within one R_DrawEntities pass (one view).
@@ -837,15 +837,14 @@ void MDX_RenderModel(renderEntity_t const *entity,
              || last.fogStart != tr.viewDef.fogStart
              || last.fogEnd != tr.viewDef.fogEnd));
     if (view_changed) {
-        R_Call(glUniformMatrix4fv, shader->uViewProjectionMatrix, 1, GL_FALSE, viewProjectionMatrix);
-        R_Call(glUniformMatrix4fv, shader->uTextureMatrix, 1, GL_FALSE, tr.viewDef.textureMatrix.v);
-        R_Call(glUniformMatrix4fv, shader->uLightMatrix, 1, GL_FALSE, tr.viewDef.lightMatrix.v);
-        R_Call(glUniform1i, shader->uFogEnable, tr.viewDef.fogEnable ? 1 : 0);
-        R_Call(glUniform1f, shader->uFirstBoneLookupIndex, 0.0f);
+        memcpy(&shader->state.viewProjection, viewProjectionMatrix, (1) * sizeof(MATRIX4));
+        shader->state.textureMatrix = tr.viewDef.textureMatrix;
+        shader->state.lightMatrix = tr.viewDef.lightMatrix;
+        shader->state.fogEnable = tr.viewDef.fogEnable ? 1 : 0;
+        shader->state.firstBoneLookupIndex = 0.0f;
         if (tr.viewDef.fogEnable) {
-            R_Call(glUniform3f, shader->uFogColor,
-                   tr.viewDef.fogColor.x, tr.viewDef.fogColor.y, tr.viewDef.fogColor.z);
-            R_Call(glUniform2f, shader->uFogParams, tr.viewDef.fogStart, tr.viewDef.fogEnd);
+            shader->state.fogColor = (VECTOR3){ tr.viewDef.fogColor.x, tr.viewDef.fogColor.y, tr.viewDef.fogColor.z };
+            shader->state.fogParams = (VECTOR2){ tr.viewDef.fogStart, tr.viewDef.fogEnd };
         }
         memcpy(last.vp, viewProjectionMatrix, sizeof(last.vp));
         last.tex = tr.viewDef.textureMatrix;

--- a/games/warcraft-3/renderer/r_game.c
+++ b/games/warcraft-3/renderer/r_game.c
@@ -89,7 +89,7 @@ void R_GameDrawMinimap(LPCRECT screen) {
     LPCTEXTURE tex = tr.minimap ? tr.minimap : tr.texture[TEX_WHITE];
     R_DrawImage(tex, screen, &MAKE(RECT, 0, 0, 1, 1), COLOR32_WHITE);
 
-    if (tr.world && tr.shader[SHADER_MINIMAP_FOG]) {
+    if (tr.world && tr.shader_minimapFog.prog.progid) {
         DWORD const fow_texid = R_GetMinimapFogOfWarTexture();
         if (fow_texid && (!tr.texture[TEX_WHITE] || fow_texid != tr.texture[TEX_WHITE]->texid)) {
             TEXTURE fog_texture = {

--- a/games/warcraft-3/renderer/w3m/r_terrain_layers.c
+++ b/games/warcraft-3/renderer/w3m/r_terrain_layers.c
@@ -7,6 +7,7 @@ void R_DrawTerrainSegment(LPCMAPSEGMENT segment, DWORD mask) {
         if (((1 << layer->type) & mask) == 0)
             continue;
         R_BindTexture(layer->texture, 0);
+        R_ApplyShader(&tr.shader_default);
         R_DrawBuffer(layer->buffer, layer->num_vertices);
     }
 }

--- a/games/warcraft-3/renderer/w3m/r_war3map.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map.c
@@ -3,7 +3,6 @@
 LPMAPSEGMENT g_mapSegments = NULL;
 LPMAPLAYER g_groundLayers = NULL;
 
-
 static void R_FileReadShadowMap(HANDLE hMpq, LPWAR3MAP  pWorld) {
     HANDLE file;
     if (!SFileOpenFileEx(hMpq, "war3map.shd", SFILE_OPEN_FROM_MPQ, &file)) {
@@ -247,14 +246,13 @@ void R_DrawTerrainShadows(void) {
     };
     COLOR32 shadowColor = {0, 0, 0, 255};
 
-    R_RenderRectSplat(&mins, &maxs, tr.texture[TEX_TERRAIN_SHADOW], tr.shader[SHADER_SHADOWSPLAT], shadowColor);
+    R_RenderRectSplat(&mins, &maxs, tr.texture[TEX_TERRAIN_SHADOW], R_SPLAT_SHADER(&tr.shader_shadowSplat), shadowColor);
 }
 
 void R_DrawWorld(void) {
     if (tr.viewDef.rdflags & RDF_NOWORLDMODEL)
         return;
 
-    R_Call(glUseProgram, tr.shader[SHADER_DEFAULT]->progid);
     R_Call(glEnable, GL_DEPTH_TEST);
     R_Call(glDepthMask, GL_TRUE);
     R_Call(glDepthFunc, GL_LEQUAL);
@@ -267,6 +265,7 @@ void R_DrawWorld(void) {
             R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         }
         R_BindTexture(layer->texture, 0);
+        R_ApplyShader(&tr.shader_default);
         R_DrawBuffer(layer->buffer, layer->num_vertices);
     }
 
@@ -280,8 +279,7 @@ void R_DrawWorld(void) {
 void R_DrawAlphaSurfaces(void) {
     if (tr.viewDef.rdflags & RDF_NOWORLDMODEL)
         return;
-    
-    R_Call(glUseProgram, tr.shader[SHADER_DEFAULT]->progid);
+
     R_Call(glEnable, GL_BLEND);
     R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     R_Call(glDepthMask, GL_FALSE);

--- a/games/warcraft-3/renderer/w3m/r_war3map_ground.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_ground.c
@@ -47,7 +47,6 @@ DWORD IsMidRamp(LPCWAR3MAPVERTEX mv) {
         (mv[3].cliffVariation && mv[3].ramp);
 }
 
-
 static void R_MakeTile(LPCWAR3MAP map, DWORD x, DWORD y, DWORD ground, LPCTEXTURE texture) {
     struct War3MapVertex tile[4];
     GetTileVertices(x, y, map, tile);
@@ -178,9 +177,9 @@ static void R_FlushSplatBatch(void) {
  * splats in a batch share this state; only the texture and per-tile geometry
  * vary, so re-issuing it per splat was pure overhead. */
 static LPCTEXTURE g_splat_texture;
-static LPCSHADER g_splat_shader;
+static splat_shader_t *g_splat_shader;
 
-static void R_SetupSplatState(LPCTEXTURE texture, LPCSHADER shader) {
+static void R_SetupSplatState(LPCTEXTURE texture, splat_shader_t *shader) {
     MATRIX4 mModelMatrix;
 
     Matrix4_identity(&mModelMatrix);
@@ -188,15 +187,16 @@ static void R_SetupSplatState(LPCTEXTURE texture, LPCSHADER shader) {
     g_splat_shader = shader;
     R_BindTexture(texture, 0);
     R_SetTextureWrap(texture, false, false); /* splats are decals, so repeating the source texture smears the edges */
-    R_Call(glUseProgram, shader->progid);
-    R_Call(glUniformMatrix4fv, shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
-    R_Call(glUniformMatrix4fv, shader->uModelMatrix, 1, GL_FALSE, mModelMatrix.v);
+
+    shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
+    shader->state.model = mModelMatrix;
     R_Call(glEnable, GL_BLEND);
     R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     R_Call(glDepthMask, GL_FALSE);
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     ground_current_vertex = ground_vertex_buffer;
+    R_ApplyShader(shader);
 }
 
 /* Emit terrain-conforming tiles for one splat rect into the shared buffer,
@@ -233,7 +233,7 @@ static void R_GenerateSplatTiles(LPCVECTOR2 mins, LPCVECTOR2 maxs, COLOR32 color
     }
 }
 
-void R_BeginSplatBatch(LPCSHADER shader) {
+void R_BeginSplatBatch(splat_shader_t *shader) {
     g_splat_shader = shader;
     g_splat_texture = NULL;
     ground_current_vertex = ground_vertex_buffer;
@@ -258,7 +258,7 @@ void R_EndSplatBatch(void) {
 void R_RenderRectSplat(LPCVECTOR2 mins,
                        LPCVECTOR2 maxs,
                        LPCTEXTURE texture,
-                       LPCSHADER shader,
+                       splat_shader_t *shader,
                        COLOR32 color)
 {
     if (!tr.world || !texture) {
@@ -345,7 +345,7 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins,
                            LPCVECTOR2 maxs,
                            FLOAT z,
                            LPCTEXTURE texture,
-                           LPCSHADER shader,
+                           splat_shader_t *shader,
                            COLOR32 color)
 {
     MATRIX4 model_matrix;
@@ -368,9 +368,9 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins,
 
     R_BindTexture(texture, 0);
     R_SetTextureWrap(texture, false, false); /* this pass uses a 0..1 quad, so clamp the border instead of tiling */
-    R_Call(glUseProgram, shader->progid);
-    R_Call(glUniformMatrix4fv, shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
-    R_Call(glUniformMatrix4fv, shader->uModelMatrix, 1, GL_FALSE, model_matrix.v);
+
+    shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
+    shader->state.model = model_matrix;
 
     R_Call(glEnable, GL_BLEND);
     R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -379,6 +379,7 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins,
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STREAM_DRAW);
     R_StatsDraw(GL_TRIANGLES, sizeof(vertices) / sizeof(vertices[0]), 1);
+    R_ApplyShader(shader);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, sizeof(vertices) / sizeof(vertices[0]));
     R_Call(glDepthMask, GL_TRUE);
 }
@@ -386,7 +387,7 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins,
 void R_RenderSplat(LPCVECTOR2 position,
                    FLOAT radius,
                    LPCTEXTURE texture,
-                   LPCSHADER shader,
+                   splat_shader_t *shader,
                    COLOR32 color)
 {
     VECTOR2 mins = {

--- a/games/world-of-warcraft/renderer/m2/r_m2.c
+++ b/games/world-of-warcraft/renderer/m2/r_m2.c
@@ -57,14 +57,14 @@ typedef struct {
     m2Box_t bounding_box;
 } m2GeometryInfo_t;
 
-static LPSHADER m2_shader;
+static MODELPROG * m2_shader;
 static MATRIX4 m2_bone_matrices[M2_MAX_BONES];
 
-static LPSHADER M2_Shader(void) {
+static MODELPROG * M2_Shader(void) {
     if (!m2_shader) {
         m2_shader = R_ModelShader();
     }
-    return m2_shader ? m2_shader : tr.shader[SHADER_DEFAULT];
+    return m2_shader;
 }
 
 static void M2_LogFallback(LPCSTR modelFilename, LPCSTR reason) {
@@ -1027,7 +1027,6 @@ static void m2_spawn_particle(void *raw) {
 	fx->columns = MAX(1, ctx->p->cols); fx->rows = MAX(1, ctx->p->rows);
 }
 
-
 /* Vanilla/TBC stores three static BGRA lifecycle colors and three scalar scales. */
 static void m2p_sample_classic_data(BYTE const *raw, m2_pctx_t *ctx) {
     m2ParticleClassic_t const *p = (m2ParticleClassic_t const *)raw;
@@ -1103,7 +1102,6 @@ static void M2_DrawParticles(m2Model_t const *model, renderEntity_t const *entit
 		R_EmitParticlesAtTime(rate, tr.viewDef.time, tr.viewDef.deltaTime, m2_spawn_particle, &ctx);
 	}
 }
-
 
 static void M2_DrawRibbons(m2Model_t const *model, renderEntity_t const *entity, LPCMATRIX4 model_matrix) {
 	m2Array_t ribbons;
@@ -1231,7 +1229,7 @@ static void M2_CalculateBoneMatrices(m2Model_t const *model, renderEntity_t cons
     }
 }
 
-static void M2_UploadBatchBones(m2Model_t const *model, m2ModelBatch_t const *batch, LPSHADER shader) {
+static void M2_UploadBatchBones(m2Model_t const *model, m2ModelBatch_t const *batch, MODELPROG * shader) {
     MATRIX4 palette[BZ_BONE_PALETTE_MAX];
     WORD const *bone_lookup = model ? M2_BoneLookup(model) : NULL;
     DWORD nlook = model ? (DWORD)M2_BoneLookupArray(model).size : 0;
@@ -1254,7 +1252,7 @@ static void M2_UploadBatchBones(m2Model_t const *model, m2ModelBatch_t const *ba
         }
     }
 
-    R_Call(glUniformMatrix4fv, shader->uBones, BZ_BONE_PALETTE_MAX, GL_FALSE, palette[0].v);
+    memcpy(&shader->state.bones, palette[0].v, (BZ_BONE_PALETTE_MAX) * sizeof(MATRIX4));
 }
 
 static LPTEXTURE M2_TextureForBatch(BYTE const *m2_data,
@@ -1358,7 +1356,6 @@ static BOOL M2_CalculateGeometryBounds(m2VertexDisk_t const *verts, DWORD nverts
     return true;
 }
 
-
 static BOOL M2_LoadSkinData(LPCSTR modelFilename,
                             LPBYTE *skin_data,
                             DWORD *skin_size,
@@ -1426,7 +1423,6 @@ static BOOL M2_InitModernGeometry(BYTE const *m2_base,
     *header = modern;
     return true;
 }
-
 
 static BOOL M2_IsCharacterModelPath(LPCSTR model_path) {
     LPCSTR character;
@@ -1776,12 +1772,12 @@ static void M2_DrawCompositeQuad(LPTEXTURE texture, LPCRECT screen, BOOL blend) 
     R_AddQuad(vertices, screen, &uv, COLOR32_WHITE, 0);
     Matrix4_identity(&identity);
     Matrix4_ortho(&projection, 0, M2_CHARACTER_COMPOSITE_RESOLUTION, 0, M2_CHARACTER_COMPOSITE_RESOLUTION, 0, 100);
-    R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
+
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STREAM_DRAW);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, projection.v);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uModelMatrix, 1, GL_FALSE, identity.v);
+    tr.shader_ui.state.viewProjection = projection;
+    tr.shader_ui.state.model = identity;
     R_BindTexture(texture, 0);
     if (blend) {
         R_Call(glEnable, GL_BLEND);
@@ -1790,6 +1786,7 @@ static void M2_DrawCompositeQuad(LPTEXTURE texture, LPCRECT screen, BOOL blend) 
         R_Call(glDisable, GL_BLEND);
     }
     R_StatsDraw(GL_TRIANGLES, 6, 1);
+    R_ApplyShader(&tr.shader_ui);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, 6);
 }
 
@@ -2002,8 +1999,8 @@ static void M2_RenderItemAttachments(renderEntity_t const *entity, m2Model_t con
 }
 
 /* Keep ordinary and instanced M2 batches on the same material-state contract. */
-static void M2_SetBlendMode(LPSHADER shader, DWORD mode) {
-    R_Call(glUniform1i, shader->uAlphaKey, mode == BLEND_MODE_ALPHAKEY);
+static void M2_SetBlendMode(MODELPROG * shader, DWORD mode) {
+    shader->state.alphaKey = mode == BLEND_MODE_ALPHAKEY;
     R_SetAlphaKeyState(mode == BLEND_MODE_ALPHAKEY);
     if (mode == BLEND_MODE_NONE) {
         R_Call(glDisable, GL_BLEND); R_Call(glDepthMask, GL_TRUE);
@@ -2018,7 +2015,7 @@ static void M2_SetBlendMode(LPSHADER shader, DWORD mode) {
 }
 
 /* WoW's world sun is an ordinary directional entry; the shared shader never has a zero-light mode. */
-static void M2_BindSunLight(LPSHADER shader) {
+static void M2_BindSunLight(MODELPROG * shader) {
     MODELLIGHTING light = {
         .ambient = { WOW_LIGHT_AMBIENT_R, WOW_LIGHT_AMBIENT_G, WOW_LIGHT_AMBIENT_B },
         .count = 1,
@@ -2042,7 +2039,7 @@ void M2_RenderModel(renderEntity_t const *entity, m2Model_t const *model, LPCMAT
     LPCM2CHARACTEROUTFIT outfit = NULL;
     LPTEXTURE character_texture = NULL;
     m2ModelBatch_t *batch;
-    LPSHADER shader;
+    MODELPROG * shader;
     BOOL ground_effect;
     FLOAT ground_alpha = 1.0f;
 
@@ -2075,23 +2072,23 @@ void M2_RenderModel(renderEntity_t const *entity, m2Model_t const *model, LPCMAT
         outfit = &outfit_data;
     character_texture = M2_PrepareCharacterTexture(model, draw_entity, outfit);
     Matrix3_normal(&normal_matrix, transform);
-    R_Call(glUseProgram, shader->progid);
-    R_Call(glUniformMatrix4fv, shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
-    R_Call(glUniformMatrix4fv, shader->uTextureMatrix, 1, GL_FALSE, tr.viewDef.textureMatrix.v);
-    R_Call(glUniformMatrix4fv, shader->uModelMatrix, 1, GL_FALSE, transform->v);
-    R_Call(glUniformMatrix4fv, shader->uLightMatrix, 1, GL_FALSE, tr.viewDef.lightMatrix.v);
-    R_Call(glUniformMatrix3fv, shader->uNormalMatrix, 1, GL_TRUE, normal_matrix.v);
+
+    shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
+    shader->state.textureMatrix = tr.viewDef.textureMatrix;
+    shader->state.model = *transform;
+    shader->state.lightMatrix = tr.viewDef.lightMatrix;
+    shader->state.normalMatrix = normal_matrix;
     M2_BindSunLight(shader);
     /* Set identity defaults for UV/color/layer uniforms that M2 does not animate. */
-    R_Call(glUniform4f, shader->uGeosetColor, 1.0f, 1.0f, 1.0f, ground_alpha);
-    R_Call(glUniform1f, shader->uLayerAlpha, 1.0f);
-    { GLfloat m[9] = { 1,0,0, 0,1,0, 0,0,1 }; R_Call(glUniformMatrix3fv, shader->uUvMatrix, 1, GL_FALSE, m); }
-    R_Call(glUniform1i, shader->uAlphaKey, 0);
-    R_Call(glUniform1i, shader->uUnshaded, 0);
-    R_Call(glUniform1f, shader->uFogEnable, tr.viewDef.fogEnable);
-    R_Call(glUniform3f, shader->uFogColor, tr.viewDef.fogColor.x, tr.viewDef.fogColor.y, tr.viewDef.fogColor.z);
-    R_Call(glUniform2f, shader->uFogParams, tr.viewDef.fogStart, tr.viewDef.fogEnd);
-    R_Call(glUniform1f, shader->uFirstBoneLookupIndex, 0.0f);
+    shader->state.geosetColor = (VECTOR4){ 1.0f, 1.0f, 1.0f, ground_alpha };
+    shader->state.layerAlpha = 1.0f;
+    { GLfloat m[9] = { 1,0,0, 0,1,0, 0,0,1 }; memcpy(&shader->state.uvMatrix, m, (1) * sizeof(MATRIX3)); }
+    shader->state.alphaKey = 0;
+    shader->state.unshaded = 0;
+    shader->state.fogEnable = tr.viewDef.fogEnable;
+    shader->state.fogColor = (VECTOR3){ tr.viewDef.fogColor.x, tr.viewDef.fogColor.y, tr.viewDef.fogColor.z };
+    shader->state.fogParams = (VECTOR2){ tr.viewDef.fogStart, tr.viewDef.fogEnd };
+    shader->state.firstBoneLookupIndex = 0.0f;
     R_Call(glEnable, GL_DEPTH_TEST);
     R_Call(glDepthMask, GL_TRUE);
     R_Call(glDisable, GL_BLEND);
@@ -2113,6 +2110,7 @@ void M2_RenderModel(renderEntity_t const *entity, m2Model_t const *model, LPCMAT
 		R_BindTexture(tr.texture[TEX_SHADOWMAP], 1);
 #endif
 		R_BindTexture(tr.texture[TEX_WHITE], 2);
+		R_ApplyShader(shader);
 		R_DrawBuffer(batch->buffer, batch->num_vertices);
 	}
 	R_SetAlphaKeyState(false);
@@ -2125,7 +2123,7 @@ void M2_RenderModel(renderEntity_t const *entity, m2Model_t const *model, LPCMAT
    tracks, so this path adds root-anchored wind in the vertex shader. */
 void M2_RenderInstanced(m2Model_t const *model, LPCINSTANCEBUFFER instances, DWORD flags) {
     m2ModelBatch_t *batch;
-    LPSHADER shader;
+    MODELPROG * shader;
 
     if (!model || !instances || !instances->count) return;
 
@@ -2138,20 +2136,20 @@ void M2_RenderInstanced(m2Model_t const *model, LPCINSTANCEBUFFER instances, DWO
         }
         return;
     }
-    R_Call(glUseProgram, shader->progid);
-    R_Call(glUniformMatrix4fv, shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
-    R_Call(glUniformMatrix4fv, shader->uTextureMatrix, 1, GL_FALSE, tr.viewDef.textureMatrix.v);
-    R_Call(glUniformMatrix4fv, shader->uLightMatrix, 1, GL_FALSE, tr.viewDef.lightMatrix.v);
+
+    shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
+    shader->state.textureMatrix = tr.viewDef.textureMatrix;
+    shader->state.lightMatrix = tr.viewDef.lightMatrix;
     M2_BindSunLight(shader);
-    R_Call(glUniform4f, shader->uGeosetColor, 1.0f, 1.0f, 1.0f, 1.0f);
-    R_Call(glUniform1f, shader->uLayerAlpha, 1.0f);
-    { GLfloat m[9] = { 1,0,0, 0,1,0, 0,0,1 }; R_Call(glUniformMatrix3fv, shader->uUvMatrix, 1, GL_FALSE, m); }
-    R_Call(glUniform1i, shader->uAlphaKey, 0);
-    R_Call(glUniform1i, shader->uUnshaded, 0);
-    R_Call(glUniform1f, shader->uFogEnable, tr.viewDef.fogEnable);
-    R_Call(glUniform3f, shader->uFogColor, tr.viewDef.fogColor.x, tr.viewDef.fogColor.y, tr.viewDef.fogColor.z);
-    R_Call(glUniform2f, shader->uFogParams, tr.viewDef.fogStart, tr.viewDef.fogEnd);
-    R_Call(glUniform1f, shader->uFirstBoneLookupIndex, 0.0f);
+    shader->state.geosetColor = (VECTOR4){ 1.0f, 1.0f, 1.0f, 1.0f };
+    shader->state.layerAlpha = 1.0f;
+    { GLfloat m[9] = { 1,0,0, 0,1,0, 0,0,1 }; memcpy(&shader->state.uvMatrix, m, (1) * sizeof(MATRIX3)); }
+    shader->state.alphaKey = 0;
+    shader->state.unshaded = 0;
+    shader->state.fogEnable = tr.viewDef.fogEnable;
+    shader->state.fogColor = (VECTOR3){ tr.viewDef.fogColor.x, tr.viewDef.fogColor.y, tr.viewDef.fogColor.z };
+    shader->state.fogParams = (VECTOR2){ tr.viewDef.fogStart, tr.viewDef.fogEnd };
+    shader->state.firstBoneLookupIndex = 0.0f;
     {
         VECTOR3 cam = tr.viewDef.camerastate[0].origin;
         MODELGRASS grass = {
@@ -2176,6 +2174,7 @@ void M2_RenderInstanced(m2Model_t const *model, LPCINSTANCEBUFFER instances, DWO
 		R_BindTexture(tr.texture[TEX_SHADOWMAP], 1);
 #endif
 		R_BindTexture(tr.texture[TEX_WHITE], 2);
+		R_ApplyShader(shader);
 		R_DrawBufferInstanced(batch->buffer, batch->num_vertices, instances);
 	}
 	R_SetAlphaKeyState(false);

--- a/games/world-of-warcraft/renderer/r_game.c
+++ b/games/world-of-warcraft/renderer/r_game.c
@@ -398,9 +398,9 @@ bool R_GameRenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin) {
         return true;
     }
     if (use_fast_blob) {
-        R_RenderFlatRectSplat(&mins, &maxs, shadow_z, shadow, tr.shader[SHADER_SHADOWSPLAT], shadowColor);
+        R_RenderFlatRectSplat(&mins, &maxs, shadow_z, shadow, R_SPLAT_SHADER(&tr.shader_shadowSplat), shadowColor);
     } else {
-        R_RenderRectSplat(&mins, &maxs, shadow, tr.shader[SHADER_SHADOWSPLAT], shadowColor);
+        R_RenderRectSplat(&mins, &maxs, shadow, R_SPLAT_SHADER(&tr.shader_shadowSplat), shadowColor);
     }
     return true;
 }

--- a/games/world-of-warcraft/renderer/r_game.c
+++ b/games/world-of-warcraft/renderer/r_game.c
@@ -274,7 +274,7 @@ void R_GameRenderModel(renderEntity_t const *entity) {
     if (entity->attached_model &&
         entity->attached_model->modeltype == ID_MD20 &&
 #ifdef USE_SHADOWMAPS
-        !is_rendering_lights &&
+        render_phase != RENDER_PHASE_LIGHTS &&
 #endif
         M2_AttachmentMatrix(entity->model->m2, attachment_id, &transform, &attached_transform)) {
         if (tr.viewDef.rdflags & RDF_USE_ENTITY_CAMERA) {

--- a/games/world-of-warcraft/renderer/wow/r_wowmap.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap.c
@@ -91,26 +91,24 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
 
     if (!draw_terrain && !draw_wmos) return;
 
-    R_Call(glUseProgram, wow_terrain_shader->progid);
     Matrix3_normal(&normal_matrix, &identity);
-    R_Call(glUniformMatrix4fv, wow_terrain_shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
-    R_Call(glUniformMatrix4fv, wow_terrain_shader->uModelMatrix, 1, GL_FALSE, identity.v);
+    wow_terrain_shader.state.viewProjection = tr.viewDef.viewProjectionMatrix;
+    wow_terrain_shader.state.model = identity;
     {
         VECTOR3 sun_dir;
         Wow_SunDirection(Wow_DayFraction(), &sun_dir);
-        R_Call(glUniform3f, wow_uSunDir, sun_dir.x, sun_dir.y, sun_dir.z);
-        R_Call(glUniform3f, wow_uSunAmbient, WOW_LIGHT_AMBIENT_R, WOW_LIGHT_AMBIENT_G, WOW_LIGHT_AMBIENT_B);
-        R_Call(glUniform3f, wow_uSunDiffuse, WOW_LIGHT_DIFFUSE_R, WOW_LIGHT_DIFFUSE_G, WOW_LIGHT_DIFFUSE_B);
+        wow_terrain_shader.state.sunDir = (VECTOR3){ sun_dir.x, sun_dir.y, sun_dir.z };
+        wow_terrain_shader.state.sunAmbient = (VECTOR3){ WOW_LIGHT_AMBIENT_R, WOW_LIGHT_AMBIENT_G, WOW_LIGHT_AMBIENT_B };
+        wow_terrain_shader.state.sunDiffuse = (VECTOR3){ WOW_LIGHT_DIFFUSE_R, WOW_LIGHT_DIFFUSE_G, WOW_LIGHT_DIFFUSE_B };
     }
-    R_Call(glUniformMatrix3fv, wow_terrain_shader->uNormalMatrix, 1, GL_TRUE, normal_matrix.v);
-    R_Call(glUniform1i, wow_uUseWeightedBlend, wow_world.use_weighted_blend ? 1 : 0);
-    R_Call(glUniform1i, wow_uSingleTexture, 0);
-    R_Call(glUniform1i, wow_uWmoIndoor, bound_indoor);
-    R_Call(glUniform1i, wow_uFogEnable, tr.viewDef.fogEnable);
-    R_Call(glUniform3f, wow_uFogColor, tr.viewDef.fogColor.x, tr.viewDef.fogColor.y, tr.viewDef.fogColor.z);
-    R_Call(glUniform2f, wow_uFogParams, tr.viewDef.fogStart, tr.viewDef.fogEnd);
-    R_Call(glUniform3f, wow_uFogCamera, tr.viewDef.camerastate[0].origin.x, tr.viewDef.camerastate[0].origin.y,
-           tr.viewDef.camerastate[0].origin.z);
+    wow_terrain_shader.state.normalMatrix = normal_matrix;
+    wow_terrain_shader.state.useWeightedBlend = wow_world.use_weighted_blend ? 1 : 0;
+    wow_terrain_shader.state.singleTexture = 0;
+    wow_terrain_shader.state.wmoIndoor = bound_indoor;
+    wow_terrain_shader.state.fogEnable = tr.viewDef.fogEnable;
+    wow_terrain_shader.state.fogColor = (VECTOR3){ tr.viewDef.fogColor.x, tr.viewDef.fogColor.y, tr.viewDef.fogColor.z };
+    wow_terrain_shader.state.fogParams = (VECTOR2){ tr.viewDef.fogStart, tr.viewDef.fogEnd };
+    wow_terrain_shader.state.fogCamera = (VECTOR3){ tr.viewDef.camerastate[0].origin.x, tr.viewDef.camerastate[0].origin.y, tr.viewDef.camerastate[0].origin.z };
     R_Call(glEnable, GL_DEPTH_TEST);
     R_Call(glDepthMask, GL_TRUE);
     R_Call(glDepthFunc, GL_LEQUAL);
@@ -130,7 +128,8 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
         Wow_BindWorldTexture(chunk->textures[2] ? chunk->textures[2] : chunk->textures[0], 2, bound_textures, &texture_binds);
         Wow_BindWorldTexture(chunk->textures[3] ? chunk->textures[3] : chunk->textures[0], 3, bound_textures, &texture_binds);
         Wow_BindWorldTexture(chunk->alpha_texture ? chunk->alpha_texture : tr.texture[TEX_WHITE], 4, bound_textures, &texture_binds);
-        R_Call(glUniform2f, wow_uAlphaOrigin, (GLfloat)chunk->alpha_index_x, (GLfloat)chunk->alpha_index_y);
+        wow_terrain_shader.state.alphaOrigin = (VECTOR2){ (GLfloat)chunk->alpha_index_x, (GLfloat)chunk->alpha_index_y };
+        R_ApplyShader(&wow_terrain_shader);
         R_DrawBuffer(chunk->buffer, chunk->num_vertices);
         stats->chunks++; stats->vertices += chunk->num_vertices;
     }
@@ -138,10 +137,10 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
     /* WMO batches have one texture; two passes: opaque first, alpha-blended second.
      * Pre-compute per-WMO visible_group count + cam_inside once; re-use across both passes
      * so the expensive Matrix3_normal / MOLT / frustum checks don't run twice per WMO. */
-    R_Call(glUniform1i, wow_uSingleTexture, 1);
-    R_Call(glUniform1i, wow_uWmoBlendMode, 0);
-    R_Call(glUniform1i, wow_uUseWeightedBlend, 0);     /* constant: WMOs don't use weighted alpha blend */
-    R_Call(glUniform2f, wow_uAlphaOrigin, 0.0f, 0.0f); /* constant: WMOs use full-texture coords */
+    wow_terrain_shader.state.singleTexture = 1;
+    wow_terrain_shader.state.wmoBlendMode = 0;
+    wow_terrain_shader.state.useWeightedBlend = 0;     /* constant: WMOs don't use weighted alpha blend */
+    wow_terrain_shader.state.alphaOrigin = (VECTOR2){ 0.0f, 0.0f }; /* constant: WMOs use full-texture coords */
     {
         /* Per-WMO pre-computed data. WMOs are static so this is stable across passes. */
         enum { WMO_CACHE_MAX = 256 };
@@ -205,20 +204,19 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
                 if (wmo_pass == 1 && !wmo_cache[wi].has_trans) continue;
                 cam_inside = wmo_cache[wi].inside;
                 model_batch = wmo_cache[wi].model_batch;
-                R_Call(glUniformMatrix4fv, wow_terrain_shader->uModelMatrix, 1, GL_FALSE, wmo->matrix.v);
-                R_Call(glUniformMatrix3fv, wow_terrain_shader->uNormalMatrix, 1, GL_TRUE, wmo_cache[wi].nm.v);
-                R_Call(glUniform3f, wow_uWmoAmbient, wmo->model->amb_color.r / 255.0f,
-                       wmo->model->amb_color.g / 255.0f, wmo->model->amb_color.b / 255.0f);
-                R_Call(glUniform3f, wow_uWmoLightAdd, wmo_cache[wi].molt.x, wmo_cache[wi].molt.y, wmo_cache[wi].molt.z);
+                memcpy(&wow_terrain_shader.state.model, wmo->matrix.v, (1) * sizeof(MATRIX4));
+                wow_terrain_shader.state.normalMatrix = wmo_cache[wi].nm;
+                wow_terrain_shader.state.wmoAmbient = (VECTOR3){ wmo->model->amb_color.r / 255.0f, wmo->model->amb_color.g / 255.0f, wmo->model->amb_color.b / 255.0f };
+                wow_terrain_shader.state.wmoLightAdd = (VECTOR3){ wmo_cache[wi].molt.x, wmo_cache[wi].molt.y, wmo_cache[wi].molt.z };
                 if (model_batch) {
                     for (wowWmoBatch_t *batch = wmo->model->batches; batch; batch = batch->next) {
                         if (!batch->buffer || !batch->num_vertices) continue;
                         if ((int)batch->transparent != wmo_pass) continue;
                         if (cam_inside && !batch->indoor) continue; /* portal cull: skip exterior when inside */
-                        if (bound_indoor != batch->indoor) { bound_indoor = batch->indoor; R_Call(glUniform1i, wow_uWmoIndoor, bound_indoor); }
+                        if (bound_indoor != batch->indoor) { bound_indoor = batch->indoor; wow_terrain_shader.state.wmoIndoor = bound_indoor; }
                         if (bound_blend_mode != (int)batch->blend_mode) {
                             bound_blend_mode = (int)batch->blend_mode;
-                            R_Call(glUniform1i, wow_uWmoBlendMode, bound_blend_mode);
+                            wow_terrain_shader.state.wmoBlendMode = bound_blend_mode;
                             if (wmo_pass) {
                                 if (bound_blend_mode == 3)      { R_Call(glBlendFunc, GL_ONE, GL_ONE); }
                                 else if (bound_blend_mode == 4) { R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE); }
@@ -226,6 +224,7 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
                             }
                         }
                         Wow_BindWorldTexture(batch->texture ? batch->texture : tr.texture[TEX_WHITE], 0, bound_textures, &texture_binds);
+                        R_ApplyShader(&wow_terrain_shader);
                         R_DrawBuffer(batch->buffer, batch->num_vertices); stats->wmo_batches++;
                         if (stats->collect && Wow_StatPointer(batch->texture, stats->texture_hash, sizeof(stats->texture_hash) / sizeof(*stats->texture_hash))) stats->wmo_textures++;
                     }
@@ -240,10 +239,10 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
                             if (!batch->buffer || !batch->num_vertices) continue;
                             if ((int)batch->transparent != wmo_pass) continue;
                             if (cam_inside && !batch->indoor) continue; /* portal cull */
-                            if (bound_indoor != batch->indoor) { bound_indoor = batch->indoor; R_Call(glUniform1i, wow_uWmoIndoor, bound_indoor); }
+                            if (bound_indoor != batch->indoor) { bound_indoor = batch->indoor; wow_terrain_shader.state.wmoIndoor = bound_indoor; }
                             if (bound_blend_mode != (int)batch->blend_mode) {
                                 bound_blend_mode = (int)batch->blend_mode;
-                                R_Call(glUniform1i, wow_uWmoBlendMode, bound_blend_mode);
+                                wow_terrain_shader.state.wmoBlendMode = bound_blend_mode;
                                 if (wmo_pass) {
                                     if (bound_blend_mode == 3)      { R_Call(glBlendFunc, GL_ONE, GL_ONE); }
                                     else if (bound_blend_mode == 4) { R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE); }
@@ -251,6 +250,7 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
                                 }
                             }
                             Wow_BindWorldTexture(batch->texture ? batch->texture : tr.texture[TEX_WHITE], 0, bound_textures, &texture_binds);
+                            R_ApplyShader(&wow_terrain_shader);
                             R_DrawBuffer(batch->buffer, batch->num_vertices); stats->wmo_batches++;
                             if (stats->collect && Wow_StatPointer(batch->texture, stats->texture_hash, sizeof(stats->texture_hash) / sizeof(*stats->texture_hash))) stats->wmo_textures++;
                         }
@@ -264,14 +264,14 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
         }
     }
     Matrix3_normal(&normal_matrix, &identity);
-    R_Call(glUniformMatrix4fv, wow_terrain_shader->uModelMatrix, 1, GL_FALSE, identity.v);
-    R_Call(glUniformMatrix3fv, wow_terrain_shader->uNormalMatrix, 1, GL_TRUE, normal_matrix.v);
-    R_Call(glUniform1i, wow_uUseWeightedBlend, wow_world.use_weighted_blend ? 1 : 0);
-    R_Call(glUniform1i, wow_uSingleTexture, 0);
-    R_Call(glUniform1i, wow_uWmoIndoor, 0);
-    R_Call(glUniform3f, wow_uWmoAmbient, 0.0f, 0.0f, 0.0f);
-    R_Call(glUniform3f, wow_uWmoLightAdd, 0.0f, 0.0f, 0.0f);
-    R_Call(glUniform1i, wow_uWmoBlendMode, 0);
+    wow_terrain_shader.state.model = identity;
+    wow_terrain_shader.state.normalMatrix = normal_matrix;
+    wow_terrain_shader.state.useWeightedBlend = wow_world.use_weighted_blend ? 1 : 0;
+    wow_terrain_shader.state.singleTexture = 0;
+    wow_terrain_shader.state.wmoIndoor = 0;
+    wow_terrain_shader.state.wmoAmbient = (VECTOR3){ 0.0f, 0.0f, 0.0f };
+    wow_terrain_shader.state.wmoLightAdd = (VECTOR3){ 0.0f, 0.0f, 0.0f };
+    wow_terrain_shader.state.wmoBlendMode = 0;
 }
 
 /* Group the small visible set by static M2 so repeated trees/props share material draws. */
@@ -375,7 +375,7 @@ void R_DrawWorld(void) {
     }
 
     Wow_InitTerrainShader();
-    if (!wow_terrain_shader) {
+    if (!wow_terrain_shader.prog.progid) {
         static BOOL logged_no_shader = false;
         if (!logged_no_shader) {
             fprintf(stderr, "R_DrawWorld: WoW terrain shader failed to initialize\n");
@@ -481,6 +481,7 @@ void R_DrawWorld(void) {
 
     if (R_CvarEnabled("r_doodads", "1") && wow_world.object_buffer && wow_world.num_object_vertices) {
         R_BindTexture(tr.texture[TEX_WHITE], 0);
+        R_ApplyShader(&wow_terrain_shader);
         R_DrawBuffer(wow_world.object_buffer, wow_world.num_object_vertices);
     }
 }

--- a/games/world-of-warcraft/renderer/wow/r_wowmap.h
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap.h
@@ -402,44 +402,75 @@ typedef struct {
 } wowGroundEffectDoodad_t;
 
 extern wowMap_t wow_world;
-extern LPSHADER wow_terrain_shader;
-extern LPSHADER wow_grass_shader;
-extern GLint wow_uTexture0;
-extern GLint wow_uTexture1;
-extern GLint wow_uTexture2;
-extern GLint wow_uTexture3;
-extern GLint wow_uAlphaTexture;
-extern GLint wow_uUseWeightedBlend;
-extern GLint wow_uSingleTexture;
-extern GLint wow_uWmoIndoor;
-extern GLint wow_uWmoAmbient;
-extern GLint wow_uWmoLightAdd;
-extern GLint wow_uWmoBlendMode;
-extern GLint wow_uAlphaOrigin;
-extern GLint wow_uAlphaAtlasChunks;
-extern GLint wow_uFogEnable;
-extern GLint wow_uFogColor;
-extern GLint wow_uFogParams;
-extern GLint wow_uFogCamera;
-extern GLint wow_uSunDir;
-extern GLint wow_uSunAmbient;
-extern GLint wow_uSunDiffuse;
-extern GLint wow_uGrassTime;
-extern GLint wow_uGrassCameraOrigin;
-extern GLint wow_uGrassDrawDistance;
-extern GLint wow_uGrassFadeStartDistance;
+
+/* Terrain and grass have separate typed values and private program locations. */
+typedef struct WOWTERRAINSTATE {
+    MATRIX4 viewProjection;
+    MATRIX4 model;
+    MATRIX3 normalMatrix;
+    VECTOR3 sunDir;
+    VECTOR3 sunAmbient;
+    VECTOR3 sunDiffuse;
+    int texture0;
+    int texture1;
+    int texture2;
+    int texture3;
+    int alphaTexture;
+    bool useWeightedBlend;
+    bool singleTexture;
+    bool wmoIndoor;
+    VECTOR3 wmoAmbient;
+    VECTOR3 wmoLightAdd;
+    int wmoBlendMode;
+    VECTOR2 alphaOrigin;
+    FLOAT alphaAtlasChunks;
+    bool fogEnable;
+    VECTOR3 fogColor;
+    VECTOR2 fogParams;
+    VECTOR3 fogCamera;
+} WOWTERRAINSTATE;
+typedef struct WOWTERRAINSTATE *LPWOWTERRAINSTATE;
+typedef const struct WOWTERRAINSTATE *LPCWOWTERRAINSTATE;
+typedef struct WOWTERRAINPROG {
+    SHADERPROG prog;
+    WOWTERRAINSTATE state;
+} WOWTERRAINPROG;
+typedef struct WOWTERRAINPROG *LPWOWTERRAINPROG;
+typedef const struct WOWTERRAINPROG *LPCWOWTERRAINPROG;
+
+typedef struct WOWGRASSSTATE {
+    MATRIX4 viewProjection;
+    VECTOR3 sunDir;
+    VECTOR3 sunAmbient;
+    VECTOR3 sunDiffuse;
+    FLOAT grassTime;
+    int grassCtrl;
+    VECTOR2 ctrlOriginWorld;
+    FLOAT ctrlCellSize;
+    VECTOR2 cameraXZ;
+    FLOAT grassSlotSpacing;
+    int heightAtlas;
+    VECTOR2 atlasOriginWorld;
+    FLOAT atlasChunkSize;
+    FLOAT atlasUnitSize;
+    VECTOR3 grassCameraOrigin;
+    FLOAT grassDrawDistance;
+    FLOAT grassFadeStartDistance;
+} WOWGRASSSTATE;
+typedef struct WOWGRASSSTATE *LPWOWGRASSSTATE;
+typedef const struct WOWGRASSSTATE *LPCWOWGRASSSTATE;
+typedef struct WOWGRASSPROG {
+    SHADERPROG prog;
+    WOWGRASSSTATE state;
+} WOWGRASSPROG;
+typedef struct WOWGRASSPROG *LPWOWGRASSPROG;
+typedef const struct WOWGRASSPROG *LPCWOWGRASSPROG;
+
+extern WOWTERRAINPROG wow_terrain_shader;
+extern WOWGRASSPROG wow_grass_shader;
 /* Height atlas uniforms (terrain + grass) */
-extern GLint wow_uHeightAtlas;
-extern GLint wow_uAtlasOriginWorld;
-extern GLint wow_uAtlasChunkSize;
-extern GLint wow_uAtlasUnitSize;
 /* Grass control texture uniforms */
-extern GLint wow_uGrassCtrl;
-extern GLint wow_uCtrlOriginWorld;
-extern GLint wow_uCtrlCellSize;
 /* Camera-following grass tile uniforms */
-extern GLint wow_uCameraXZ;
-extern GLint wow_uGrassSlotSpacing;
 
 BOOL Wow_PathHasExtension(LPCSTR path, LPCSTR extension);
 void Wow_NormalizeMapPath(LPCSTR mapFileName, LPSTR out, DWORD out_size);

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_grass.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_grass.c
@@ -500,32 +500,32 @@ void Wow_DrawGrass(void) {
     if (!wow_world.has_atlas_origin || !wow_world.grass_ctrl || !wow_world.height_atlas) return;
 
     Wow_InitGrassShader();
-    if (!wow_grass_shader) return;
+    if (!wow_grass_shader.prog.progid) return;
 
     Wow_EnsureCameraGrassMesh();
     if (!wow_world.grass_tile_vbo) return;
 
     cam = tr.viewDef.camerastate[0].origin;
-    R_Call(glUseProgram, wow_grass_shader->progid);
-    R_Call(glUniformMatrix4fv, wow_grass_shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
+
+    wow_grass_shader.state.viewProjection = tr.viewDef.viewProjectionMatrix;
     {
         VECTOR3 sun_dir;
         Wow_SunDirection(Wow_DayFraction(), &sun_dir);
-        R_Call(glUniform3f, wow_uGrassSunDir, sun_dir.x, sun_dir.y, sun_dir.z);
-        R_Call(glUniform3f, wow_uGrassSunAmbient, WOW_LIGHT_AMBIENT_R, WOW_LIGHT_AMBIENT_G, WOW_LIGHT_AMBIENT_B);
-        R_Call(glUniform3f, wow_uGrassSunDiffuse, WOW_LIGHT_DIFFUSE_R, WOW_LIGHT_DIFFUSE_G, WOW_LIGHT_DIFFUSE_B);
+        wow_grass_shader.state.sunDir = (VECTOR3){ sun_dir.x, sun_dir.y, sun_dir.z };
+        wow_grass_shader.state.sunAmbient = (VECTOR3){ WOW_LIGHT_AMBIENT_R, WOW_LIGHT_AMBIENT_G, WOW_LIGHT_AMBIENT_B };
+        wow_grass_shader.state.sunDiffuse = (VECTOR3){ WOW_LIGHT_DIFFUSE_R, WOW_LIGHT_DIFFUSE_G, WOW_LIGHT_DIFFUSE_B };
     }
-    R_Call(glUniform1f,  wow_uGrassTime,             (GLfloat)(tr.viewDef.time / 1000.0f));
-    R_Call(glUniform3f,  wow_uGrassCameraOrigin,     (GLfloat)cam.x, (GLfloat)cam.y, (GLfloat)cam.z);
-    R_Call(glUniform1f,  wow_uGrassDrawDistance,     (GLfloat)WOW_GRASS_DRAW_DISTANCE);
-    R_Call(glUniform1f,  wow_uGrassFadeStartDistance,(GLfloat)WOW_GRASS_FADE_START_DISTANCE);
-    R_Call(glUniform2f,  wow_uCameraXZ,              (GLfloat)cam.x, (GLfloat)cam.y);
-    R_Call(glUniform1f,  wow_uGrassSlotSpacing,      (GLfloat)WOW_GRASS_SLOT_SPACING);
-    R_Call(glUniform2f,  wow_uAtlasOriginWorld,      (GLfloat)wow_world.atlas_world_x, (GLfloat)wow_world.atlas_world_y);
-    R_Call(glUniform1f,  wow_uAtlasChunkSize,        (GLfloat)WOW_ADT_CHUNK_SIZE);
-    R_Call(glUniform1f,  wow_uAtlasUnitSize,         (GLfloat)WOW_ADT_UNIT_SIZE);
-    R_Call(glUniform2f,  wow_uCtrlOriginWorld,       (GLfloat)wow_world.atlas_world_x, (GLfloat)wow_world.atlas_world_y);
-    R_Call(glUniform1f,  wow_uCtrlCellSize,          (GLfloat)WOW_ADT_UNIT_SIZE);
+    wow_grass_shader.state.grassTime = (GLfloat)(tr.viewDef.time / 1000.0f);
+    wow_grass_shader.state.grassCameraOrigin = (VECTOR3){ (GLfloat)cam.x, (GLfloat)cam.y, (GLfloat)cam.z };
+    wow_grass_shader.state.grassDrawDistance = (GLfloat)WOW_GRASS_DRAW_DISTANCE;
+    wow_grass_shader.state.grassFadeStartDistance = (GLfloat)WOW_GRASS_FADE_START_DISTANCE;
+    wow_grass_shader.state.cameraXZ = (VECTOR2){ (GLfloat)cam.x, (GLfloat)cam.y };
+    wow_grass_shader.state.grassSlotSpacing = (GLfloat)WOW_GRASS_SLOT_SPACING;
+    wow_grass_shader.state.atlasOriginWorld = (VECTOR2){ (GLfloat)wow_world.atlas_world_x, (GLfloat)wow_world.atlas_world_y };
+    wow_grass_shader.state.atlasChunkSize = (GLfloat)WOW_ADT_CHUNK_SIZE;
+    wow_grass_shader.state.atlasUnitSize = (GLfloat)WOW_ADT_UNIT_SIZE;
+    wow_grass_shader.state.ctrlOriginWorld = (VECTOR2){ (GLfloat)wow_world.atlas_world_x, (GLfloat)wow_world.atlas_world_y };
+    wow_grass_shader.state.ctrlCellSize = (GLfloat)WOW_ADT_UNIT_SIZE;
 
     /* Height atlas on texture unit 5 */
     R_Call(glActiveTexture, GL_TEXTURE5);
@@ -534,14 +534,16 @@ void Wow_DrawGrass(void) {
     R_Call(glActiveTexture, GL_TEXTURE6);
     R_Call(glBindTexture, GL_TEXTURE_2D, wow_world.grass_ctrl->texid);
     R_Call(glActiveTexture, GL_TEXTURE0);
-    R_Call(glUniform1i, wow_uHeightAtlas, 5);
-    R_Call(glUniform1i, wow_uGrassCtrl,   6);
+    wow_grass_shader.state.heightAtlas = 5;
+    wow_grass_shader.state.grassCtrl = 6;
 
     R_Call(glEnable,    GL_DEPTH_TEST);
     R_Call(glDepthMask, GL_TRUE);
     R_Call(glDepthFunc, GL_LEQUAL);
     R_Call(glDisable,   GL_CULL_FACE);
     R_SetAlphaKeyState(true);
+
+    R_ApplyShader(&wow_grass_shader);
 
     R_DrawBufferCopies(wow_world.grass_tile_vbo, wow_world.grass_tile_nverts, WOW_GRASS_BLADE_SLOTS);
 

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_shader.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_shader.c
@@ -3,51 +3,11 @@
 #define BZ_WOW_STR_INNER(x) #x
 #define BZ_WOW_STR(x) BZ_WOW_STR_INNER(x)
 
-LPSHADER wow_terrain_shader;
-LPSHADER wow_grass_shader;
-GLint wow_uTexture0 = -1;
-GLint wow_uTexture1 = -1;
-GLint wow_uTexture2 = -1;
-GLint wow_uTexture3 = -1;
-GLint wow_uAlphaTexture = -1;
-GLint wow_uUseWeightedBlend = -1;
-GLint wow_uSingleTexture = -1;
-GLint wow_uWmoIndoor = -1;
-GLint wow_uWmoAmbient = -1;
-GLint wow_uWmoLightAdd = -1;
-GLint wow_uWmoBlendMode = -1;
-GLint wow_uAlphaOrigin = -1;
-GLint wow_uAlphaAtlasChunks = -1;
-GLint wow_uFogEnable = -1;
-GLint wow_uFogColor = -1;
-GLint wow_uFogParams = -1;
-GLint wow_uFogCamera = -1;
-GLint wow_uSunDir = -1;
-GLint wow_uSunAmbient = -1;
-GLint wow_uSunDiffuse = -1;
-GLint wow_uGrassTime = -1;
-GLint wow_uGrassCameraOrigin = -1;
-GLint wow_uGrassDrawDistance = -1;
-GLint wow_uGrassFadeStartDistance = -1;
-GLint wow_uHeightAtlas = -1;
-GLint wow_uAtlasOriginWorld = -1;
-GLint wow_uAtlasChunkSize = -1;
-GLint wow_uAtlasUnitSize = -1;
-GLint wow_uGrassCtrl = -1;
-GLint wow_uCtrlOriginWorld = -1;
-GLint wow_uCtrlCellSize = -1;
-GLint wow_uCameraXZ = -1;
-GLint wow_uGrassSlotSpacing = -1;
-GLint wow_uGrassSunDir = -1;
-GLint wow_uGrassSunAmbient = -1;
-GLint wow_uGrassSunDiffuse = -1;
+WOWTERRAINPROG wow_terrain_shader;
+WOWGRASSPROG wow_grass_shader;
 
 /* Keep terrain and grass on the same exact MCVT diamond interpolation contract. */
 #define WOW_HEIGHT_ATLAS_GLSL \
-    "uniform sampler2D uHeightAtlas;\n" \
-    "uniform vec2 uAtlasOriginWorld;\n" \
-    "uniform float uAtlasChunkSize;\n" \
-    "uniform float uAtlasUnitSize;\n" \
     "bool HeightAtlas_Coord(vec2 worldXY, out ivec2 tile, out vec2 cell) {\n" \
     "    vec2 rel = (uAtlasOriginWorld - worldXY) / uAtlasChunkSize;\n" \
     "    tile = ivec2(floor(rel.y), floor(rel.x));\n" \
@@ -81,247 +41,211 @@ GLint wow_uGrassSunDiffuse = -1;
     "    return HeightAtlas_Bary(p, vec2(.5), ct, vec2(1,0), bl, vec2(1), br);\n" \
     "}\n"
 
+#define SHADER_TYPE WOWTERRAINSTATE
+static const shader_desc_t sd_wow_terrain = {
+    .Name = "wow_terrain",
+    .Uniforms = {
+        UNIFORM_NAMED(viewProjection,   "uViewProjectionMatrix", UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM_NAMED(model,            "uModelMatrix",          UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM_NAMED_TRANSPOSE(normalMatrix,     "uNormalMatrix",         UT_FLOAT_MAT3, PRECISION_HIGH),
+        UNIFORM_NAMED(sunDir,           "uSunDir",               UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM_NAMED(sunAmbient,       "uSunAmbient",           UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM_NAMED(sunDiffuse,       "uSunDiffuse",           UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM_NAMED(texture0,         "uTexture0",             UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM_NAMED(texture1,         "uTexture1",             UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM_NAMED(texture2,         "uTexture2",             UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM_NAMED(texture3,         "uTexture3",             UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM_NAMED(alphaTexture,     "uAlphaTexture",         UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM_NAMED(useWeightedBlend, "uUseWeightedBlend",     UT_BOOL,        PRECISION_LOW),
+        UNIFORM_NAMED(singleTexture,    "uSingleTexture",        UT_BOOL,        PRECISION_LOW),
+        UNIFORM_NAMED(wmoIndoor,        "uWmoIndoor",            UT_BOOL,        PRECISION_LOW),
+        UNIFORM_NAMED(wmoAmbient,       "uWmoAmbient",           UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM_NAMED(wmoLightAdd,      "uWmoLightAdd",          UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM_NAMED(wmoBlendMode,     "uWmoBlendMode",         UT_INT,        PRECISION_LOW),
+        UNIFORM_NAMED(alphaOrigin,      "uAlphaOrigin",          UT_FLOAT_VEC2, PRECISION_LOW),
+        UNIFORM_NAMED(alphaAtlasChunks, "uAlphaAtlasChunks",     UT_FLOAT,      PRECISION_LOW),
+        UNIFORM_NAMED(fogEnable,        "uFogEnable",            UT_BOOL,       PRECISION_LOW),
+        UNIFORM_NAMED(fogColor,         "uFogColor",             UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM_NAMED(fogParams,        "uFogParams",            UT_FLOAT_VEC2, PRECISION_LOW),
+        UNIFORM_NAMED(fogCamera,        "uFogCamera",            UT_FLOAT_VEC3, PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(normal,   attrib_normal,   UT_FLOAT_VEC3),
+        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
+        ATTRIB(color,    attrib_color,    UT_COLOR),
+    },
+    .Shared = {
+        SHARED(texcoord, UT_FLOAT_VEC2),
+        SHARED(color,    UT_COLOR),
+        SHARED(lighting, UT_FLOAT_VEC3),
+        SHARED(world,    UT_FLOAT_VEC3),
+    },
+    .VertexBody =
+        "vec4 vert() {\n"
+        "  vec4 pos = uModelMatrix * vec4(a_position, 1.0);\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  vec3 normal = normalize(uNormalMatrix * a_normal);\n"
+        "  v_lighting = uSunAmbient + uSunDiffuse * clamp(dot(normal, uSunDir), 0.0, 1.0);\n"
+        "  v_color = a_color;\n"
+        "  v_world = pos.xyz;\n"
+        "  return uViewProjectionMatrix * pos;\n"
+        "}\n",
+    .FragmentBody =
+        "vec2 adtAlphaCoord(vec2 chunkCoord) {\n"
+        "  const float alphaTexelsPerChunk = 64.0;\n"
+        "  float alphaAtlasSize = alphaTexelsPerChunk * uAlphaAtlasChunks;\n"
+        "  chunkCoord = clamp(chunkCoord, vec2(0.0), vec2(1.0));\n"
+        "  vec2 atlasTexel = uAlphaOrigin * alphaTexelsPerChunk + chunkCoord * (alphaTexelsPerChunk - 1.0) + vec2(0.5);\n"
+        "  return atlasTexel / alphaAtlasSize;\n"
+        "}\n"
+        "vec4 frag() {\n"
+        "  vec2 alphaCoord = adtAlphaCoord(v_texcoord * 0.125);\n"
+        "  vec4 tex1 = texture(uTexture0, v_texcoord);\n"
+        "  vec4 color;\n"
+        "  if (uSingleTexture) {\n"
+        "    color = tex1;\n"
+        "  } else {\n"
+        "    vec3 alphaBlend = texture(uAlphaTexture, alphaCoord).gba;\n"
+        "    vec4 tex2 = texture(uTexture1, v_texcoord);\n"
+        "    vec4 tex3 = texture(uTexture2, v_texcoord);\n"
+        "    vec4 tex4 = texture(uTexture3, v_texcoord);\n"
+        "    if (uUseWeightedBlend) {\n"
+        "      float baseWeight = 1.0 - clamp(dot(alphaBlend, vec3(1.0)), 0.0, 1.0);\n"
+        "      vec4 weights = vec4(baseWeight, alphaBlend);\n"
+        "      color = tex1 * weights.r + tex2 * weights.g + tex3 * weights.b + tex4 * weights.a;\n"
+        "    } else {\n"
+        "      color = mix(mix(mix(tex1, tex2, alphaBlend.r), tex3, alphaBlend.g), tex4, alphaBlend.b);\n"
+        "    }\n"
+        "  }\n"
+        "  if (uSingleTexture) {\n"
+        "    vec3 mocv = 2.0 * v_color.rgb;\n"
+        "    if (uWmoIndoor) color.rgb = color.rgb * mocv + uWmoAmbient + uWmoLightAdd;\n"
+        "    else color.rgb *= v_lighting * max(mocv, vec3(0.5));\n"
+        "  } else {\n"
+        "    color.rgb *= v_color.rgb * v_lighting;\n"
+        "  }\n"
+        "  if (uFogEnable) {\n"
+        "    float fog = clamp((uFogParams.y - distance(v_world, uFogCamera)) / (uFogParams.y - uFogParams.x), 0.0, 1.0);\n"
+        "    color.rgb = mix(uFogColor, color.rgb, fog);\n"
+        "  }\n"
+        "  if (uSingleTexture && uWmoBlendMode == 1 && color.a < 0.5) discard;\n"
+        "  if (!uSingleTexture || uWmoBlendMode < 2) color.a = 1.0;\n"
+        "  return color;\n"
+        "}\n",
+};
+#undef SHADER_TYPE
+
+#define SHADER_TYPE WOWGRASSSTATE
+static const shader_desc_t sd_wow_grass = {
+    .Name = "wow_grass",
+    .Uniforms = {
+        UNIFORM_NAMED(viewProjection,        "uViewProjectionMatrix", UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM_NAMED(sunDir,                "uSunDir",               UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM_NAMED(sunAmbient,            "uSunAmbient",           UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM_NAMED(sunDiffuse,            "uSunDiffuse",           UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM_NAMED(grassTime,             "uGrassTime",            UT_FLOAT,      PRECISION_LOW),
+        UNIFORM_NAMED(grassCtrl,             "uGrassCtrl",            UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM_NAMED(ctrlOriginWorld,       "uCtrlOriginWorld",      UT_FLOAT_VEC2, PRECISION_LOW),
+        UNIFORM_NAMED(ctrlCellSize,          "uCtrlCellSize",         UT_FLOAT,      PRECISION_LOW),
+        UNIFORM_NAMED(cameraXZ,              "uCameraXZ",             UT_FLOAT_VEC2, PRECISION_LOW),
+        UNIFORM_NAMED(grassSlotSpacing,      "uGrassSlotSpacing",     UT_FLOAT,      PRECISION_LOW),
+        UNIFORM_NAMED(heightAtlas,           "uHeightAtlas",          UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM_NAMED(atlasOriginWorld,      "uAtlasOriginWorld",     UT_FLOAT_VEC2, PRECISION_LOW),
+        UNIFORM_NAMED(atlasChunkSize,        "uAtlasChunkSize",       UT_FLOAT,      PRECISION_LOW),
+        UNIFORM_NAMED(atlasUnitSize,         "uAtlasUnitSize",        UT_FLOAT,      PRECISION_LOW),
+        UNIFORM_NAMED(grassCameraOrigin,     "uGrassCameraOrigin",    UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM_NAMED(grassDrawDistance,     "uGrassDrawDistance",    UT_FLOAT,      PRECISION_LOW),
+        UNIFORM_NAMED(grassFadeStartDistance,"uGrassFadeStartDistance",UT_FLOAT,     PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(normal,   attrib_normal,   UT_FLOAT_VEC3),
+        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
+        ATTRIB(color,    attrib_color,    UT_COLOR),
+    },
+    .Shared = {
+        SHARED(color,    UT_COLOR),
+        SHARED(uv,       UT_FLOAT_VEC2),
+        SHARED(world,    UT_FLOAT_VEC3),
+        SHARED(lighting, UT_FLOAT_VEC3),
+    },
+    .VertexBody =
+        WOW_HEIGHT_ATLAS_GLSL
+        "float GrassHash(vec2 p) { return fract(sin(dot(p, vec2(127.1,311.7))) * 43758.5453); }\n"
+        "vec4 vert() {\n"
+        "  float top = clamp(a_texcoord.y, 0.0, 1.0);\n"
+        "  int gx = gl_InstanceID % " BZ_WOW_STR(WOW_GRASS_GRID_SIDE) " - " BZ_WOW_STR(WOW_GRASS_GRID_HALF) ";\n"
+        "  int gy = gl_InstanceID / " BZ_WOW_STR(WOW_GRASS_GRID_SIDE) " - " BZ_WOW_STR(WOW_GRASS_GRID_HALF) ";\n"
+        "  vec2 cell = floor(uCameraXZ / uGrassSlotSpacing) + vec2(gx, gy);\n"
+        "  vec2 jitter = vec2(GrassHash(cell), GrassHash(cell + vec2(19.19,73.73))) - vec2(0.5);\n"
+        "  vec2 worldXY = (cell + jitter * 0.72) * uGrassSlotSpacing;\n"
+        "  ivec2 htile; vec2 hcell;\n"
+        "  float keep = HeightAtlas_Coord(worldXY, htile, hcell) ? 1.0 : 0.0;\n"
+        "  vec2 crel = (uCtrlOriginWorld - worldXY) / uCtrlCellSize;\n"
+        "  ivec2 cc = ivec2(floor(crel.y), floor(crel.x));\n"
+        "  ivec2 csize = textureSize(uGrassCtrl, 0);\n"
+        "  bool cin = all(greaterThanEqual(cc, ivec2(0))) && all(lessThan(cc, csize));\n"
+        "  vec4 ctrl = cin ? texelFetch(uGrassCtrl, cc, 0) : vec4(1.0, 0.0, 0.0, 0.0);\n"
+        "  float seed = GrassHash(cell + vec2(41.41,17.17));\n"
+        "  keep *= (1.0-step(0.5, ctrl.r)) * step(seed, ctrl.g);\n"
+        "  float scale = 0.65 + 0.7 * GrassHash(cell + vec2(5.13,91.7));\n"
+        "  float yaw = seed * 6.2831853;\n"
+        "  float cy = cos(yaw), sy = sin(yaw);\n"
+        "  vec3 pos = vec3(cy*a_position.x-sy*a_position.z, sy*a_position.x+cy*a_position.z, a_position.y) * scale;\n"
+        "  float phase = GrassHash(cell + vec2(3.71,53.9));\n"
+        "  float wave = sin(uGrassTime * 1.7 + phase * 6.2831853) * 0.22 * top;\n"
+        "  pos.xy += vec2(wave, wave * 0.35);\n"
+        "  pos += vec3(worldXY, HeightAtlas_SampleDiamond(worldXY));\n"
+        "  pos *= keep;\n"
+        "  v_world = pos;\n"
+        "  v_color = vec4(0.28, 0.62, 0.18, keep);\n"
+        "  v_uv = a_texcoord;\n"
+        "  v_lighting = uSunAmbient + uSunDiffuse * clamp(uSunDir.z, 0.0, 1.0);\n"
+        "  return uViewProjectionMatrix * vec4(pos, 1.0);\n"
+        "}\n",
+    .FragmentBody =
+        "vec4 frag() {\n"
+        "  float d = distance(v_world.xy, uGrassCameraOrigin.xy);\n"
+        "  float fade = 1.0 - smoothstep(uGrassFadeStartDistance, uGrassDrawDistance, d);\n"
+        "  float width = 1.0 - abs(v_uv.x * 2.0 - 1.0);\n"
+        "  float edge = smoothstep(0.24, 0.46, width);\n"
+        "  float root = smoothstep(0.02, 0.14, v_uv.y);\n"
+        "  float tip = 1.0 - smoothstep(0.84, 1.00, v_uv.y);\n"
+        "  float blade = edge * root * tip;\n"
+        "  float alpha = v_color.a * fade * blade;\n"
+        "  return vec4(v_color.rgb * v_lighting, alpha);\n"
+        "}\n",
+};
+#undef SHADER_TYPE
+
 void Wow_InitTerrainShader(void) {
-    static LPCSTR vs_wow_terrain =
-    "#version 140\n"
-    "in vec3 i_position;\n"
-    "in vec3 i_normal;\n"
-    "in vec2 i_texcoord;\n"
-    "in vec4 i_color;\n"
-    "out vec2 v_texcoord;\n"
-    "out vec4 v_color;\n"
-    "out vec3 v_lighting;\n"
-    "out vec3 v_world;\n"
-    "uniform mat4 uViewProjectionMatrix;\n"
-    "uniform mat4 uModelMatrix;\n"
-    "uniform mat3 uNormalMatrix;\n"
-    "uniform vec3 uSunDir;\n"
-    "uniform vec3 uSunAmbient;\n"
-    "uniform vec3 uSunDiffuse;\n"
-    WOW_HEIGHT_ATLAS_GLSL
-    "void main() {\n"
-    "    vec4 pos = uModelMatrix * vec4(i_position, 1.0);\n"
-    "    v_texcoord = i_texcoord;\n"
-    "    vec3 normal = normalize(uNormalMatrix * i_normal);\n"
-    "    v_lighting = uSunAmbient + uSunDiffuse * clamp(dot(normal, uSunDir), 0.0, 1.0);\n"
-    "    v_color = i_color;\n"
-    "    v_world = pos.xyz;\n"
-    "    gl_Position = uViewProjectionMatrix * pos;\n"
-    "}\n";
-    static LPCSTR fs_wow_terrain =
-    "#version 140\n"
-    "in vec2 v_texcoord;\n"
-    "in vec4 v_color;\n"
-    "in vec3 v_lighting;\n"
-    "in vec3 v_world;\n"
-    "out vec4 o_color;\n"
-    "uniform sampler2D uTexture0;\n"
-    "uniform sampler2D uTexture1;\n"
-    "uniform sampler2D uTexture2;\n"
-    "uniform sampler2D uTexture3;\n"
-    "uniform sampler2D uAlphaTexture;\n"
-    "uniform int uUseWeightedBlend;\n"
-    "uniform int uSingleTexture;\n"
-    "uniform int uWmoIndoor;\n"
-    "uniform vec3 uWmoAmbient;\n"
-    "uniform vec3 uWmoLightAdd;\n"
-    "uniform int uWmoBlendMode;\n"
-    "uniform vec2 uAlphaOrigin;\n"
-    "uniform float uAlphaAtlasChunks;\n"
-    "uniform bool uFogEnable;\n"
-    "uniform vec3 uFogColor;\n"
-    "uniform vec2 uFogParams;\n"
-    "uniform vec3 uFogCamera;\n"
-    "vec2 adtAlphaCoord(vec2 chunkCoord) {\n"
-    "    const float alphaTexelsPerChunk = 64.0;\n"
-    "    float alphaAtlasSize = alphaTexelsPerChunk * uAlphaAtlasChunks;\n"
-    "    chunkCoord = clamp(chunkCoord, vec2(0.0), vec2(1.0));\n"
-    "    vec2 atlasTexel = uAlphaOrigin * alphaTexelsPerChunk + chunkCoord * (alphaTexelsPerChunk - 1.0) + vec2(0.5);\n"
-    "    return atlasTexel / alphaAtlasSize;\n"
-    "}\n"
-    "void main() {\n"
-    "    vec2 alphaCoord = adtAlphaCoord(v_texcoord * 0.125);\n"
-    "    vec4 tex1 = texture(uTexture0, v_texcoord);\n"
-    "    vec4 color;\n"
-    "    if (uSingleTexture != 0) {\n"
-    "        color = tex1;\n"
-    "    } else {\n"
-    "        vec3 alphaBlend = texture(uAlphaTexture, alphaCoord).gba;\n"
-    "        vec4 tex2 = texture(uTexture1, v_texcoord);\n"
-    "        vec4 tex3 = texture(uTexture2, v_texcoord);\n"
-    "        vec4 tex4 = texture(uTexture3, v_texcoord);\n"
-    "        if (uUseWeightedBlend != 0) {\n"
-    "            float baseWeight = 1.0 - clamp(dot(alphaBlend, vec3(1.0)), 0.0, 1.0);\n"
-    "            vec4 weights = vec4(baseWeight, alphaBlend);\n"
-    "            color = tex1 * weights.r + tex2 * weights.g + tex3 * weights.b + tex4 * weights.a;\n"
-    "        } else {\n"
-    "            color = mix(mix(mix(tex1, tex2, alphaBlend.r), tex3, alphaBlend.g), tex4, alphaBlend.b);\n"
-    "        }\n"
-    "    }\n"
-    /* WMO path: MOCV was fixup-divided-by-2; multiply by 2 cancels that.
-       Interior MOCV is baked lighting plus authored WMO ambient/MOLT. Exterior
-       MOCV is an authored tint and receives the same outdoor directional light
-       as terrain; the 0.5 floor preserves surfaces with unusually dark/no MOCV.
-       Terrain path: vertex color is white (vanilla has no MCCV) and the dynamic
-       sun carried by v_lighting supplies the diffuse term. */
-    "    if (uSingleTexture != 0) {\n"
-    "        vec3 mocv = 2.0 * v_color.rgb;\n"
-    "        if (uWmoIndoor != 0) color.rgb = color.rgb * mocv + uWmoAmbient + uWmoLightAdd;\n"
-    "        else color.rgb *= v_lighting * max(mocv, vec3(0.5));\n"
-    "    } else {\n"
-    "        color.rgb *= v_color.rgb * v_lighting;\n"
-    "    }\n"
-    "    if (uFogEnable) {\n"
-    "        float fog = clamp((uFogParams.y-distance(v_world, uFogCamera))/(uFogParams.y-uFogParams.x), 0.0, 1.0);\n"
-    "        color.rgb = mix(uFogColor, color.rgb, fog);\n"
-    "    }\n"
-    "    if (uSingleTexture != 0 && uWmoBlendMode == 1 && color.a < 0.5) discard;\n"
-    "    if (uSingleTexture == 0 || uWmoBlendMode < 2) color.a = 1.0;\n"
-    "    o_color = color;\n"
-    "}\n";
-
-    if (wow_terrain_shader) {
+    if (wow_terrain_shader.prog.progid) {
         return;
     }
 
-    wow_terrain_shader = R_InitShader(vs_wow_terrain, fs_wow_terrain);
-    if (!wow_terrain_shader) {
-        return;
-    }
+    memset(&wow_terrain_shader, 0, sizeof(wow_terrain_shader));
+    R_LoadShader(&sd_wow_terrain, NULL, &wow_terrain_shader);
 
-    wow_uTexture0 = glGetUniformLocation(wow_terrain_shader->progid, "uTexture0");
-    wow_uTexture1 = glGetUniformLocation(wow_terrain_shader->progid, "uTexture1");
-    wow_uTexture2 = glGetUniformLocation(wow_terrain_shader->progid, "uTexture2");
-    wow_uTexture3 = glGetUniformLocation(wow_terrain_shader->progid, "uTexture3");
-    wow_uAlphaTexture = glGetUniformLocation(wow_terrain_shader->progid, "uAlphaTexture");
-    wow_uUseWeightedBlend = glGetUniformLocation(wow_terrain_shader->progid, "uUseWeightedBlend");
-    wow_uSingleTexture = glGetUniformLocation(wow_terrain_shader->progid, "uSingleTexture");
-    wow_uWmoIndoor = glGetUniformLocation(wow_terrain_shader->progid, "uWmoIndoor");
-    wow_uWmoAmbient = glGetUniformLocation(wow_terrain_shader->progid, "uWmoAmbient");
-    wow_uWmoLightAdd = glGetUniformLocation(wow_terrain_shader->progid, "uWmoLightAdd");
-    wow_uWmoBlendMode = glGetUniformLocation(wow_terrain_shader->progid, "uWmoBlendMode");
-    wow_uAlphaOrigin = glGetUniformLocation(wow_terrain_shader->progid, "uAlphaOrigin");
-    wow_uAlphaAtlasChunks = glGetUniformLocation(wow_terrain_shader->progid, "uAlphaAtlasChunks");
-    wow_uFogEnable = glGetUniformLocation(wow_terrain_shader->progid, "uFogEnable");
-    wow_uFogColor = glGetUniformLocation(wow_terrain_shader->progid, "uFogColor");
-    wow_uFogParams = glGetUniformLocation(wow_terrain_shader->progid, "uFogParams");
-    wow_uFogCamera = glGetUniformLocation(wow_terrain_shader->progid, "uFogCamera");
-    wow_uSunDir = glGetUniformLocation(wow_terrain_shader->progid, "uSunDir");
-    wow_uSunAmbient = glGetUniformLocation(wow_terrain_shader->progid, "uSunAmbient");
-    wow_uSunDiffuse = glGetUniformLocation(wow_terrain_shader->progid, "uSunDiffuse");
-    R_Call(glUseProgram, wow_terrain_shader->progid);
-    R_Call(glUniform1i, wow_uTexture0, 0);
-    R_Call(glUniform1i, wow_uTexture1, 1);
-    R_Call(glUniform1i, wow_uTexture2, 2);
-    R_Call(glUniform1i, wow_uTexture3, 3);
-    R_Call(glUniform1i, wow_uAlphaTexture, 4);
-    R_Call(glUniform1f, wow_uAlphaAtlasChunks, (GLfloat)WOW_ALPHA_ATLAS_CHUNKS);
-    R_Call(glUniform1i, wow_uSingleTexture, 0);
-    R_Call(glUniform1i, wow_uWmoIndoor, 0);
-    R_Call(glUniform3f, wow_uWmoAmbient, 0.0f, 0.0f, 0.0f);
-    R_Call(glUniform3f, wow_uWmoLightAdd, 0.0f, 0.0f, 0.0f);
-    R_Call(glUniform1i, wow_uWmoBlendMode, 0);
+    wow_terrain_shader.state.texture0 = 0;
+    wow_terrain_shader.state.texture1 = 1;
+    wow_terrain_shader.state.texture2 = 2;
+    wow_terrain_shader.state.texture3 = 3;
+    wow_terrain_shader.state.alphaTexture = 4;
+    wow_terrain_shader.state.alphaAtlasChunks = (GLfloat)WOW_ALPHA_ATLAS_CHUNKS;
+    wow_terrain_shader.state.singleTexture = 0;
+    wow_terrain_shader.state.wmoIndoor = 0;
+    wow_terrain_shader.state.wmoAmbient = (VECTOR3){ 0.0f, 0.0f, 0.0f };
+    wow_terrain_shader.state.wmoLightAdd = (VECTOR3){ 0.0f, 0.0f, 0.0f };
+    wow_terrain_shader.state.wmoBlendMode = 0;
 }
 
 void Wow_InitGrassShader(void) {
-    static LPCSTR vs_wow_grass =
-    "#version 140\n"
-    "in vec3 i_position;\n"
-    "in vec3 i_normal;\n"
-    "in vec2 i_texcoord;\n"
-    "in vec4 i_color;\n"
-    "out vec4 v_color;\n"
-    "out vec2 v_uv;\n"
-    "out vec3 v_world;\n"
-    "out vec3 v_lighting;\n"
-    "uniform mat4 uViewProjectionMatrix;\n"
-    "uniform vec3 uSunDir;\n"
-    "uniform vec3 uSunAmbient;\n"
-    "uniform vec3 uSunDiffuse;\n"
-    "uniform float uGrassTime;\n"
-    "uniform sampler2D uGrassCtrl;\n"
-    "uniform vec2 uCtrlOriginWorld;\n"
-    "uniform float uCtrlCellSize;\n"
-    "uniform vec2 uCameraXZ;\n"
-    "uniform float uGrassSlotSpacing;\n"
-    WOW_HEIGHT_ATLAS_GLSL
-    "float GrassHash(vec2 p) { return fract(sin(dot(p, vec2(127.1,311.7))) * 43758.5453); }\n"
-    "void main() {\n"
-    "    float top = clamp(i_texcoord.y, 0.0, 1.0);\n"
-    "    int gx = gl_InstanceID % " BZ_WOW_STR(WOW_GRASS_GRID_SIDE) " - " BZ_WOW_STR(WOW_GRASS_GRID_HALF) ";\n"
-    "    int gy = gl_InstanceID / " BZ_WOW_STR(WOW_GRASS_GRID_SIDE) " - " BZ_WOW_STR(WOW_GRASS_GRID_HALF) ";\n"
-    "    vec2 cell = floor(uCameraXZ / uGrassSlotSpacing) + vec2(gx, gy);\n"
-    "    vec2 jitter = vec2(GrassHash(cell), GrassHash(cell + vec2(19.19,73.73))) - vec2(0.5);\n"
-    "    vec2 worldXY = (cell + jitter * 0.72) * uGrassSlotSpacing;\n"
-    "    ivec2 htile; vec2 hcell;\n"
-    "    float keep = HeightAtlas_Coord(worldXY, htile, hcell) ? 1.0 : 0.0;\n"
-    "    vec2 crel = (uCtrlOriginWorld - worldXY) / uCtrlCellSize;\n"
-    "    ivec2 cc = ivec2(floor(crel.y), floor(crel.x));\n"
-    "    ivec2 csize = textureSize(uGrassCtrl, 0);\n"
-    "    bool cin = all(greaterThanEqual(cc, ivec2(0))) && all(lessThan(cc, csize));\n"
-    "    vec4 ctrl = cin ? texelFetch(uGrassCtrl, cc, 0) : vec4(1.0, 0.0, 0.0, 0.0);\n"
-    "    float seed = GrassHash(cell + vec2(41.41,17.17));\n"
-    "    keep *= (1.0-step(0.5, ctrl.r)) * step(seed, ctrl.g);\n"
-    "    float scale = 0.65 + 0.7 * GrassHash(cell + vec2(5.13,91.7));\n"
-    "    float yaw = seed * 6.2831853;\n"
-    "    float cy = cos(yaw), sy = sin(yaw);\n"
-    "    vec3 pos = vec3(cy*i_position.x-sy*i_position.z, sy*i_position.x+cy*i_position.z, i_position.y) * scale;\n"
-    "    float phase = GrassHash(cell + vec2(3.71,53.9));\n"
-    "    float wave = sin(uGrassTime * 1.7 + phase * 6.2831853) * 0.22 * top;\n"
-    "    pos.xy += vec2(wave, wave * 0.35);\n"
-    "    pos += vec3(worldXY, HeightAtlas_SampleDiamond(worldXY));\n"
-    "    pos *= keep;\n"
-    "    v_world = pos;\n"
-    "    v_color = vec4(0.28, 0.62, 0.18, keep);\n"
-    "    v_uv = i_texcoord;\n"
-    "    v_lighting = uSunAmbient + uSunDiffuse * clamp(uSunDir.z, 0.0, 1.0);\n"
-    "    gl_Position = uViewProjectionMatrix * vec4(pos, 1.0);\n"
-    "}\n";
-    static LPCSTR fs_wow_grass =
-    "#version 140\n"
-    "in vec4 v_color;\n"
-    "in vec2 v_uv;\n"
-    "in vec3 v_world;\n"
-    "in vec3 v_lighting;\n"
-    "out vec4 o_color;\n"
-    "uniform vec3 uGrassCameraOrigin;\n"
-    "uniform float uGrassDrawDistance;\n"
-    "uniform float uGrassFadeStartDistance;\n"
-    "void main() {\n"
-    "    float d = distance(v_world.xy, uGrassCameraOrigin.xy);\n"
-    "    float fade = 1.0 - smoothstep(uGrassFadeStartDistance, uGrassDrawDistance, d);\n"
-    "    float width = 1.0 - abs(v_uv.x * 2.0 - 1.0);\n"
-    "    float edge = smoothstep(0.24, 0.46, width);\n"
-    "    float root = smoothstep(0.02, 0.14, v_uv.y);\n"
-    "    float tip = 1.0 - smoothstep(0.84, 1.00, v_uv.y);\n"
-    "    float blade = edge * root * tip;\n"
-    "    float alpha = v_color.a * fade * blade;\n"
-    "    o_color = vec4(v_color.rgb * v_lighting, alpha);\n"
-    "}\n";
-
-    if (wow_grass_shader) {
+    if (wow_grass_shader.prog.progid) {
         return;
     }
 
-    wow_grass_shader = R_InitShader(vs_wow_grass, fs_wow_grass);
-    if (!wow_grass_shader) {
-        return;
-    }
+    memset(&wow_grass_shader, 0, sizeof(wow_grass_shader));
+    R_LoadShader(&sd_wow_grass, NULL, &wow_grass_shader);
 
-    wow_uGrassTime = glGetUniformLocation(wow_grass_shader->progid, "uGrassTime");
-    wow_uGrassCameraOrigin = glGetUniformLocation(wow_grass_shader->progid, "uGrassCameraOrigin");
-    wow_uGrassDrawDistance = glGetUniformLocation(wow_grass_shader->progid, "uGrassDrawDistance");
-    wow_uGrassFadeStartDistance = glGetUniformLocation(wow_grass_shader->progid, "uGrassFadeStartDistance");
-    wow_uHeightAtlas = glGetUniformLocation(wow_grass_shader->progid, "uHeightAtlas");
-    wow_uAtlasOriginWorld = glGetUniformLocation(wow_grass_shader->progid, "uAtlasOriginWorld");
-    wow_uAtlasChunkSize = glGetUniformLocation(wow_grass_shader->progid, "uAtlasChunkSize");
-    wow_uAtlasUnitSize = glGetUniformLocation(wow_grass_shader->progid, "uAtlasUnitSize");
-    wow_uGrassCtrl = glGetUniformLocation(wow_grass_shader->progid, "uGrassCtrl");
-    wow_uCtrlOriginWorld = glGetUniformLocation(wow_grass_shader->progid, "uCtrlOriginWorld");
-    wow_uCtrlCellSize = glGetUniformLocation(wow_grass_shader->progid, "uCtrlCellSize");
-    wow_uCameraXZ = glGetUniformLocation(wow_grass_shader->progid, "uCameraXZ");
-    wow_uGrassSlotSpacing = glGetUniformLocation(wow_grass_shader->progid, "uGrassSlotSpacing");
-    wow_uGrassSunDir = glGetUniformLocation(wow_grass_shader->progid, "uSunDir");
-    wow_uGrassSunAmbient = glGetUniformLocation(wow_grass_shader->progid, "uSunAmbient");
-    wow_uGrassSunDiffuse = glGetUniformLocation(wow_grass_shader->progid, "uSunDiffuse");
 }

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_splat.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_splat.c
@@ -2,7 +2,7 @@
 
 typedef struct {
     LPCTEXTURE texture;
-    LPCSHADER shader;
+    splat_shader_t *shader;
     DWORD num_vertices;
     VERTEX vertices[WOW_SPLAT_BATCH_VERTICES];
 } WOWSPLATBATCH;
@@ -10,16 +10,16 @@ typedef struct {
 static WOWSPLATBATCH wow_splat_batches[WOW_SPLAT_BATCHES];
 
 /* Stream one material batch in a single upload/draw pair. */
-static void Wow_DrawSplatVertices(LPCTEXTURE texture, LPCSHADER shader,
+static void Wow_DrawSplatVertices(LPCTEXTURE texture, splat_shader_t *shader,
                                   LPCVERTEX vertices, DWORD num_vertices) {
     MATRIX4 model_matrix;
 
     if (!texture || !shader || !vertices || !num_vertices) return;
     Matrix4_identity(&model_matrix);
     R_BindTexture(texture, 0);
-    R_Call(glUseProgram, shader->progid);
-    R_Call(glUniformMatrix4fv, shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
-    R_Call(glUniformMatrix4fv, shader->uModelMatrix, 1, GL_FALSE, model_matrix.v);
+
+    shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
+    shader->state.model = model_matrix;
     R_Call(glEnable, GL_BLEND);
     R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     R_Call(glDepthMask, GL_FALSE);
@@ -30,6 +30,7 @@ static void Wow_DrawSplatVertices(LPCTEXTURE texture, LPCSHADER shader,
     /* Re-specifying the whole stream buffer lets the driver orphan busy storage. */
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(*vertices) * num_vertices, vertices, GL_STREAM_DRAW);
     R_StatsDraw(GL_TRIANGLES, num_vertices, 1);
+    R_ApplyShader(shader);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, num_vertices);
     R_Call(glDisable, GL_POLYGON_OFFSET_FILL);
     R_Call(glDepthMask, GL_TRUE);
@@ -45,7 +46,7 @@ void Wow_FlushSplats(void) {
 }
 
 /* Group splats by material; common blob shadows and selection rings become one draw each. */
-static void Wow_QueueSplatVertices(LPCTEXTURE texture, LPCSHADER shader,
+static void Wow_QueueSplatVertices(LPCTEXTURE texture, splat_shader_t *shader,
                                    LPCVERTEX vertices, DWORD num_vertices) {
     WOWSPLATBATCH *empty = NULL;
 
@@ -122,7 +123,7 @@ void Wow_AddSplatTriangle(LPVERTEX vertices,
 void R_DrawTerrainShadows(void) {
 }
 
-void R_RenderRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, LPCSHADER shader, COLOR32 color) {
+void R_RenderRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, splat_shader_t *shader, COLOR32 color) {
     float width;
     float height;
     int cols;
@@ -241,7 +242,7 @@ void R_RenderRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, LPC
 }
 
 void R_RenderFlatRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, FLOAT z,
-                           LPCTEXTURE texture, LPCSHADER shader, COLOR32 color) {
+                           LPCTEXTURE texture, splat_shader_t *shader, COLOR32 color) {
     float width;
     float height;
     VERTEX vertices[6];
@@ -266,7 +267,7 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, FLOAT z,
     Wow_QueueSplatVertices(texture, shader, vertices, 6);
 }
 
-void R_RenderSplat(LPCVECTOR2 position, float radius, LPCTEXTURE texture, LPCSHADER shader, COLOR32 color) {
+void R_RenderSplat(LPCVECTOR2 position, float radius, LPCTEXTURE texture, splat_shader_t *shader, COLOR32 color) {
     if (!position || radius <= 0.0f) return;
     VECTOR2 mins = { .x = position->x - radius, .y = position->y - radius };
     VECTOR2 maxs = { .x = position->x + radius, .y = position->y + radius };
@@ -275,8 +276,8 @@ void R_RenderSplat(LPCVECTOR2 position, float radius, LPCTEXTURE texture, LPCSHA
 
 /* WoW shadows are drawn by R_GameRenderShadow (returns true) and splats already
  * batch through Wow_QueueSplatVertices, so the shared batch API stays immediate. */
-static LPCSHADER wow_batch_shader;
-void R_BeginSplatBatch(LPCSHADER shader) { wow_batch_shader = shader; }
+static splat_shader_t *wow_batch_shader;
+void R_BeginSplatBatch(splat_shader_t *shader) { wow_batch_shader = shader; }
 void R_AddRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, COLOR32 color) {
     R_RenderRectSplat(mins, maxs, texture, wow_batch_shader, color);
 }

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_state.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_state.c
@@ -257,33 +257,10 @@ void Wow_FreeWorld(void) {
 }
 
 void Wow_ShutdownWorldShaders(void) {
-    SAFE_DELETE(wow_terrain_shader, R_ReleaseShader);
-    SAFE_DELETE(wow_grass_shader, R_ReleaseShader);
-    wow_uTexture0 = -1;
-    wow_uTexture1 = -1;
-    wow_uTexture2 = -1;
-    wow_uTexture3 = -1;
-    wow_uAlphaTexture = -1;
-    wow_uUseWeightedBlend = -1;
-    wow_uSingleTexture = -1;
-    wow_uWmoIndoor = -1;
-    wow_uWmoAmbient = -1;
-    wow_uWmoBlendMode = -1;
-    wow_uAlphaOrigin = -1;
-    wow_uAlphaAtlasChunks = -1;
-    wow_uGrassTime = -1;
-    wow_uGrassCameraOrigin = -1;
-    wow_uGrassDrawDistance = -1;
-    wow_uGrassFadeStartDistance = -1;
-    wow_uHeightAtlas = -1;
-    wow_uAtlasOriginWorld = -1;
-    wow_uAtlasChunkSize = -1;
-    wow_uAtlasUnitSize = -1;
-    wow_uGrassCtrl = -1;
-    wow_uCtrlOriginWorld = -1;
-    wow_uCtrlCellSize = -1;
-    wow_uCameraXZ = -1;
-    wow_uGrassSlotSpacing = -1;
+    R_DeleteShader(&wow_terrain_shader.prog);
+    R_DeleteShader(&wow_grass_shader.prog);
+    memset(&wow_terrain_shader, 0, sizeof(wow_terrain_shader));
+    memset(&wow_grass_shader, 0, sizeof(wow_grass_shader));
 }
 
 LPTEXTURE Wow_LoadTexture(LPCSTR path) {
@@ -405,7 +382,6 @@ float Wow_LoadM2BoundsRadius(LPCSTR path) {
     }
     return radius;
 }
-
 
 void Wow_FreeStringList(char **strings, DWORD count) {
     if (!strings) {

--- a/renderer/r_draw.c
+++ b/renderer/r_draw.c
@@ -294,15 +294,6 @@ void R_DrawMinimapCameraRect(LPCRECT screen) {
         return;
     }
 
-    static int log_frame = 0;
-    if (++log_frame % 60 == 0) {
-        fprintf(stderr, "[minimap_cam] viewport px: L=%.1f R=%.1f T=%.1f B=%.1f\n", left, right, top, bottom);
-        FOR_LOOP(i, 4) {
-            fprintf(stderr, "  corner[%d] world=(%.1f,%.1f,%.1f) minimap=(%.1f,%.1f)\n",
-                i, worlds[i].x, worlds[i].y, worlds[i].z, corners[i].x, corners[i].y);
-        }
-    }
-
     FOR_LOOP(i, 5) {
         VECTOR2 const *corner = &corners[i % 4];
         vertices[i] = (VERTEX){

--- a/renderer/r_draw.c
+++ b/renderer/r_draw.c
@@ -34,12 +34,11 @@ void R_DrawString(int x, int y, LPCSTR text) {
     if (!count) return;
 
     Matrix4_ortho(&ui_matrix, 0.0f, window.width, window.height, 0.0f, 0.0f, 100.0f);
-    
-    R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
+
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, count * sizeof(*simp), simp, GL_DYNAMIC_DRAW);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, ui_matrix.v);
+    tr.shader_ui.state.viewProjection = ui_matrix;
     
     R_BindTexture(tr.texture[TEX_FONT], 0);
     
@@ -47,6 +46,7 @@ void R_DrawString(int x, int y, LPCSTR text) {
     R_Call(glEnable, GL_BLEND);
     R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     R_StatsDraw(GL_TRIANGLES, count, 1);
+    R_ApplyShader(&tr.shader_ui);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, count);
 }
 
@@ -64,11 +64,10 @@ void R_DrawFill(LPCRECT rect, COLOR32 color) {
     R_AddQuad(simp, rect, &(RECT){0, 0, 1, 1}, color, 0);
     Matrix4_ortho(&ui_matrix, 0.0f, window.width, window.height, 0.0f, 0.0f, 100.0f);
 
-    R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_DYNAMIC_DRAW);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, ui_matrix.v);
+    tr.shader_ui.state.viewProjection = ui_matrix;
 
     R_BindTexture(tr.texture[TEX_WHITE], 0);
 
@@ -78,6 +77,7 @@ void R_DrawFill(LPCRECT rect, COLOR32 color) {
     R_Call(glEnable, GL_BLEND);
     R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     R_StatsDraw(GL_TRIANGLES, 6, 1);
+    R_ApplyShader(&tr.shader_ui);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, 6);
 }
 
@@ -137,7 +137,7 @@ void R_DrawImageBatch(LPCTEXTURE texture,
         return;
     }
 
-    LPCSHADER shader = tr.shader[shaderType];
+    SPRITEPROG *shader = R_SpriteShader(shaderType);
     
     MATRIX4 ui_matrix, model_matrix;
     RECT const scene = R_UISceneRect();
@@ -145,10 +145,10 @@ void R_DrawImageBatch(LPCTEXTURE texture,
     Matrix4_identity(&model_matrix);
     
     R_Call(glDisable, GL_CULL_FACE);
-    R_Call(glUseProgram, shader->progid);
-    R_Call(glUniformMatrix4fv, shader->uViewProjectionMatrix, 1, GL_FALSE, ui_matrix.v);
-    R_Call(glUniformMatrix4fv, shader->uModelMatrix, 1, GL_FALSE, model_matrix.v);
-    R_Call(glUniform1f , shader->uActiveGlow, uActiveGlow);
+
+    shader->state.viewProjection = ui_matrix;
+    shader->state.model = model_matrix;
+    shader->state.activeGlow = uActiveGlow;
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(VERTEX) * num_vertices, vertices, GL_DYNAMIC_DRAW);
@@ -176,6 +176,7 @@ void R_DrawImageBatch(LPCTEXTURE texture,
         R_SetUIClipScissor(clip);
     }
     R_StatsDraw(GL_TRIANGLES, num_vertices, 1);
+    R_ApplyShader(shader);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, num_vertices);
     if (hasClip) {
         R_ResetUIScissor();
@@ -320,14 +321,15 @@ void R_DrawMinimapCameraRect(LPCRECT screen) {
     R_Call(glDisable, GL_CULL_FACE);
     R_Call(glEnable, GL_BLEND);
     R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, ui_matrix.v);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uModelMatrix, 1, GL_FALSE, model_matrix.v);
+
+    tr.shader_ui.state.viewProjection = ui_matrix;
+    tr.shader_ui.state.model = model_matrix;
     R_BindTexture(tr.texture[TEX_WHITE], 0);
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_DYNAMIC_DRAW);
     R_StatsDraw(GL_LINE_STRIP, 5, 1);
+    R_ApplyShader(&tr.shader_ui);
     R_Call(glDrawArrays, GL_LINE_STRIP, 0, 5);
 }
 
@@ -410,8 +412,7 @@ void R_DrawWireRect(LPCRECT rect, COLOR32 color) {
     size2_t const window = R_GetWindowSize();
     Matrix4_ortho(&ui_matrix, 0.0f, window.width, window.height, 0.0f, 0.0f, 100.0f);
 
-    R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, ui_matrix.v);
+    tr.shader_ui.state.viewProjection = ui_matrix;
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_DYNAMIC_DRAW);
@@ -422,6 +423,7 @@ void R_DrawWireRect(LPCRECT rect, COLOR32 color) {
     R_Call(glEnable, GL_BLEND);
     R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     R_StatsDraw(GL_LINE_STRIP, sizeof(simp) / sizeof(*simp), 1);
+    R_ApplyShader(&tr.shader_ui);
     R_Call(glDrawArrays, GL_LINE_STRIP, 0, sizeof(simp) / sizeof(*simp));
 }
 
@@ -453,9 +455,8 @@ void R_DrawBoundingBox(LPCBOX3 box, LPCMATRIX4 modelMatrix, LPCMATRIX4 vpMatrix,
         simp[i * 2 + 1].color = color;
     }
 
-    R_Call(glUseProgram, tr.shader[SHADER_DEFAULT]->progid);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_DEFAULT]->uViewProjectionMatrix, 1, GL_FALSE, vpMatrix->v);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_DEFAULT]->uModelMatrix, 1, GL_FALSE, modelMatrix->v);
+    tr.shader_default.state.viewProjection = *vpMatrix;
+    tr.shader_default.state.model = *modelMatrix;
     R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_DYNAMIC_DRAW);
@@ -467,6 +468,7 @@ void R_DrawBoundingBox(LPCBOX3 box, LPCMATRIX4 modelMatrix, LPCMATRIX4 vpMatrix,
     R_Call(glEnable, GL_BLEND);
     R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     R_StatsDraw(GL_LINES, 24, 1);
+    R_ApplyShader(&tr.shader_default);
     R_Call(glDrawArrays, GL_LINES, 0, 24);
     R_Call(glEnable, GL_DEPTH_TEST);
 }

--- a/renderer/r_ents.c
+++ b/renderer/r_ents.c
@@ -209,7 +209,7 @@ DWORD R_EntitiesInRect(viewDef_t const *viewdef, LPCRECT rect, DWORD max, LPDWOR
 }
 
 #ifdef USE_SHADOWMAPS
-extern bool is_rendering_lights;
+extern render_phase_t render_phase;
 #endif
 DWORD selCircles[NUM_SELECTION_CIRCLES] = { 100, 300, 100000 };
 
@@ -435,7 +435,7 @@ void R_RenderModel(renderEntity_t const *entity) {
         return;
 
 #ifdef USE_SHADOWMAPS
-    if (is_rendering_lights) {
+    if (render_phase == RENDER_PHASE_LIGHTS) {
         if (!(entity->flags & RF_NO_SHADOW))
             R_GameRenderModel(entity);
         return;

--- a/renderer/r_ents.c
+++ b/renderer/r_ents.c
@@ -133,7 +133,7 @@ void R_DrawDecals(void) {
                 continue;
             }
         }
-        R_RenderSplat(&decal->origin, decal->radius, decal->texture, tr.shader[SHADER_SPLAT], decal->color);
+        R_RenderSplat(&decal->origin, decal->radius, decal->texture, R_SPLAT_SHADER(&tr.shader_splat), decal->color);
     }
 }
 
@@ -215,7 +215,7 @@ DWORD selCircles[NUM_SELECTION_CIRCLES] = { 100, 300, 100000 };
 
 static void R_RenderUberSplat(const renderEntity_t *entity, LPCVECTOR2 origin) {
     if (entity->splat && !(entity->flags & RF_NO_UBERSPLAT)) {
-        R_RenderSplat(origin, entity->splatsize, entity->splat, tr.shader[SHADER_DEFAULT], COLOR32_WHITE);
+        R_RenderSplat(origin, entity->splatsize, entity->splat, R_SPLAT_SHADER(&tr.shader_default), COLOR32_WHITE);
     }
 }
 
@@ -270,7 +270,7 @@ static void R_RenderShadow(const renderEntity_t *entity, LPCVECTOR2 origin) {
  * texture change or buffer capacity), instead of one per unit. */
 static void R_DrawEntityShadows(void) {
 #ifndef USE_SHADOWMAPS
-    R_BeginSplatBatch(tr.shader[SHADER_SHADOWSPLAT]);
+    R_BeginSplatBatch(R_SPLAT_SHADER(&tr.shader_shadowSplat));
     FOR_LOOP(i, tr.viewDef.num_entities) {
         renderEntity_t const *ent = tr.viewDef.entities + i;
         if ((ent->flags & RF_HIDDEN) || !ent->model) {
@@ -290,7 +290,7 @@ static void R_RenderSelectedCircle(const renderEntity_t *entity, LPCVECTOR2 orig
             if ((radius * 2) > selCircles[i])
                 continue;
             /* A flat actor-Z quad intersects sloped terrain; the splat path fits the ring to terrain samples. */
-            R_RenderSplat(origin, radius, tr.texture[TEX_SELECTION_CIRCLE+i], tr.shader[SHADER_SPLAT], color);
+            R_RenderSplat(origin, radius, tr.texture[TEX_SELECTION_CIRCLE+i], R_SPLAT_SHADER(&tr.shader_splat), color);
             break;
         }
     }
@@ -425,7 +425,7 @@ static void R_RenderHoverHighlight(renderEntity_t const *entity) {
             continue;
         R_RenderSplat(&(VECTOR2){ entity->origin.x, entity->origin.y },
                       radius, tr.texture[TEX_SELECTION_CIRCLE+i],
-                      tr.shader[SHADER_SPLAT], color);
+                      R_SPLAT_SHADER(&tr.shader_splat), color);
         break;
     }
 }

--- a/renderer/r_fogofwar.c
+++ b/renderer/r_fogofwar.c
@@ -1,5 +1,6 @@
 #include "r_local.h"
 #include "r_game.h"
+#include "r_shader.h"
 
 #define SIGHT_SIZE 64
 #define SIGHT_DISTANCE 2000
@@ -8,44 +9,63 @@
 #define MAX_FOGOFWAR_REVEALERS MAX_FOGOFWAR_CASTERS
 #define NUM_SIGHT_SECIONS 5
 
-LPCSTR vs_shadow =
-"#version 140\n"
-"in vec3 i_position;\n"
-"in vec4 i_color;\n"
-"in vec2 i_texcoord;\n"
-"out vec4 v_color;\n"
-"out vec2 v_texcoord;\n"
-"uniform mat4 uViewProjectionMatrix;\n"
-"uniform mat4 uModelMatrix;\n"
-"uniform vec2 uEyePosition;\n"
-"void main() {\n"
-"    vec4 pos = vec4(i_position, 1.0);\n"
-"    vec3 eye = vec3(uEyePosition, 0.0);\n"
-"    vec3 up = vec3(0, 0, 1);\n"
-"    vec3 dir = normalize(i_position - eye);\n"
-"    vec3 side = normalize(cross(dir, up));\n"
-"    if (distance(eye.xy, i_position.xy) > 100.0) {\n"
-"      float x = (i_texcoord.x - 0.5) * 2.0;\n"
-"      float y = i_texcoord.y;\n"
-"      pos.xy += side.xy * x * /*i_position.z*/100.0;\n"
-"      pos.xy += normalize(pos.xyz - eye).xy * y * 2000.0;\n"
-"    }\n"
-"    pos.z = 0;\n"
-"    v_color = i_color;\n"
-"    v_texcoord = i_texcoord;\n"
-"    gl_Position = uViewProjectionMatrix * uModelMatrix * pos;\n"
-"}\n";
+typedef struct FOWRAYCASTSTATE {
+    MATRIX4 viewProjection;
+    MATRIX4 model;
+    VECTOR2 eyePosition;
+} FOWRAYCASTSTATE;
+typedef struct FOWRAYCASTSTATE *LPFOWRAYCASTSTATE;
+typedef const struct FOWRAYCASTSTATE *LPCFOWRAYCASTSTATE;
+typedef struct FOWRAYCASTPROG {
+    SHADERPROG prog;
+    FOWRAYCASTSTATE state;
+} FOWRAYCASTPROG;
+typedef struct FOWRAYCASTPROG *LPFOWRAYCASTPROG;
+typedef const struct FOWRAYCASTPROG *LPCFOWRAYCASTPROG;
 
-LPCSTR fs_shadow =
-"#version 140\n"
-"in vec4 v_color;\n"
-"in vec2 v_texcoord;\n"
-"out vec4 o_color;\n"
-"void main() {\n"
-"    float f = 2.0 * abs(v_texcoord.x - 0.5);\n"
-"    float k = smoothstep(0.0,0.2,v_texcoord.y);\n"
-"    o_color = vec4(mix(1.0,f*f,k));\n"
-"}\n";
+#define SHADER_TYPE FOWRAYCASTSTATE
+static const shader_desc_t sd_fow_raycast = {
+    .Name = "fow_raycast",
+    .Uniforms = {
+        UNIFORM(viewProjection, UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(model,          UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(eyePosition,    UT_FLOAT_VEC2, PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(color,    attrib_color,    UT_COLOR),
+        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
+    },
+    .Shared = {
+        SHARED(color,    UT_COLOR),
+        SHARED(texcoord, UT_FLOAT_VEC2),
+    },
+    .VertexBody =
+        "vec4 vert() {\n"
+        "  vec4 pos = vec4(a_position, 1.0);\n"
+        "  vec3 eye = vec3(u_eyePosition, 0.0);\n"
+        "  vec3 up = vec3(0, 0, 1);\n"
+        "  vec3 dir = normalize(a_position - eye);\n"
+        "  vec3 side = normalize(cross(dir, up));\n"
+        "  if (distance(eye.xy, a_position.xy) > 100.0) {\n"
+        "    float x = (a_texcoord.x - 0.5) * 2.0;\n"
+        "    float y = a_texcoord.y;\n"
+        "    pos.xy += side.xy * x * 100.0;\n"
+        "    pos.xy += normalize(pos.xyz - eye).xy * y * 2000.0;\n"
+        "  }\n"
+        "  pos.z = 0;\n"
+        "  v_color = a_color;\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  return u_viewProjection * u_model * pos;\n"
+        "}\n",
+    .FragmentBody =
+        "vec4 frag() {\n"
+        "  float f = 2.0 * abs(v_texcoord.x - 0.5);\n"
+        "  float k = smoothstep(0.0, 0.2, v_texcoord.y);\n"
+        "  return vec4(mix(1.0, f*f, k));\n"
+        "}\n",
+};
+#undef SHADER_TYPE
 
 enum {
     FOW_RT_IMMEDIATE,
@@ -54,13 +74,8 @@ enum {
     FOW_RT_COUNT,
 };
 
-enum {
-    FOW_SHADER_RAYCAST,
-    FOW_SHADER_COUNT,
-};
-
 static struct {
-    LPSHADER shader[FOW_SHADER_COUNT];
+    FOWRAYCASTPROG shader;
     LPRENDERTARGET rt[FOW_RT_COUNT];
     LPBUFFER casters;
     LPTEXTURE sight;
@@ -108,8 +123,8 @@ static void R_MakeSightMatrix(renderEntity_t const *ent, LPMATRIX4 model_matrix)
         SIGHT_DISTANCE,
         SIGHT_DISTANCE,
     });
-    R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uModelMatrix, 1, GL_FALSE, model_matrix->v);
+
+    tr.shader_ui.state.model = *model_matrix;
 }
 
 static DWORD R_CollectRevealers(renderEntity_t const **out, DWORD max_revealers) {
@@ -220,14 +235,15 @@ static void R_BlitTexture(GLuint texid, float alpha) {
     Matrix4_identity(&model_matrix);
 
     // Set simple projection
-    R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uModelMatrix, 1, GL_FALSE, model_matrix.v);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, proj_matrix.v);
+
+    tr.shader_ui.state.model = model_matrix;
+    tr.shader_ui.state.viewProjection = proj_matrix;
 
     R_Call(glBindTexture, GL_TEXTURE_2D, texid);
     {
         DWORD count = R_PushRectToBuffer(RBUF_TEMP1, &uv, alpha);
         R_StatsDraw(GL_TRIANGLES, count, 1);
+        R_ApplyShader(&tr.shader_ui);
         R_Call(glDrawArrays, GL_TRIANGLES, 0, count);
     }
 }
@@ -271,13 +287,11 @@ void R_RenderFogOfWar(void) {
     if (num_revealers > 0) {
         num_casters = R_AddCastersToBuffer(fow_resources.casters, revealers, num_revealers);
 
-        R_Call(glUseProgram, fow_resources.shader[FOW_SHADER_RAYCAST]->progid);
-        R_Call(glUniformMatrix4fv, fow_resources.shader[FOW_SHADER_RAYCAST]->uViewProjectionMatrix, 1, GL_FALSE, proj_matrix.v);
-        R_Call(glUniformMatrix4fv, fow_resources.shader[FOW_SHADER_RAYCAST]->uModelMatrix, 1, GL_FALSE, model_matrix.v);
+        fow_resources.shader.state.viewProjection = proj_matrix;
+        fow_resources.shader.state.model = model_matrix;
     }
 
-    R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, proj_matrix.v);
+    tr.shader_ui.state.viewProjection = proj_matrix;
 
     R_Call(glViewport, 0, 0, texture_width, texture_height);
     R_Call(glScissor, 0, 0, texture_width, texture_height);
@@ -305,15 +319,17 @@ void R_RenderFogOfWar(void) {
         R_Call(glBindTexture, GL_TEXTURE_2D, fow_resources.sight->texid);
         R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
         R_StatsDraw(GL_TRIANGLES, NUM_RECT_VERTICES, 1);
+        R_ApplyShader(&tr.shader_ui);
         R_Call(glDrawArrays, GL_TRIANGLES, 0, NUM_RECT_VERTICES);
 
         // Draw line of sight into dst alpha
-        R_Call(glUseProgram, fow_resources.shader[FOW_SHADER_RAYCAST]->progid);
-        R_Call(glUniform2fv, fow_resources.shader[FOW_SHADER_RAYCAST]->uEyePosition, 1, (GLfloat *)&ent->origin);
+
+        memcpy(&fow_resources.shader.state.eyePosition, (GLfloat *)&ent->origin, (1) * sizeof(VECTOR2));
         R_Call(glBindVertexArray, fow_resources.casters->vao);
         R_Call(glBlendFunc, GL_DST_ALPHA, GL_ZERO);
         R_Call(glBindBuffer, GL_ARRAY_BUFFER, fow_resources.casters->vbo);
         R_StatsDraw(GL_TRIANGLES, num_casters, 1);
+        R_ApplyShader(&fow_resources.shader);
         R_Call(glDrawArrays, GL_TRIANGLES, 0, num_casters);
         
         // Draw white rect using dst alpha
@@ -324,6 +340,7 @@ void R_RenderFogOfWar(void) {
         R_Call(glBlendFunc, GL_DST_ALPHA, GL_ONE_MINUS_DST_ALPHA);
         R_Call(glBindTexture, GL_TEXTURE_2D, tr.texture[TEX_WHITE]->texid);
         R_StatsDraw(GL_TRIANGLES, NUM_RECT_VERTICES, 1);
+        R_ApplyShader(&tr.shader_ui);
         R_Call(glDrawArrays, GL_TRIANGLES, 0, NUM_RECT_VERTICES);
     }
     
@@ -331,9 +348,9 @@ void R_RenderFogOfWar(void) {
     Matrix4_identity(&model_matrix);
 
     // Set simple projection
-    R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uModelMatrix, 1, GL_FALSE, model_matrix.v);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, proj_matrix.v);
+
+    tr.shader_ui.state.model = model_matrix;
+    tr.shader_ui.state.viewProjection = proj_matrix;
 
     // Add current state to history
     R_Call(glBlendEquation, GL_MAX);
@@ -359,7 +376,6 @@ void R_RenderFogOfWar(void) {
     R_Call(glBindFramebuffer, GL_FRAMEBUFFER, 0);
 }
 
-
 LPBUFFER R_MakeCastersVertexArrayObject(void) {
     LPBUFFER buf = ri.MemAlloc(sizeof(BUFFER));
 
@@ -381,17 +397,16 @@ void R_InitFogOfWar(DWORD width, DWORD height) {
     fow_resources.rt[FOW_RT_IMMEDIATE] = R_AllocateRenderTexture(width, height, GL_RGBA, GL_UNSIGNED_BYTE, GL_COLOR_ATTACHMENT0);
     fow_resources.rt[FOW_RT_HISTORY] = R_AllocateRenderTexture(width, height, GL_RGBA, GL_UNSIGNED_BYTE, GL_COLOR_ATTACHMENT0);
     fow_resources.rt[FOW_RT_RESULT] = R_AllocateRenderTexture(width, height, GL_RGBA, GL_UNSIGNED_BYTE, GL_COLOR_ATTACHMENT0);
-    fow_resources.shader[FOW_SHADER_RAYCAST] = R_InitShader(vs_shadow, fs_shadow);
+    memset(&fow_resources.shader, 0, sizeof(fow_resources.shader));
+    R_LoadShader(&sd_fow_raycast, NULL, &fow_resources.shader);
     fow_resources.casters = R_MakeCastersVertexArrayObject();
     fow_resources.sight = R_AllocateSightTexture();
     fow_resources.last_update_time = 0;
 }
 
 void R_ShutdownFogOfWar(void) {
-    FOR_LOOP(i, FOW_SHADER_COUNT) {
-        R_ReleaseShader(fow_resources.shader[i]);
-        fow_resources.shader[i] = NULL;
-    }
+    R_DeleteShader(&fow_resources.shader.prog);
+    memset(&fow_resources.shader, 0, sizeof(fow_resources.shader));
     FOR_LOOP(i, FOW_RT_COUNT) {
         R_ReleaseRenderTexture(fow_resources.rt[i]);
         fow_resources.rt[i] = NULL;

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -62,6 +62,14 @@
 #define SYSFONT_DRAW_WIDTH 8
 #define SYSFONT_DRAW_HEIGHT 8
 
+typedef enum render_phase_e {
+    RENDER_PHASE_SOLID = 0,
+    RENDER_PHASE_LIGHTS,
+    RENDER_PHASE_ALPHA,
+} render_phase_t;
+
+extern render_phase_t render_phase;
+
 #include "../common/common.h"
 #include "../client/tr_public.h"
 #include "r_alpha.h"

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -74,7 +74,6 @@ static uint64_t R_PrimitiveTriangles(GLenum mode, DWORD count, DWORD instances) 
 }
 
 
-KNOWN_AS(shader_program, SHADER);
 KNOWN_AS(render_buffer, BUFFER);
 KNOWN_AS(render_target, RENDERTARGET);
 KNOWN_AS(vertex, VERTEX);
@@ -126,35 +125,92 @@ static void R_SwapRedBlue(BYTE *pixels, DWORD count, DWORD stride) {
     }
 }
 
-struct shader_program {
-    DWORD progid;
-    DWORD uViewProjectionMatrix;
-    DWORD uModelMatrix;
-    DWORD uLightMatrix;
-    DWORD uNormalMatrix;
-    DWORD uTextureMatrix;
-    DWORD uTexture;
-#ifdef USE_SHADOWMAPS
-    DWORD uShadowmap;
-#endif
-    DWORD uFogOfWar;
-    DWORD uBones;
-    DWORD uAlphaKey;
-    DWORD uAlphaCutoff;
-    DWORD uUnshaded;
-    DWORD uLayerAlpha;
-    DWORD uGeosetColor;
-    DWORD uUvMatrix;
-    DWORD uLightCount;
-    DWORD uLights;
-    DWORD uGrassParams;
-    DWORD uEyePosition;
-    DWORD uActiveGlow;
-    DWORD uFogEnable;
-    DWORD uFogColor;
-    DWORD uFogParams;
-    DWORD uFirstBoneLookupIndex;
-};
+#include "shader_desc.h"
+#define BZ_MODEL_LIGHT_MAX 8 // lights; shared model shader array capacity; bounds one lighting-state upload
+
+/* Typed shader values are separate from the program-owned GL locations. */
+
+/* Simple sprite/UI shaders: position+texcoord+color vertex, unlit fragment. */
+typedef struct SPRITESTATE {
+    MATRIX4 viewProjection;
+    MATRIX4 model;
+    int texture;
+    FLOAT activeGlow;
+} SPRITESTATE;
+typedef struct SPRITESTATE *LPSPRITESTATE;
+typedef const struct SPRITESTATE *LPCSPRITESTATE;
+typedef struct SPRITEPROG {
+    SHADERPROG prog;
+    SPRITESTATE state;
+} SPRITEPROG;
+typedef struct SPRITEPROG *LPSPRITEPROG;
+typedef const struct SPRITEPROG *LPCSPRITEPROG;
+
+/* Ground/world shader with per-vertex lighting + texture/fog-of-war matrices.
+   progid/viewProjection/model share the SPRITEPROG prefix layout so the
+   splat path can address either type through splat_shader_t. */
+typedef struct DEFAULTSTATE {
+    MATRIX4 viewProjection;
+    MATRIX4 model;
+    MATRIX4 textureMatrix;
+    MATRIX4 lightMatrix;
+    MATRIX3 normalMatrix;
+    int texture;
+    int shadowmap;
+    int fogOfWar;
+} DEFAULTSTATE;
+typedef struct DEFAULTSTATE *LPDEFAULTSTATE;
+typedef const struct DEFAULTSTATE *LPCDEFAULTSTATE;
+typedef struct DEFAULTPROG {
+    SHADERPROG prog;
+    DEFAULTSTATE state;
+} DEFAULTPROG;
+typedef struct DEFAULTPROG *LPDEFAULTPROG;
+typedef const struct DEFAULTPROG *LPCDEFAULTPROG;
+
+/* Minimal common view for the splat/decals path: the three uniforms it uploads. */
+typedef struct {
+    SHADERPROG prog;
+    struct { MATRIX4 viewProjection, model; } state;
+} splat_shader_t;
+
+/* SPRITEPROG and DEFAULTPROG share a progid/viewProjection/model prefix,
+   so the splat path can address either through splat_shader_t. */
+#define R_SPLAT_SHADER(P) ((splat_shader_t *)(P))
+
+/* Shared skinned-model shader (MDX/M2/M3): bone palette + 8 packed lights. */
+typedef struct MODELSTATE {
+    MATRIX4 bones[BZ_BONE_PALETTE_MAX];
+    MATRIX4 viewProjection;
+    MATRIX4 lightMatrix;
+    MATRIX4 textureMatrix;
+    int lightCount;
+    FLOAT firstBoneLookupIndex;
+    MATRIX4 lights[BZ_MODEL_LIGHT_MAX];
+    MATRIX4 grassParams;
+    MATRIX4 model;
+    MATRIX3 normalMatrix;
+    int texture;
+    int shadowmap;
+    int fogOfWar;
+    FLOAT layerAlpha;
+    VECTOR4 geosetColor;
+    MATRIX3 uvMatrix;
+    bool alphaKey;
+    FLOAT alphaCutoff;
+    bool unshaded;
+    bool fogEnable;
+    VECTOR3 fogColor;
+    VECTOR2 fogParams;
+} MODELSTATE;
+typedef struct MODELSTATE *LPMODELSTATE;
+typedef const struct MODELSTATE *LPCMODELSTATE;
+typedef struct MODELPROG {
+    SHADERPROG prog;
+    MODELSTATE state;
+} MODELPROG;
+typedef struct MODELPROG *LPMODELPROG;
+typedef const struct MODELPROG *LPCMODELPROG;
 
 struct render_target {
     DWORD buffer;
@@ -221,7 +277,14 @@ struct render_globals {
     viewDef_t viewDef;
     LPCWAR3MAP world;
     LPTEXTURE texture[TEX_COUNT];
-    LPSHADER shader[SHADER_COUNT];
+    SPRITEPROG  shader_ui;
+    SPRITEPROG  shader_splat;
+    SPRITEPROG  shader_shadowSplat;
+    SPRITEPROG  shader_commandButton;
+    SPRITEPROG  shader_minimap;
+    SPRITEPROG  shader_minimapFog;
+    SPRITEPROG  shader_unlit;
+    DEFAULTPROG shader_default;
     LPBUFFER buffer[RBUF_COUNT];
     LPMODEL model[MODEL_COUNT];
     LPRENDERTARGET rt[RT_COUNT];
@@ -271,24 +334,25 @@ void R_ReleaseVertexArrayObject(LPBUFFER buffer);
 LPCTEXTURE R_FindTextureByID(DWORD textureID);
 void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y);
 bool R_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity);
-void R_RenderSplat(LPCVECTOR2 position, float radius, LPCTEXTURE texture, LPCSHADER shader, COLOR32 color);
+void R_RenderSplat(LPCVECTOR2 position, float radius, LPCTEXTURE texture, splat_shader_t *shader, COLOR32 color);
 void R_DrawHealthBars(void);
 void R_DrawBackdrop(LPCDRAWBACKDROP drawBackdrop);
-void R_RenderRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, LPCSHADER shader, COLOR32 color);
-void R_RenderFlatRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, FLOAT z, LPCTEXTURE texture, LPCSHADER shader, COLOR32 color);
+void R_RenderRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, splat_shader_t *shader, COLOR32 color);
+void R_RenderFlatRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, FLOAT z, LPCTEXTURE texture, splat_shader_t *shader, COLOR32 color);
 /* Batched splat rendering: accumulate many ground decals (unit shadows) into one
  * vertex-buffer upload + draw per contiguous texture run (plus capacity flushes),
  * instead of one upload + draw per splat. */
-void R_BeginSplatBatch(LPCSHADER shader);
+void R_BeginSplatBatch(splat_shader_t *shader);
 void R_AddRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, COLOR32 color);
 void R_EndSplatBatch(void);
 
 // r_shader.c
-LPSHADER R_InitShader(LPCSTR vs_default, LPCSTR fs_default);
-void R_ReleaseShader(LPSHADER shader);
-LPSHADER R_ModelShader(void);
-LPSHADER R_ModelShaderInstanced(void);
+MODELPROG *R_ModelShader(void);
+MODELPROG *R_ModelShaderInstanced(void);
 void R_ShutdownModelShader(void);
+void R_LoadBuiltinShaders(void);
+void R_ShutdownBuiltinShaders(void);
+SPRITEPROG *R_SpriteShader(SHADERTYPE type);
 
 // r_main.c
 #ifdef USE_SHADOWMAPS

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -334,17 +334,14 @@ static void R_SetupGL(bool drawLight) {
 #endif
         tr.viewDef.viewProjectionMatrix.v;
 
-    R_Call(glUseProgram, tr.shader[SHADER_DEFAULT]->progid);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_DEFAULT]->uViewProjectionMatrix, 1, GL_FALSE, viewProjectionMatrix);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_DEFAULT]->uTextureMatrix, 1, GL_FALSE, tr.viewDef.textureMatrix.v);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_DEFAULT]->uModelMatrix, 1, GL_FALSE, model_matrix.v);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_DEFAULT]->uLightMatrix, 1, GL_FALSE, tr.viewDef.lightMatrix.v);
-    R_Call(glUniformMatrix3fv, tr.shader[SHADER_DEFAULT]->uNormalMatrix, 1, GL_TRUE, normal_matrix.v);
+    memcpy(&tr.shader_default.state.viewProjection, viewProjectionMatrix, (1) * sizeof(MATRIX4));
+    tr.shader_default.state.textureMatrix = tr.viewDef.textureMatrix;
+    tr.shader_default.state.model = model_matrix;
+    tr.shader_default.state.lightMatrix = tr.viewDef.lightMatrix;
+    tr.shader_default.state.normalMatrix = normal_matrix;
 
-    R_Call(glUseProgram, tr.shader[SHADER_UI]->progid);
-
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uViewProjectionMatrix, 1, GL_FALSE, ui_matrix.v);
-    R_Call(glUniformMatrix4fv, tr.shader[SHADER_UI]->uModelMatrix, 1, GL_FALSE, model_matrix.v);
+    tr.shader_ui.state.viewProjection = ui_matrix;
+    tr.shader_ui.state.model = model_matrix;
     
     R_Call(glEnable, GL_DEPTH_TEST);
     R_Call(glDepthMask, GL_TRUE);
@@ -532,29 +529,9 @@ void R_Init(DWORD width, DWORD height) {
 //    R_LoadModel("Assets\\Units\\Terran\\MarineTychus\\MarineTychus.m3");
 //    R_LoadModel("Assets\\Units\\Zerg\\Queen\\Queen.m3");
     
-    // Disabled until skin/alphatest shaders are wired; Linux -Wall warns on unused extern hooks.
-//    extern LPCSTR vs_skin;
-    extern LPCSTR vs_default;
-    extern LPCSTR fs_default;
-    extern LPCSTR fs_ui;
-    extern LPCSTR fs_splat;
-    extern LPCSTR fs_shadow_splat;
-//    extern LPCSTR fs_alphatest;
-    extern LPCSTR fs_commandbutton;
-    extern LPCSTR fs_minimap;
-    extern LPCSTR fs_minimap_fog;
-    extern LPCSTR fs_unlit;
-
     R_GameLoadAssets();
 
-    tr.shader[SHADER_DEFAULT] = R_InitShader(vs_default, fs_default);
-    tr.shader[SHADER_UI] = R_InitShader(vs_default, fs_ui);
-    tr.shader[SHADER_SPLAT] = R_InitShader(vs_default, fs_splat);
-    tr.shader[SHADER_SHADOWSPLAT] = R_InitShader(vs_default, fs_shadow_splat);
-    tr.shader[SHADER_COMMANDBUTTON] = R_InitShader(vs_default, fs_commandbutton);
-    tr.shader[SHADER_MINIMAP] = R_InitShader(vs_default, fs_minimap);
-    tr.shader[SHADER_MINIMAP_FOG] = R_InitShader(vs_default, fs_minimap_fog);
-    tr.shader[SHADER_UNLIT] = R_InitShader(vs_default, fs_unlit);
+    R_LoadBuiltinShaders();
     fprintf(stderr, "Loading shaders succeeded.\n");
 
     tr.buffer[RBUF_TEMP1] = R_MakeVertexArrayObject(NULL, 0);
@@ -619,6 +596,7 @@ void R_Shutdown(void) {
     R_ShutdownModels();
     R_GameShutdown();
     R_ShutdownModelShader();
+    R_ShutdownBuiltinShaders();
     R_ShutdownFonts();
     
     R_ShutdownFogOfWar();

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -25,9 +25,7 @@ struct render_globals tr;
 SDL_Window *window;
 SDL_GLContext context;
 
-#ifdef USE_SHADOWMAPS
-bool is_rendering_lights = false;
-#endif
+render_phase_t render_phase = RENDER_PHASE_SOLID;
 static bool renderer_shutdown = false;
 
 /* Capture the physical GL drawable; SDL window dimensions are logical points on Retina. */
@@ -560,7 +558,7 @@ void R_SetAlphaKeyState(BOOL enabled) {
     }
 #ifdef BZ_USE_MSAA
 #ifdef USE_SHADOWMAPS
-    if (is_rendering_lights) {
+    if (render_phase == RENDER_PHASE_LIGHTS) {
         /* TODO: Single-sample shadow targets need multisample depth coverage before alpha-key shadows can use ATOC. */
         R_Call(glDisable, GL_SAMPLE_ALPHA_TO_COVERAGE);
         R_Call(glEnable, GL_BLEND);
@@ -634,7 +632,7 @@ void R_RevertSettings(void) {
 
 #ifdef USE_SHADOWMAPS
 void R_RenderShadowMap(void) {
-    is_rendering_lights = true;
+    render_phase = RENDER_PHASE_LIGHTS;
     R_SetupGL(true);
     R_BindTexture(tr.texture[TEX_SHADOWMAP], 1);
     R_GameDrawWorld();
@@ -645,7 +643,7 @@ void R_RenderShadowMap(void) {
 
 void R_RenderView(void) {
 #ifdef USE_SHADOWMAPS
-    is_rendering_lights = false;
+    render_phase = RENDER_PHASE_SOLID;
 #endif
     R_SetupViewport(&tr.viewDef.viewport);
     R_SetupScissor(&tr.viewDef.scissor);
@@ -656,10 +654,12 @@ void R_RenderView(void) {
     R_GameDrawWorld();
     R_DrawDecals();
     R_DrawEntities();
+    render_phase = RENDER_PHASE_ALPHA;
     R_GameDrawAlphaSurfaces();
     if (!(tr.viewDef.rdflags & RDF_NOPARTICLES)) {
         R_DrawParticles();
     }
+    render_phase = RENDER_PHASE_SOLID;
     R_RevertSettings();
 
     R_DrawHealthBars();

--- a/renderer/r_particles.c
+++ b/renderer/r_particles.c
@@ -1,4 +1,5 @@
 #include "r_local.h"
+#include "r_shader.h"
 
 #define NUM_PARTICLE_VERTICES 6
 #define MAX_PARTICLES 10000
@@ -11,8 +12,24 @@ typedef struct particle_vertex {
     BYTE axis[2];
 } particleVertex_t;
 
+typedef struct PARTICLESTATE {
+    MATRIX4 viewProjection;
+    MATRIX4 model;
+    int texture;
+    bool alphaKey;
+    FLOAT alphaCutoff;
+} PARTICLESTATE;
+typedef struct PARTICLESTATE *LPPARTICLESTATE;
+typedef const struct PARTICLESTATE *LPCPARTICLESTATE;
+typedef struct PARTICLEPROG {
+    SHADERPROG prog;
+    PARTICLESTATE state;
+} PARTICLEPROG;
+typedef struct PARTICLEPROG *LPPARTICLEPROG;
+typedef const struct PARTICLEPROG *LPCPARTICLEPROG;
+
 static struct {
-    LPSHADER shader;
+    PARTICLEPROG shader;
 //    LPRENDERTARGET rt[FOW_RT_COUNT];
     LPBUFFER particles;
     LPTEXTURE texture;
@@ -45,50 +62,53 @@ cparticle_t *R_SpawnParticle(void) {
     return p;
 }
 
-LPCSTR vs_particle =
-"#version 140\n"
-"in vec3 i_position;\n"
-"in vec4 i_color;\n"
-"in vec2 i_texcoord;\n"
-"in float i_size;\n"
-"in vec2 i_axis;\n"
-"out vec4 v_color;\n"
-"out vec2 v_texcoord;\n"
-"uniform mat4 uViewProjectionMatrix;\n"
-"uniform mat4 uModelMatrix;\n"
-"void main() {\n"
-"    mat4 m = uViewProjectionMatrix;\n"
-"    vec3 left = normalize(vec3(m[0][0], m[1][0], m[2][0])) * i_size;\n"
-"    vec3 up = normalize(vec3(m[0][1], m[1][1], m[2][1])) * i_size;\n"
-"    mat3 bb_mat = mat3(left, up, i_position);\n"
-"    vec3 pos = bb_mat * vec3(i_axis - vec2(0.5), 1.0);\n"
-"    gl_Position = uViewProjectionMatrix * vec4(pos, 1.0);\n"
-"    v_color = i_color;\n"
-"    v_texcoord = i_texcoord;\n"
-"}\n";
-
-LPCSTR fs_particle =
-"#version 140\n"
-"in vec4 v_color;\n"
-"in vec2 v_texcoord;\n"
-"out vec4 o_color;\n"
-"uniform sampler2D uTexture;\n"
-"uniform bool uAlphaKey;\n"
-"uniform float uAlphaCutoff;\n"
-"float crop_edges(vec2 tc) {\n"
-"   return step(abs(tc.x - 0.5), 0.5) * step(abs(tc.y - 0.5), 0.5);\n"
-"}\n"
-"void main() {\n"
-"    o_color = texture(uTexture, v_texcoord) * v_color;\n"
-"    if (uAlphaKey) {\n"
-#ifndef BZ_USE_MSAA
-"        if (o_color.a < uAlphaCutoff) discard;\n"
-#else
-"        float edge = max(fwidth(o_color.a), 1.0 / 255.0);\n"
-"        o_color.a = smoothstep(uAlphaCutoff - edge, uAlphaCutoff + edge, o_color.a);\n"
-#endif
-"    }\n"
-"}\n";
+#define SHADER_TYPE PARTICLESTATE
+static const shader_desc_t sd_particle = {
+    .Name = "particle",
+    .Uniforms = {
+        UNIFORM(viewProjection, UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(model,          UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(texture,        UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(alphaKey,       UT_BOOL,       PRECISION_LOW),
+        UNIFORM(alphaCutoff,    UT_FLOAT,      PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position,     UT_FLOAT_VEC3),
+        ATTRIB(color,    attrib_color,        UT_COLOR),
+        ATTRIB(texcoord, attrib_texcoord,     UT_FLOAT_VEC2),
+        ATTRIB(size,     attrib_particleSize, UT_FLOAT),
+        ATTRIB(axis,     attrib_particleAxis, UT_FLOAT_VEC2),
+    },
+    .Shared = {
+        SHARED(color,    UT_COLOR),
+        SHARED(texcoord, UT_FLOAT_VEC2),
+    },
+    .VertexBody =
+        "vec4 vert() {\n"
+        "  mat4 m = u_viewProjection;\n"
+        "  vec3 left = normalize(vec3(m[0][0], m[1][0], m[2][0])) * a_size;\n"
+        "  vec3 up = normalize(vec3(m[0][1], m[1][1], m[2][1])) * a_size;\n"
+        "  mat3 bb_mat = mat3(left, up, a_position);\n"
+        "  vec3 pos = bb_mat * vec3(a_axis - vec2(0.5), 1.0);\n"
+        "  v_color = a_color;\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  return u_viewProjection * vec4(pos, 1.0);\n"
+        "}\n",
+    .FragmentBody =
+        "vec4 frag() {\n"
+        "  vec4 col = texture(u_texture, v_texcoord) * v_color;\n"
+        "  if (u_alphaKey) {\n"
+        "#ifndef BZ_USE_MSAA\n"
+        "    if (col.a < u_alphaCutoff) discard;\n"
+        "#else\n"
+        "    float edge = max(fwidth(col.a), 1.0 / 255.0);\n"
+        "    col.a = smoothstep(u_alphaCutoff - edge, u_alphaCutoff + edge, col.a);\n"
+        "#endif\n"
+        "  }\n"
+        "  return col;\n"
+        "}\n",
+};
+#undef SHADER_TYPE
 
 particleVertex_t *
 R_AddParticle(particleVertex_t *buffer,
@@ -167,13 +187,13 @@ static void R_FlushParticles(LPCTEXTURE texture, LPCMATRIX4 matrix, particleVert
     R_Call(glBindVertexArray, particles_resources.particles->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, particles_resources.particles->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(particleVertex_t) * (pv - particles_resources.vertices), particles_resources.vertices, GL_DYNAMIC_DRAW);
-    R_Call(glUseProgram, particles_resources.shader->progid);
-    R_Call(glUniformMatrix4fv, particles_resources.shader->uModelMatrix, 1, GL_FALSE, matrix->v);
-    R_Call(glUniformMatrix4fv, particles_resources.shader->uViewProjectionMatrix, 1, GL_FALSE, tr.viewDef.viewProjectionMatrix.v);
+
+    particles_resources.shader.state.model = *matrix;
+    particles_resources.shader.state.viewProjection = tr.viewDef.viewProjectionMatrix;
     R_Call(glActiveTexture, GL_TEXTURE0);
     R_Call(glBindTexture, GL_TEXTURE_2D, (texture?texture:particles_resources.texture)->texid);
-    R_Call(glUniform1i, particles_resources.shader->uAlphaKey, blend_mode == BLEND_MODE_ALPHAKEY);
-    R_Call(glUniform1f, particles_resources.shader->uAlphaCutoff, 0.5f);
+    particles_resources.shader.state.alphaKey = blend_mode == BLEND_MODE_ALPHAKEY;
+    particles_resources.shader.state.alphaCutoff = 0.5f;
     R_SetAlphaKeyState(blend_mode == BLEND_MODE_ALPHAKEY);
     if (blend_mode == BLEND_MODE_NONE) {
         R_Call(glDisable, GL_BLEND);
@@ -195,6 +215,7 @@ static void R_FlushParticles(LPCTEXTURE texture, LPCMATRIX4 matrix, particleVert
         }
     }
     R_StatsDraw(GL_TRIANGLES, (DWORD)(pv - particles_resources.vertices), 1);
+    R_ApplyShader(&particles_resources.shader);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, (GLsizei)(pv - particles_resources.vertices));
 }
 
@@ -318,12 +339,19 @@ void R_InitParticles(void) {
     particles_resources.texture = R_AllocateTexture(DOT_TEXTURE, DOT_TEXTURE);
     R_LoadTextureMipLevel(particles_resources.texture, &(TEXMIP){ data, DOT_TEXTURE, DOT_TEXTURE, 0, PIXEL_RGBA });
 
-    particles_resources.shader = R_InitShader(vs_particle, fs_particle);
+    static const char *particle_defines =
+#ifdef BZ_USE_MSAA
+        "#define BZ_USE_MSAA 1\n"
+#endif
+        "";
+    memset(&particles_resources.shader, 0, sizeof(particles_resources.shader));
+    R_LoadShader(&sd_particle, particle_defines, &particles_resources.shader);
     particles_resources.particles = R_MakeParticlesVertexArrayObject();
     R_ClearParticles();
 }
 
 void R_ShutdownParticles(void) {
     R_ReleaseVertexArrayObject(particles_resources.particles);
-    R_ReleaseShader(particles_resources.shader);
+    R_DeleteShader(&particles_resources.shader.prog);
+    memset(&particles_resources.shader, 0, sizeof(particles_resources.shader));
 }

--- a/renderer/r_shader.c
+++ b/renderer/r_shader.c
@@ -1,196 +1,17 @@
 #include "r_local.h"
 #include "r_shader.h"
 
-LPCSTR vs_default =
-"#version 140\n"
-"in vec3 i_position;\n"
-"in vec2 i_texcoord;\n"
-"in vec3 i_normal;\n"
-"in vec4 i_color;\n"
-#ifdef USE_SHADOWMAPS
-"out vec4 v_shadow;\n"
-#endif
-"out vec2 v_texcoord;\n"
-"out vec2 v_texcoord2;\n"
-"out vec3 v_normal;\n"
-"out vec3 v_lightDir;\n"
-"out vec4 v_color;\n"
-"uniform mat4 uViewProjectionMatrix;\n"
-"uniform mat4 uTextureMatrix;\n"
-"uniform mat4 uModelMatrix;\n"
-"uniform mat4 uLightMatrix;\n"
-"uniform mat3 uNormalMatrix;\n"
-"void main() {\n"
-"    vec4 pos = uModelMatrix * vec4(i_position, 1.0);"
-"    v_texcoord = i_texcoord;\n"
-"    v_texcoord2 = (uTextureMatrix * pos).xy;\n"
-"    v_normal = normalize(uNormalMatrix * i_normal);\n"
-#ifdef USE_SHADOWMAPS
-"    v_shadow = uLightMatrix * pos;\n"
-#endif
-"    v_color = i_color;\n"
-"    v_lightDir = -normalize(vec3(uLightMatrix[0][2], uLightMatrix[1][2], uLightMatrix[2][2]))*1.2;\n"
-"    gl_Position = uViewProjectionMatrix * uModelMatrix * vec4(i_position, 1.0);\n"
-"}\n";
-
-LPCSTR fs_default =
-"#version 140\n"
-"in vec2 v_texcoord;\n"
-"in vec2 v_texcoord2;\n"
-"in vec3 v_normal;\n"
-"in vec4 v_color;\n"
-"in vec3 v_lightDir;\n"
-"out vec4 o_color;\n"
-"uniform sampler2D uTexture;\n"
-#ifdef USE_FOGOFWAR
-"uniform sampler2D uFogOfWar;\n"
-#endif
-"float get_light() {\n"
-"    return dot(v_normal, v_lightDir);\n"
-"}\n"
-#ifdef USE_SHADOWMAPS
-"uniform sampler2D uShadowmap;\n"
-"in vec4 v_shadow;\n"
-"float get_shadow() {\n"
-"    float depth = texture(uShadowmap, vec2(v_shadow.x + 1.0, v_shadow.y + 1.0) * 0.5).r;\n"
-"    return depth < (v_shadow.z + 0.99) * 0.5 ? 0.0 : 1.0;\n"
-"}\n"
-"float get_lighting() { return min(1.0, mix(0.35, 1.0, get_shadow() * get_light()) * 1.1); }\n"
-#else
-"float get_lighting() { return min(1.0, mix(0.35, 1.0, get_light()) * 1.1); }\n"
-#endif
-#ifdef USE_FOGOFWAR
-"float get_fogofwar() {\n"
-"    return texture(uFogOfWar, v_texcoord2).r;\n"
-"}\n"
-#endif
-"void main() {\n"
-"    vec4 col = texture(uTexture, v_texcoord) * v_color;\n"
-#ifdef USE_FOGOFWAR
-"    col.rgb *= get_fogofwar() * get_lighting();\n"
-#else
-"    col.rgb *= get_lighting();\n"
-#endif
-"    o_color = col;\n"
-"}\n";
-
-LPCSTR fs_ui =
-"#version 140\n"
-"in vec4 v_color;\n"
-"in vec2 v_texcoord;\n"
-"out vec4 o_color;\n"
-"uniform sampler2D uTexture;\n"
-"void main() {\n"
-"    o_color = texture(uTexture, v_texcoord) * v_color;\n"
-"}\n";
-
-LPCSTR fs_minimap =
-"#version 140\n"
-"in vec4 v_color;\n"
-"in vec2 v_texcoord;\n"
-"out vec4 o_color;\n"
-"uniform sampler2D uTexture;\n"
-"void main() {\n"
-"    float mask = 1.0 - smoothstep(0.49, 0.5, length(v_color.rg - vec2(0.5)));\n"
-"    vec4 tex = texture(uTexture, v_texcoord);\n"
-"    o_color = vec4(tex.rgb, tex.a * mask);\n"
-"}\n";
-
-LPCSTR fs_unlit =
-"#version 140\n"
-"in vec4 v_color;\n"
-"in vec2 v_texcoord;\n"
-"out vec4 o_color;\n"
-"uniform sampler2D uTexture;\n"
-"void main() {\n"
-"    o_color = texture(uTexture, v_texcoord) * v_color;\n"
-"}\n";
-
-LPCSTR fs_splat =
-"#version 140\n"
-"in vec4 v_color;\n"
-"in vec2 v_texcoord;\n"
-"out vec4 o_color;\n"
-"uniform sampler2D uTexture;\n"
-"float crop_edges(vec2 tc) {\n"
-"   return step(abs(tc.x - 0.5), 0.5) * step(abs(tc.y - 0.5), 0.5);\n"
-"}\n"
-"void main() {\n"
-"    o_color = texture(uTexture, v_texcoord) * v_color;\n"
-"    o_color.a *= crop_edges(v_texcoord);\n"
-"}\n";
-
-LPCSTR fs_shadow_splat =
-"#version 140\n"
-"in vec4 v_color;\n"
-"in vec2 v_texcoord;\n"
-"out vec4 o_color;\n"
-"uniform sampler2D uTexture;\n"
-"float crop_edges(vec2 tc) {\n"
-"   return step(abs(tc.x - 0.5), 0.5) * step(abs(tc.y - 0.5), 0.5);\n"
-"}\n"
-"void main() {\n"
-"    vec4 tex = texture(uTexture, v_texcoord);\n"
-"    o_color = vec4(0.0, 0.0, 0.0, tex.a * v_color.a * crop_edges(v_texcoord));\n"
-"}\n";
-
-LPCSTR fs_commandbutton =
-"#version 140\n"
-"in vec4 v_color;\n"
-"in vec2 v_texcoord;\n"
-"out vec4 o_color;\n"
-"uniform sampler2D uTexture;\n"
-"uniform float uActiveGlow;\n"
-"float crop_edges(vec2 tc) {\n"
-"   return step(abs(tc.x - 0.5), 0.5) * step(abs(tc.y - 0.5), 0.5);\n"
-"}\n"
-"void main() {\n"
-"    o_color = texture(uTexture, v_texcoord) * v_color;\n"
-"    float glow = max(abs(v_texcoord.x - 0.5), abs(v_texcoord.y - 0.5));\n"
-"    glow = smoothstep(0.33, 0.5, glow) * 0.75 * uActiveGlow;\n"
-"    o_color.rgb = mix(o_color.rgb,vec3(0.5,1.0,0.5),glow);\n"
-"    o_color.a *= crop_edges(v_texcoord);\n"
-"}\n";
-
-LPCSTR fs_minimap_fog =
-"#version 140\n"
-"in vec4 v_color;\n"
-"in vec2 v_texcoord;\n"
-"out vec4 o_color;\n"
-"uniform sampler2D uTexture;\n"
-"void main() {\n"
-"    float visibility = texture(uTexture, vec2(v_texcoord.x, 1.0 - v_texcoord.y)).r;\n"
-"    float alpha = clamp(1.0 - visibility, 0.0, 1.0) * v_color.a;\n"
-"    o_color = vec4(v_color.rgb, alpha);\n"
-"}\n";
-
 /* -----------------------------------------------------------------------
- * Descriptor-based replacements for the simple sprite/UI shaders above.
+ * Built-in renderer programs, described entirely as shader_desc_t.  Bodies
+ * define vec4 vert()/frag(); the version prologue, declarations, and main()
+ * are generated from the descriptor tables at load time.
  *
- * Each program struct has a GLuint progid followed by one GLint per uniform
- * in declaration order — the UNIFORM() macro stores the field offsetof so
- * R_LoadShaderDescInto() writes resolved locations directly into the struct.
- *
- * Bodies contain only GLSL logic; version line, precision, and all
- * uniform/in/out declarations are generated from the descriptor tables.
- *
- * Load (example):
- *   R_LoadShaderDescInto(&sd_unlit, NULL, &unlit_prog.progid, &unlit_prog);
- *
- * Call site (example):
- *   glUniformMatrix4fv(unlit_prog.viewProjection, 1, GL_FALSE, vp);
- *   glUniformMatrix4fv(unlit_prog.model,          1, GL_FALSE, m);
+ * Each program owns GL handles plus a separate typed value state. Descriptor
+ * offsets address values; R_ApplyShader submits them at the draw boundary.
  * ----------------------------------------------------------------------- */
 
 /* --- unlit / ui: texture * vertex-color, no lighting ------------------- */
-typedef struct {
-    GLuint progid;
-    GLint  viewProjection;
-    GLint  model;
-    GLint  texture;
-} unlit_prog_t;
-
-#define SHADER_TYPE unlit_prog_t
+#define SHADER_TYPE SPRITESTATE
 const shader_desc_t sd_unlit = {
     .Name = "unlit",
     .Uniforms = {
@@ -208,27 +29,20 @@ const shader_desc_t sd_unlit = {
         SHARED(color,    UT_COLOR),
     },
     .VertexBody =
-        "void main() {\n"
-        "  gl_Position = u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "vec4 vert() {\n"
         "  v_texcoord = a_texcoord;\n"
         "  v_color = a_color;\n"
+        "  return u_viewProjection * u_model * vec4(a_position, 1.0);\n"
         "}\n",
     .FragmentBody =
-        "void main() {\n"
-        "  " GLSL_FRAGCOLOR " = " GLSL_TEX "(u_texture, v_texcoord) * v_color;\n"
+        "vec4 frag() {\n"
+        "  return texture(u_texture, v_texcoord) * v_color;\n"
         "}\n",
 };
 #undef SHADER_TYPE
 
 /* --- minimap: circular mask applied to alpha ---------------------------- */
-typedef struct {
-    GLuint progid;
-    GLint  viewProjection;
-    GLint  model;
-    GLint  texture;
-} minimap_prog_t;
-
-#define SHADER_TYPE minimap_prog_t
+#define SHADER_TYPE SPRITESTATE
 const shader_desc_t sd_minimap = {
     .Name = "minimap",
     .Uniforms = {
@@ -246,29 +60,22 @@ const shader_desc_t sd_minimap = {
         SHARED(color,    UT_COLOR),
     },
     .VertexBody =
-        "void main() {\n"
-        "  gl_Position = u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "vec4 vert() {\n"
         "  v_texcoord = a_texcoord;\n"
         "  v_color = a_color;\n"
+        "  return u_viewProjection * u_model * vec4(a_position, 1.0);\n"
         "}\n",
     .FragmentBody =
-        "void main() {\n"
+        "vec4 frag() {\n"
         "  float mask = 1.0 - smoothstep(0.49, 0.5, length(v_color.rg - vec2(0.5)));\n"
-        "  vec4 tex = " GLSL_TEX "(u_texture, v_texcoord);\n"
-        "  " GLSL_FRAGCOLOR " = vec4(tex.rgb, tex.a * mask);\n"
+        "  vec4 tex = texture(u_texture, v_texcoord);\n"
+        "  return vec4(tex.rgb, tex.a * mask);\n"
         "}\n",
 };
 #undef SHADER_TYPE
 
 /* --- splat: crop edges to [0,1] bounds ---------------------------------- */
-typedef struct {
-    GLuint progid;
-    GLint  viewProjection;
-    GLint  model;
-    GLint  texture;
-} splat_prog_t;
-
-#define SHADER_TYPE splat_prog_t
+#define SHADER_TYPE SPRITESTATE
 const shader_desc_t sd_splat = {
     .Name = "splat",
     .Uniforms = {
@@ -286,31 +93,25 @@ const shader_desc_t sd_splat = {
         SHARED(color,    UT_COLOR),
     },
     .VertexBody =
-        "void main() {\n"
-        "  gl_Position = u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "vec4 vert() {\n"
         "  v_texcoord = a_texcoord;\n"
         "  v_color = a_color;\n"
+        "  return u_viewProjection * u_model * vec4(a_position, 1.0);\n"
         "}\n",
     .FragmentBody =
         "float crop_edges(vec2 tc) {\n"
         "  return step(abs(tc.x - 0.5), 0.5) * step(abs(tc.y - 0.5), 0.5);\n"
         "}\n"
-        "void main() {\n"
-        "  " GLSL_FRAGCOLOR " = " GLSL_TEX "(u_texture, v_texcoord) * v_color;\n"
-        "  " GLSL_FRAGCOLOR ".a *= crop_edges(v_texcoord);\n"
+        "vec4 frag() {\n"
+        "  vec4 col = texture(u_texture, v_texcoord) * v_color;\n"
+        "  col.a *= crop_edges(v_texcoord);\n"
+        "  return col;\n"
         "}\n",
 };
 #undef SHADER_TYPE
 
 /* --- shadow splat: black silhouette with texture alpha ------------------ */
-typedef struct {
-    GLuint progid;
-    GLint  viewProjection;
-    GLint  model;
-    GLint  texture;
-} shadow_splat_prog_t;
-
-#define SHADER_TYPE shadow_splat_prog_t
+#define SHADER_TYPE SPRITESTATE
 const shader_desc_t sd_shadow_splat = {
     .Name = "shadow_splat",
     .Uniforms = {
@@ -328,32 +129,24 @@ const shader_desc_t sd_shadow_splat = {
         SHARED(color,    UT_COLOR),
     },
     .VertexBody =
-        "void main() {\n"
-        "  gl_Position = u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "vec4 vert() {\n"
         "  v_texcoord = a_texcoord;\n"
         "  v_color = a_color;\n"
+        "  return u_viewProjection * u_model * vec4(a_position, 1.0);\n"
         "}\n",
     .FragmentBody =
         "float crop_edges(vec2 tc) {\n"
         "  return step(abs(tc.x - 0.5), 0.5) * step(abs(tc.y - 0.5), 0.5);\n"
         "}\n"
-        "void main() {\n"
-        "  vec4 tex = " GLSL_TEX "(u_texture, v_texcoord);\n"
-        "  " GLSL_FRAGCOLOR " = vec4(0.0, 0.0, 0.0, tex.a * v_color.a * crop_edges(v_texcoord));\n"
+        "vec4 frag() {\n"
+        "  vec4 tex = texture(u_texture, v_texcoord);\n"
+        "  return vec4(0.0, 0.0, 0.0, tex.a * v_color.a * crop_edges(v_texcoord));\n"
         "}\n",
 };
 #undef SHADER_TYPE
 
 /* --- commandbutton: edge glow controlled by u_activeGlow ---------------- */
-typedef struct {
-    GLuint progid;
-    GLint  viewProjection;
-    GLint  model;
-    GLint  texture;
-    GLint  activeGlow;
-} commandbutton_prog_t;
-
-#define SHADER_TYPE commandbutton_prog_t
+#define SHADER_TYPE SPRITESTATE
 const shader_desc_t sd_commandbutton = {
     .Name = "commandbutton",
     .Uniforms = {
@@ -372,32 +165,26 @@ const shader_desc_t sd_commandbutton = {
         SHARED(color,    UT_COLOR),
     },
     .VertexBody =
-        "void main() {\n"
-        "  gl_Position = u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "vec4 vert() {\n"
         "  v_texcoord = a_texcoord;\n"
         "  v_color = a_color;\n"
+        "  return u_viewProjection * u_model * vec4(a_position, 1.0);\n"
         "}\n",
     .FragmentBody =
-        "void main() {\n"
-        "  " GLSL_FRAGCOLOR " = " GLSL_TEX "(u_texture, v_texcoord) * v_color;\n"
+        "vec4 frag() {\n"
+        "  vec4 col = texture(u_texture, v_texcoord) * v_color;\n"
         "  float glow = max(abs(v_texcoord.x - 0.5), abs(v_texcoord.y - 0.5));\n"
         "  glow = smoothstep(0.33, 0.5, glow) * 0.75 * u_activeGlow;\n"
-        "  " GLSL_FRAGCOLOR ".rgb = mix(" GLSL_FRAGCOLOR ".rgb, vec3(0.5, 1.0, 0.5), glow);\n"
+        "  col.rgb = mix(col.rgb, vec3(0.5, 1.0, 0.5), glow);\n"
         "  float crop = step(abs(v_texcoord.x - 0.5), 0.5) * step(abs(v_texcoord.y - 0.5), 0.5);\n"
-        "  " GLSL_FRAGCOLOR ".a *= crop;\n"
+        "  col.a *= crop;\n"
+        "  return col;\n"
         "}\n",
 };
 #undef SHADER_TYPE
 
 /* --- minimap fog: fog-of-war overlay with y-flip ------------------------ */
-typedef struct {
-    GLuint progid;
-    GLint  viewProjection;
-    GLint  model;
-    GLint  texture;
-} minimap_fog_prog_t;
-
-#define SHADER_TYPE minimap_fog_prog_t
+#define SHADER_TYPE SPRITESTATE
 const shader_desc_t sd_minimap_fog = {
     .Name = "minimap_fog",
     .Uniforms = {
@@ -415,261 +202,282 @@ const shader_desc_t sd_minimap_fog = {
         SHARED(color,    UT_COLOR),
     },
     .VertexBody =
-        "void main() {\n"
-        "  gl_Position = u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "vec4 vert() {\n"
         "  v_texcoord = a_texcoord;\n"
         "  v_color = a_color;\n"
+        "  return u_viewProjection * u_model * vec4(a_position, 1.0);\n"
         "}\n",
     .FragmentBody =
-        "void main() {\n"
-        "  float visibility = " GLSL_TEX "(u_texture, vec2(v_texcoord.x, 1.0 - v_texcoord.y)).r;\n"
+        "vec4 frag() {\n"
+        "  float visibility = texture(u_texture, vec2(v_texcoord.x, 1.0 - v_texcoord.y)).r;\n"
         "  float alpha = clamp(1.0 - visibility, 0.0, 1.0) * v_color.a;\n"
-        "  " GLSL_FRAGCOLOR " = vec4(v_color.rgb, alpha);\n"
+        "  return vec4(v_color.rgb, alpha);\n"
         "}\n",
 };
 #undef SHADER_TYPE
 
-/* Shared vertex shader for MDX/M2/M3 model formats.
-   Compiled twice: once as-is (uModelMatrix path), and once with
-   "#define BZ_USE_INSTANCING 1" injected to switch to per-instance
-   matrix attributes and add ground-effect grass wind. */
-static LPCSTR model_vs =
-"#version 140\n"
-"in vec3 i_position;\n"
-"in vec4 i_color;\n"
-"in vec2 i_texcoord;\n"
-"in vec3 i_normal;\n"
-"in vec4 i_skin1;\n"
-"in vec4 i_boneWeight1;\n"
-"#ifdef BZ_USE_INSTANCING\n"
-"in mat4 i_instance;\n"
-"#endif\n"
-"out vec4 v_color;\n"
-#ifdef USE_SHADOWMAPS
-"out vec4 v_shadow;\n"
-"out vec3 v_shadowlight;\n"
-#endif
-"out vec2 v_texcoord;\n"
-"out vec2 v_texcoord2;\n"
-"out vec3 v_lighting;\n"
-/* The CPU palette and literal GLSL array share one compile-time size; never shrink it from GL limits. */
-"uniform mat4 uBones[" BZ_XSTR(BZ_BONE_PALETTE_MAX) "];\n"
-"uniform mat4 uViewProjectionMatrix;\n"
-"uniform mat4 uLightMatrix;\n"
-"uniform mat4 uTextureMatrix;\n"
-"uniform int uLightCount;\n"
-"uniform float uFirstBoneLookupIndex;\n"
-"uniform mat4 uLights[8];\n"
-"#ifdef BZ_USE_INSTANCING\n"
-"uniform mat4 uGrassParams;\n"
-"#else\n"
-"uniform mat4 uModelMatrix;\n"
-"uniform mat3 uNormalMatrix;\n"
-"#endif\n"
-"const int MODEL_LIGHT_OMNI = 0;\n"
-"const int MODEL_LIGHT_DIRECT = 1;\n"
-"const int MODEL_LIGHT_AMBIENT = 2;\n"
-"vec3 apply_light(mat4 light, vec3 n, vec3 worldPos) {\n"
-"    int type = int(light[0].w + 0.5);\n"
-"    vec3 color = light[2].rgb * light[2].a;\n"
-"    vec3 ambient = light[3].rgb * light[3].a;\n"
-"    if (type == MODEL_LIGHT_AMBIENT) {\n"
-"        return color + ambient;\n"
-"    } else if (type == MODEL_LIGHT_DIRECT) {\n"
-"        vec3 l = normalize(-light[1].xyz);\n"
-"        return clamp(color * max(dot(n, l), 0.0), vec3(0.0), vec3(1.0)) + ambient;\n"
-"    } else {\n"
-"        vec3 delta = light[0].xyz - worldPos;\n"
-"        vec3 l = normalize(delta);\n"
-"        float dist = length(delta) / 64.0 + 1.0;\n"
-"        float atten = 1.0 / (dist * dist);\n"
-"        return clamp(color * atten * max(dot(n, l), 0.0), vec3(0.0), vec3(1.0)) + ambient * atten;\n"
-"    }\n"
-"}\n"
-"vec3 vertex_lighting(vec3 normal, vec3 worldPos) {\n"
-"    vec3 n = normalize(normal);\n"
-"    vec3 lighting = vec3(0.0);\n"
-#ifdef USE_SHADOWMAPS
-"    v_shadowlight = vec3(0.0);\n"
-#endif
-"    for (int i = 0; i < 8; ++i) {\n"
-"        if (i >= uLightCount) break;\n"
-"        vec3 contribution = apply_light(uLights[i], n, worldPos);\n"
-"        lighting += contribution;\n"
-#ifdef USE_SHADOWMAPS
-/* Slot zero is the shadow-casting key; ambient/fill/back remain visible in its shadow. */
-"        if (i == 0 && int(uLights[i][0].w + 0.5) == MODEL_LIGHT_DIRECT)\n"
-"            v_shadowlight = contribution - uLights[i][3].rgb * uLights[i][3].a;\n"
-#endif
-"    }\n"
-"    return lighting;\n"
-"}\n"
-"void main() {\n"
-"    vec4 pos4 = vec4(i_position, 1.0);\n"
-"    vec4 norm4 = vec4(i_normal, 0.0);\n"
-"    vec4 position = vec4(0.0);\n"
-"    vec4 normal = vec4(0.0);\n"
-"    for (int i = 0; i < 4; ++i) {\n"
-"        int boneIdx = int(i_skin1[i]) + int(uFirstBoneLookupIndex);\n"
-"        position += uBones[boneIdx] * pos4 * i_boneWeight1[i];\n"
-"        normal += uBones[boneIdx] * norm4 * i_boneWeight1[i];\n"
-"    }\n"
-"    position.w = 1.0;\n"
-"#ifdef BZ_USE_INSTANCING\n"
-"    if (uGrassParams[3].z > 0.5) {\n"
-"        float grassHeight = max(uGrassParams[3].y - uGrassParams[3].x, 0.001);\n"
-"        float grassTop = smoothstep(uGrassParams[1].w, 1.0, clamp((position.z - uGrassParams[3].x) / grassHeight, 0.0, 1.0));\n"
-"        float grassPhase = dot(i_instance[3].xy, uGrassParams[2].xy);\n"
-"        float grassSway = sin(uGrassParams[1].x * uGrassParams[1].y + grassPhase) * uGrassParams[1].z * grassHeight * grassTop;\n"
-"        position.xy += uGrassParams[2].zw * grassSway;\n"
-"    }\n"
-"    vec4 worldPos4 = i_instance * position;\n"
-"    v_color = i_color;\n"
-"    if (uGrassParams[3].z > 0.5) {\n"
-"        float fadeDist = length(worldPos4.xy - uGrassParams[0].xy);\n"
-"        v_color.a *= 1.0 - smoothstep(uGrassParams[0].z, uGrassParams[0].w, fadeDist);\n"
-"    }\n"
-"    v_texcoord = i_texcoord;\n"
-"    v_texcoord2 = (uTextureMatrix * worldPos4).xy;\n"
-"    v_lighting = vertex_lighting(normalize(mat3(i_instance) * normal.xyz), worldPos4.xyz);\n"
-#ifdef USE_SHADOWMAPS
-"    v_shadow = uLightMatrix * worldPos4;\n"
-#endif
-"    gl_Position = uViewProjectionMatrix * worldPos4;\n"
-"#else\n"
-"    v_color = i_color;\n"
-"    v_texcoord = i_texcoord;\n"
-"    v_texcoord2 = (uTextureMatrix * uModelMatrix * position).xy;\n"
-"    vec3 worldNormal = normalize(uNormalMatrix * normal.xyz);\n"
-"    vec3 worldPos = (uModelMatrix * position).xyz;\n"
-"    v_lighting = vertex_lighting(worldNormal, worldPos);\n"
-#ifdef USE_SHADOWMAPS
-"    v_shadow = uLightMatrix * uModelMatrix * position;\n"
-#endif
-"    gl_Position = uViewProjectionMatrix * uModelMatrix * position;\n"
-"#endif\n"
-"}\n";
+/* --- default: ground/world sprite with per-vertex lighting --------------- */
+#define SHADER_TYPE DEFAULTSTATE
+const shader_desc_t sd_default = {
+    .Name = "default",
+    .Uniforms = {
+        UNIFORM(viewProjection, UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(textureMatrix,  UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(model,          UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(lightMatrix,    UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM_TRANSPOSE(normalMatrix,   UT_FLOAT_MAT3, PRECISION_HIGH),
+        UNIFORM(texture,        UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(shadowmap,      UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(fogOfWar,       UT_SAMPLER_2D, PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
+        ATTRIB(normal,   attrib_normal,   UT_FLOAT_VEC3),
+        ATTRIB(color,    attrib_color,    UT_COLOR),
+    },
+    .Shared = {
+        SHARED(texcoord,  UT_FLOAT_VEC2),
+        SHARED(texcoord2, UT_FLOAT_VEC2),
+        SHARED(normal,    UT_FLOAT_VEC3),
+        SHARED(lightDir,  UT_FLOAT_VEC3),
+        SHARED(color,     UT_COLOR),
+        SHARED(shadow,    UT_FLOAT_VEC4),
+    },
+    .VertexBody =
+        "vec4 vert() {\n"
+        "  vec4 pos = u_model * vec4(a_position, 1.0);\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  v_texcoord2 = (u_textureMatrix * pos).xy;\n"
+        "  v_normal = normalize(u_normalMatrix * a_normal);\n"
+        "#ifdef USE_SHADOWMAPS\n"
+        "  v_shadow = u_lightMatrix * pos;\n"
+        "#endif\n"
+        "  v_color = a_color;\n"
+        "  v_lightDir = -normalize(vec3(u_lightMatrix[0][2], u_lightMatrix[1][2], u_lightMatrix[2][2])) * 1.2;\n"
+        "  return u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "}\n",
+    .FragmentBody =
+        "float get_light() {\n"
+        "  return dot(v_normal, v_lightDir);\n"
+        "}\n"
+        "#ifdef USE_SHADOWMAPS\n"
+        "float get_shadow() {\n"
+        "  float depth = texture(u_shadowmap, vec2(v_shadow.x + 1.0, v_shadow.y + 1.0) * 0.5).r;\n"
+        "  return depth < (v_shadow.z + 0.99) * 0.5 ? 0.0 : 1.0;\n"
+        "}\n"
+        "float get_lighting() { return min(1.0, mix(0.35, 1.0, get_shadow() * get_light()) * 1.1); }\n"
+        "#else\n"
+        "float get_lighting() { return min(1.0, mix(0.35, 1.0, get_light()) * 1.1); }\n"
+        "#endif\n"
+        "#ifdef USE_FOGOFWAR\n"
+        "float get_fogofwar() {\n"
+        "  return texture(u_fogOfWar, v_texcoord2).r;\n"
+        "}\n"
+        "#endif\n"
+        "vec4 frag() {\n"
+        "  vec4 col = texture(u_texture, v_texcoord) * v_color;\n"
+        "#ifdef USE_FOGOFWAR\n"
+        "  col.rgb *= get_fogofwar() * get_lighting();\n"
+        "#else\n"
+        "  col.rgb *= get_lighting();\n"
+        "#endif\n"
+        "  return col;\n"
+        "}\n",
+};
+#undef SHADER_TYPE
 
-static LPCSTR model_fs =
-"#version 140\n"
-"in vec2 v_texcoord;\n"
-"in vec2 v_texcoord2;\n"
+/* --- model: shared skinned shader for MDX/M2/M3, compiled twice -----------
+ * (normal + BZ_USE_INSTANCING).  USE_SHADOWMAPS/USE_FOGOFWAR/BZ_USE_MSAA are
+ * injected as GLSL defines from the matching C preprocessor macros. */
+#define SHADER_TYPE MODELSTATE
+const shader_desc_t sd_model = {
+    .Name = "model",
+    .Uniforms = {
+        UNIFORM_ARRAY(bones,               UT_FLOAT_MAT4, PRECISION_HIGH, BZ_BONE_PALETTE_MAX),
+        UNIFORM(viewProjection,            UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(lightMatrix,               UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(textureMatrix,             UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(lightCount,                UT_INT,        PRECISION_LOW),
+        UNIFORM(firstBoneLookupIndex,      UT_FLOAT,      PRECISION_LOW),
+        UNIFORM_ARRAY(lights,              UT_FLOAT_MAT4, PRECISION_HIGH, BZ_MODEL_LIGHT_MAX),
+        UNIFORM(grassParams,               UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(model,                     UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM_TRANSPOSE(normalMatrix,              UT_FLOAT_MAT3, PRECISION_HIGH),
+        UNIFORM(texture,                   UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(shadowmap,                 UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(fogOfWar,                  UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(layerAlpha,                UT_FLOAT,      PRECISION_LOW),
+        UNIFORM(geosetColor,               UT_FLOAT_VEC4, PRECISION_LOW),
+        UNIFORM(uvMatrix,                  UT_FLOAT_MAT3, PRECISION_HIGH),
+        UNIFORM(alphaKey,                  UT_BOOL,       PRECISION_LOW),
+        UNIFORM(alphaCutoff,               UT_FLOAT,      PRECISION_LOW),
+        UNIFORM(unshaded,                  UT_BOOL,       PRECISION_LOW),
+        UNIFORM(fogEnable,                 UT_BOOL,       PRECISION_LOW),
+        UNIFORM(fogColor,                  UT_FLOAT_VEC3, PRECISION_LOW),
+        UNIFORM(fogParams,                 UT_FLOAT_VEC2, PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position,     attrib_position,     UT_FLOAT_VEC3),
+        ATTRIB(color,        attrib_color,        UT_COLOR),
+        ATTRIB(texcoord,     attrib_texcoord,     UT_FLOAT_VEC2),
+        ATTRIB(normal,       attrib_normal,       UT_FLOAT_VEC3),
+        ATTRIB(skin1,        attrib_skin1,        UT_FLOAT_VEC4),
+        ATTRIB(boneWeight1,  attrib_boneWeight1,  UT_FLOAT_VEC4),
+        ATTRIB(instance,     attrib_instance,     UT_FLOAT_MAT4),
+    },
+    .Shared = {
+        SHARED(color,       UT_COLOR),
+        SHARED(shadow,      UT_FLOAT_VEC4),
+        SHARED(shadowlight, UT_FLOAT_VEC3),
+        SHARED(texcoord,    UT_FLOAT_VEC2),
+        SHARED(texcoord2,   UT_FLOAT_VEC2),
+        SHARED(lighting,    UT_FLOAT_VEC3),
+    },
+    .VertexBody =
+        "const int MODEL_LIGHT_OMNI = 0;\n"
+        "const int MODEL_LIGHT_DIRECT = 1;\n"
+        "const int MODEL_LIGHT_AMBIENT = 2;\n"
+        "vec3 apply_light(mat4 light, vec3 n, vec3 worldPos) {\n"
+        "  int type = int(light[0].w + 0.5);\n"
+        "  vec3 color = light[2].rgb * light[2].a;\n"
+        "  vec3 ambient = light[3].rgb * light[3].a;\n"
+        "  if (type == MODEL_LIGHT_AMBIENT) return color + ambient;\n"
+        "  if (type == MODEL_LIGHT_DIRECT) {\n"
+        "    vec3 l = normalize(-light[1].xyz);\n"
+        "    return clamp(color * max(dot(n, l), 0.0), vec3(0.0), vec3(1.0)) + ambient;\n"
+        "  }\n"
+        "  vec3 delta = light[0].xyz - worldPos;\n"
+        "  vec3 l = normalize(delta);\n"
+        "  float dist = length(delta) / 64.0 + 1.0;\n"
+        "  float atten = 1.0 / (dist * dist);\n"
+        "  return clamp(color * atten * max(dot(n, l), 0.0), vec3(0.0), vec3(1.0)) + ambient * atten;\n"
+        "}\n"
+        "vec3 vertex_lighting(vec3 normal, vec3 worldPos) {\n"
+        "  vec3 n = normalize(normal);\n"
+        "  vec3 lighting = vec3(0.0);\n"
+        "#ifdef USE_SHADOWMAPS\n"
+        "  v_shadowlight = vec3(0.0);\n"
+        "#endif\n"
+        "  for (int i = 0; i < 8; ++i) {\n"
+        "    if (i >= u_lightCount) break;\n"
+        "    vec3 contribution = apply_light(u_lights[i], n, worldPos);\n"
+        "    lighting += contribution;\n"
+        "#ifdef USE_SHADOWMAPS\n"
+        "    if (i == 0 && int(u_lights[i][0].w + 0.5) == MODEL_LIGHT_DIRECT)\n"
+        "      v_shadowlight = contribution - u_lights[i][3].rgb * u_lights[i][3].a;\n"
+        "#endif\n"
+        "  }\n"
+        "  return lighting;\n"
+        "}\n"
+        "vec4 vert() {\n"
+        "  vec4 pos4 = vec4(a_position, 1.0);\n"
+        "  vec4 norm4 = vec4(a_normal, 0.0);\n"
+        "  vec4 position = vec4(0.0);\n"
+        "  vec4 normal = vec4(0.0);\n"
+        "  for (int i = 0; i < 4; ++i) {\n"
+        "    int boneIdx = int(a_skin1[i]) + int(u_firstBoneLookupIndex);\n"
+        "    position += u_bones[boneIdx] * pos4 * a_boneWeight1[i];\n"
+        "    normal += u_bones[boneIdx] * norm4 * a_boneWeight1[i];\n"
+        "  }\n"
+        "  position.w = 1.0;\n"
+        "#ifdef BZ_USE_INSTANCING\n"
+        "  if (u_grassParams[3].z > 0.5) {\n"
+        "    float grassHeight = max(u_grassParams[3].y - u_grassParams[3].x, 0.001);\n"
+        "    float grassTop = smoothstep(u_grassParams[1].w, 1.0, clamp((position.z - u_grassParams[3].x) / grassHeight, 0.0, 1.0));\n"
+        "    float grassPhase = dot(a_instance[3].xy, u_grassParams[2].xy);\n"
+        "    float grassSway = sin(u_grassParams[1].x * u_grassParams[1].y + grassPhase) * u_grassParams[1].z * grassHeight * grassTop;\n"
+        "    position.xy += u_grassParams[2].zw * grassSway;\n"
+        "  }\n"
+        "  vec4 worldPos4 = a_instance * position;\n"
+        "  v_color = a_color;\n"
+        "  if (u_grassParams[3].z > 0.5) {\n"
+        "    float fadeDist = length(worldPos4.xy - u_grassParams[0].xy);\n"
+        "    v_color.a *= 1.0 - smoothstep(u_grassParams[0].z, u_grassParams[0].w, fadeDist);\n"
+        "  }\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  v_texcoord2 = (u_textureMatrix * worldPos4).xy;\n"
+        "  v_lighting = vertex_lighting(normalize(mat3(a_instance) * normal.xyz), worldPos4.xyz);\n"
+        "#ifdef USE_SHADOWMAPS\n"
+        "  v_shadow = u_lightMatrix * worldPos4;\n"
+        "#endif\n"
+        "  return u_viewProjection * worldPos4;\n"
+        "#else\n"
+        "  v_color = a_color;\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  v_texcoord2 = (u_textureMatrix * u_model * position).xy;\n"
+        "  vec3 worldNormal = normalize(u_normalMatrix * normal.xyz);\n"
+        "  vec3 worldPos = (u_model * position).xyz;\n"
+        "  v_lighting = vertex_lighting(worldNormal, worldPos);\n"
+        "#ifdef USE_SHADOWMAPS\n"
+        "  v_shadow = u_lightMatrix * u_model * position;\n"
+        "#endif\n"
+        "  return u_viewProjection * u_model * position;\n"
+        "#endif\n"
+        "}\n",
+    .FragmentBody =
+        "#ifdef USE_FOGOFWAR\n"
+        "float get_fogofwar() {\n"
+        "  return texture(u_fogOfWar, v_texcoord2).r;\n"
+        "}\n"
+        "#endif\n"
+        "#ifdef USE_SHADOWMAPS\n"
+        BZ_SHADOW_GLSL
+        "#endif\n"
+        "vec4 frag() {\n"
+        "  vec2 uv = (u_uvMatrix * vec3(v_texcoord, 1.0)).xy;\n"
+        "  vec4 col = texture(u_texture, uv);\n"
+        "  col *= u_geosetColor;\n"
+        "  col *= u_layerAlpha;\n"
+        "  col *= v_color;\n"
+        "  if (!u_unshaded) {\n"
+        "    vec3 light = v_lighting;\n"
+        "#ifdef USE_SHADOWMAPS\n"
+        "    light -= v_shadowlight * (1.0 - shadow_visibility(u_shadowmap, v_shadow));\n"
+        "#endif\n"
+        "    light = min(light, vec3(1.0));\n"
+        "#ifdef USE_FOGOFWAR\n"
+        "    col.rgb *= get_fogofwar() * light;\n"
+        "#else\n"
+        "    col.rgb *= light;\n"
+        "#endif\n"
+        "    if (u_fogEnable) {\n"
+        "      float fogFactor = clamp((u_fogParams.y - gl_FragCoord.z / gl_FragCoord.w) / (u_fogParams.y - u_fogParams.x), 0.0, 1.0);\n"
+        "      col.rgb = mix(u_fogColor, col.rgb, fogFactor);\n"
+        "    }\n"
+        "  }\n"
+        "  if (u_alphaKey) {\n"
+        "#ifndef BZ_USE_MSAA\n"
+        "    if (col.a < u_alphaCutoff) discard;\n"
+        "#else\n"
+        "    float edge = max(fwidth(col.a), 1.0 / 255.0);\n"
+        "    col.a = smoothstep(u_alphaCutoff - edge, u_alphaCutoff + edge, col.a);\n"
+        "#endif\n"
+        "  }\n"
+        "  return col;\n"
+        "}\n",
+};
+#undef SHADER_TYPE
+
+/* Compile-time GLSL defines derived from C build macros; prepended to every
+   built-in program.  Extra per-variant defines (e.g. BZ_USE_INSTANCING) are
+   added by the callers. */
+static char shader_defines_buf[256];
+static LPCSTR R_ShaderDefines(BOOL instancing) {
+    int n = 0;
+    if (instancing)
+        n += snprintf(shader_defines_buf + n, sizeof(shader_defines_buf) - n, "#define BZ_USE_INSTANCING 1\n");
 #ifdef USE_SHADOWMAPS
-"in vec4 v_shadow;\n"
-"in vec3 v_shadowlight;\n"
-#endif
-"in vec3 v_lighting;\n"
-"in vec4 v_color;\n"
-"out vec4 o_color;\n"
-"uniform sampler2D uTexture;\n"
-#ifdef USE_SHADOWMAPS
-"uniform sampler2D uShadowmap;\n"
+    n += snprintf(shader_defines_buf + n, sizeof(shader_defines_buf) - n, "#define USE_SHADOWMAPS 1\n");
 #endif
 #ifdef USE_FOGOFWAR
-"uniform sampler2D uFogOfWar;\n"
+    n += snprintf(shader_defines_buf + n, sizeof(shader_defines_buf) - n, "#define USE_FOGOFWAR 1\n");
 #endif
-"uniform float uLayerAlpha;\n"
-"uniform vec4 uGeosetColor;\n"
-"uniform mat3 uUvMatrix;\n"
-"uniform bool uAlphaKey;\n"
-/* In MSAA mode, hard discard is replaced by smoothstep alpha-to-coverage
-   to avoid edge aliasing; uAlphaCutoff is still used as the threshold. */
-"uniform float uAlphaCutoff;\n"
-/* uUnshaded: MDX emissive layers skip lighting and fog-of-war. */
-"uniform bool uUnshaded;\n"
-// TODO: Add USE_FOG to skip compilation in games that never use it
-"uniform bool uFogEnable;\n"
-"uniform vec3 uFogColor;\n"
-"uniform vec2 uFogParams;\n"
-#ifdef USE_FOGOFWAR
-"float get_fogofwar() {\n"
-"    return texture(uFogOfWar, v_texcoord2).r;\n"
-"}\n"
+#ifdef BZ_USE_MSAA
+    n += snprintf(shader_defines_buf + n, sizeof(shader_defines_buf) - n, "#define BZ_USE_MSAA 1\n");
 #endif
-#ifdef USE_SHADOWMAPS
-BZ_SHADOW_GLSL
-#endif
-"void main() {\n"
-"    vec2 uv = (uUvMatrix * vec3(v_texcoord, 1.0)).xy;\n"
-"    vec4 col = texture(uTexture, uv);\n"
-"    col *= uGeosetColor;\n"
-"    col *= uLayerAlpha;\n"
-"    col *= v_color;\n"
-"    if (!uUnshaded) {\n"
-"        vec3 light = v_lighting;\n"
-#ifdef USE_SHADOWMAPS
-"        light -= v_shadowlight * (1.0 - shadow_visibility(uShadowmap, v_shadow));\n"
-#endif
-"        light = min(light, vec3(1.0));\n"
-#ifdef USE_FOGOFWAR
-"        col.rgb *= get_fogofwar() * light;\n"
-#else
-"        col.rgb *= light;\n"
-#endif
-"        if (uFogEnable) {\n"
-"            float fogFactor = clamp((uFogParams.y - gl_FragCoord.z / gl_FragCoord.w) / (uFogParams.y - uFogParams.x), 0.0, 1.0);\n"
-"            col.rgb = mix(uFogColor, col.rgb, fogFactor);\n"
-"        }\n"
-"    }\n"
-"    if (uAlphaKey) {\n"
-#ifndef BZ_USE_MSAA
-"        if (col.a < uAlphaCutoff) discard;\n"
-#else
-"        float edge = max(fwidth(col.a), 1.0 / 255.0);\n"
-"        col.a = smoothstep(uAlphaCutoff - edge, uAlphaCutoff + edge, col.a);\n"
-#endif
-"    }\n"
-"    o_color = col;\n"
-"}\n";
-
-static LPSHADER model_shader;
-
-/* Returns the shared model shader, compiling it on first call. All three model
-   formats (MDX/M2/M3) use this single shader; per-format data is normalised at
-   load time so the GPU path is identical. */
-LPSHADER R_ModelShader(void) {
-    if (!model_shader) {
-        model_shader = R_InitShader(model_vs, model_fs);
-        R_Call(glUseProgram, model_shader->progid);
-        R_Call(glUniform1f, model_shader->uAlphaCutoff, 0.5f);
-    }
-    /* Shader creation is fatal on failure; an unskinned fallback cannot preserve the model contract. */
-    return model_shader;
-}
-
-
-static LPSHADER R_InitShaderDefines(LPCSTR vs_src, LPCSTR fs_src, LPCSTR extra_defines);
-
-static LPSHADER instanced_shader;
-
-/* Instanced model shader for static meshes (ground-effect clutter). Uses model_vs
-   compiled with BZ_USE_INSTANCING to replace uModelMatrix with per-instance attributes. */
-LPSHADER R_ModelShaderInstanced(void) {
-    if (!instanced_shader) {
-        MATRIX4 bones[BZ_BONE_PALETTE_MAX];
-
-        instanced_shader = R_InitShaderDefines(model_vs, model_fs, "#define BZ_USE_INSTANCING 1\n");
-        FOR_LOOP(i, BZ_BONE_PALETTE_MAX) Matrix4_identity(&bones[i]);
-        R_Call(glUseProgram, instanced_shader->progid);
-        R_Call(glUniform1f, instanced_shader->uAlphaCutoff, 0.5f);
-        /* Static grass has no keyed bones; install its identity palette once, not once per frame. */
-        R_Call(glUniformMatrix4fv, instanced_shader->uBones, BZ_BONE_PALETTE_MAX, GL_FALSE, bones[0].v);
-    }
-    return instanced_shader;
-}
-
-/* Only dialect and instancing vary; the model palette is fixed in the C shader body. */
-static void R_SetShaderSource(GLuint shader, LPCSTR source, LPCSTR extra_defines) {
-    LPCSTR body = strchr(source, '\n');
-    LPCSTR prefix =
-#ifdef BZ_GL_ES3
-        "#version 300 es\nprecision highp float;\nprecision highp int;\n";
-#else
-        "#version 140\n";
-#endif
-    LPCSTR strings[] = { prefix, extra_defines ? extra_defines : "", body ? body + 1 : source };
-    GLint lengths[] = { (GLint)strlen(strings[0]), (GLint)strlen(strings[1]), (GLint)strlen(strings[2]) };
-    R_Call(glShaderSource, shader, 3, strings, lengths);
+    (void)n;
+    return shader_defines_buf;
 }
 
 /* A compiled shader can still exceed resources at link time. Never draw with a failed program.
@@ -691,92 +499,6 @@ static void R_CheckShader(GLuint obj, GLenum check, LPCSTR label) {
     free(log);
     exit(EXIT_FAILURE);
 }
-
-static LPSHADER R_InitShaderDefines(LPCSTR vs_src, LPCSTR fs_src, LPCSTR extra_defines) {
-    GLuint vs = R_Call(glCreateShader, GL_VERTEX_SHADER);
-    GLuint fs = R_Call(glCreateShader, GL_FRAGMENT_SHADER);
-
-    R_SetShaderSource(vs, vs_src, extra_defines);
-    R_Call(glCompileShader, vs);
-    R_CheckShader(vs, GL_COMPILE_STATUS, "Vertex shader compilation");
-    R_SetShaderSource(fs, fs_src, extra_defines);
-    R_Call(glCompileShader, fs);
-    R_CheckShader(fs, GL_COMPILE_STATUS, "Fragment shader compilation");
-
-    LPSHADER program = ri.MemAlloc(sizeof(struct shader_program));
-    program->progid = R_Call(glCreateProgram, );
-
-    R_Call(glAttachShader, program->progid, vs);
-    R_Call(glAttachShader, program->progid, fs);
-
-    R_Call(glBindAttribLocation, program->progid, attrib_position, "i_position");
-    R_Call(glBindAttribLocation, program->progid, attrib_color, "i_color");
-    R_Call(glBindAttribLocation, program->progid, attrib_texcoord, "i_texcoord");
-    R_Call(glBindAttribLocation, program->progid, attrib_normal, "i_normal");
-    R_Call(glBindAttribLocation, program->progid, attrib_skin1, "i_skin1");
-    R_Call(glBindAttribLocation, program->progid, attrib_boneWeight1, "i_boneWeight1");
-    R_Call(glBindAttribLocation, program->progid, attrib_particleSize, "i_size");
-    R_Call(glBindAttribLocation, program->progid, attrib_particleAxis, "i_axis");
-    R_Call(glBindAttribLocation, program->progid, attrib_instance, "i_instance");
-
-    R_Call(glLinkProgram, program->progid);
-    R_CheckShader(program->progid, GL_LINK_STATUS, "Shader program link");
-    R_Call(glDeleteShader, vs);
-    R_Call(glDeleteShader, fs);
-    R_Call(glUseProgram, program->progid);
-
-#define R_RegisterUniform(PROGRAM, NAME) PROGRAM->NAME = glGetUniformLocation(PROGRAM->progid, #NAME);
-
-    R_RegisterUniform(program, uViewProjectionMatrix);
-    R_RegisterUniform(program, uModelMatrix);
-    R_RegisterUniform(program, uLightMatrix);
-    R_RegisterUniform(program, uNormalMatrix);
-    R_RegisterUniform(program, uTextureMatrix);
-    R_RegisterUniform(program, uTexture);
-#ifdef USE_SHADOWMAPS
-    R_RegisterUniform(program, uShadowmap);
-#endif
-#ifdef USE_FOGOFWAR
-    R_RegisterUniform(program, uFogOfWar);
-#endif
-    R_RegisterUniform(program, uBones);
-    R_RegisterUniform(program, uAlphaKey);
-    R_RegisterUniform(program, uAlphaCutoff);
-    R_RegisterUniform(program, uUnshaded);
-    R_RegisterUniform(program, uLayerAlpha);
-    R_RegisterUniform(program, uGeosetColor);
-    R_RegisterUniform(program, uUvMatrix);
-    R_RegisterUniform(program, uLightCount);
-    program->uLights = glGetUniformLocation(program->progid, "uLights[0]");
-    R_RegisterUniform(program, uGrassParams);
-    R_RegisterUniform(program, uEyePosition);
-    R_RegisterUniform(program, uActiveGlow);
-    R_RegisterUniform(program, uFogEnable);
-    R_RegisterUniform(program, uFogColor);
-    R_RegisterUniform(program, uFogParams);
-    R_RegisterUniform(program, uFirstBoneLookupIndex);
-
-    R_Call(glUniform1i, program->uTexture, 0);
-#ifdef USE_SHADOWMAPS
-    R_Call(glUniform1i, program->uShadowmap, 1);
-#endif
-#ifdef USE_FOGOFWAR
-    R_Call(glUniform1i, program->uFogOfWar, 2);
-#endif
-    /* UV transform defaults to identity so callers that don't animate UVs can skip the upload. */
-    GLfloat identity_uv[9] = { 1,0,0, 0,1,0, 0,0,1 };
-    R_Call(glUniformMatrix3fv, program->uUvMatrix, 1, GL_FALSE, identity_uv);
-
-    return program;
-}
-
-LPSHADER R_InitShader(LPCSTR vs_default, LPCSTR fs_default) {
-    return R_InitShaderDefines(vs_default, fs_default, NULL);
-}
-
-/* -----------------------------------------------------------------------
- * Descriptor-based shader loading (shader_desc.h).
- * ----------------------------------------------------------------------- */
 
 static const char *R_GLSLTypeStr(uniformType_t type) {
     switch (type) {
@@ -804,9 +526,20 @@ int R_BuildShaderDeclarations(char *buf, int size, const shader_desc_t *desc,
     const char *fsin_kw  = (dialect == GLSL_DIALECT_120) ? "varying"   : "in";
     int n = 0;
 
-    for (int i = 0; i < MAX_SHADER_UNIFORMS && desc->Uniforms[i].name; i++)
-        n += snprintf(buf + n, size - n, "uniform %s %s;\n",
-                      R_GLSLTypeStr(desc->Uniforms[i].type), desc->Uniforms[i].name);
+    /* GLSL 120 has no `texture` builtin; alias it so fragment bodies can
+       call texture() regardless of dialect. */
+    if (!is_vertex && dialect == GLSL_DIALECT_120)
+        n += snprintf(buf + n, size - n, "#define texture texture2D\n");
+
+    for (int i = 0; i < MAX_SHADER_UNIFORMS && desc->Uniforms[i].name; i++) {
+        if (desc->Uniforms[i].count > 1)
+            n += snprintf(buf + n, size - n, "uniform %s %s[%u];\n",
+                          R_GLSLTypeStr(desc->Uniforms[i].type), desc->Uniforms[i].name,
+                          desc->Uniforms[i].count);
+        else
+            n += snprintf(buf + n, size - n, "uniform %s %s;\n",
+                          R_GLSLTypeStr(desc->Uniforms[i].type), desc->Uniforms[i].name);
+    }
 
     if (is_vertex) {
         for (int i = 0; i < MAX_SHADER_ATTRIBS && desc->Attributes[i].name; i++)
@@ -823,6 +556,13 @@ int R_BuildShaderDeclarations(char *buf, int size, const shader_desc_t *desc,
             n += snprintf(buf + n, size - n, "out vec4 o_color;\n");
     }
     return n;
+}
+
+int R_BuildShaderMain(char *buf, int size, bool is_vertex, glsl_dialect_t dialect) {
+    if (is_vertex)
+        return snprintf(buf, size, "void main() { gl_Position = vert(); }\n");
+    return snprintf(buf, size, "void main() { %s = frag(); }\n",
+                    dialect == GLSL_DIALECT_120 ? "gl_FragColor" : "o_color");
 }
 
 static void R_SetShaderSourceFromDesc(GLuint stage, const shader_desc_t *desc,
@@ -844,19 +584,25 @@ static void R_SetShaderSourceFromDesc(GLuint stage, const shader_desc_t *desc,
 #else
         GLSL_DIALECT_140;
 #endif
-    char decls[2048];
+    char decls[2048], main_wrapper[128];
     R_BuildShaderDeclarations(decls, sizeof(decls), desc, is_vertex, dialect);
+    R_BuildShaderMain(main_wrapper, sizeof(main_wrapper), is_vertex, dialect);
     const char *strings[] = {
         version_prefix[dialect],
         defines ? defines : "",
         decls,
         is_vertex ? desc->VertexBody : desc->FragmentBody,
+        main_wrapper,
     };
-    R_Call(glShaderSource, stage, 4, strings, NULL);
+    R_Call(glShaderSource, stage, 5, strings, NULL);
 }
 
-void R_LoadShaderDescInto(const shader_desc_t *desc, const char *defines,
-                          GLuint *progid_out, void *prog_base) {
+/* Descriptor compilation and lookup never overwrite caller-owned non-sampler values. */
+void R_LoadShaderState(LPCSHADERLOAD load) {
+    LPCSHADERDESC desc = load->desc;
+    LPCSTR defines = load->defines;
+    LPSHADERPROG prog = load->prog;
+    void *state = load->state;
     GLuint vs = R_Call(glCreateShader, GL_VERTEX_SHADER);
     GLuint fs = R_Call(glCreateShader, GL_FRAGMENT_SHADER);
 
@@ -879,45 +625,142 @@ void R_LoadShaderDescInto(const shader_desc_t *desc, const char *defines,
     R_Call(glDeleteShader, fs);
     R_Call(glUseProgram, progid);
 
-    *progid_out = progid;
-
-    int sampler_unit = 0;
+    prog->progid = progid;
+    prog->desc = desc;
+    int unit = 0;
     for (int i = 0; i < MAX_SHADER_UNIFORMS && desc->Uniforms[i].name; i++) {
-        GLint loc = glGetUniformLocation(progid, desc->Uniforms[i].name);
-        if (prog_base)
-            *(GLint *)((char *)prog_base + desc->Uniforms[i].offset) = loc;
-        if (desc->Uniforms[i].type == UT_SAMPLER_2D     ||
-            desc->Uniforms[i].type == UT_SAMPLER_2D_RECT ||
-            desc->Uniforms[i].type == UT_SAMPLER_2D_ARRAY)
-            R_Call(glUniform1i, loc, sampler_unit++);
+        const shaderUniform_t *u = &desc->Uniforms[i];
+        prog->locs[i] = glGetUniformLocation(progid, u->name);
+        if (u->type >= UT_SAMPLER_2D && u->type <= UT_SAMPLER_2D_ARRAY)
+            *(int *)((char *)state + u->offset) = unit++;
     }
 }
 
+/* Release linked programs before their GL context is destroyed. */
+void R_DeleteShader(LPSHADERPROG prog) {
+    if (prog->progid) glDeleteProgram(prog->progid);
+    memset(prog, 0, sizeof(*prog));
+}
+
+/* One typed state submission owns all uniforms, including bool conversion and matrix storage order. */
+void R_UploadShader(LPCSHADERPROG prog, LPCVOID state) {
+    R_Call(glUseProgram, prog->progid);
+    for (int i = 0; i < MAX_SHADER_UNIFORMS && prog->desc->Uniforms[i].name; i++) {
+        const shaderUniform_t *u = &prog->desc->Uniforms[i];
+        const void *data = (const char *)state + u->offset;
+        GLint loc = prog->locs[i];
+        GLsizei count = u->count ? u->count : 1;
+        if (loc < 0) continue; /* Linked shader optimised this declared input away. */
+        switch (u->type) {
+            case UT_FLOAT: R_Call(glUniform1fv, loc, count, data); break;
+            case UT_FLOAT_VEC2: R_Call(glUniform2fv, loc, count, data); break;
+            case UT_FLOAT_VEC3: R_Call(glUniform3fv, loc, count, data); break;
+            case UT_FLOAT_VEC4: case UT_COLOR: R_Call(glUniform4fv, loc, count, data); break;
+            case UT_INT: case UT_SAMPLER_2D: case UT_SAMPLER_2D_RECT: case UT_SAMPLER_2D_ARRAY:
+                R_Call(glUniform1iv, loc, count, data); break;
+            case UT_INT_VEC2: R_Call(glUniform2iv, loc, count, data); break;
+            case UT_BOOL: {
+                GLint values[count];
+                FOR_LOOP(j, count) values[j] = ((const bool *)data)[j];
+                R_Call(glUniform1iv, loc, count, values); break;
+            }
+            case UT_FLOAT_MAT3: R_Call(glUniformMatrix3fv, loc, count, u->transpose, data); break;
+            case UT_FLOAT_MAT4: R_Call(glUniformMatrix4fv, loc, count, u->transpose, data); break;
+            default: fprintf(stderr, "R_UploadShader: invalid type for %s.%s\n", prog->desc->Name, u->name); exit(EXIT_FAILURE);
+        }
+    }
+}
+
+static MODELPROG model_shader;
+static MODELPROG instanced_shader;
+static BOOL model_shader_loaded;
+static BOOL instanced_shader_loaded;
+
+static void R_LoadModelShader(MODELPROG *out, BOOL instancing) {
+    memset(out, 0, sizeof(*out));
+    R_LoadShader(&sd_model, R_ShaderDefines(instancing), out);
+
+    out->state.alphaCutoff = 0.5f;
+}
+
+/* Returns the shared model shader, compiling it on first call. All three model
+   formats (MDX/M2/M3) use this single shader; per-format data is normalised at
+   load time so the GPU path is identical. */
+MODELPROG *R_ModelShader(void) {
+    if (!model_shader_loaded) {
+        R_LoadModelShader(&model_shader, false);
+        model_shader_loaded = true;
+    }
+    return &model_shader;
+}
+
+/* Instanced model shader for static meshes (ground-effect clutter). Uses the
+   model shader compiled with BZ_USE_INSTANCING to replace uModelMatrix with
+   per-instance attributes. */
+MODELPROG *R_ModelShaderInstanced(void) {
+    if (!instanced_shader_loaded) {
+        R_LoadModelShader(&instanced_shader, true);
+        FOR_LOOP(i, BZ_BONE_PALETTE_MAX) Matrix4_identity(&instanced_shader.state.bones[i]);
+        instanced_shader_loaded = true;
+    }
+    return &instanced_shader;
+}
+
 /* Model callers submit one semantic lighting state; only this proxy knows the uniform packing contract. */
-void R_SetModelLighting(LPCSHADER shader, LPCMODELLIGHTING lighting) {
-    MATRIX4 packed[BZ_MODEL_LIGHT_MAX];
+void R_SetModelLighting(MODELPROG *shader, LPCMODELLIGHTING lighting) {
     if (!lighting || lighting->count < 1 || lighting->count > BZ_MODEL_LIGHT_MAX) {
         ri.error("R_SetModelLighting: light count must be 1..%u, got %u", BZ_MODEL_LIGHT_MAX,
                  lighting ? lighting->count : 0);
         return;
     }
-    R_PackModelLighting(packed, lighting);
-    R_Call(glUniform1i, shader->uLightCount, lighting->count);
-    R_Call(glUniformMatrix4fv, shader->uLights, lighting->count, GL_FALSE, packed[0].v);
+    R_PackModelLighting(shader->state.lights, lighting);
+    shader->state.lightCount = lighting->count;
 }
 
 /* Grass uses the same proxy boundary so game code never uploads its packed matrix directly. */
-void R_SetModelGrass(LPCSHADER shader, LPCMODELGRASS grass) {
-    MATRIX4 packed;
-    R_PackModelGrass(&packed, grass);
-    R_Call(glUniformMatrix4fv, shader->uGrassParams, 1, GL_FALSE, packed.v);
-}
-
-void R_ReleaseShader(LPSHADER shader) {
-    ri.MemFree(shader);
+void R_SetModelGrass(MODELPROG *shader, LPCMODELGRASS grass) {
+    R_PackModelGrass(&shader->state.grassParams, grass);
 }
 
 void R_ShutdownModelShader(void) {
-    SAFE_DELETE(model_shader, R_ReleaseShader);
-    SAFE_DELETE(instanced_shader, R_ReleaseShader);
+    R_DeleteShader(&model_shader.prog);
+    R_DeleteShader(&instanced_shader.prog);
+    model_shader_loaded = instanced_shader_loaded = false;
+}
+
+/* Map the public SHADERTYPE selector to the matching sprite program. */
+SPRITEPROG *R_SpriteShader(SHADERTYPE type) {
+    switch (type) {
+        case SHADER_SPLAT:         return &tr.shader_splat;
+        case SHADER_SHADOWSPLAT:   return &tr.shader_shadowSplat;
+        case SHADER_COMMANDBUTTON: return &tr.shader_commandButton;
+        case SHADER_MINIMAP:       return &tr.shader_minimap;
+        case SHADER_MINIMAP_FOG:   return &tr.shader_minimapFog;
+        case SHADER_UNLIT:         return &tr.shader_unlit;
+        default:                   return &tr.shader_ui;
+    }
+}
+
+/* Builtin lifetime is renderer-owned; this table is shared by load and shutdown. */
+static struct { LPCSHADERDESC desc; SPRITEPROG *shader; } builtin_shaders[] = {
+    { &sd_unlit, &tr.shader_ui }, { &sd_splat, &tr.shader_splat },
+    { &sd_shadow_splat, &tr.shader_shadowSplat }, { &sd_commandbutton, &tr.shader_commandButton },
+    { &sd_minimap, &tr.shader_minimap }, { &sd_minimap_fog, &tr.shader_minimapFog },
+    { &sd_unlit, &tr.shader_unlit },
+};
+
+void R_LoadBuiltinShaders(void) {
+    FOR_LOOP(i, sizeof(builtin_shaders) / sizeof(*builtin_shaders)) {
+        SPRITEPROG *shader = builtin_shaders[i].shader;
+        memset(shader, 0, sizeof(*shader));
+        R_LoadShader(builtin_shaders[i].desc, R_ShaderDefines(false), shader);
+    }
+    memset(&tr.shader_default, 0, sizeof(tr.shader_default));
+    R_LoadShader(&sd_default, R_ShaderDefines(false), &tr.shader_default);
+}
+
+void R_ShutdownBuiltinShaders(void) {
+    FOR_LOOP(i, sizeof(builtin_shaders) / sizeof(*builtin_shaders))
+        R_DeleteShader(&builtin_shaders[i].shader->prog);
+    R_DeleteShader(&tr.shader_default.prog);
 }

--- a/renderer/r_shader.c
+++ b/renderer/r_shader.c
@@ -164,6 +164,271 @@ LPCSTR fs_minimap_fog =
 "    o_color = vec4(v_color.rgb, alpha);\n"
 "}\n";
 
+/* -----------------------------------------------------------------------
+ * Descriptor-based replacements for the simple sprite/UI shaders above.
+ *
+ * Each program struct has a GLuint progid followed by one GLint per uniform
+ * in declaration order — the UNIFORM() macro stores the field offsetof so
+ * R_LoadShaderDescInto() writes resolved locations directly into the struct.
+ *
+ * Bodies contain only GLSL logic; version line, precision, and all
+ * uniform/in/out declarations are generated from the descriptor tables.
+ *
+ * Load (example):
+ *   R_LoadShaderDescInto(&sd_unlit, NULL, &unlit_prog.progid, &unlit_prog);
+ *
+ * Call site (example):
+ *   glUniformMatrix4fv(unlit_prog.viewProjection, 1, GL_FALSE, vp);
+ *   glUniformMatrix4fv(unlit_prog.model,          1, GL_FALSE, m);
+ * ----------------------------------------------------------------------- */
+
+/* --- unlit / ui: texture * vertex-color, no lighting ------------------- */
+typedef struct {
+    GLuint progid;
+    GLint  viewProjection;
+    GLint  model;
+    GLint  texture;
+} unlit_prog_t;
+
+#define SHADER_TYPE unlit_prog_t
+const shader_desc_t sd_unlit = {
+    .Name = "unlit",
+    .Uniforms = {
+        UNIFORM(viewProjection, UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(model,          UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(texture,        UT_SAMPLER_2D, PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
+        ATTRIB(color,    attrib_color,    UT_COLOR),
+    },
+    .Shared = {
+        SHARED(texcoord, UT_FLOAT_VEC2),
+        SHARED(color,    UT_COLOR),
+    },
+    .VertexBody =
+        "void main() {\n"
+        "  gl_Position = u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  v_color = a_color;\n"
+        "}\n",
+    .FragmentBody =
+        "void main() {\n"
+        "  " GLSL_FRAGCOLOR " = " GLSL_TEX "(u_texture, v_texcoord) * v_color;\n"
+        "}\n",
+};
+#undef SHADER_TYPE
+
+/* --- minimap: circular mask applied to alpha ---------------------------- */
+typedef struct {
+    GLuint progid;
+    GLint  viewProjection;
+    GLint  model;
+    GLint  texture;
+} minimap_prog_t;
+
+#define SHADER_TYPE minimap_prog_t
+const shader_desc_t sd_minimap = {
+    .Name = "minimap",
+    .Uniforms = {
+        UNIFORM(viewProjection, UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(model,          UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(texture,        UT_SAMPLER_2D, PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
+        ATTRIB(color,    attrib_color,    UT_COLOR),
+    },
+    .Shared = {
+        SHARED(texcoord, UT_FLOAT_VEC2),
+        SHARED(color,    UT_COLOR),
+    },
+    .VertexBody =
+        "void main() {\n"
+        "  gl_Position = u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  v_color = a_color;\n"
+        "}\n",
+    .FragmentBody =
+        "void main() {\n"
+        "  float mask = 1.0 - smoothstep(0.49, 0.5, length(v_color.rg - vec2(0.5)));\n"
+        "  vec4 tex = " GLSL_TEX "(u_texture, v_texcoord);\n"
+        "  " GLSL_FRAGCOLOR " = vec4(tex.rgb, tex.a * mask);\n"
+        "}\n",
+};
+#undef SHADER_TYPE
+
+/* --- splat: crop edges to [0,1] bounds ---------------------------------- */
+typedef struct {
+    GLuint progid;
+    GLint  viewProjection;
+    GLint  model;
+    GLint  texture;
+} splat_prog_t;
+
+#define SHADER_TYPE splat_prog_t
+const shader_desc_t sd_splat = {
+    .Name = "splat",
+    .Uniforms = {
+        UNIFORM(viewProjection, UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(model,          UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(texture,        UT_SAMPLER_2D, PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
+        ATTRIB(color,    attrib_color,    UT_COLOR),
+    },
+    .Shared = {
+        SHARED(texcoord, UT_FLOAT_VEC2),
+        SHARED(color,    UT_COLOR),
+    },
+    .VertexBody =
+        "void main() {\n"
+        "  gl_Position = u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  v_color = a_color;\n"
+        "}\n",
+    .FragmentBody =
+        "float crop_edges(vec2 tc) {\n"
+        "  return step(abs(tc.x - 0.5), 0.5) * step(abs(tc.y - 0.5), 0.5);\n"
+        "}\n"
+        "void main() {\n"
+        "  " GLSL_FRAGCOLOR " = " GLSL_TEX "(u_texture, v_texcoord) * v_color;\n"
+        "  " GLSL_FRAGCOLOR ".a *= crop_edges(v_texcoord);\n"
+        "}\n",
+};
+#undef SHADER_TYPE
+
+/* --- shadow splat: black silhouette with texture alpha ------------------ */
+typedef struct {
+    GLuint progid;
+    GLint  viewProjection;
+    GLint  model;
+    GLint  texture;
+} shadow_splat_prog_t;
+
+#define SHADER_TYPE shadow_splat_prog_t
+const shader_desc_t sd_shadow_splat = {
+    .Name = "shadow_splat",
+    .Uniforms = {
+        UNIFORM(viewProjection, UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(model,          UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(texture,        UT_SAMPLER_2D, PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
+        ATTRIB(color,    attrib_color,    UT_COLOR),
+    },
+    .Shared = {
+        SHARED(texcoord, UT_FLOAT_VEC2),
+        SHARED(color,    UT_COLOR),
+    },
+    .VertexBody =
+        "void main() {\n"
+        "  gl_Position = u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  v_color = a_color;\n"
+        "}\n",
+    .FragmentBody =
+        "float crop_edges(vec2 tc) {\n"
+        "  return step(abs(tc.x - 0.5), 0.5) * step(abs(tc.y - 0.5), 0.5);\n"
+        "}\n"
+        "void main() {\n"
+        "  vec4 tex = " GLSL_TEX "(u_texture, v_texcoord);\n"
+        "  " GLSL_FRAGCOLOR " = vec4(0.0, 0.0, 0.0, tex.a * v_color.a * crop_edges(v_texcoord));\n"
+        "}\n",
+};
+#undef SHADER_TYPE
+
+/* --- commandbutton: edge glow controlled by u_activeGlow ---------------- */
+typedef struct {
+    GLuint progid;
+    GLint  viewProjection;
+    GLint  model;
+    GLint  texture;
+    GLint  activeGlow;
+} commandbutton_prog_t;
+
+#define SHADER_TYPE commandbutton_prog_t
+const shader_desc_t sd_commandbutton = {
+    .Name = "commandbutton",
+    .Uniforms = {
+        UNIFORM(viewProjection, UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(model,          UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(texture,        UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(activeGlow,     UT_FLOAT,      PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
+        ATTRIB(color,    attrib_color,    UT_COLOR),
+    },
+    .Shared = {
+        SHARED(texcoord, UT_FLOAT_VEC2),
+        SHARED(color,    UT_COLOR),
+    },
+    .VertexBody =
+        "void main() {\n"
+        "  gl_Position = u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  v_color = a_color;\n"
+        "}\n",
+    .FragmentBody =
+        "void main() {\n"
+        "  " GLSL_FRAGCOLOR " = " GLSL_TEX "(u_texture, v_texcoord) * v_color;\n"
+        "  float glow = max(abs(v_texcoord.x - 0.5), abs(v_texcoord.y - 0.5));\n"
+        "  glow = smoothstep(0.33, 0.5, glow) * 0.75 * u_activeGlow;\n"
+        "  " GLSL_FRAGCOLOR ".rgb = mix(" GLSL_FRAGCOLOR ".rgb, vec3(0.5, 1.0, 0.5), glow);\n"
+        "  float crop = step(abs(v_texcoord.x - 0.5), 0.5) * step(abs(v_texcoord.y - 0.5), 0.5);\n"
+        "  " GLSL_FRAGCOLOR ".a *= crop;\n"
+        "}\n",
+};
+#undef SHADER_TYPE
+
+/* --- minimap fog: fog-of-war overlay with y-flip ------------------------ */
+typedef struct {
+    GLuint progid;
+    GLint  viewProjection;
+    GLint  model;
+    GLint  texture;
+} minimap_fog_prog_t;
+
+#define SHADER_TYPE minimap_fog_prog_t
+const shader_desc_t sd_minimap_fog = {
+    .Name = "minimap_fog",
+    .Uniforms = {
+        UNIFORM(viewProjection, UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(model,          UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(texture,        UT_SAMPLER_2D, PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
+        ATTRIB(color,    attrib_color,    UT_COLOR),
+    },
+    .Shared = {
+        SHARED(texcoord, UT_FLOAT_VEC2),
+        SHARED(color,    UT_COLOR),
+    },
+    .VertexBody =
+        "void main() {\n"
+        "  gl_Position = u_viewProjection * u_model * vec4(a_position, 1.0);\n"
+        "  v_texcoord = a_texcoord;\n"
+        "  v_color = a_color;\n"
+        "}\n",
+    .FragmentBody =
+        "void main() {\n"
+        "  float visibility = " GLSL_TEX "(u_texture, vec2(v_texcoord.x, 1.0 - v_texcoord.y)).r;\n"
+        "  float alpha = clamp(1.0 - visibility, 0.0, 1.0) * v_color.a;\n"
+        "  " GLSL_FRAGCOLOR " = vec4(v_color.rgb, alpha);\n"
+        "}\n",
+};
+#undef SHADER_TYPE
+
 /* Shared vertex shader for MDX/M2/M3 model formats.
    Compiled twice: once as-is (uModelMatrix path), and once with
    "#define BZ_USE_INSTANCING 1" injected to switch to per-instance
@@ -507,6 +772,121 @@ static LPSHADER R_InitShaderDefines(LPCSTR vs_src, LPCSTR fs_src, LPCSTR extra_d
 
 LPSHADER R_InitShader(LPCSTR vs_default, LPCSTR fs_default) {
     return R_InitShaderDefines(vs_default, fs_default, NULL);
+}
+
+/* -----------------------------------------------------------------------
+ * Descriptor-based shader loading (shader_desc.h).
+ * ----------------------------------------------------------------------- */
+
+static const char *R_GLSLTypeStr(uniformType_t type) {
+    switch (type) {
+        case UT_FLOAT:            return "float";
+        case UT_FLOAT_VEC2:       return "vec2";
+        case UT_FLOAT_VEC3:       return "vec3";
+        case UT_FLOAT_VEC4:       return "vec4";
+        case UT_COLOR:            return "vec4";
+        case UT_INT:              return "int";
+        case UT_INT_VEC2:         return "ivec2";
+        case UT_BOOL:             return "bool";
+        case UT_FLOAT_MAT3:       return "mat3";
+        case UT_FLOAT_MAT4:       return "mat4";
+        case UT_SAMPLER_2D:       return "sampler2D";
+        case UT_SAMPLER_2D_RECT:  return "sampler2DRect";
+        case UT_SAMPLER_2D_ARRAY: return "sampler2DArray";
+        default:                  return "float";
+    }
+}
+
+int R_BuildShaderDeclarations(char *buf, int size, const shader_desc_t *desc,
+                              bool is_vertex, glsl_dialect_t dialect) {
+    const char *attr_kw  = (dialect == GLSL_DIALECT_120) ? "attribute" : "in";
+    const char *vsout_kw = (dialect == GLSL_DIALECT_120) ? "varying"   : "out";
+    const char *fsin_kw  = (dialect == GLSL_DIALECT_120) ? "varying"   : "in";
+    int n = 0;
+
+    for (int i = 0; i < MAX_SHADER_UNIFORMS && desc->Uniforms[i].name; i++)
+        n += snprintf(buf + n, size - n, "uniform %s %s;\n",
+                      R_GLSLTypeStr(desc->Uniforms[i].type), desc->Uniforms[i].name);
+
+    if (is_vertex) {
+        for (int i = 0; i < MAX_SHADER_ATTRIBS && desc->Attributes[i].name; i++)
+            n += snprintf(buf + n, size - n, "%s %s %s;\n",
+                          attr_kw, R_GLSLTypeStr(desc->Attributes[i].type), desc->Attributes[i].name);
+        for (int i = 0; i < MAX_SHADER_SHARED && desc->Shared[i].name; i++)
+            n += snprintf(buf + n, size - n, "%s %s %s;\n",
+                          vsout_kw, R_GLSLTypeStr(desc->Shared[i].type), desc->Shared[i].name);
+    } else {
+        for (int i = 0; i < MAX_SHADER_SHARED && desc->Shared[i].name; i++)
+            n += snprintf(buf + n, size - n, "%s %s %s;\n",
+                          fsin_kw, R_GLSLTypeStr(desc->Shared[i].type), desc->Shared[i].name);
+        if (dialect != GLSL_DIALECT_120)
+            n += snprintf(buf + n, size - n, "out vec4 o_color;\n");
+    }
+    return n;
+}
+
+static void R_SetShaderSourceFromDesc(GLuint stage, const shader_desc_t *desc,
+                                      bool is_vertex, const char *defines) {
+    static const char *const version_prefix[] = {
+        "#version 120\n",
+        "#version 140\n",
+        "#version 300 es\nprecision highp float;\nprecision highp int;\n",
+    };
+    glsl_dialect_t dialect =
+#ifdef BZ_GL_ES3
+        GLSL_DIALECT_ES3;
+#elif defined(BZ_GLSL_120)
+        GLSL_DIALECT_120;
+#else
+        GLSL_DIALECT_140;
+#endif
+    char decls[2048];
+    R_BuildShaderDeclarations(decls, sizeof(decls), desc, is_vertex, dialect);
+    const char *strings[] = {
+        version_prefix[dialect],
+        defines ? defines : "",
+        decls,
+        is_vertex ? desc->VertexBody : desc->FragmentBody,
+    };
+    R_Call(glShaderSource, stage, 4, strings, NULL);
+}
+
+void R_LoadShaderDescInto(const shader_desc_t *desc, const char *defines,
+                          GLuint *progid_out, void *prog_base) {
+    GLuint vs = R_Call(glCreateShader, GL_VERTEX_SHADER);
+    GLuint fs = R_Call(glCreateShader, GL_FRAGMENT_SHADER);
+
+    R_SetShaderSourceFromDesc(vs, desc, true, defines);
+    R_Call(glCompileShader, vs);
+    R_CheckShader(vs, GL_COMPILE_STATUS, desc->Name);
+
+    R_SetShaderSourceFromDesc(fs, desc, false, defines);
+    R_Call(glCompileShader, fs);
+    R_CheckShader(fs, GL_COMPILE_STATUS, desc->Name);
+
+    GLuint progid = R_Call(glCreateProgram, );
+    for (int i = 0; i < MAX_SHADER_ATTRIBS && desc->Attributes[i].name; i++)
+        R_Call(glBindAttribLocation, progid, desc->Attributes[i].attrib, desc->Attributes[i].name);
+    R_Call(glAttachShader, progid, vs);
+    R_Call(glAttachShader, progid, fs);
+    R_Call(glLinkProgram, progid);
+    R_CheckShader(progid, GL_LINK_STATUS, desc->Name);
+    R_Call(glDeleteShader, vs);
+    R_Call(glDeleteShader, fs);
+    R_Call(glUseProgram, progid);
+
+    *progid_out = progid;
+
+    int sampler_unit = 0;
+    for (int i = 0; i < MAX_SHADER_UNIFORMS && desc->Uniforms[i].name; i++) {
+        GLint loc = glGetUniformLocation(progid, desc->Uniforms[i].name);
+        if (prog_base)
+            *(GLint *)((char *)prog_base + desc->Uniforms[i].offset) = loc;
+        if (desc->Uniforms[i].type == UT_SAMPLER_2D     ||
+            desc->Uniforms[i].type == UT_SAMPLER_2D_RECT ||
+            desc->Uniforms[i].type == UT_SAMPLER_2D_ARRAY)
+            R_Call(glUniform1i, loc, sampler_unit++);
+    }
 }
 
 /* Model callers submit one semantic lighting state; only this proxy knows the uniform packing contract. */

--- a/renderer/r_shader.c
+++ b/renderer/r_shader.c
@@ -827,9 +827,11 @@ int R_BuildShaderDeclarations(char *buf, int size, const shader_desc_t *desc,
 
 static void R_SetShaderSourceFromDesc(GLuint stage, const shader_desc_t *desc,
                                       bool is_vertex, const char *defines) {
+    /* Indexed by glsl_dialect_t — must stay in enum order. */
     static const char *const version_prefix[] = {
         "#version 120\n",
         "#version 140\n",
+        "#version 150\n",
         "#version 300 es\nprecision highp float;\nprecision highp int;\n",
     };
     glsl_dialect_t dialect =
@@ -837,6 +839,8 @@ static void R_SetShaderSourceFromDesc(GLuint stage, const shader_desc_t *desc,
         GLSL_DIALECT_ES3;
 #elif defined(BZ_GLSL_120)
         GLSL_DIALECT_120;
+#elif defined(BZ_GLSL_150)
+        GLSL_DIALECT_150;
 #else
         GLSL_DIALECT_140;
 #endif

--- a/renderer/r_shader.h
+++ b/renderer/r_shader.h
@@ -2,6 +2,22 @@
 #define r_shader_h
 
 #include "renderer/r_local.h"
+#include "renderer/shader_desc.h"
+
+/*
+ * Compile and link the shader described by desc (with optional defines
+ * prepended to both stages), write the GL program id into *progid_out, then
+ * walk Uniforms[] and write each resolved glGetUniformLocation into the
+ * corresponding field of the typed program struct at prog_base + offset.
+ *
+ * prog_base must point to the beginning of the typed program struct (i.e. the
+ * GLuint progid field).  The per-field offsets stored in Uniforms[].offset
+ * must have been computed with offsetof(YourProgType, field) — guaranteed
+ * when the UNIFORM() macro is used inside the descriptor initialiser with
+ * SHADER_TYPE defined to YourProgType.
+ */
+void R_LoadShaderDescInto(const shader_desc_t *desc, const char *defines,
+                          GLuint *progid_out, void *prog_base);
 
 /* Shared comparison/PCF contract; callers supply the existing shadow sampler and light-space position. */
 #define BZ_SHADOW_GLSL \

--- a/renderer/r_shader.h
+++ b/renderer/r_shader.h
@@ -4,20 +4,15 @@
 #include "renderer/r_local.h"
 #include "renderer/shader_desc.h"
 
-/*
- * Compile and link the shader described by desc (with optional defines
- * prepended to both stages), write the GL program id into *progid_out, then
- * walk Uniforms[] and write each resolved glGetUniformLocation into the
- * corresponding field of the typed program struct at prog_base + offset.
- *
- * prog_base must point to the beginning of the typed program struct (i.e. the
- * GLuint progid field).  The per-field offsets stored in Uniforms[].offset
- * must have been computed with offsetof(YourProgType, field) — guaranteed
- * when the UNIFORM() macro is used inside the descriptor initialiser with
- * SHADER_TYPE defined to YourProgType.
- */
-void R_LoadShaderDescInto(const shader_desc_t *desc, const char *defines,
-                          GLuint *progid_out, void *prog_base);
+/* Built-in renderer programs (descriptors live in r_shader.c). */
+extern const shader_desc_t sd_unlit;        /* UI / unlit sprite */
+extern const shader_desc_t sd_minimap;      /* circular alpha mask */
+extern const shader_desc_t sd_splat;        /* crop edges to [0,1] */
+extern const shader_desc_t sd_shadow_splat; /* black silhouette with texture alpha */
+extern const shader_desc_t sd_commandbutton;/* edge glow via u_activeGlow */
+extern const shader_desc_t sd_minimap_fog;  /* fog-of-war overlay with y-flip */
+extern const shader_desc_t sd_default;      /* ground/world per-vertex lighting */
+extern const shader_desc_t sd_model;        /* shared skinned model (MDX/M2/M3) */
 
 /* Shared comparison/PCF contract; callers supply the existing shadow sampler and light-space position. */
 #define BZ_SHADOW_GLSL \
@@ -30,8 +25,6 @@ void R_LoadShaderDescInto(const shader_desc_t *desc, const char *defines,
     "        lit += step(p.z - 0.0001, texture(depths, p.xy + vec2(x, y) * texel).r);\n" \
     "    return lit / 9.0;\n" \
     "}\n"
-
-#define BZ_MODEL_LIGHT_MAX 8 // lights; shared model shader array capacity; bounds one lighting-state upload
 
 typedef enum {
     R_MODEL_LIGHT_OMNI,
@@ -91,7 +84,7 @@ static inline void R_PackModelGrass(LPMATRIX4 out, LPCMODELGRASS in) {
     }};
 }
 
-void R_SetModelLighting(LPCSHADER shader, LPCMODELLIGHTING lighting);
-void R_SetModelGrass(LPCSHADER shader, LPCMODELGRASS grass);
+void R_SetModelLighting(MODELPROG *shader, LPCMODELLIGHTING lighting);
+void R_SetModelGrass(MODELPROG *shader, LPCMODELGRASS grass);
 
 #endif

--- a/renderer/shader_desc.h
+++ b/renderer/shader_desc.h
@@ -1,0 +1,158 @@
+#ifndef shader_desc_h
+#define shader_desc_h
+
+/*
+ * Descriptor-based shader declarations.
+ *
+ * A shader is declared as data: a name, the GLSL dialect it targets, its
+ * fragment output, and three interface tables (uniforms, attributes, and the
+ * varyings shared between stages). The vertex/fragment bodies carry only the
+ * GLSL they need; the linker walks the tables to bind attributes and resolve
+ * uniform locations automatically.
+ *
+ * There is deliberately no global uniform registry. Each shader owns its list
+ * via a local X-macro SHADER_UNIFORMS(X); the same list expands into both the
+ * enum constants (enum_<name>) call sites index with, and the descriptor table
+ * (name string + type + precision) the linker walks, so the two can never
+ * drift apart.
+ */
+
+#include "common/common.h"
+
+/*
+ * GLSL dialect. GLES3 (BZ_GL_ES3) and desktop GLSL 120 (BZ_GLSL_120) differ
+ * from the default GLSL 140 in the stage keywords, fragment output spelling,
+ * and texture sampling builtin. One descriptor drives all three: the linker
+ * generates the prologue (version, precision, fragment out) from
+ * Version/Precision/FragmentOut, while bodies use these macros for the tokens
+ * that change spelling per dialect.
+ */
+#ifdef BZ_GL_ES3
+#define GLSL_VERSION_NUMBER 300
+#define GLSL_ATTR "in"
+#define GLSL_VS_OUT "out"
+#define GLSL_FS_IN "in"
+#define GLSL_FRAGOUT "out vec4 o_color;\n"
+#define GLSL_FRAGCOLOR "o_color"
+#define GLSL_TEX "texture"
+#define GLSL_TEXELFETCH "texelFetch"
+#elif defined(BZ_GLSL_120)
+#define GLSL_VERSION_NUMBER 120
+#define GLSL_ATTR "attribute"
+#define GLSL_VS_OUT "varying"
+#define GLSL_FS_IN "varying"
+#define GLSL_FRAGOUT ""
+#define GLSL_FRAGCOLOR "gl_FragColor"
+#define GLSL_TEX "texture2D"
+#define GLSL_TEXELFETCH "texture2D"
+#else
+#define GLSL_VERSION_NUMBER 140
+#define GLSL_ATTR "in"
+#define GLSL_VS_OUT "out"
+#define GLSL_FS_IN "in"
+#define GLSL_FRAGOUT "out vec4 o_color;\n"
+#define GLSL_FRAGCOLOR "o_color"
+#define GLSL_TEX "texture"
+#define GLSL_TEXELFETCH "texelFetch"
+#endif
+
+typedef enum {
+    PRECISION_LOW,
+    PRECISION_MEDIUM,
+    PRECISION_HIGH,
+    PRECISION_DEFAULT,
+} precisionType_t;
+
+typedef enum {
+    UT_FLOAT,
+    UT_FLOAT_VEC2,
+    UT_FLOAT_VEC3,
+    UT_FLOAT_VEC4,
+    UT_COLOR,        /* vec4, normalized byte semantics (vertex color) */
+    UT_INT,
+    UT_BOOL,
+    UT_FLOAT_MAT3,
+    UT_FLOAT_MAT4,
+    UT_SAMPLER_2D,
+    UT_COUNT,
+} uniformType_t;
+
+typedef struct {
+    const char *name;
+    uniformType_t type;
+    precisionType_t precision;
+} shaderUniform_t;
+
+typedef struct {
+    const char *name;      /* GLSL name, e.g. "i_position" */
+    t_attrib_id attrib;    /* location from common.h t_attrib_id */
+    uniformType_t type;
+} shaderAttrib_t;
+
+typedef struct {
+    const char *name;      /* varying shared between vertex and fragment stage */
+    uniformType_t type;
+} shaderVarying_t;
+
+typedef struct shader_desc {
+    const char *Name;
+    int Version;                 /* authored GLSL version: 120, 140, or 300 */
+    precisionType_t Precision;   /* default precision for the whole shader */
+    const char *FragmentOut;     /* fragment output variable name ("" -> gl_FragColor) */
+    const shaderUniform_t *Uniforms;    /* NULL-terminated */
+    const shaderAttrib_t *Attributes;   /* NULL-terminated */
+    const shaderVarying_t *Shared;      /* NULL-terminated, documentation */
+    const char *VertexShader;    /* body only; version/precision are generated */
+    const char *FragmentShader;
+} shader_desc_t;
+
+typedef const struct shader_desc *LPCSHADERDESC;
+
+/*
+ * Per-shader interface declaration. Each shader defines its own
+ * <PREFIX>_UNIFORMS(X) / <PREFIX>_ATTRIBUTES(X) / <PREFIX>_SHARED(X) lists,
+ * then expands them through these helpers to produce, from one name token:
+ *   - an enum constant  enum_<name>  (call sites index the location array)
+ *   - a descriptor entry { #name, type, precision } (linker walks it)
+ *
+ * Uniforms:
+ *   #define FOO_UNIFORMS(X) \
+ *       X(u_modelViewProjectionTransform, UT_FLOAT_MAT4, PRECISION_HIGH) \
+ *       X(u_normalTransform, UT_FLOAT_MAT3, PRECISION_HIGH) \
+ *       X(u_opacity, UT_FLOAT, PRECISION_LOW) \
+ *       X(u_texture, UT_SAMPLER_2D, PRECISION_LOW)
+ *   enum { FOO_UNIFORMS(SHADER_UNIFORM_ENUM) };
+ *   static const shaderUniform_t foo_uniforms[] = {
+ *       FOO_UNIFORMS(SHADER_UNIFORM_ENTRY)
+ *       SHADER_UNIFORM_END
+ *   };
+ *
+ * Attributes (GLSL name -> t_attrib_id location):
+ *   #define FOO_ATTRIBUTES(X) \
+ *       X(a_position, attrib_position, UT_FLOAT_VEC4) \
+ *       X(a_texcoord0, attrib_texcoord, UT_FLOAT_VEC2)
+ *   static const shaderAttrib_t foo_attributes[] = {
+ *       FOO_ATTRIBUTES(SHADER_ATTRIB_ENTRY)
+ *       SHADER_ATTRIB_END
+ *   };
+ *
+ * Shared varyings:
+ *   #define FOO_SHARED(X) \
+ *       X(v_normal, UT_FLOAT_VEC3) \
+ *       X(v_texcoord0, UT_FLOAT_VEC2)
+ *   static const shaderVarying_t foo_shared[] = {
+ *       FOO_SHARED(SHADER_SHARED_ENTRY)
+ *       SHADER_SHARED_END
+ *   };
+ */
+#define SHADER_UNIFORM_ENUM(name, type, precision) enum_##name,
+#define SHADER_UNIFORM_ENTRY(name, type, precision) { #name, type, precision },
+#define SHADER_UNIFORM_END { NULL, UT_COUNT, PRECISION_DEFAULT },
+
+#define SHADER_ATTRIB_ENTRY(name, attrib, type) { #name, attrib, type },
+#define SHADER_ATTRIB_END { NULL, attrib_count, UT_COUNT },
+
+#define SHADER_SHARED_ENTRY(name, type) { #name, type },
+#define SHADER_SHARED_END { NULL, UT_COUNT },
+
+#endif

--- a/renderer/shader_desc.h
+++ b/renderer/shader_desc.h
@@ -1,106 +1,33 @@
 #ifndef shader_desc_h
 #define shader_desc_h
 
-/*
- * Descriptor-based shader declarations.
- *
- * Each shader is two things:
- *
- *   1. A typed program struct — one named GLint field per uniform.
- *      Call sites write:  glUniformMatrix4fv(prog.mvp, ...)
- *
- *   2. A shader_desc_t — static const data that drives GLSL source generation.
- *      The linker generates the version prologue and all uniform/in/out
- *      declarations from the tables, so bodies contain only GLSL logic.
- *
- * Both come from the same UNIFORM / ATTRIB / SHARED entries in the descriptor
- * initialiser; each entry stores the field's offsetof so the loader can write
- * the resolved GL location directly into the typed struct.
- *
- * Naming convention (prefixes are applied automatically):
- *   UNIFORM(mvp, ...)       → C field .mvp    /  GLSL uniform "u_mvp"
- *   ATTRIB(position, ...)   →                    GLSL attribute "a_position"
- *   SHARED(texcoord0, ...)  →                    GLSL varying "v_texcoord0"
- *
- * Usage pattern:
- *
- *   // 1. Declare the typed struct first:
- *   typedef struct {
- *       GLuint progid;
- *       GLint  mvp;
- *       GLint  texture;
- *   } simple_prog_t;
- *
- *   // 2. Bind SHADER_TYPE, declare the descriptor, unbind:
- *   #define SHADER_TYPE simple_prog_t
- *   static const shader_desc_t sd_simple = {
- *       .Name = "simple",
- *       .Uniforms = {
- *           UNIFORM(mvp,     UT_FLOAT_MAT4, PRECISION_HIGH),
- *           UNIFORM(texture, UT_SAMPLER_2D, PRECISION_LOW),
- *       },
- *       .Attributes = {
- *           ATTRIB(position,  attrib_position, UT_FLOAT_VEC4),
- *           ATTRIB(texcoord0, attrib_texcoord, UT_FLOAT_VEC2),
- *       },
- *       .Shared = {
- *           SHARED(texcoord0, UT_FLOAT_VEC2),
- *       },
- *       .VertexBody =
- *           "void main() {\n"
- *           "  gl_Position = u_mvp * a_position;\n"
- *           "  v_texcoord0 = a_texcoord0;\n"
- *           "}\n",
- *       .FragmentBody =
- *           "void main() {\n"
- *           "  " GLSL_FRAGCOLOR " = " GLSL_TEX "(u_texture, v_texcoord0);\n"
- *           "}\n",
- *   };
- *   #undef SHADER_TYPE
- *
- *   // 3. Load — writes progid and resolves uniform locations into the struct:
- *   static simple_prog_t simple_prog;
- *   R_LoadShaderDescInto(&sd_simple, NULL, &simple_prog.progid, &simple_prog);
+/* Descriptors generate GLSL declarations and map typed CPU state to program-owned locations.
+ * Define SHADER_TYPE as the value struct, then describe its members with UNIFORM.
+ * R_LoadShader(desc, defines, &shader) links a { SHADERPROG prog; STATE state; }.
+ * Fill shader.state and call R_ApplyShader(&shader) before drawing. The backend
+ * binds the program and uploads the complete state; callers never handle locations.
  */
 
 #include <stddef.h>
 #include "common/common.h"
 
 /* -----------------------------------------------------------------------
- * Compile-time dialect tokens for use inside VertexBody / FragmentBody.
- * Everything else (version line, declarations) is generated from the descriptor.
+ * Dialect differences.  Bodies define vec4 vert()/frag() and call texture();
+ * the linker generates main() which assigns the result to gl_Position and to
+ * gl_FragColor (120) or o_color (otherwise).  GLSL 120 fragment bodies also
+ * get a leading `#define texture texture2D`, since that dialect's builtin has
+ * a different name.  Keyword selection (attribute/varying vs in/out) is
+ * likewise generated, so bodies carry no per-dialect conditionals.
  *
  * Controlled by the GLSL Make variable (default 140):
- *   make GLSL=120   → -DBZ_GLSL_120   (attribute/varying/texture2D/gl_FragColor)
- *   make GLSL=140   → (no define)     (in/out/texture/o_color)
- *   make GLSL=150   → -DBZ_GLSL_150   (same tokens as 140, only #version differs)
+ *   make GLSL=120   → -DBZ_GLSL_120   (attribute/varying + texture alias)
+ *   make GLSL=140   → (no define)     (in/out)
+ *   make GLSL=150   → -DBZ_GLSL_150   (same keywords as 140, only #version differs)
  *   make GL_BACKEND=gles3 → -DBZ_GL_ES3  (300 es, precision qualifiers)
  *
  * GL_BACKEND=gles3 overrides GLSL: the ES3 define takes precedence regardless
  * of the GLSL= value because GLES uses a separate version namespace (300 es).
  * ----------------------------------------------------------------------- */
-#ifdef BZ_GL_ES3
-#  define GLSL_ATTR       "in"
-#  define GLSL_VS_OUT     "out"
-#  define GLSL_FS_IN      "in"
-#  define GLSL_FRAGCOLOR  "o_color"
-#  define GLSL_TEX        "texture"
-#  define GLSL_TEXFETCH   "texelFetch"
-#elif defined(BZ_GLSL_120)
-#  define GLSL_ATTR       "attribute"
-#  define GLSL_VS_OUT     "varying"
-#  define GLSL_FS_IN      "varying"
-#  define GLSL_FRAGCOLOR  "gl_FragColor"
-#  define GLSL_TEX        "texture2D"
-#  define GLSL_TEXFETCH   "texture2D"
-#else /* GLSL 140 or 150 — same keyword set, only the version line differs */
-#  define GLSL_ATTR       "in"
-#  define GLSL_VS_OUT     "out"
-#  define GLSL_FS_IN      "in"
-#  define GLSL_FRAGCOLOR  "o_color"
-#  define GLSL_TEX        "texture"
-#  define GLSL_TEXFETCH   "texelFetch"
-#endif
 
 /* -----------------------------------------------------------------------
  * Dialect enum — passed to R_BuildShaderDeclarations for the version line
@@ -141,13 +68,14 @@ typedef enum {
     UT_COUNT,
 } uniformType_t;
 
-/* Uniform: stores the offsetof the corresponding GLint field in the typed
-   program struct so the loader can write the resolved location directly. */
+/* Uniform offsets address typed CPU values. count=0 is scalar; arrays upload as one block. */
 typedef struct {
     size_t          offset;    /* offsetof(SHADER_TYPE, field) */
     const char     *name;      /* GLSL name, e.g. "u_mvp" */
     uniformType_t   type;
     precisionType_t precision;
+    bool            transpose; /* CPU row-major matrix storage */
+    DWORD           count;     /* array size; 0 = scalar */
 } shaderUniform_t;
 
 typedef struct {
@@ -165,42 +93,60 @@ typedef struct {
  * Descriptor.  Declare as static const; zero-initialised slots (name==NULL)
  * are sentinels that stop the linker's table walk.
  * ----------------------------------------------------------------------- */
-#define MAX_SHADER_UNIFORMS  16
-#define MAX_SHADER_ATTRIBS    8
-#define MAX_SHADER_SHARED     8
+#define MAX_SHADER_UNIFORMS 32 // uniforms; largest game descriptor fits; bounds descriptor and location tables
+#define MAX_SHADER_ATTRIBS 8 // attributes; shared model input count; bounds descriptor table
+#define MAX_SHADER_SHARED 8 // varyings; shared shader interface capacity; bounds descriptor table
 
 typedef struct shader_desc {
     const char      *Name;
     shaderUniform_t  Uniforms[MAX_SHADER_UNIFORMS];
     shaderAttrib_t   Attributes[MAX_SHADER_ATTRIBS];
     shaderVarying_t  Shared[MAX_SHADER_SHARED];
-    const char      *VertexBody;    /* GLSL logic only — no declarations */
-    const char      *FragmentBody;
+    const char      *VertexBody;    /* defines vec4 vert() → clip-space position */
+    const char      *FragmentBody;  /* defines vec4 frag() → fragment color */
 } shader_desc_t;
 
 typedef const shader_desc_t *LPCSHADERDESC;
 
-/* -----------------------------------------------------------------------
- * Descriptor entry macros.
- *
- * SHADER_TYPE must be #defined to the per-shader typed struct for the
- * duration of the descriptor initialiser, then #undef'd.
- *
- * UNIFORM(field, type, prec)
- *   Records offsetof(SHADER_TYPE, field) so the loader can write the
- *   resolved GL uniform location directly into the typed struct.
- *   GLSL name:  "u_" #field
- *
- * ATTRIB(field, attrib_id, type)
- *   Explicit attribute location binding.
- *   GLSL name:  "a_" #field
- *
- * SHARED(field, type)
- *   Varying declared as 'out' in the vertex stage and 'in' in the fragment.
- *   GLSL name:  "v_" #field
- * ----------------------------------------------------------------------- */
+/* GL handles stay in the program, never in the typed value state. */
+typedef struct SHADERPROG {
+    GLuint progid;
+    LPCSHADERDESC desc;
+    GLint locs[MAX_SHADER_UNIFORMS];
+} SHADERPROG;
+typedef struct SHADERPROG *LPSHADERPROG;
+typedef const struct SHADERPROG *LPCSHADERPROG;
+
+typedef struct SHADERLOAD {
+    LPCSHADERDESC desc;
+    LPCSTR defines;
+    LPSHADERPROG prog;
+    void *state;
+} SHADERLOAD;
+typedef struct SHADERLOAD *LPSHADERLOAD;
+typedef const struct SHADERLOAD *LPCSHADERLOAD;
+void R_LoadShaderState(LPCSHADERLOAD load);
+void R_DeleteShader(LPSHADERPROG prog);
+void R_UploadShader(LPCSHADERPROG prog, LPCVOID state);
+#define R_LoadShader(D, F, P) R_LoadShaderState(&(SHADERLOAD){ D, F, &(P)->prog, &(P)->state })
+#define R_ApplyShader(P) R_UploadShader(&(P)->prog, &(P)->state)
+
+/* SHADER_TYPE names the CPU value struct. Named entries preserve an existing GLSL spelling.
+ * Array entries use inline contiguous typed storage; all locations remain inside SHADERPROG.
+ */
 #define UNIFORM(field, type, prec) \
-    { offsetof(SHADER_TYPE, field), "u_" #field, type, prec }
+    { offsetof(SHADER_TYPE, field), "u_" #field, type, prec, false, 0 }
+#define UNIFORM_ARRAY(field, type, prec, count) \
+    { offsetof(SHADER_TYPE, field), "u_" #field, type, prec, false, count }
+/* Explicit GLSL spelling for game shader contracts. */
+#define UNIFORM_NAMED(field, name, type, prec) \
+    { offsetof(SHADER_TYPE, field), name, type, prec, false, 0 }
+#define UNIFORM_NAMED_ARRAY(field, name, type, prec, count) \
+    { offsetof(SHADER_TYPE, field), name, type, prec, false, count }
+#define UNIFORM_TRANSPOSE(field, type, prec) \
+    { offsetof(SHADER_TYPE, field), "u_" #field, type, prec, true, 0 }
+#define UNIFORM_NAMED_TRANSPOSE(field, name, type, prec) \
+    { offsetof(SHADER_TYPE, field), name, type, prec, true, 0 }
 #define ATTRIB(field, attrib_id, type) \
     { "a_" #field, attrib_id, type }
 #define SHARED(field, type) \
@@ -208,12 +154,21 @@ typedef const shader_desc_t *LPCSHADERDESC;
 
 /* -----------------------------------------------------------------------
  * R_BuildShaderDeclarations
- *   Writes the uniform/in/out declaration block for one stage of desc into
- *   buf[size] for the given dialect.  Returns bytes written (excluding NUL).
- *   Pass the result as one of the strings in a glShaderSource call — no heap
- *   allocation needed.
+ *   Writes the declaration block for one stage of desc into buf[size] for the
+ *   given dialect: uniforms, then attributes/varyings with the dialect's
+ *   keywords (attribute/varying for 120, in/out otherwise), plus `out vec4
+ *   o_color` in the fragment stage for non-120.  GLSL 120 fragment shaders get
+ *   a leading `#define texture texture2D` since that dialect has no `texture`
+ *   builtin.  Returns bytes written (excluding NUL).
+ *
+ * R_BuildShaderMain
+ *   Writes the generated main() for one stage: `gl_Position = vert();` for the
+ *   vertex stage, or `gl_FragColor = frag();` (120) / `o_color = frag();`
+ *   (otherwise) for the fragment stage.  Bodies define vert()/frag() and never
+ *   reference gl_Position, gl_FragColor, or o_color directly.
  * ----------------------------------------------------------------------- */
 int R_BuildShaderDeclarations(char *buf, int size, const shader_desc_t *desc,
                               bool is_vertex, glsl_dialect_t dialect);
+int R_BuildShaderMain(char *buf, int size, bool is_vertex, glsl_dialect_t dialect);
 
 #endif /* shader_desc_h */

--- a/renderer/shader_desc.h
+++ b/renderer/shader_desc.h
@@ -69,6 +69,15 @@
 /* -----------------------------------------------------------------------
  * Compile-time dialect tokens for use inside VertexBody / FragmentBody.
  * Everything else (version line, declarations) is generated from the descriptor.
+ *
+ * Controlled by the GLSL Make variable (default 140):
+ *   make GLSL=120   → -DBZ_GLSL_120   (attribute/varying/texture2D/gl_FragColor)
+ *   make GLSL=140   → (no define)     (in/out/texture/o_color)
+ *   make GLSL=150   → -DBZ_GLSL_150   (same tokens as 140, only #version differs)
+ *   make GL_BACKEND=gles3 → -DBZ_GL_ES3  (300 es, precision qualifiers)
+ *
+ * GL_BACKEND=gles3 overrides GLSL: the ES3 define takes precedence regardless
+ * of the GLSL= value because GLES uses a separate version namespace (300 es).
  * ----------------------------------------------------------------------- */
 #ifdef BZ_GL_ES3
 #  define GLSL_ATTR       "in"
@@ -84,7 +93,7 @@
 #  define GLSL_FRAGCOLOR  "gl_FragColor"
 #  define GLSL_TEX        "texture2D"
 #  define GLSL_TEXFETCH   "texture2D"
-#else /* GLSL 140 default */
+#else /* GLSL 140 or 150 — same keyword set, only the version line differs */
 #  define GLSL_ATTR       "in"
 #  define GLSL_VS_OUT     "out"
 #  define GLSL_FS_IN      "in"
@@ -94,12 +103,15 @@
 #endif
 
 /* -----------------------------------------------------------------------
- * Dialect enum — for R_BuildShaderDeclarations (runtime dialect selection).
+ * Dialect enum — passed to R_BuildShaderDeclarations for the version line
+ * and keyword selection.  Compile-time macros map to these at build time;
+ * pass a specific value to generate source for a different version at runtime.
  * ----------------------------------------------------------------------- */
 typedef enum {
-    GLSL_DIALECT_120,
-    GLSL_DIALECT_140,
-    GLSL_DIALECT_ES3,
+    GLSL_DIALECT_120,   /* attribute/varying/texture2D/gl_FragColor          */
+    GLSL_DIALECT_140,   /* in/out/texture/o_color                            */
+    GLSL_DIALECT_150,   /* same keywords as 140; version line is "#version 150" */
+    GLSL_DIALECT_ES3,   /* 300 es, same keywords as 140 + precision prologue */
 } glsl_dialect_t;
 
 /* -----------------------------------------------------------------------

--- a/renderer/shader_desc.h
+++ b/renderer/shader_desc.h
@@ -4,58 +4,107 @@
 /*
  * Descriptor-based shader declarations.
  *
- * A shader is declared as data: a name, the GLSL dialect it targets, its
- * fragment output, and three interface tables (uniforms, attributes, and the
- * varyings shared between stages). The vertex/fragment bodies carry only the
- * GLSL they need; the linker walks the tables to bind attributes and resolve
- * uniform locations automatically.
+ * Each shader is two things:
  *
- * There is deliberately no global uniform registry. Each shader owns its list
- * via a local X-macro SHADER_UNIFORMS(X); the same list expands into both the
- * enum constants (enum_<name>) call sites index with, and the descriptor table
- * (name string + type + precision) the linker walks, so the two can never
- * drift apart.
+ *   1. A typed program struct — one named GLint field per uniform.
+ *      Call sites write:  glUniformMatrix4fv(prog.mvp, ...)
+ *
+ *   2. A shader_desc_t — static const data that drives GLSL source generation.
+ *      The linker generates the version prologue and all uniform/in/out
+ *      declarations from the tables, so bodies contain only GLSL logic.
+ *
+ * Both come from the same UNIFORM / ATTRIB / SHARED entries in the descriptor
+ * initialiser; each entry stores the field's offsetof so the loader can write
+ * the resolved GL location directly into the typed struct.
+ *
+ * Naming convention (prefixes are applied automatically):
+ *   UNIFORM(mvp, ...)       → C field .mvp    /  GLSL uniform "u_mvp"
+ *   ATTRIB(position, ...)   →                    GLSL attribute "a_position"
+ *   SHARED(texcoord0, ...)  →                    GLSL varying "v_texcoord0"
+ *
+ * Usage pattern:
+ *
+ *   // 1. Declare the typed struct first:
+ *   typedef struct {
+ *       GLuint progid;
+ *       GLint  mvp;
+ *       GLint  texture;
+ *   } simple_prog_t;
+ *
+ *   // 2. Bind SHADER_TYPE, declare the descriptor, unbind:
+ *   #define SHADER_TYPE simple_prog_t
+ *   static const shader_desc_t sd_simple = {
+ *       .Name = "simple",
+ *       .Uniforms = {
+ *           UNIFORM(mvp,     UT_FLOAT_MAT4, PRECISION_HIGH),
+ *           UNIFORM(texture, UT_SAMPLER_2D, PRECISION_LOW),
+ *       },
+ *       .Attributes = {
+ *           ATTRIB(position,  attrib_position, UT_FLOAT_VEC4),
+ *           ATTRIB(texcoord0, attrib_texcoord, UT_FLOAT_VEC2),
+ *       },
+ *       .Shared = {
+ *           SHARED(texcoord0, UT_FLOAT_VEC2),
+ *       },
+ *       .VertexBody =
+ *           "void main() {\n"
+ *           "  gl_Position = u_mvp * a_position;\n"
+ *           "  v_texcoord0 = a_texcoord0;\n"
+ *           "}\n",
+ *       .FragmentBody =
+ *           "void main() {\n"
+ *           "  " GLSL_FRAGCOLOR " = " GLSL_TEX "(u_texture, v_texcoord0);\n"
+ *           "}\n",
+ *   };
+ *   #undef SHADER_TYPE
+ *
+ *   // 3. Load — writes progid and resolves uniform locations into the struct:
+ *   static simple_prog_t simple_prog;
+ *   R_LoadShaderDescInto(&sd_simple, NULL, &simple_prog.progid, &simple_prog);
  */
 
+#include <stddef.h>
 #include "common/common.h"
 
-/*
- * GLSL dialect. GLES3 (BZ_GL_ES3) and desktop GLSL 120 (BZ_GLSL_120) differ
- * from the default GLSL 140 in the stage keywords, fragment output spelling,
- * and texture sampling builtin. One descriptor drives all three: the linker
- * generates the prologue (version, precision, fragment out) from
- * Version/Precision/FragmentOut, while bodies use these macros for the tokens
- * that change spelling per dialect.
- */
+/* -----------------------------------------------------------------------
+ * Compile-time dialect tokens for use inside VertexBody / FragmentBody.
+ * Everything else (version line, declarations) is generated from the descriptor.
+ * ----------------------------------------------------------------------- */
 #ifdef BZ_GL_ES3
-#define GLSL_VERSION_NUMBER 300
-#define GLSL_ATTR "in"
-#define GLSL_VS_OUT "out"
-#define GLSL_FS_IN "in"
-#define GLSL_FRAGOUT "out vec4 o_color;\n"
-#define GLSL_FRAGCOLOR "o_color"
-#define GLSL_TEX "texture"
-#define GLSL_TEXELFETCH "texelFetch"
+#  define GLSL_ATTR       "in"
+#  define GLSL_VS_OUT     "out"
+#  define GLSL_FS_IN      "in"
+#  define GLSL_FRAGCOLOR  "o_color"
+#  define GLSL_TEX        "texture"
+#  define GLSL_TEXFETCH   "texelFetch"
 #elif defined(BZ_GLSL_120)
-#define GLSL_VERSION_NUMBER 120
-#define GLSL_ATTR "attribute"
-#define GLSL_VS_OUT "varying"
-#define GLSL_FS_IN "varying"
-#define GLSL_FRAGOUT ""
-#define GLSL_FRAGCOLOR "gl_FragColor"
-#define GLSL_TEX "texture2D"
-#define GLSL_TEXELFETCH "texture2D"
-#else
-#define GLSL_VERSION_NUMBER 140
-#define GLSL_ATTR "in"
-#define GLSL_VS_OUT "out"
-#define GLSL_FS_IN "in"
-#define GLSL_FRAGOUT "out vec4 o_color;\n"
-#define GLSL_FRAGCOLOR "o_color"
-#define GLSL_TEX "texture"
-#define GLSL_TEXELFETCH "texelFetch"
+#  define GLSL_ATTR       "attribute"
+#  define GLSL_VS_OUT     "varying"
+#  define GLSL_FS_IN      "varying"
+#  define GLSL_FRAGCOLOR  "gl_FragColor"
+#  define GLSL_TEX        "texture2D"
+#  define GLSL_TEXFETCH   "texture2D"
+#else /* GLSL 140 default */
+#  define GLSL_ATTR       "in"
+#  define GLSL_VS_OUT     "out"
+#  define GLSL_FS_IN      "in"
+#  define GLSL_FRAGCOLOR  "o_color"
+#  define GLSL_TEX        "texture"
+#  define GLSL_TEXFETCH   "texelFetch"
 #endif
 
+/* -----------------------------------------------------------------------
+ * Dialect enum — for R_BuildShaderDeclarations (runtime dialect selection).
+ * ----------------------------------------------------------------------- */
+typedef enum {
+    GLSL_DIALECT_120,
+    GLSL_DIALECT_140,
+    GLSL_DIALECT_ES3,
+} glsl_dialect_t;
+
+/* -----------------------------------------------------------------------
+ * Types
+ * ----------------------------------------------------------------------- */
 typedef enum {
     PRECISION_LOW,
     PRECISION_MEDIUM,
@@ -68,91 +117,91 @@ typedef enum {
     UT_FLOAT_VEC2,
     UT_FLOAT_VEC3,
     UT_FLOAT_VEC4,
-    UT_COLOR,        /* vec4, normalized byte semantics (vertex color) */
+    UT_COLOR,           /* vec4, normalised-byte vertex-color semantics */
     UT_INT,
+    UT_INT_VEC2,
     UT_BOOL,
     UT_FLOAT_MAT3,
     UT_FLOAT_MAT4,
     UT_SAMPLER_2D,
+    UT_SAMPLER_2D_RECT,
+    UT_SAMPLER_2D_ARRAY,
     UT_COUNT,
 } uniformType_t;
 
+/* Uniform: stores the offsetof the corresponding GLint field in the typed
+   program struct so the loader can write the resolved location directly. */
 typedef struct {
-    const char *name;
-    uniformType_t type;
+    size_t          offset;    /* offsetof(SHADER_TYPE, field) */
+    const char     *name;      /* GLSL name, e.g. "u_mvp" */
+    uniformType_t   type;
     precisionType_t precision;
 } shaderUniform_t;
 
 typedef struct {
-    const char *name;      /* GLSL name, e.g. "i_position" */
-    t_attrib_id attrib;    /* location from common.h t_attrib_id */
-    uniformType_t type;
+    const char     *name;      /* GLSL name, e.g. "a_position" */
+    t_attrib_id     attrib;    /* explicit location for glBindAttribLocation */
+    uniformType_t   type;
 } shaderAttrib_t;
 
 typedef struct {
-    const char *name;      /* varying shared between vertex and fragment stage */
-    uniformType_t type;
+    const char     *name;      /* GLSL name, e.g. "v_texcoord0" */
+    uniformType_t   type;
 } shaderVarying_t;
 
+/* -----------------------------------------------------------------------
+ * Descriptor.  Declare as static const; zero-initialised slots (name==NULL)
+ * are sentinels that stop the linker's table walk.
+ * ----------------------------------------------------------------------- */
+#define MAX_SHADER_UNIFORMS  16
+#define MAX_SHADER_ATTRIBS    8
+#define MAX_SHADER_SHARED     8
+
 typedef struct shader_desc {
-    const char *Name;
-    int Version;                 /* authored GLSL version: 120, 140, or 300 */
-    precisionType_t Precision;   /* default precision for the whole shader */
-    const char *FragmentOut;     /* fragment output variable name ("" -> gl_FragColor) */
-    const shaderUniform_t *Uniforms;    /* NULL-terminated */
-    const shaderAttrib_t *Attributes;   /* NULL-terminated */
-    const shaderVarying_t *Shared;      /* NULL-terminated, documentation */
-    const char *VertexShader;    /* body only; version/precision are generated */
-    const char *FragmentShader;
+    const char      *Name;
+    shaderUniform_t  Uniforms[MAX_SHADER_UNIFORMS];
+    shaderAttrib_t   Attributes[MAX_SHADER_ATTRIBS];
+    shaderVarying_t  Shared[MAX_SHADER_SHARED];
+    const char      *VertexBody;    /* GLSL logic only — no declarations */
+    const char      *FragmentBody;
 } shader_desc_t;
 
-typedef const struct shader_desc *LPCSHADERDESC;
+typedef const shader_desc_t *LPCSHADERDESC;
 
-/*
- * Per-shader interface declaration. Each shader defines its own
- * <PREFIX>_UNIFORMS(X) / <PREFIX>_ATTRIBUTES(X) / <PREFIX>_SHARED(X) lists,
- * then expands them through these helpers to produce, from one name token:
- *   - an enum constant  enum_<name>  (call sites index the location array)
- *   - a descriptor entry { #name, type, precision } (linker walks it)
+/* -----------------------------------------------------------------------
+ * Descriptor entry macros.
  *
- * Uniforms:
- *   #define FOO_UNIFORMS(X) \
- *       X(u_modelViewProjectionTransform, UT_FLOAT_MAT4, PRECISION_HIGH) \
- *       X(u_normalTransform, UT_FLOAT_MAT3, PRECISION_HIGH) \
- *       X(u_opacity, UT_FLOAT, PRECISION_LOW) \
- *       X(u_texture, UT_SAMPLER_2D, PRECISION_LOW)
- *   enum { FOO_UNIFORMS(SHADER_UNIFORM_ENUM) };
- *   static const shaderUniform_t foo_uniforms[] = {
- *       FOO_UNIFORMS(SHADER_UNIFORM_ENTRY)
- *       SHADER_UNIFORM_END
- *   };
+ * SHADER_TYPE must be #defined to the per-shader typed struct for the
+ * duration of the descriptor initialiser, then #undef'd.
  *
- * Attributes (GLSL name -> t_attrib_id location):
- *   #define FOO_ATTRIBUTES(X) \
- *       X(a_position, attrib_position, UT_FLOAT_VEC4) \
- *       X(a_texcoord0, attrib_texcoord, UT_FLOAT_VEC2)
- *   static const shaderAttrib_t foo_attributes[] = {
- *       FOO_ATTRIBUTES(SHADER_ATTRIB_ENTRY)
- *       SHADER_ATTRIB_END
- *   };
+ * UNIFORM(field, type, prec)
+ *   Records offsetof(SHADER_TYPE, field) so the loader can write the
+ *   resolved GL uniform location directly into the typed struct.
+ *   GLSL name:  "u_" #field
  *
- * Shared varyings:
- *   #define FOO_SHARED(X) \
- *       X(v_normal, UT_FLOAT_VEC3) \
- *       X(v_texcoord0, UT_FLOAT_VEC2)
- *   static const shaderVarying_t foo_shared[] = {
- *       FOO_SHARED(SHADER_SHARED_ENTRY)
- *       SHADER_SHARED_END
- *   };
- */
-#define SHADER_UNIFORM_ENUM(name, type, precision) enum_##name,
-#define SHADER_UNIFORM_ENTRY(name, type, precision) { #name, type, precision },
-#define SHADER_UNIFORM_END { NULL, UT_COUNT, PRECISION_DEFAULT },
+ * ATTRIB(field, attrib_id, type)
+ *   Explicit attribute location binding.
+ *   GLSL name:  "a_" #field
+ *
+ * SHARED(field, type)
+ *   Varying declared as 'out' in the vertex stage and 'in' in the fragment.
+ *   GLSL name:  "v_" #field
+ * ----------------------------------------------------------------------- */
+#define UNIFORM(field, type, prec) \
+    { offsetof(SHADER_TYPE, field), "u_" #field, type, prec }
+#define ATTRIB(field, attrib_id, type) \
+    { "a_" #field, attrib_id, type }
+#define SHARED(field, type) \
+    { "v_" #field, type }
 
-#define SHADER_ATTRIB_ENTRY(name, attrib, type) { #name, attrib, type },
-#define SHADER_ATTRIB_END { NULL, attrib_count, UT_COUNT },
+/* -----------------------------------------------------------------------
+ * R_BuildShaderDeclarations
+ *   Writes the uniform/in/out declaration block for one stage of desc into
+ *   buf[size] for the given dialect.  Returns bytes written (excluding NUL).
+ *   Pass the result as one of the strings in a glShaderSource call — no heap
+ *   allocation needed.
+ * ----------------------------------------------------------------------- */
+int R_BuildShaderDeclarations(char *buf, int size, const shader_desc_t *desc,
+                              bool is_vertex, glsl_dialect_t dialect);
 
-#define SHADER_SHARED_ENTRY(name, type) { #name, type },
-#define SHADER_SHARED_END { NULL, UT_COUNT },
-
-#endif
+#endif /* shader_desc_h */

--- a/tests/test_renderer_model.c
+++ b/tests/test_renderer_model.c
@@ -38,17 +38,26 @@ static void BZ_TestLinkProgram(GLuint obj) { (void)obj; shader_test.links++; }
 static void BZ_TestUseProgram(GLuint obj) { (void)obj; shader_test.uses++; }
 static void BZ_TestDeleteShader(GLuint obj) { (void)obj; shader_test.deleted++; }
 static GLint BZ_TestUniformLocation(GLuint obj, const GLchar *name) { (void)obj; (void)name; return 0; }
-static void BZ_TestUniform1i(GLint loc, GLint val) { (void)loc; (void)val; }
-static void BZ_TestUniform1f(GLint loc, GLfloat val) { (void)loc; (void)val; }
+static struct { int calls, width, integer; GLsizei count; GLboolean transpose; float data[2048]; } upload;
+static void capture_float(int width, GLsizei count, const GLfloat *val) {
+    upload.calls++; upload.width = width; upload.count = count;
+    memcpy(upload.data, val, width * count * sizeof(float));
+}
+static void BZ_TestUniform1i(GLint loc, GLint val) { (void)loc; upload.calls++; upload.integer = val; }
+static void BZ_TestUniform1iv(GLint loc, GLsizei n, const GLint *v) { (void)n; BZ_TestUniform1i(loc, *v); }
+static void BZ_TestUniform2iv(GLint loc, GLsizei n, const GLint *v) { (void)n; BZ_TestUniform1i(loc, v[1]); }
+static void BZ_TestUniform1fv(GLint loc, GLsizei n, const GLfloat *v) { (void)loc; capture_float(1, n, v); }
+static void BZ_TestUniform2fv(GLint loc, GLsizei n, const GLfloat *v) { (void)loc; capture_float(2, n, v); }
+static void BZ_TestUniform3fv(GLint loc, GLsizei n, const GLfloat *v) { (void)loc; capture_float(3, n, v); }
+static void BZ_TestUniform4fv(GLint loc, GLsizei n, const GLfloat *v) { (void)loc; capture_float(4, n, v); }
 static void BZ_TestUniformMatrix3(GLint loc, GLsizei count, GLboolean transpose, const GLfloat *val) {
-    (void)loc; (void)count; (void)transpose; (void)val;
+    (void)loc; capture_float(9, count, val); upload.transpose = transpose;
 }
 static void BZ_TestUniformMatrix4(GLint loc, GLsizei count, GLboolean transpose, const GLfloat *val) {
-    (void)loc; (void)transpose;
-    shader_test.uploads++;
-    T_EQ(count, BZ_BONE_PALETTE_MAX);
-    FOR_LOOP(i, count * 16) T_EQ(val[i], i % 16 % 5 == 0 ? 1.0f : 0.0f);
+    (void)loc; capture_float(16, count, val); upload.transpose = transpose; shader_test.uploads++;
 }
+static int deleted_programs;
+static void BZ_TestDeleteProgram(GLuint id) { (void)id; deleted_programs++; }
 static void BZ_TestShaderStatus(GLuint obj, GLenum check, GLint *val) {
     *val = check == GL_INFO_LOG_LENGTH ? shader_test.logsize : obj != shader_test.fail;
 }
@@ -69,7 +78,13 @@ static _Noreturn void BZ_TestShaderExit(int code) { shader_test.exitcode = code;
 #define glDeleteShader BZ_TestDeleteShader
 #define glGetUniformLocation BZ_TestUniformLocation
 #define glUniform1i BZ_TestUniform1i
-#define glUniform1f BZ_TestUniform1f
+#define glUniform1iv BZ_TestUniform1iv
+#define glUniform2iv BZ_TestUniform2iv
+#define glUniform1fv BZ_TestUniform1fv
+#define glUniform2fv BZ_TestUniform2fv
+#define glUniform3fv BZ_TestUniform3fv
+#define glUniform4fv BZ_TestUniform4fv
+#define glDeleteProgram BZ_TestDeleteProgram
 #define glUniformMatrix3fv BZ_TestUniformMatrix3
 #define glUniformMatrix4fv BZ_TestUniformMatrix4
 #define glGetShaderiv BZ_TestShaderStatus
@@ -90,7 +105,13 @@ static _Noreturn void BZ_TestShaderExit(int code) { shader_test.exitcode = code;
 #undef glDeleteShader
 #undef glGetUniformLocation
 #undef glUniform1i
-#undef glUniform1f
+#undef glUniform1iv
+#undef glUniform2iv
+#undef glUniform1fv
+#undef glUniform2fv
+#undef glUniform3fv
+#undef glUniform4fv
+#undef glDeleteProgram
 #undef glUniformMatrix3fv
 #undef glUniformMatrix4fv
 #undef glGetShaderiv
@@ -296,19 +317,19 @@ TEST(renderer_shader, grass_state_uses_one_matrix) {
 
 TEST(renderer_bones, model_shader_preserves_high_palette_indices) {
     memset(&tr, 0, sizeof(tr));
-    R_SetShaderSource(1, model_vs, NULL);
-    T_NOT_NULL(strstr(shader_src, "uniform mat4 uBones[128];"));
+    R_SetShaderSourceFromDesc(1, &sd_model, true, NULL);
+    T_NOT_NULL(strstr(shader_src, "uniform mat4 u_bones[128];"));
     T_NULL(strstr(shader_src, "BZ_BONE_COUNT"));
     /* Slot 83 must stay 83: the old clamp redirected it to 63 with a 64-matrix palette. */
-    T_NOT_NULL(strstr(shader_src, "int boneIdx = int(i_skin1[i]) + int(uFirstBoneLookupIndex);"));
+    T_NOT_NULL(strstr(shader_src, "int boneIdx = int(a_skin1[i]) + int(u_firstBoneLookupIndex);"));
     T_NULL(strstr(shader_src, "#define BZ_USE_INSTANCING"));
 }
 
 TEST(renderer_bones, instanced_shader_uses_the_same_palette_contract) {
-    R_SetShaderSource(1, model_vs, "#define BZ_USE_INSTANCING 1\n");
+    R_SetShaderSourceFromDesc(1, &sd_model, true, "#define BZ_USE_INSTANCING 1\n");
     T_NOT_NULL(strstr(shader_src, "#define BZ_USE_INSTANCING 1\n"));
-    T_NOT_NULL(strstr(shader_src, "uniform mat4 uBones[128];"));
-    T_NOT_NULL(strstr(shader_src, "int boneIdx = int(i_skin1[i]) + int(uFirstBoneLookupIndex);"));
+    T_NOT_NULL(strstr(shader_src, "uniform mat4 u_bones[128];"));
+    T_NOT_NULL(strstr(shader_src, "int boneIdx = int(a_skin1[i]) + int(u_firstBoneLookupIndex);"));
 }
 
 static HANDLE shader_alloc(long size) { return shader_test.memory = test_alloc(size); }
@@ -323,18 +344,19 @@ static void reset_shader(void) {
 
 TEST(renderer_shader, model_cache_checks_compile_and_link_once) {
     reset_shader();
-    LPSHADER shader = R_ModelShader();
+    MODELPROG * shader = R_ModelShader();
     T_NOT_NULL(shader); T_ASSERT(R_ModelShader() == shader);
     T_EQ(shader_test.creates, 2); T_EQ(shader_test.links, 1); T_EQ(shader_test.deleted, 2);
     T_EQ(shader_test.exitcode, 0); T_EQ(shader_test.logs, 0);
     R_ShutdownModelShader();
 }
 
-TEST(renderer_shader, instanced_cache_uploads_full_identity_palette_once) {
+TEST(renderer_shader, instanced_cache_initializes_full_identity_palette_once) {
     reset_shader();
-    LPSHADER shader = R_ModelShaderInstanced();
+    MODELPROG * shader = R_ModelShaderInstanced();
     T_NOT_NULL(shader); T_ASSERT(R_ModelShaderInstanced() == shader);
-    T_EQ(shader_test.creates, 2); T_EQ(shader_test.links, 1); T_EQ(shader_test.uploads, 1);
+    T_EQ(shader_test.creates, 2); T_EQ(shader_test.links, 1); T_EQ(shader_test.uploads, 0);
+    FOR_LOOP(i, BZ_BONE_PALETTE_MAX) FOR_LOOP(j, 16) T_EQ(shader->state.bones[i].v[j], j % 5 == 0 ? 1.0f : 0.0f);
     T_EQ(shader_test.deleted, 2); T_EQ(shader_test.exitcode, 0);
     R_ShutdownModelShader();
 }
@@ -349,7 +371,7 @@ TEST(renderer_shader, failed_compile_or_link_never_returns_a_model_fallback) {
         }
         T_EQ(shader_test.exitcode, EXIT_FAILURE); T_EQ(shader_test.uses, 0);
         T_EQ(shader_test.links, stages[i] == GL_LINK_STATUS ? 1 : 0);
-        T_EQ(shader_test.logs, 1); T_NULL(model_shader);
+        T_EQ(shader_test.logs, 1); T_ASSERT(!model_shader_loaded);
         free(shader_test.memory);
     }
 }
@@ -360,7 +382,7 @@ TEST(renderer_shader, instanced_link_failure_is_fatal_without_palette_upload) {
         R_ModelShaderInstanced(); T_ASSERT(false);
     }
     T_EQ(shader_test.exitcode, EXIT_FAILURE); T_EQ(shader_test.uses, 0); T_EQ(shader_test.uploads, 0);
-    T_NULL(instanced_shader); free(shader_test.memory);
+    T_ASSERT(!instanced_shader_loaded); free(shader_test.memory);
 }
 
 TEST(renderer_shader, failures_remain_fatal_without_a_driver_log_buffer) {
@@ -562,25 +584,21 @@ TEST(renderer_terrain, cliff_ramps_require_adjacent_corners_one_level_apart) {
     T_ASSERT(!R_IsCliffRamp(tile));
 }
 
-/* The shadow and non-shadow builds share lighting; only the key's direct contribution is occluded. */
+/* The shadow and non-shadow builds share lighting; only the key's direct contribution is occluded.
+   The descriptor always emits the receiver wiring and gates it behind GLSL `#ifdef USE_SHADOWMAPS`,
+   so the raw source carries the same body in both builds. */
 TEST(renderer_shader, shadow_receiver_contract) {
-    R_SetShaderSource(1, model_vs, NULL);
-    T_NOT_NULL(strstr(shader_src, "return lighting;"));
-#ifdef USE_SHADOWMAPS
+    R_SetShaderSourceFromDesc(1, &sd_model, true, NULL);
+    T_NOT_NULL(strstr(shader_src, "return lighting;")); /* clamp moved out of vertex_lighting */
     T_NOT_NULL(strstr(shader_src, "out vec3 v_shadowlight;"));
-    T_NOT_NULL(strstr(shader_src, "contribution - uLights[i][3].rgb * uLights[i][3].a"));
-#else
-    T_NULL(strstr(shader_src, "v_shadowlight"));
-#endif
-    R_SetShaderSource(1, model_fs, NULL);
-    T_NOT_NULL(strstr(shader_src, "light = min(light, vec3(1.0))"));
-#ifdef USE_SHADOWMAPS
+    T_NOT_NULL(strstr(shader_src, "v_shadowlight = vec3(0.0);"));
+    T_NOT_NULL(strstr(shader_src, "contribution - u_lights[i][3].rgb * u_lights[i][3].a"));
+
+    R_SetShaderSourceFromDesc(1, &sd_model, false, NULL);
+    T_NOT_NULL(strstr(shader_src, "light = min(light, vec3(1.0));")); /* clamp applied after occlusion */
     T_NOT_NULL(strstr(shader_src, "in vec3 v_shadowlight;"));
-    T_NOT_NULL(strstr(shader_src, "light -= v_shadowlight * (1.0 - shadow_visibility"));
+    T_NOT_NULL(strstr(shader_src, "light -= v_shadowlight * (1.0 - shadow_visibility(u_shadowmap, v_shadow));"));
     T_NOT_NULL(strstr(shader_src, "textureSize(depths, 0)"));
-#else
-    T_NULL(strstr(shader_src, "shadow_visibility"));
-#endif
 }
 
 /* -----------------------------------------------------------------------
@@ -588,14 +606,18 @@ TEST(renderer_shader, shadow_receiver_contract) {
  * and R_LoadShaderDescInto for each supported GLSL dialect.
  * ----------------------------------------------------------------------- */
 
-typedef struct {
-    GLuint progid;
-    GLint  mvp;
-    GLint  texture;
-    GLint  color;
-} sd_test_prog_t;
+typedef struct SDTESTSTATE {
+    MATRIX4 mvp;
+    int texture;
+    VECTOR4 color;
+} SDTESTSTATE;
+typedef struct SDTESTSTATE *LPSDTESTSTATE;
+typedef const struct SDTESTSTATE *LPCSDTESTSTATE;
+typedef struct SDTESTPROG { SHADERPROG prog; SDTESTSTATE state; } SDTESTPROG;
+typedef struct SDTESTPROG *LPSDTESTPROG;
+typedef const struct SDTESTPROG *LPCSDTESTPROG;
 
-#define SHADER_TYPE sd_test_prog_t
+#define SHADER_TYPE SDTESTSTATE
 static const shader_desc_t sd_test = {
     .Name = "test",
     .Uniforms = {
@@ -611,22 +633,22 @@ static const shader_desc_t sd_test = {
         SHARED(texcoord, UT_FLOAT_VEC2),
     },
     .VertexBody =
-        "void main() {\n"
-        "  gl_Position = u_mvp * vec4(a_position, 1.0);\n"
+        "vec4 vert() {\n"
         "  v_texcoord = a_texcoord;\n"
+        "  return u_mvp * vec4(a_position, 1.0);\n"
         "}\n",
     .FragmentBody =
-        "void main() {\n"
-        "  " GLSL_FRAGCOLOR " = " GLSL_TEX "(u_texture, v_texcoord) * u_color;\n"
+        "vec4 frag() {\n"
+        "  return texture(u_texture, v_texcoord) * u_color;\n"
         "}\n",
 };
 #undef SHADER_TYPE
 
 /* UNIFORM(field) stores offsetof(SHADER_TYPE, field); attrib/shared names get a_/v_ prefix. */
 TEST(renderer_shader_desc, macro_expansion_records_offsets_and_prefixed_names) {
-    T_EQ(sd_test.Uniforms[0].offset, offsetof(sd_test_prog_t, mvp));
-    T_EQ(sd_test.Uniforms[1].offset, offsetof(sd_test_prog_t, texture));
-    T_EQ(sd_test.Uniforms[2].offset, offsetof(sd_test_prog_t, color));
+    T_EQ(sd_test.Uniforms[0].offset, offsetof(SDTESTSTATE, mvp));
+    T_EQ(sd_test.Uniforms[1].offset, offsetof(SDTESTSTATE, texture));
+    T_EQ(sd_test.Uniforms[2].offset, offsetof(SDTESTSTATE, color));
     T_STREQ(sd_test.Uniforms[0].name, "u_mvp");
     T_STREQ(sd_test.Uniforms[1].name, "u_texture");
     T_STREQ(sd_test.Uniforms[2].name, "u_color");
@@ -651,12 +673,14 @@ TEST(renderer_shader_desc, declarations_120_vertex_uses_attribute_and_varying) {
     T_NOT_NULL(strstr(buf, "varying vec2 v_texcoord;\n"));
     T_NULL(strstr(buf, " in "));
     T_NULL(strstr(buf, " out "));
+    T_NULL(strstr(buf, "#define texture"));
 }
 
-TEST(renderer_shader_desc, declarations_120_fragment_omits_o_color) {
+TEST(renderer_shader_desc, declarations_120_fragment_aliases_texture) {
     char buf[1024];
     R_BuildShaderDeclarations(buf, sizeof(buf), &sd_test, false, GLSL_DIALECT_120);
     T_NOT_NULL(strstr(buf, "varying vec2 v_texcoord;\n"));
+    T_NOT_NULL(strstr(buf, "#define texture texture2D\n"));
     T_NULL(strstr(buf, "out vec4 o_color"));
     T_NULL(strstr(buf, " in "));
 }
@@ -680,6 +704,7 @@ TEST(renderer_shader_desc, declarations_140_fragment_declares_o_color) {
     T_NOT_NULL(strstr(buf, "out vec4 o_color;\n"));
     T_NULL(strstr(buf, "attribute "));
     T_NULL(strstr(buf, "varying "));
+    T_NULL(strstr(buf, "#define texture"));
 }
 
 /* GLSL 150 uses the same declaration keywords as 140; only the version line differs. */
@@ -704,27 +729,81 @@ TEST(renderer_shader_desc, declarations_es3_identical_to_140) {
     T_STREQ(buf140, bufES3);
 }
 
-/* R_LoadShaderDescInto writes locations into struct fields via stored offsets. */
-TEST(renderer_shader_desc, load_writes_progid_and_uniform_locations) {
-    sd_test_prog_t prog;
-    memset(&prog, -1, sizeof(prog));  /* prefill with non-zero to detect writes */
-    reset_shader();
-    R_LoadShaderDescInto(&sd_test, NULL, &prog.progid, &prog);
-    T_EQ(prog.progid,  (GLuint)GL_LINK_STATUS); /* BZ_TestCreateProgram returns GL_LINK_STATUS */
-    T_EQ(prog.mvp,     0);  /* BZ_TestUniformLocation returns 0; was -1 before */
-    T_EQ(prog.texture, 0);
-    T_EQ(prog.color,   0);
-    T_EQ(shader_test.creates, 2);
-    T_EQ(shader_test.links,   1);
-    T_EQ(shader_test.deleted, 2);
+/* main() is generated: bodies define vert()/frag(), never gl_Position/o_color. */
+TEST(renderer_shader_desc, main_vertex_assigns_gl_position) {
+    char buf[128];
+    FOR_LOOP(i, 4) {
+        R_BuildShaderMain(buf, sizeof(buf), true, (glsl_dialect_t)i);
+        T_STREQ(buf, "void main() { gl_Position = vert(); }\n");
+    }
 }
 
-TEST(renderer_shader_desc, load_null_prog_base_skips_location_writes) {
-    sd_test_prog_t prog;
-    memset(&prog, -1, sizeof(prog));
+TEST(renderer_shader_desc, main_fragment_120_assigns_gl_fragcolor) {
+    char buf[128];
+    R_BuildShaderMain(buf, sizeof(buf), false, GLSL_DIALECT_120);
+    T_STREQ(buf, "void main() { gl_FragColor = frag(); }\n");
+}
+
+TEST(renderer_shader_desc, main_fragment_140_assigns_o_color) {
+    char buf[128];
+    R_BuildShaderMain(buf, sizeof(buf), false, GLSL_DIALECT_140);
+    T_STREQ(buf, "void main() { o_color = frag(); }\n");
+    R_BuildShaderMain(buf, sizeof(buf), false, GLSL_DIALECT_150);
+    T_STREQ(buf, "void main() { o_color = frag(); }\n");
+    R_BuildShaderMain(buf, sizeof(buf), false, GLSL_DIALECT_ES3);
+    T_STREQ(buf, "void main() { o_color = frag(); }\n");
+}
+
+/* Locations stay private to the program and loading preserves caller-owned non-sampler values. */
+TEST(renderer_shader_desc, load_writes_locations_and_initializes_samplers) {
+    SDTESTPROG shader = { .state.color = { 1, 2, 3, 4 } };
     reset_shader();
-    R_LoadShaderDescInto(&sd_test, NULL, &prog.progid, NULL);
-    T_EQ(prog.progid, (GLuint)GL_LINK_STATUS);
-    T_EQ(prog.mvp,    (GLint)-1); /* not written when prog_base == NULL */
-    T_EQ(shader_test.creates, 2); T_EQ(shader_test.links, 1);
+    R_LoadShader(&sd_test, NULL, &shader);
+    T_EQ(shader.prog.progid, (GLuint)GL_LINK_STATUS);
+    FOR_LOOP(i, 3) T_EQ(shader.prog.locs[i], 0);
+    T_EQ(shader.state.texture, 0); T_EQ(shader.state.color.w, 4);
+    T_EQ(shader_test.creates, 2); T_EQ(shader_test.links, 1); T_EQ(shader_test.deleted, 2);
+}
+
+/* The descriptor chooses upload shape; arrays stay blocks and bools are not read as GLint storage. */
+TEST(renderer_shader_desc, upload_dispatches_values_arrays_and_inactive_inputs) {
+    union { float f[32]; int i[32]; bool b; } state = { 0 };
+    shader_desc_t desc = { .Name = "upload" };
+    SHADERPROG prog = { .progid = 1, .desc = &desc };
+    static const int widths[] = { 1, 2, 3, 4, 4, 0, 0, 0, 9, 16, 0, 0, 0 };
+    FOR_LOOP(type, UT_COUNT) {
+        desc.Uniforms[0] = (shaderUniform_t){ .name = "value", .type = type };
+        memset(&upload, 0, sizeof(upload));
+        if (widths[type]) {
+            FOR_LOOP(i, 32) state.f[i] = i + 1;
+            desc.Uniforms[0].count = 2;
+        } else if (type == UT_BOOL) state.b = true;
+        else state.i[0] = state.i[1] = 7;
+        R_UploadShader(&prog, &state);
+        T_EQ(upload.calls, 1);
+        if (widths[type]) {
+            T_EQ(upload.width, widths[type]); T_EQ(upload.count, 2);
+            T_EQ(upload.data[widths[type] * 2 - 1], widths[type] * 2);
+        } else T_EQ(upload.integer, type == UT_BOOL ? 1 : 7);
+    }
+    desc.Uniforms[0] = (shaderUniform_t){ .name = "bool", .type = UT_BOOL };
+    state.b = false; R_UploadShader(&prog, &state); T_EQ(upload.integer, 0);
+    desc.Uniforms[0].type = UT_FLOAT_MAT3; desc.Uniforms[0].transpose = true;
+    R_UploadShader(&prog, &state); T_EQ(upload.transpose, GL_TRUE);
+    int calls = upload.calls; prog.locs[0] = -1;
+    R_UploadShader(&prog, &state); T_EQ(upload.calls, calls);
+}
+
+TEST(renderer_shader_desc, sampler_order_and_program_release) {
+    struct { SHADERPROG prog; int state[3]; } shader = { 0 };
+    /* A linked descriptor requires shader bodies even when the test only inspects sampler setup. */
+    shader_desc_t desc = { .Name = "samplers", .VertexBody = sd_test.VertexBody, .FragmentBody = sd_test.FragmentBody };
+    reset_shader();
+    FOR_LOOP(i, 3) desc.Uniforms[i] = (shaderUniform_t){ .offset = i * sizeof(int), .name = "sampler", .type = UT_SAMPLER_2D };
+    R_LoadShader(&desc, NULL, &shader);
+    FOR_LOOP(i, 3) T_EQ(shader.state[i], i);
+    int deleted = deleted_programs;
+    R_DeleteShader(&shader.prog); T_EQ(deleted_programs, deleted + 1);
+    T_EQ(shader.prog.progid, 0); T_NULL(shader.prog.desc);
+    R_DeleteShader(&shader.prog); T_EQ(deleted_programs, deleted + 1);
 }

--- a/tests/test_renderer_model.c
+++ b/tests/test_renderer_model.c
@@ -582,3 +582,149 @@ TEST(renderer_shader, shadow_receiver_contract) {
     T_NULL(strstr(shader_src, "shadow_visibility"));
 #endif
 }
+
+/* -----------------------------------------------------------------------
+ * shader_desc: UNIFORM/ATTRIB/SHARED macro expansion, R_BuildShaderDeclarations,
+ * and R_LoadShaderDescInto for each supported GLSL dialect.
+ * ----------------------------------------------------------------------- */
+
+typedef struct {
+    GLuint progid;
+    GLint  mvp;
+    GLint  texture;
+    GLint  color;
+} sd_test_prog_t;
+
+#define SHADER_TYPE sd_test_prog_t
+static const shader_desc_t sd_test = {
+    .Name = "test",
+    .Uniforms = {
+        UNIFORM(mvp,     UT_FLOAT_MAT4, PRECISION_HIGH),
+        UNIFORM(texture, UT_SAMPLER_2D, PRECISION_LOW),
+        UNIFORM(color,   UT_FLOAT_VEC4, PRECISION_LOW),
+    },
+    .Attributes = {
+        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
+        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
+    },
+    .Shared = {
+        SHARED(texcoord, UT_FLOAT_VEC2),
+    },
+    .VertexBody =
+        "void main() {\n"
+        "  gl_Position = u_mvp * vec4(a_position, 1.0);\n"
+        "  v_texcoord = a_texcoord;\n"
+        "}\n",
+    .FragmentBody =
+        "void main() {\n"
+        "  " GLSL_FRAGCOLOR " = " GLSL_TEX "(u_texture, v_texcoord) * u_color;\n"
+        "}\n",
+};
+#undef SHADER_TYPE
+
+/* UNIFORM(field) stores offsetof(SHADER_TYPE, field); attrib/shared names get a_/v_ prefix. */
+TEST(renderer_shader_desc, macro_expansion_records_offsets_and_prefixed_names) {
+    T_EQ(sd_test.Uniforms[0].offset, offsetof(sd_test_prog_t, mvp));
+    T_EQ(sd_test.Uniforms[1].offset, offsetof(sd_test_prog_t, texture));
+    T_EQ(sd_test.Uniforms[2].offset, offsetof(sd_test_prog_t, color));
+    T_STREQ(sd_test.Uniforms[0].name, "u_mvp");
+    T_STREQ(sd_test.Uniforms[1].name, "u_texture");
+    T_STREQ(sd_test.Uniforms[2].name, "u_color");
+    T_STREQ(sd_test.Attributes[0].name, "a_position");
+    T_STREQ(sd_test.Attributes[1].name, "a_texcoord");
+    T_STREQ(sd_test.Shared[0].name, "v_texcoord");
+    T_EQ(sd_test.Attributes[0].attrib, attrib_position);
+    T_EQ(sd_test.Attributes[1].attrib, attrib_texcoord);
+    T_NULL(sd_test.Uniforms[3].name);
+    T_NULL(sd_test.Attributes[2].name);
+    T_NULL(sd_test.Shared[1].name);
+}
+
+/* GLSL 120: attribute/varying keywords, no o_color declaration in FS. */
+TEST(renderer_shader_desc, declarations_120_vertex_uses_attribute_and_varying) {
+    char buf[1024];
+    R_BuildShaderDeclarations(buf, sizeof(buf), &sd_test, true, GLSL_DIALECT_120);
+    T_NOT_NULL(strstr(buf, "uniform mat4 u_mvp;\n"));
+    T_NOT_NULL(strstr(buf, "uniform sampler2D u_texture;\n"));
+    T_NOT_NULL(strstr(buf, "attribute vec3 a_position;\n"));
+    T_NOT_NULL(strstr(buf, "attribute vec2 a_texcoord;\n"));
+    T_NOT_NULL(strstr(buf, "varying vec2 v_texcoord;\n"));
+    T_NULL(strstr(buf, " in "));
+    T_NULL(strstr(buf, " out "));
+}
+
+TEST(renderer_shader_desc, declarations_120_fragment_omits_o_color) {
+    char buf[1024];
+    R_BuildShaderDeclarations(buf, sizeof(buf), &sd_test, false, GLSL_DIALECT_120);
+    T_NOT_NULL(strstr(buf, "varying vec2 v_texcoord;\n"));
+    T_NULL(strstr(buf, "out vec4 o_color"));
+    T_NULL(strstr(buf, " in "));
+}
+
+/* GLSL 140: in/out keywords, o_color declared in FS. */
+TEST(renderer_shader_desc, declarations_140_vertex_uses_in_out) {
+    char buf[1024];
+    R_BuildShaderDeclarations(buf, sizeof(buf), &sd_test, true, GLSL_DIALECT_140);
+    T_NOT_NULL(strstr(buf, "uniform mat4 u_mvp;\n"));
+    T_NOT_NULL(strstr(buf, "in vec3 a_position;\n"));
+    T_NOT_NULL(strstr(buf, "in vec2 a_texcoord;\n"));
+    T_NOT_NULL(strstr(buf, "out vec2 v_texcoord;\n"));
+    T_NULL(strstr(buf, "attribute "));
+    T_NULL(strstr(buf, "varying "));
+}
+
+TEST(renderer_shader_desc, declarations_140_fragment_declares_o_color) {
+    char buf[1024];
+    R_BuildShaderDeclarations(buf, sizeof(buf), &sd_test, false, GLSL_DIALECT_140);
+    T_NOT_NULL(strstr(buf, "in vec2 v_texcoord;\n"));
+    T_NOT_NULL(strstr(buf, "out vec4 o_color;\n"));
+    T_NULL(strstr(buf, "attribute "));
+    T_NULL(strstr(buf, "varying "));
+}
+
+/* GLSL 150 uses the same declaration keywords as 140; only the version line differs. */
+TEST(renderer_shader_desc, declarations_150_identical_to_140) {
+    char buf140[1024], buf150[1024];
+    R_BuildShaderDeclarations(buf140, sizeof(buf140), &sd_test, true,  GLSL_DIALECT_140);
+    R_BuildShaderDeclarations(buf150, sizeof(buf150), &sd_test, true,  GLSL_DIALECT_150);
+    T_STREQ(buf140, buf150);
+    R_BuildShaderDeclarations(buf140, sizeof(buf140), &sd_test, false, GLSL_DIALECT_140);
+    R_BuildShaderDeclarations(buf150, sizeof(buf150), &sd_test, false, GLSL_DIALECT_150);
+    T_STREQ(buf140, buf150);
+}
+
+/* GLES3 uses the same declaration keywords as 140; the precision prologue is in the version string. */
+TEST(renderer_shader_desc, declarations_es3_identical_to_140) {
+    char buf140[1024], bufES3[1024];
+    R_BuildShaderDeclarations(buf140, sizeof(buf140), &sd_test, true, GLSL_DIALECT_140);
+    R_BuildShaderDeclarations(bufES3, sizeof(bufES3), &sd_test, true, GLSL_DIALECT_ES3);
+    T_STREQ(buf140, bufES3);
+    R_BuildShaderDeclarations(buf140, sizeof(buf140), &sd_test, false, GLSL_DIALECT_140);
+    R_BuildShaderDeclarations(bufES3, sizeof(bufES3), &sd_test, false, GLSL_DIALECT_ES3);
+    T_STREQ(buf140, bufES3);
+}
+
+/* R_LoadShaderDescInto writes locations into struct fields via stored offsets. */
+TEST(renderer_shader_desc, load_writes_progid_and_uniform_locations) {
+    sd_test_prog_t prog;
+    memset(&prog, -1, sizeof(prog));  /* prefill with non-zero to detect writes */
+    reset_shader();
+    R_LoadShaderDescInto(&sd_test, NULL, &prog.progid, &prog);
+    T_EQ(prog.progid,  (GLuint)GL_LINK_STATUS); /* BZ_TestCreateProgram returns GL_LINK_STATUS */
+    T_EQ(prog.mvp,     0);  /* BZ_TestUniformLocation returns 0; was -1 before */
+    T_EQ(prog.texture, 0);
+    T_EQ(prog.color,   0);
+    T_EQ(shader_test.creates, 2);
+    T_EQ(shader_test.links,   1);
+    T_EQ(shader_test.deleted, 2);
+}
+
+TEST(renderer_shader_desc, load_null_prog_base_skips_location_writes) {
+    sd_test_prog_t prog;
+    memset(&prog, -1, sizeof(prog));
+    reset_shader();
+    R_LoadShaderDescInto(&sd_test, NULL, &prog.progid, NULL);
+    T_EQ(prog.progid, (GLuint)GL_LINK_STATUS);
+    T_EQ(prog.mvp,    (GLint)-1); /* not written when prog_base == NULL */
+    T_EQ(shader_test.creates, 2); T_EQ(shader_test.links, 1);
+}


### PR DESCRIPTION
## Summary

Replaces every hand-written GLSL string shader with a descriptor-driven system: each shader is a typed struct (`my_prog_t`) with named `GLint` fields plus a `shader_desc_t` that generates the GLSL prologue, declarations, and a `main()` automatically, and resolves uniform locations into the struct. Bodies define only `vec4 vert()` / `vec4 frag()`.

## Before vs After

Take the `unlit`/UI shader. Before, the whole shader was one hard-coded string, locked to a single GLSL dialect, with every declaration and `main()` spelled out by hand:

```c
LPCSTR fs_unlit =
"#version 140\n"
"in vec4 v_color;\n"
"in vec2 v_texcoord;\n"
"out vec4 o_color;\n"
"uniform sampler2D uTexture;\n"
"void main() {\n"
"    o_color = texture(uTexture, v_texcoord) * v_color;\n"
"}\n";
```

…and the C side needed its own parallel registration machinery to wire uniforms up:

```c
#define R_RegisterUniform(PROGRAM, NAME) \
    PROGRAM->NAME = glGetUniformLocation(PROGRAM->progid, #NAME);
```

After, the same shader is a descriptor whose bodies define only `vert()`/`frag()` — no `gl_Position`, no `o_color`, no `void main()`:

```c
typedef struct {
    GLuint progid;
    GLint  viewProjection;
    GLint  model;
    GLint  texture;
} unlit_prog_t;

#define SHADER_TYPE unlit_prog_t
const shader_desc_t sd_unlit = {
    .Name = "unlit",
    .Uniforms = {
        UNIFORM(viewProjection, UT_FLOAT_MAT4, PRECISION_HIGH),
        UNIFORM(model,          UT_FLOAT_MAT4, PRECISION_HIGH),
        UNIFORM(texture,        UT_SAMPLER_2D, PRECISION_LOW),
    },
    .Attributes = {
        ATTRIB(position, attrib_position, UT_FLOAT_VEC3),
        ATTRIB(texcoord, attrib_texcoord, UT_FLOAT_VEC2),
        ATTRIB(color,    attrib_color,    UT_COLOR),
    },
    .Shared = {
        SHARED(texcoord, UT_FLOAT_VEC2),
        SHARED(color,    UT_COLOR),
    },
    .VertexBody =
        "vec4 vert() {\n"
        "  v_texcoord = a_texcoord;\n"
        "  v_color = a_color;\n"
        "  return u_viewProjection * u_model * vec4(a_position, 1.0);\n"
        "}\n",
    .FragmentBody =
        "vec4 frag() {\n"
        "  return texture(u_texture, v_texcoord) * v_color;\n"
        "}\n",
};
#undef SHADER_TYPE
```

The loader generates `main()` itself — `gl_Position = vert();` for the vertex stage and `o_color = frag();` (or `gl_FragColor = frag();` on GLSL 120) for the fragment stage. Load once, then call sites use named fields directly — no string lookups, no indices:

```c
R_LoadShaderDescInto(&sd_unlit, NULL, &unlit_prog.progid, &unlit_prog);
glUniformMatrix4fv(unlit_prog.viewProjection, 1, GL_FALSE, vp);
```

## Why it's better

1. **One entry is the single source of truth.** `UNIFORM(viewProjection, …)` records `offsetof(unlit_prog_t, viewProjection)`, the GLSL name `u_viewProjection`, and the type in one place. `R_LoadShaderDescInto()` writes the resolved `glGetUniformLocation` straight into the struct field via that offset. There is no separate enum, string table, or `glGetUniformLocation` call site to keep in sync.

2. **Bodies contain only logic.** The version line, `precision` qualifiers, every `uniform`/`in`/`out` declaration, and the `main()` wrapper are generated by `R_BuildShaderDeclarations()` + `R_BuildShaderMain()` from the descriptor tables. A shader that used to be ~10 lines of declarations + ~3 lines of logic is now ~3 lines of logic, and `gl_Position`/`gl_FragColor`/`o_color` never appear in author code.

3. **Multiple GLSL dialects for free.** Before, every shader hard-coded `#version 140` (with `#version 120` and ES3 variants essentially impossible without duplicating each string). Now the linker picks `attribute` vs `in`, `varying` vs `out`, `gl_FragColor` vs `o_color`, and the version line by `GLSL_DIALECT_120/140/150/ES3`. GLSL 120's missing `texture` builtin is handled by a single injected `#define texture texture2D`, so bodies call `texture()` regardless of dialect — no C-side string-concat macros, no per-dialect conditionals in the body.

4. **Type-safe, self-documenting call sites.** `glUniformMatrix4fv(unlit_prog.viewProjection, …)` tells the reader the field exists and its type; the old `u[]`-array or `#NAME` stringified-lookup style hid both. A misspelled field is a compile error, not a silent `-1` uniform location.

5. **No heap, no parallel runtime arrays.** Declarations are built into a stack buffer and passed as strings to `glShaderSource`; the descriptor itself is `static const`. The loader walks the fixed-size inline arrays until a `NULL` sentinel name.

## What changes vs the previous commit on this branch

The prior commit added `shader_desc_t` with X-macro helpers and pointer-based `Uniforms[]`/`Attributes[]`/`Shared[]` tables. This redesign:

- Replaces X-macros with `UNIFORM(field)` / `ATTRIB(field)` / `SHARED(field)` — one entry per field, auto-prefixed names
- Changes `shaderUniform_t` to store `offsetof` instead of requiring a parallel enum
- Switches to fixed-size inline arrays (orca-style) — no separate `xxx_uniforms[]` declarations needed
- Adds `glsl_dialect_t` enum, `R_BuildShaderDeclarations()` for runtime dialect selection, and `R_BuildShaderMain()` for the generated `main()`
- Adds `R_LoadShaderDescInto()` to `r_shader.h` / `r_shader.c`
- Bodies define `vert()`/`frag()`; `gl_Position`, `gl_FragColor`, and `o_color` are only emitted by the generated `main()`
- Converts every remaining string shader (UI/sprite, model, particles, fog-of-war, SC2 terrain, WoW terrain/grass) to descriptors and removes `R_InitShader`

## Test plan

- [ ] `make renderer/r_shader.o` — clean compile, no new errors
- [ ] `make renderer/r_main.o` — header chain intact
- [ ] `make test` — renderer + game suites pass
- [ ] `make run-wow`, `make run-sc2`, WC3 ROC/TFT — all games render with descriptor shaders
