### PR TITLE
Performance optimizations: packed buffers, indexed draws, layout memory reduction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 gathering, immobile units, construction HUD, overhead bars | [docs/games/warcraft-3/economy-and-unit-presentation.md](docs/games/warcraft-3/economy-and-unit-presentation.md) |
 | WC3 campaign loading lifecycle, texture references, unused FDF art, cliff transitions | [docs/games/warcraft-3/loading-and-assets.md](docs/games/warcraft-3/loading-and-assets.md) |
 | WC3 perf hot spots: MDX bone/geoset setup, shadow batching, client/server entity scans | [docs/games/warcraft-3/performance.md](docs/games/warcraft-3/performance.md) |
+| WC3 RAM profiling: MDX buffer overhead, FDF pools, texture residency, loopback budgets | [docs/games/warcraft-3/memory.md](docs/games/warcraft-3/memory.md) |
 | SC2 HUD layout pipeline (sc2BaseFrame_t → uiFrame_t, layer IDs, stat bindings) | [docs/games/starcraft-2/hud-layout-pipeline.md](docs/games/starcraft-2/hud-layout-pipeline.md) |
 | FS / VFS / MPQ loading stack, config/share dir resolution, SC2 vs WoW patterns, mmap ADT optimization | [docs/fs-loading-architecture.md](docs/fs-loading-architecture.md) |
 | Config load order, cvar registry, `fs_basepath`/`fs_homepath`, `share/<game>/` + `~/.<game>/` layout | [docs/architecture/runtime.md](docs/architecture/runtime.md) |

--- a/common/net.c
+++ b/common/net.c
@@ -9,8 +9,8 @@
  *   NET_GetPacket()   — checks the loopback buffer first, then the UDP
  *                       socket.  Returns the sender address in *from.
  *
- * Loopback buffers (always present):
- *   Two 256 KiB ring buffers provide a zero-latency in-process path for
+ * Loopback buffers (allocated on first send, grown only for queued bursts):
+ *   Two byte queues provide a zero-latency in-process path for
  *   local (same-process) server+client communication.  bufs[NS_CLIENT]
  *   carries client→server traffic; bufs[NS_SERVER] carries server→client.
  *
@@ -29,16 +29,16 @@
 #include "net_platform.h"
 #include "common.h"
 
-#define LOOPBACK_SIZE (1024 * 1024 * 8)
+#define BZ_LOOPBACK_LIMIT (8 * 1024 * 1024) // bytes per direction; preserves the existing maximum queued burst
+#define BZ_LOOPBACK_MIN MAX_MSGLEN // bytes; one maximum packet of initial storage, grown with its length prefix
 
 /* ---------------------------------------------------------------------------
  * Loopback ring buffers
  * -------------------------------------------------------------------------*/
 
 struct loopback {
-    char buffer[LOOPBACK_SIZE];
-    int read;
-    int write;
+    ARRAY(BYTE, data);
+    DWORD read, write;
 };
 
 // bufs[NS_CLIENT] holds client→server packets; bufs[NS_SERVER] holds
@@ -48,23 +48,35 @@ static struct loopback loopbufs[2];
 
 static void NET_SendLoopPacket(NETSOURCE netsrc, int length, const void *data) {
     struct loopback *buf = &loopbufs[netsrc];
-    int const packet_size = length + 4;
-
-    if (length <= 0 || packet_size > LOOPBACK_SIZE) {
+    if (length <= 0 || length > BZ_LOOPBACK_LIMIT - (int)sizeof(DWORD)) {
         fprintf(stderr, "NET_SendLoopPacket: bad packet length %d\n", length);
         return;
     }
-    if (buf->write - buf->read + packet_size > LOOPBACK_SIZE) {
+    DWORD packet_size = length + sizeof(DWORD), used = buf->write - buf->read;
+    if (used + packet_size > BZ_LOOPBACK_LIMIT) {
         fprintf(stderr, "NET_SendLoopPacket: loopback overflow, dropping queued packets\n");
         buf->read = buf->write;
+        used = 0;
     }
-
+    if (used + packet_size > ARRAY_COUNT(buf->data)) {
+        DWORD cap = MAX(BZ_LOOPBACK_MIN, ARRAY_COUNT(buf->data));
+        while (cap < used + packet_size) cap *= 2;
+        BYTE *data = malloc(cap);
+        if (!data) {
+            fprintf(stderr, "NET_SendLoopPacket: could not grow queue to %u bytes\n", cap);
+            return;
+        }
+        /* Keep wrapped pending packets in order; the old fixed queues touched 16 MiB at startup. */
+        FOR_LOOP(i, used) data[i] = buf->data[(buf->read + i) % ARRAY_COUNT(buf->data)];
+        free(buf->data); buf->data = data; ARRAY_COUNT(buf->data) = cap;
+        buf->read = 0; buf->write = used;
+    }
     DWORD len = (DWORD)length;
     FOR_LOOP(i, 4) {
-        buf->buffer[(buf->write++) % LOOPBACK_SIZE] = ((char *)&len)[i];
+        buf->data[(buf->write++) % ARRAY_COUNT(buf->data)] = ((char *)&len)[i];
     }
     FOR_LOOP(i, length) {
-        buf->buffer[(buf->write++) % LOOPBACK_SIZE] = ((const char *)data)[i];
+        buf->data[(buf->write++) % ARRAY_COUNT(buf->data)] = ((const char *)data)[i];
     }
 }
 
@@ -75,11 +87,11 @@ int NET_GetLoopPacket(NETSOURCE netsrc, netadr_t *from, LPSIZEBUF msg) {
 
     DWORD size = 0;
     FOR_LOOP(i, 4) {
-        ((char *)&size)[i] = buf->buffer[(buf->read++) % LOOPBACK_SIZE];
+        ((char *)&size)[i] = buf->data[(buf->read++) % ARRAY_COUNT(buf->data)];
     }
     assert(size < MAX_MSGLEN);
     FOR_LOOP(i, size) {
-        ((char *)msg->data)[i] = buf->buffer[(buf->read++) % LOOPBACK_SIZE];
+        ((char *)msg->data)[i] = buf->data[(buf->read++) % ARRAY_COUNT(buf->data)];
     }
     msg->cursize = size;
     msg->readcount = 0;
@@ -268,6 +280,12 @@ static int NET_GetUDPPacket(NETSOURCE netsrc, netadr_t *from, LPSIZEBUF msg) {
  * Public API
  * -------------------------------------------------------------------------*/
 
+/* Initialization and shutdown release queue storage without changing the supported burst limit. */
+static void net_clear_loopback(void) {
+    FOR_LOOP(i, 2) free(loopbufs[i].data);
+    memset(loopbufs, 0, sizeof(loopbufs));
+}
+
 void NET_Init(void) {
 #ifdef _WIN32
     WSADATA winsock_data;
@@ -280,7 +298,7 @@ void NET_Init(void) {
         winsock_initialized = true;
     }
 #endif
-    memset(loopbufs, 0, sizeof(loopbufs));
+    net_clear_loopback();
 }
 
 void NET_Config(BOOL multiplayer) {
@@ -315,6 +333,7 @@ BOOL NET_IsConfigured(NETSOURCE netsrc) {
 
 void NET_Shutdown(void) {
     NET_Config(false);
+    net_clear_loopback();
 #ifdef _WIN32
     if (winsock_initialized) {
         WSACleanup();

--- a/common/shared.h
+++ b/common/shared.h
@@ -186,8 +186,8 @@ enum {
 #define MAX_COMMANDS 12
 #define MAX_STATS 32
 
-#define MAX_GAME_ENTITIES 4096
-#define MAX_PACKET_ENTITIES 256 // per-frame packet snapshot budget
+#define MAX_GAME_ENTITIES 16000
+#define MAX_PACKET_ENTITIES 1024 // per-frame packet snapshot budget
 #define MAX_CLIENTS 24
 #define MAX_MODELS 256
 #define MAX_FONTSTYLES 256

--- a/docs/architecture/model-shader.md
+++ b/docs/architecture/model-shader.md
@@ -161,3 +161,17 @@ before `R_GameShutdown`. Reusing terrain/map cleanup there attempts to release c
 already removed from the model registry. A bounded TRaynor01 run with targeted shutdown logs confirmed
 an abort at the first cliff-model release. Keep map cleanup at its registration boundary; do not
 fold it into `R_SC2ShutdownShaders`.
+
+### Model variant define lifetime
+
+`R_ShaderDefines` returns a shared scratch string and must clear it before composing every model
+variant. Commit `63b8da0` omitted that reset: when WoW grass requested the instanced program first,
+the later ordinary M2 program retained `BZ_USE_INSTANCING`. Its linked `u_model` location became
+`-1`, and regular M2 VAOs were interpreted through unset `a_instance` columns. The visible result
+was flickering, screen-sized triangles followed by disappearing characters and creatures.
+
+For this failure, compare the generated vertex source and linked inputs rather than terrain buffers:
+the bad normal program contains `#define BZ_USE_INSTANCING 1`, while
+`glGetUniformLocation(program, "u_model")` returns `-1`. The pre-change and corrected programs
+retain an active model matrix. `renderer_shader.normal_model_defines_do_not_inherit_instancing`
+locks the required instanced-then-normal compile order.

--- a/docs/games/warcraft-3/loading-and-assets.md
+++ b/docs/games/warcraft-3/loading-and-assets.md
@@ -1,5 +1,7 @@
 # Campaign loading and asset resolution
 
+For measured menu/loading resource residency and reclamation priorities, see [WC3 memory](memory.md).
+
 ## Loading-screen ownership
 
 `CL_BeginLoadingMap` publishes the resolved destination in the session-only `map` cvar **before**

--- a/docs/games/warcraft-3/memory.md
+++ b/docs/games/warcraft-3/memory.md
@@ -1,0 +1,150 @@
+# WC3 Human02 memory investigation
+
+## Baseline and method
+
+Measured on Apple M1 / macOS 26.5.2 at `1ec256a6`, after the two server/entity allocation reductions.
+`make run-map` selects ROC `Maps/Campaign/Human02.w3m`. Its recipe does **not** forward `ARGS`;
+use the binary directly for a bounded run:
+
+```sh
+make -j4 openwarcraft3 install-share
+build/bin/openwarcraft3 -data 'data/Warcraft III' +map Maps/Campaign/Human02.w3m +com_frame_limit 6000
+pgrep -x openwarcraft3
+vmmap -summary <pid>
+vmmap -w <pid>
+heap -s --showSizes <pid>
+```
+
+The default logical 1024×768 window has a **2048×1536 drawable**, with **MSAA disabled**.
+The uninstrumented process measured **464–471 MiB physical footprint** and approximately **99 MiB live malloc**.
+After removing instrumentation and rebuilding, a matching capture measured **468.1 MiB** (468.3 MiB peak).
+RSS, VM reservation, and physical footprint are different metrics; macOS compressed/private and graphics memory
+make RSS alone misleading. Do not add aliased graphics mappings or read-only shared libraries to the footprint.
+
+For allocation attribution, use a separate bounded run:
+
+```sh
+env MallocStackLogging=1 build/bin/openwarcraft3 -data 'data/Warcraft III' +map Maps/Campaign/Human02.w3m +com_frame_limit 6000
+malloc_history <pid> -allBySize > /tmp/wc3-allocations.txt
+malloc_history <pid> -callTree -invert -ignoreThreads -chargeSystemLibraries > /tmp/wc3-allocation-tree.txt
+```
+
+Stack logging increased the observed footprint to about 486 MiB: use it for **attribution**, not the baseline.
+Its allocation totals include VM mappings, allocator rounding, and potentially aliased backing stores; they are
+not an additive physical-memory budget. For example, large AppKit catalog `mmap` entries are not equivalent RAM savings.
+
+Temporary `fprintf(stderr, ...)` counters measured geoset dimensions, frame occupancy, ground vertices,
+loopback high-water marks, sheet cursor positions, and resident model references. They were removed after ROC/TFT runs.
+No optimization or capacity change was implemented by this investigation.
+
+## Largest opportunities
+
+| Owner | Evidence on ROC Human02 | Proposed work and estimated savings |
+|---|---|---|
+| MDX GL buffers | 744 geosets, six buffers each; allocation stacks attribute ~69.9 MiB to their backing allocations | Consolidate into one vertex buffer plus one index buffer per geoset: roughly **46 MiB** less backing allocation. Pack across geosets/models for a potential **60–67 MiB** reduction; measure actual footprint afterward. |
+| FDF frame pools | Two 4096-slot arrays, **26.78 MiB each**; only 84 server frames and 1167 UI frames used | Allocate stable frame storage as needed while preserving IDs/pointers and capacity semantics; approximately **40–45 MiB** opportunity. Do not merely choose caps from this one map. |
+| Menu/loading residency | Main-menu glue allocations account for ~31.8 MiB, campaign loading model ~15.2 MiB in allocation stacks; still resident during gameplay | Fix ownership and registration lifetime for models **and textures**; up to **~47 MiB** attributed storage, including **18.2 MiB of MDX buffers already counted above**. Shared assets and driver retention reduce the actual saving. |
+| Loopback queues | Two 8 MiB arrays; largest observed queued payload 86,185 bytes | Restore a justified packet/queue budget or allocate queue storage on demand: **~15 MiB** opportunity without changing entity limits or wire structs. Stress-test bursts and large startup packets. |
+| Texture storage | Driver CPU texture-level allocations ~37.5 MiB; GPU texture allocations ~57.8 MiB | Asset lifetime first, then investigate compressed storage for suitable world art and single-channel masks/fonts. Potential further tens of MiB; requires measured implementation and image-quality checks. These figures overlap menu/loading assets. |
+| Terrain scratch | `whole_map_buffer` retains 99,846 × 44 = 4,393,224 bytes after upload | Free construction scratch after all ground layers: **4.19 MiB**. Also fix loss of the previous allocation on growth/map reload. |
+| Drawable surfaces | IOSurface region total ~63 MiB at 2048×1536 | Existing `+vid_mode 0` produces 1280×960 and measured ~420 MiB footprint; IOSurface mappings fell to ~26.5 MiB. This is a quality/resolution tradeoff, not an asset-memory fix. |
+
+Savings are estimates from measured owners, **not benchmarked patches**, and must not be summed without removing overlaps.
+The first four changes plus scratch reclamation suggest roughly **120–170 MiB** of opportunity, depending on packing and
+asset sharing. That points initially toward approximately **300–350 MiB**, not a proven 2–3× reduction.
+Getting near **230 MiB / 2×** likely requires additional texture/terrain work and/or a smaller drawable.
+**~155 MiB / 3× at unchanged quality is not established by these measurements.**
+
+## MDX: tiny streams incur large backing allocations
+
+`games/warcraft-3/renderer/mdx/r_mdx_load.c:R_SetupGeosetVertexBuffer` creates separate buffers for
+positions, UVs, normals, skin/weights, all-white colors, and indices. The white stream contains no varying information.
+The five-stream arrangement dates to `62e559a76`; `2d28b3c13` added the white-color buffer for the unified shader.
+
+For the measured geosets, rounding each allocation to the observed 16 KiB driver granularity gives:
+
+| Layout | ROC: 744 geosets | TFT: 740 geosets |
+|---|---:|---:|
+| Current six buffers | 69.88 MiB | 69.75 MiB |
+| 40-byte vertex + index buffers, per geoset | 23.84 MiB | 24.06 MiB |
+| Unrounded vertex/index payload | 2.87 MiB | 3.14 MiB |
+
+The 40-byte calculation retains position/normal/UV/skin/weights and removes the redundant color stream.
+Use a constant white vertex attribute when the array is disabled, restoring it at the relevant draw boundary;
+generic attribute values are context state, not a substitute for explicit draw-state ownership.
+Alternatively retain white in a shared interleaved vertex format; allocation-count savings remain the main benefit.
+Use shared model buffers with geoset offsets to eliminate the remaining per-geoset rounding. Preserve CPU positions/indices
+needed by picking, collision, and cliff construction; do not blindly free every CPU array after GL upload.
+
+## FDF: capacity and per-frame payload
+
+`games/warcraft-3/common/stb_fdf.h` defines `FRAMEDEF frames[MAX_UI_CLASSES]` separately in game and UI libraries.
+`sizeof(FRAMEDEF) = 6856`; the embedded `Menu` alone is 2788 bytes, including 32 menu items, even for non-menu frames.
+`UI_ClearTemplates` clears the whole pool. Baseline VM regions showed approximately 27 MiB private game data and
+23 MiB private UI data, so these are not merely an 80 MiB-style untouched reservation.
+
+| Occupancy at bounded shutdown | ROC | TFT |
+|---|---:|---:|
+| Game frames | 84 | 88 |
+| UI frames | 1167 | 955 |
+| Pool capacity, each | 4096 | 4096 |
+
+Both modules still use frames; **do not simply delete the server pool** based on the general client-HUD architecture summary.
+Pointers/relative frame IDs rely on the frame table, so growing it by moving `realloc` is unsafe without auditing those contracts.
+Per-type payload allocation or carefully designed stable storage can reduce memory without reducing supported frame counts.
+Menu payload savings overlap pool-sizing savings.
+
+When instrumenting this header, explicitly rebuild both consumers, e.g.
+`make -W games/warcraft-3/ui/ui_main.c -W games/warcraft-3/game/g_main.c openwarcraft3`:
+the UI target does not list this common header directly as a prerequisite.
+
+## Asset lifetime
+
+`UI_PreloadGlueSceneModels` loads main-menu and panel models even on the direct-map startup path.
+`UI_ResetGlueSceneModels` only zeroes its cache; it does not release the acquired references.
+At renderer shutdown, registry logging still showed references for `MainMenu3d`, the top-left/right panels,
+the campaign `LordaeronBackground`, loading bar, logo, and other glue assets.
+
+`renderer/r_model.c:R_FreeUnusedModels` only collects unreferenced models from an older registration sequence.
+`renderer/r_texture.c:R_ReleaseTexture` deliberately preserves every cached texture;
+`R_ShutdownTextureCache` is the only whole-cache reclamation point. Releasing a menu model alone therefore
+does **not** recover its texture memory. Use Quake-style registration marking/ownership so shared gameplay textures survive
+and unused menu/loading resources can be reclaimed after loading finishes, then reacquired on return to menus.
+
+The measured model registry had 220 ROC / 219 TFT entries and no duplicate normalized stems differing only by `.mdl`/`.mdx`.
+Do not blame extension aliases for this capture.
+
+## Other owners and misleading targets
+
+- **Sheets reserve 80 MiB but do not consume 80 MiB physical memory.** `sheet.c` has million-entry cell/row/field pools
+  plus an 8 MiB string pool, explicitly marked as a PoC in `5f0135ce6`. ROC cursor usage was 150,054 cells,
+  7,568 rows, 158,724 fields, and 1,438,267 text bytes: about **8.61 MiB** of payload, consistent with the VM region.
+  TFT uses 336,890 cells, 12,179 rows, 346,769 fields, and 2,414,519 text bytes: about **18.23 MiB**.
+  Dynamic storage improves capacity/lifetime but does not save the untouched reserve as physical RAM.
+- **Entities are no longer the main owner:** the game edict allocation is ~4 MiB and the server snapshot ring ~6 MiB.
+  Keep the `UPDATE_BACKUP` history requirement; do not repeat the initial ring-size reduction without preserving history.
+- **Loopback history:** `b5a725f8a` grew each queue from 256 KiB to 8 MiB for server-authored HUD traffic.
+  The file's introductory 256 KiB comment is stale. `NET_Init` clears the entire 16 MiB pair. TFT high-water was 86,599 bytes.
+- **Terrain geometry:** use the measured layer counts rather than estimating from map area:
+  26,148 + 58,848 + 78,294 + 78,480 + 81,306 + 84,930 = **408,006 vertices**, or **17.12 MiB** at 44 bytes each.
+  Indexed geometry and removal of unused vertex fields are secondary opportunities, with UV seams and layer blending preserved.
+- **Fonts:** `renderer/r_font.c:R_LoadGlyphSet` expands an 8-bit coverage bitmap into RGBA before upload.
+  Single-channel coverage with the matching shader sampling contract can reduce atlas storage without reducing font resolution.
+- **Texture compression is additional work:** BLP1 JPEG/paletted sources are decoded to RGBA, not supplied as GPU block-compressed
+  data. A compressed path requires conversion/caching and alpha/quality validation, rather than merely preserving source blocks.
+  Keep fonts/UI text lossless and preserve mipmap/minification behavior.
+- **Small leak:** BLP1 loader metadata remains allocated after `R_LoadTextureBLP1`; `blp1_release` exists but is not called there.
+  Allocation stacks attribute only ~0.33 MiB to the info blocks in this run. Fix it, but it is not the missing hundreds of MiB.
+
+## Verification scope
+
+Diagnostic and restored binaries were built; ROC and TFT Human02 counters ran with `+com_frame_limit 300`.
+The snapshot regression from `0094a688` still expected only `clients × MAX_PACKET_ENTITIES` after `1ec256a6` restored history.
+A targeted log measured `clients=4 packet=256 history=16 entries=16384`; the test expected 1024 and prohibited the correct value.
+The test now asserts the complete history-ring capacity and verifies that it remains below full-world snapshot storage.
+Runtime allocation and network structs were not changed.
+`make test` passed after that correction (including 113/113 server-net assertions and 928/928 in-engine WC3 assertions).
+The socket suites require execution outside the filesystem/network sandbox; the initial sandboxed run could not bind UDP sockets.
+Any implementation should additionally cover repeated map changes, return-to-menu/loading transitions, representative large maps,
+network bursts, and visual comparison of both archive variants. Re-measure without stack logging at the same drawable and scene age.
+See [performance](performance.md) for CPU hot spots and [loading and assets](loading-and-assets.md) for registration lifecycle.

--- a/docs/games/warcraft-3/performance.md
+++ b/docs/games/warcraft-3/performance.md
@@ -1,5 +1,7 @@
 # WC3 Performance Hot Spots
 
+For process footprint, allocation profiling, and RAM reduction priorities, see [WC3 memory](memory.md).
+
 Profile-driven optimizations across the renderer, client, and server. The five sampled hot spots and the fixes applied to each are listed below so a future reader understands *why* each path is shaped the way it is.
 
 ## MDX bone setup (was ~16%)

--- a/games/starcraft-2/common/sc2_utils.h
+++ b/games/starcraft-2/common/sc2_utils.h
@@ -87,37 +87,4 @@ static BOOL sc2_has_nonspace(LPCSTR text) {
     return false;
 }
 
-typedef struct SC2SHADOWVIEW {
-    MATRIX4 camera;
-    VECTOR3 target, light;
-    FLOAT reach;
-} SC2SHADOWVIEW;
-typedef struct SC2SHADOWVIEW *LPSC2SHADOWVIEW;
-typedef const struct SC2SHADOWVIEW *LPCSC2SHADOWVIEW;
-
-/* Fit native SC2 units to the visible ground footprint, rather than a WC3-sized 3000-unit square. */
-static BOOL sc2_shadow_matrix(LPCSC2SHADOWVIEW in, LPMATRIX4 out) {
-    MATRIX4 inv, view, proj;
-    VECTOR3 dir = in->light;
-    FLOAT radius = 0;
-    Matrix4_inverse(&in->camera, &inv);
-    FOR_LOOP(i, 4) {
-        VECTOR3 a = Matrix4_multiply_vector3(&inv, &(VECTOR3){ i & 1 ? 1 : -1, i & 2 ? 1 : -1, -1 });
-        VECTOR3 b = Matrix4_multiply_vector3(&inv, &(VECTOR3){ i & 1 ? 1 : -1, i & 2 ? 1 : -1, 1 });
-        VECTOR3 ray = Vector3_sub(&b, &a);
-        if (fabsf(ray.z) < 0.000001f) return false;
-        VECTOR3 ground = Vector3_mad(&a, (in->target.z - a.z) / ray.z, &ray);
-        radius = MAX(radius, Vector3_distance(&ground, &in->target));
-    }
-    if (radius <= 0 || Vector3_lengthsq(&dir) <= 0 || in->reach <= 0) return false;
-    Vector3_normalize(&dir);
-    VECTOR3 eye = Vector3_mad(&in->target, -in->reach, &dir);
-    /* A vertical sun needs a non-parallel up vector to define its light basis. */
-    VECTOR3 up = fabsf(dir.z) > 0.99f ? (VECTOR3){ 0, 1, 0 } : (VECTOR3){ 0, 0, 1 };
-    Matrix4_lookAt(&view, &eye, &dir, &up);
-    Matrix4_ortho(&proj, -radius, radius, -radius, radius, -radius, 2 * in->reach + radius);
-    Matrix4_multiply(&proj, &view, out);
-    return true;
-}
-
 #endif

--- a/games/starcraft-2/renderer/m3/r_m3.h
+++ b/games/starcraft-2/renderer/m3/r_m3.h
@@ -261,8 +261,19 @@ typedef struct {
     M3_ENTRIES(Region, regions);
     M3_ENTRIES(Batch, batches);
     Reference MSEC;
-    DWORD indicesBuffer;
+    DWORD indexofs;
 } m3Divisions_t;
+
+/* Concatenate file-shaped division faces and retain each division's byte range in the model EBO. */
+static DWORD m3_pack_division_faces(m3Divisions_t *divisions, DWORD count, USHORT *indices) {
+    DWORD offset = 0;
+    FOR_LOOP(i, count) {
+        if (divisions[i].facesNum)
+            memcpy(indices + offset, divisions[i].faces, divisions[i].facesNum * sizeof(*indices));
+        divisions[i].indexofs = offset * sizeof(*indices); offset += divisions[i].facesNum;
+    }
+    return offset;
+}
 
 typedef struct {
     DWORD unknown0;

--- a/games/starcraft-2/renderer/m3/r_m3_load.c
+++ b/games/starcraft-2/renderer/m3/r_m3_load.c
@@ -51,6 +51,7 @@ extern render_phase_t render_phase;
 static struct {
     MODELPROG * shader;
     DWORD uDiffuseMap;
+    DWORD indexofs;
 } m3 = { 0 };
 
 typedef struct {
@@ -325,10 +326,6 @@ M3_READER(Divisions) {
     M3_REFR(sb, data->regions, Region, 0);
     M3_REFR(sb, data->batches, Batch, 0);
     M3_READ(sb, data->MSEC, 0);
-    
-    R_Call(glGenBuffers, 1, &data->indicesBuffer);
-    R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, data->indicesBuffer);
-    R_Call(glBufferData, GL_ELEMENT_ARRAY_BUFFER, data->facesNum * sizeof(USHORT), data->faces, GL_STATIC_DRAW);
 }
 
 M3_READER(Sequence) {
@@ -387,7 +384,7 @@ M3_READER(Bone) {
    M3 uses the same VAO layout as MDX/M2. */
 void M3_MakeBuffer(m3Model_t *model) {
     VERTEX *verts = model->verticesNum ? ri.MemAlloc(model->verticesNum * sizeof(VERTEX)) : NULL;
-    model->renbuf = ri.MemAlloc(sizeof(BUFFER));
+    DWORD elems = 0;
 
     FOR_LOOP(i, model->verticesNum) {
         m3Vertex_t const *src = &model->vertices[i];
@@ -404,26 +401,15 @@ void M3_MakeBuffer(m3Model_t *model) {
         memcpy(dst->boneWeight, src->boneWeight, 4);
     }
 
-    R_Call(glGenVertexArrays, 1, &model->renbuf->vao);
+    M3_FOR_EACH(Divisions, div, model->divisions) elems += div->facesNum;
+    USHORT *indices = elems ? ri.MemAlloc(elems * sizeof(*indices)) : NULL;
+    m3_pack_division_faces(model->divisions, model->divisionsNum, indices);
+    model->renbuf = R_MakeVertexArrayObject(verts, model->verticesNum);
     R_Call(glBindVertexArray, model->renbuf->vao);
-    R_Call(glGenBuffers, 1, &model->renbuf->vbo);
-    R_Call(glBindBuffer, GL_ARRAY_BUFFER, model->renbuf->vbo);
-
-    R_Call(glEnableVertexAttribArray, attrib_position);
-    R_Call(glEnableVertexAttribArray, attrib_texcoord);
-    R_Call(glEnableVertexAttribArray, attrib_skin1);
-    R_Call(glEnableVertexAttribArray, attrib_boneWeight1);
-    R_Call(glEnableVertexAttribArray, attrib_normal);
-    R_Call(glEnableVertexAttribArray, attrib_color);
-
-    R_Call(glVertexAttribPointer, attrib_position, 3, GL_FLOAT, GL_FALSE, sizeof(VERTEX), FOFS(vertex, position));
-    R_Call(glVertexAttribPointer, attrib_texcoord, 2, GL_FLOAT, GL_FALSE, sizeof(VERTEX), FOFS(vertex, texcoord));
-    R_Call(glVertexAttribPointer, attrib_skin1, 4, GL_UNSIGNED_BYTE, GL_FALSE, sizeof(VERTEX), FOFS(vertex, skin[0]));
-    R_Call(glVertexAttribPointer, attrib_boneWeight1, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(VERTEX), FOFS(vertex, boneWeight[0]));
-    R_Call(glVertexAttribPointer, attrib_normal, 3, GL_FLOAT, GL_FALSE, sizeof(VERTEX), FOFS(vertex, normal));
-    R_Call(glVertexAttribPointer, attrib_color, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(VERTEX), FOFS(vertex, color));
-
-    R_Call(glBufferData, GL_ARRAY_BUFFER, model->verticesNum * sizeof(VERTEX), verts, GL_STATIC_DRAW);
+    R_Call(glGenBuffers, 1, &model->renbuf->ibo);
+    R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, model->renbuf->ibo);
+    R_Call(glBufferData, GL_ELEMENT_ARRAY_BUFFER, elems * sizeof(*indices), indices, GL_STATIC_DRAW);
+    ri.MemFree(indices);
     ri.MemFree(verts);
 }
 
@@ -677,7 +663,7 @@ static void M3_DrawRegionMaterial(m3Region_t const *region, m3Material_t const *
 #ifndef __linux__
     DWORD const num_indices = region->triangleIndicesCount;
     DWORD const first_vertex = region->firstVertexIndex;
-    HANDLE const indices = (HANDLE)(sizeof(USHORT) * region->firstTriangleIndex);
+    HANDLE const indices = (HANDLE)(uintptr_t)(m3.indexofs + sizeof(USHORT) * region->firstTriangleIndex);
 #endif
 
     if (!M3_SetMaterialBlendMode(material)) {
@@ -742,9 +728,9 @@ static void M3_DrawRegionMaterialReference(m3Model_t const *model,
 }
 
 void M3_DrawDivisions(m3Model_t const *model, m3Divisions_t const *divisions, BOOL blendedPass) {
-    if (!model || !divisions || !divisions->indicesBuffer)
+    if (!model || !model->renbuf || !model->renbuf->ibo || !divisions)
         return;
-    R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, divisions->indicesBuffer);
+    m3.indexofs = divisions->indexofs;
     M3_FOR_EACH(Batch, batch, divisions->batches) {
         if (batch->regionIndex >= divisions->regionsNum ||
             batch->materialReferenceIndex >= model->materialReferencesNum)

--- a/games/starcraft-2/renderer/sc2/r_sc2map.c
+++ b/games/starcraft-2/renderer/sc2/r_sc2map.c
@@ -4,6 +4,7 @@ extern render_phase_t render_phase;
 
 #include "games/starcraft-2/common/sc2_map.c"
 #include "games/starcraft-2/renderer/m3/r_m3.h"
+#include "games/starcraft-2/renderer/sc2/sc2_shadow.h"
 #define SC2_REUSE_WAR3_CLIFF_BAKER
 #include "games/warcraft-3/renderer/w3m/r_war3map_cliffs.c"
 #undef SC2_REUSE_WAR3_CLIFF_BAKER

--- a/games/starcraft-2/renderer/sc2/sc2_shadow.h
+++ b/games/starcraft-2/renderer/sc2/sc2_shadow.h
@@ -1,0 +1,39 @@
+#ifndef SC2_SHADOW_H
+#define SC2_SHADOW_H
+
+#include "common/common.h"
+
+typedef struct SC2SHADOWVIEW {
+    MATRIX4 camera;
+    VECTOR3 target, light;
+    FLOAT reach;
+} SC2SHADOWVIEW;
+typedef struct SC2SHADOWVIEW *LPSC2SHADOWVIEW;
+typedef const struct SC2SHADOWVIEW *LPCSC2SHADOWVIEW;
+
+/* Fit native SC2 units to the visible ground footprint, rather than a WC3-sized 3000-unit square. */
+static BOOL sc2_shadow_matrix(LPCSC2SHADOWVIEW in, LPMATRIX4 out) {
+    MATRIX4 inv, view, proj;
+    VECTOR3 dir = in->light;
+    FLOAT radius = 0;
+    Matrix4_inverse(&in->camera, &inv);
+    FOR_LOOP(i, 4) {
+        VECTOR3 a = Matrix4_multiply_vector3(&inv, &(VECTOR3){ i & 1 ? 1 : -1, i & 2 ? 1 : -1, -1 });
+        VECTOR3 b = Matrix4_multiply_vector3(&inv, &(VECTOR3){ i & 1 ? 1 : -1, i & 2 ? 1 : -1, 1 });
+        VECTOR3 ray = Vector3_sub(&b, &a);
+        if (fabsf(ray.z) < 0.000001f) return false;
+        VECTOR3 ground = Vector3_mad(&a, (in->target.z - a.z) / ray.z, &ray);
+        radius = MAX(radius, Vector3_distance(&ground, &in->target));
+    }
+    if (radius <= 0 || Vector3_lengthsq(&dir) <= 0 || in->reach <= 0) return false;
+    Vector3_normalize(&dir);
+    VECTOR3 eye = Vector3_mad(&in->target, -in->reach, &dir);
+    /* A vertical sun needs a non-parallel up vector to define its light basis. */
+    VECTOR3 up = fabsf(dir.z) > 0.99f ? (VECTOR3){ 0, 1, 0 } : (VECTOR3){ 0, 0, 1 };
+    Matrix4_lookAt(&view, &eye, &dir, &up);
+    Matrix4_ortho(&proj, -radius, radius, -radius, radius, -radius, 2 * in->reach + radius);
+    Matrix4_multiply(&proj, &view, out);
+    return true;
+}
+
+#endif

--- a/games/starcraft-2/tests/test_sc2_map.c
+++ b/games/starcraft-2/tests/test_sc2_map.c
@@ -10,6 +10,7 @@
 #include "games/starcraft-2/common/sc2_map.h"
 #include "test.h"
 #include "games/starcraft-2/common/sc2_utils.h"
+#include "games/starcraft-2/renderer/m3/r_m3.h"
 
 #ifndef TEST_SC2_MPQ
 #define TEST_SC2_MPQ "build/tests/test-sc2.SC2Maps"
@@ -23,6 +24,14 @@
 
 static BOOL sc2_tests_initialized;
 static DWORD short_terrain_dimensions;
+
+TEST(sc2_map, m3_division_faces_pack_into_model_ranges) {
+    USHORT a[] = {0,1,2}, b[] = {2,3,0}, indices[6];
+    m3Divisions_t divisions[2] = {{.facesNum=3,.faces=a}, {.facesNum=3,.faces=b}};
+    T_EQ((int)m3_pack_division_faces(divisions, 2, indices), 6);
+    T_EQ((int)divisions[0].indexofs, 0); T_EQ((int)divisions[1].indexofs, 6);
+    T_EQ(indices[0], 0); T_EQ(indices[3], 2); T_EQ(indices[5], 0);
+}
 static DWORD listed_count;
 static PATHSTR listed_map;
 

--- a/games/starcraft-2/tests/test_sc2_map.c
+++ b/games/starcraft-2/tests/test_sc2_map.c
@@ -9,7 +9,7 @@
 #include "common.h"
 #include "games/starcraft-2/common/sc2_map.h"
 #include "test.h"
-#include "games/starcraft-2/common/sc2_utils.h"
+#include "games/starcraft-2/renderer/sc2/sc2_shadow.h"
 #include "games/starcraft-2/renderer/m3/r_m3.h"
 
 #ifndef TEST_SC2_MPQ

--- a/games/warcraft-3/common/stb_fdf.h
+++ b/games/warcraft-3/common/stb_fdf.h
@@ -24,7 +24,7 @@
 /* -------------------------------------------------------------------------- */
 #define MAX_BUILD_QUEUE 7
 #ifndef MAX_UI_CLASSES
-#define MAX_UI_CLASSES 4096
+#define MAX_UI_CLASSES 2048 // frames per module; measured peak is 1167, leaving 75% headroom
 #endif
 #include "ui_constants.h"
 #define UI_MAX_MAP_LIST_ITEMS 1024
@@ -121,10 +121,10 @@ typedef struct {
 #ifndef FRAMEPOINT_DEFINED
 #define FRAMEPOINT_DEFINED
 typedef struct {
-    uiFramePointPos_t targetPos;
-    bool used;
     LPCFRAMEDEF relativeTo;
     FLOAT offset;
+    uiFramePointPos_t targetPos: 7;
+    DWORD used: 1;
 } FRAMEPOINT;
 #endif
 
@@ -193,11 +193,11 @@ struct uiFrameDef_s {
     FLOAT Width, Height;
     COLOR32 Color;
     BLEND_MODE AlphaMode;
-    BOOL DecorateFileNames;
-    BOOL inuse;
-    BOOL AnyPointsSet;
-    BOOL hidden;
-    BOOL disabled;
+    DWORD DecorateFileNames: 1;
+    DWORD inuse: 1;
+    DWORD AnyPointsSet: 1;
+    DWORD hidden: 1;
+    DWORD disabled: 1;
     DWORD TextLength;
     DWORD Stat;
     LPSTR DynamicText;
@@ -212,15 +212,15 @@ struct uiFrameDef_s {
         BOX2 TexCoord;
     } Texture;
     struct {
-        BOOL TileBackground;
         DWORD Background;
         DWORD CornerFlags;
         FLOAT CornerSize;
         FLOAT BackgroundSize;
         FLOAT BackgroundInsets[4];
         DWORD EdgeFile;
-        BOOL BlendAll;
-        BOOL Mirrored;
+        DWORD TileBackground: 1;
+        DWORD BlendAll: 1;
+        DWORD Mirrored: 1;
     } Backdrop;
     UINAME DialogBackdropName;
     LPCFRAMEDEF DialogBackdrop;
@@ -315,9 +315,9 @@ struct uiFrameDef_s {
         FLOAT BorderSize;
         COLOR32 CursorColor;
         COLOR32 HighlightColor;
-        BOOL HighlightInitial;
         DWORD MaxChars;
-        BOOL Focus;
+        DWORD HighlightInitial: 1;
+        DWORD Focus: 1;
         UINAME Text;
         COLOR32 TextColor;
         UINAME TextFrame;
@@ -1076,6 +1076,7 @@ LPFRAMEDEF UI_Spawn(FRAMETYPE type, LPFRAMEDEF parent) {
             return frame;
         }
     }
+    fprintf(stderr, "FDF: frame capacity %u exhausted\n", MAX_UI_CLASSES);
     return NULL;
 }
 

--- a/games/warcraft-3/game.mk
+++ b/games/warcraft-3/game.mk
@@ -165,8 +165,8 @@ TEST_UI_SRCS := \
 
 $(eval $(call test_schema,test-commands,test-assets $(SHARED_LIB) $(SHEET_LIB),$(TEST_CFLAGS),$(BIN_DIR)/test_commands$(EXE_EXT),tests/test_runner.c $(WC3_TEST_DIR)/test_commands.c client/cl_screenshot.c common/common.c common/cmd.c common/cvar.c common/msg.c common/net.c common/mpq.c,-lsheet -lshared -lm -lz $(NET_LIBS),))
 $(eval $(call test_schema,test-server-net,test-assets $(SHARED_LIB) $(SHEET_LIB),$(TEST_CFLAGS),$(BIN_DIR)/test_server_net$(EXE_EXT),tests/test_runner.c $(WC3_TEST_DIR)/test_server_net.c $(WC3_TEST_DIR)/test_client_stubs.c server/sv_init.c server/sv_lan.c server/sv_main.c server/sv_lobby.c server/sv_send.c common/net.c common/msg.c,-lsheet -lshared -lm $(NET_LIBS),))
-$(eval $(call test_schema,test-renderer-model,$(SHARED_LIB),$(TEST_CFLAGS) -Wno-unused-function,$(BIN_DIR)/test_renderer_model$(EXE_EXT),tests/test_runner.c tests/test_renderer_model.c renderer/r_model.c,-lshared -lm $(LIBS),))
-$(eval $(call test_schema,test-renderer-shadows,$(SHARED_LIB),$(TEST_CFLAGS) -Wno-unused-function -DUSE_SHADOWMAPS,$(BIN_DIR)/test_renderer_shadows$(EXE_EXT),tests/test_runner.c tests/test_renderer_model.c renderer/r_model.c,-lshared -lm $(LIBS),))
+$(eval $(call test_schema,test-renderer-model,$(SHARED_LIB),$(TEST_CFLAGS) -Wno-unused-function,$(BIN_DIR)/test_renderer_model$(EXE_EXT),tests/test_runner.c tests/test_renderer_model.c renderer/r_model.c $(WC3_DIR)/renderer/mdx/r_mdx_buffer.c,-lshared -lm $(LIBS),))
+$(eval $(call test_schema,test-renderer-shadows,$(SHARED_LIB),$(TEST_CFLAGS) -Wno-unused-function -DUSE_SHADOWMAPS,$(BIN_DIR)/test_renderer_shadows$(EXE_EXT),tests/test_runner.c tests/test_renderer_model.c renderer/r_model.c $(WC3_DIR)/renderer/mdx/r_mdx_buffer.c,-lshared -lm $(LIBS),))
 $(eval $(call test_schema,test-ui,test-assets $(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB),$(TEST_UI_CFLAGS),$(BIN_DIR)/test_openwarcraft3_ui$(EXE_EXT),tests/test_runner.c $(TEST_UI_SRCS) common/mpq.c $(call CSRC,$(WC3_DIR)/ui),-lsheet -lshared -ljass -lm -lz,))
 
 test-mpq-compat: mpqtool $(MPQ_TEST)

--- a/games/warcraft-3/renderer/mdx/r_mdx.h
+++ b/games/warcraft-3/renderer/mdx/r_mdx.h
@@ -41,7 +41,7 @@ enum {
     MODEL_EMITTER_TAIL = 2
 };
 
-#define MAX_MDLX_BUFFERS 8
+enum { BZ_MDX_VERTEX_BUFFER, BZ_MDX_INDEX_BUFFER, BZ_MDX_BUFFER_COUNT };
 
 #define MDLXNODE_Helper 0
 #define MDLXNODE_DontInheritTranslation 1
@@ -337,11 +337,12 @@ typedef struct mdxGeoset_s {
     int num_bounds;
     int num_texcoordChannels;    
     DWORD vertexArrayBuffer;
-    DWORD buffer[MAX_MDLX_BUFFERS];
+    DWORD indexofs; // bytes into the model-owned index buffer; indices remain geoset-local
     struct mdxGeoset_s *next;
 } mdxGeoset_t;
 
 typedef struct mdxModel_s {
+    DWORD buffers[BZ_MDX_BUFFER_COUNT];
     DWORD version;
     mdxInfo_t info;
     mdxBounds_t bounds;
@@ -383,6 +384,8 @@ mdxSequence_t const *MDLX_FindSequenceByName(mdxModel_t const *model, LPCSTR nam
 
 mdxModel_t *R_LoadModelMDLX(void *buffer, DWORD size);
 void MDLX_Release(mdxModel_t *model);
+void MDX_BuildBuffers(mdxModel_t *model);
+void MDX_PackModelGeometry(mdxModel_t *model, LPVERTEX vertices, USHORT *indices);
 void MDLX_Init(void);
 void MDLX_Shutdown(void);
 void MDX_RenderModel(renderEntity_t const *entity, mdxModel_t const *model, LPCMATRIX4 model_matrix);

--- a/games/warcraft-3/renderer/mdx/r_mdx_buffer.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_buffer.c
@@ -1,0 +1,188 @@
+#include "r_mdx.h"
+
+typedef struct { DWORD count; int first; } MDXPALETTEERROR, *LPMDXPALETTEERROR;
+
+static BYTE R_AddGeosetMatrixPaletteEntry(mdxGeoset_t *geoset, int matrix_id, LPMDXPALETTEERROR overflow) {
+    if (matrix_id < 0) {
+        matrix_id = 0;
+    }
+    FOR_LOOP(i, geoset->num_matrixPalette) {
+        if (geoset->matrixPalette[i] == matrix_id) {
+            return (BYTE)i;
+        }
+    }
+    if (geoset->num_matrixPalette >= MDX_MATRIX_PALETTE) {
+        if (!overflow->count)
+            overflow->first = matrix_id;
+        overflow->count++;
+        return 0;
+    }
+    geoset->matrixPalette[geoset->num_matrixPalette] = matrix_id;
+    return (BYTE)geoset->num_matrixPalette++;
+}
+
+/* Keep geoset-local palette indices while packing every stream into the shared vertex format. */
+static void mdx_pack_vertices(mdxGeoset_t *geoset, LPVERTEX vertices) {
+    typedef BYTE matrixGroup_t[MAX_SKIN_BONES];
+    DWORD matrixGroupCount = geoset->num_matrixGroupSizes > 0 && geoset->matrixGroupSizes && geoset->matrices
+        ? (DWORD)geoset->num_matrixGroupSizes
+        : 1;
+    matrixGroup_t *matrixGroups = ri.MemAlloc(sizeof(matrixGroup_t) * matrixGroupCount);
+    DWORD indexOffset = 0;
+    MDXPALETTEERROR overflow = {0};
+    geoset->matrixPalette = ri.MemAlloc(sizeof(*geoset->matrixPalette) * MDX_MATRIX_PALETTE);
+    geoset->num_matrixPalette = 0;
+
+    FOR_LOOP(matrixGroupIndex, matrixGroupCount) {
+        memset(&matrixGroups[matrixGroupIndex], 0x00, sizeof(matrixGroup_t));
+        if (matrixGroupCount == 1 &&
+            (!geoset->matrixGroupSizes || !geoset->matrices || geoset->num_matrixGroupSizes <= 0)) {
+            matrixGroups[matrixGroupIndex][0] = R_AddGeosetMatrixPaletteEntry(geoset, 0, &overflow);
+            continue;
+        }
+        DWORD sourceGroupSize = geoset->matrixGroupSizes[matrixGroupIndex];
+        DWORD groupSize = MIN(sourceGroupSize, MAX_SKIN_BONES);
+        if (indexOffset >= (DWORD)geoset->num_matrices) {
+            groupSize = 0;
+        } else if (indexOffset + groupSize > (DWORD)geoset->num_matrices) {
+            groupSize = (DWORD)geoset->num_matrices - indexOffset;
+        }
+        FOR_LOOP(matrixIndex, groupSize) {
+            int matrix_id = geoset->matrices[indexOffset + matrixIndex];
+            matrixGroups[matrixGroupIndex][matrixIndex] = R_AddGeosetMatrixPaletteEntry(geoset, matrix_id, &overflow);
+        }
+        /* Top-four filtering consumes four matrices but the next group still
+           starts after the complete file-shaped group. */
+        indexOffset += sourceGroupSize;
+    }
+    if (overflow.count) {
+        fprintf(stderr,
+                "MDX geoset uses more than %d unique matrices; %u matrix refs fell back to palette slot 0 (first node %d)\n",
+                MDX_MATRIX_PALETTE,
+                overflow.count,
+                overflow.first);
+    }
+
+    FOR_LOOP(vertex, geoset->num_vertices) {
+        vertices[vertex].position = geoset->vertices[vertex];
+        vertices[vertex].normal = geoset->normals[vertex];
+        vertices[vertex].texcoord = geoset->texcoord[vertex];
+        vertices[vertex].color = COLOR32_WHITE;
+        DWORD matrixGroupIndex = 0;
+        DWORD matrixGroupSize = 1;
+        BYTE leftover = 0xff;
+        BYTE leftoversize = 1;
+        if (geoset->vertexGroups && geoset->matrixGroupSizes && geoset->num_matrixGroupSizes > 0) {
+            matrixGroupIndex = (BYTE)geoset->vertexGroups[vertex];
+            if (matrixGroupIndex >= matrixGroupCount) {
+                matrixGroupIndex = matrixGroupCount - 1;
+            }
+            matrixGroupSize = MAX(1, geoset->matrixGroupSizes[matrixGroupIndex]);
+            if (matrixGroupSize > MAX_SKIN_BONES) {
+                matrixGroupSize = MAX_SKIN_BONES;
+            }
+            if (matrixGroupSize > geoset->num_matrices) {
+                matrixGroupSize = geoset->num_matrices;
+            }
+            leftoversize = matrixGroupSize;
+        }
+        BYTE *matrixGroup = matrixGroups[matrixGroupIndex];
+        /* Distribute equal weights across all bones in the group, then keep
+           the top 4 by weight (descending) and renormalize to sum=255. */
+        BYTE rawSkin[MAX_SKIN_BONES] = {0};
+        BYTE rawWeight[MAX_SKIN_BONES] = {0};
+        memcpy(rawSkin, matrixGroup, MAX_SKIN_BONES);
+        if (matrixGroupCount == 1 && matrixGroup[0] == 0) {
+            rawWeight[0] = 255;
+        } else {
+            FOR_LOOP(matrixIndex, matrixGroupSize) {
+                BYTE value = (float)leftover / (float)leftoversize;
+                rawWeight[matrixIndex] = value;
+                leftover = MAX(0, leftover - value);
+                leftoversize = MAX(1, leftoversize - 1);
+            }
+        }
+        /* Insertion-sort top 4 (weight desc) into the 4-slot skin/boneWeight. */
+        memset(vertices[vertex].skin, 0, 4);
+        memset(vertices[vertex].boneWeight, 0, 4);
+        FOR_LOOP(i, MAX_SKIN_BONES) {
+            if (!rawWeight[i]) continue;
+            FOR_LOOP(j, 4) {
+                if (rawWeight[i] > vertices[vertex].boneWeight[j]) {
+                    /* Shift lower entries down, dropping slot 3. */
+                    for (int k = 3; k > (int)j; k--) {
+                        vertices[vertex].skin[k] = vertices[vertex].skin[k - 1];
+                        vertices[vertex].boneWeight[k] = vertices[vertex].boneWeight[k - 1];
+                    }
+                    vertices[vertex].skin[j] = rawSkin[i];
+                    vertices[vertex].boneWeight[j] = rawWeight[i];
+                    break;
+                }
+            }
+        }
+        /* Renormalize top-4 weights to sum=255. */
+        DWORD wsum = 0;
+        FOR_LOOP(j, 4) wsum += vertices[vertex].boneWeight[j];
+        if (wsum && wsum != 255) {
+            DWORD acc = 0;
+            FOR_LOOP(j, 4) {
+                DWORD w = vertices[vertex].boneWeight[j] * 255 / wsum;
+                vertices[vertex].boneWeight[j] = (BYTE)w;
+                acc += w;
+            }
+            /* Fix rounding remainder in the highest-weight slot. */
+            if (acc < 255) vertices[vertex].boneWeight[0] += (BYTE)(255 - acc);
+        }
+    }
+    ri.MemFree(matrixGroups);
+}
+
+/* One model owns two buffers; VAOs retain each geoset's vertex range and local 16-bit index interpretation. */
+void MDX_PackModelGeometry(mdxModel_t *model, LPVERTEX vertices, USHORT *indices) {
+    DWORD base = 0, elems = 0;
+    FOR_EACH_LIST(mdxGeoset_t, geo, model->geosets) {
+        mdx_pack_vertices(geo, vertices + base);
+        memcpy(indices + elems, geo->triangles, geo->num_triangles * sizeof(*indices));
+        geo->indexofs = elems * sizeof(*indices);
+        elems += geo->num_triangles; base += geo->num_vertices;
+    }
+}
+
+/* Build compact model-owned GPU storage after all geoset blocks have been parsed. */
+void MDX_BuildBuffers(mdxModel_t *model) {
+    static const struct { GLuint attr; GLint size; GLenum type; GLboolean norm; size_t ofs; } attrs[] = {
+        { attrib_position, 3, GL_FLOAT, GL_FALSE, offsetof(VERTEX, position) },
+        { attrib_texcoord, 2, GL_FLOAT, GL_FALSE, offsetof(VERTEX, texcoord) },
+        { attrib_normal, 3, GL_FLOAT, GL_FALSE, offsetof(VERTEX, normal) },
+        { attrib_color, 4, GL_UNSIGNED_BYTE, GL_TRUE, offsetof(VERTEX, color) },
+        { attrib_skin1, 4, GL_UNSIGNED_BYTE, GL_FALSE, offsetof(VERTEX, skin) },
+        { attrib_boneWeight1, 4, GL_UNSIGNED_BYTE, GL_TRUE, offsetof(VERTEX, boneWeight) },
+    };
+    DWORD verts = 0, elems = 0, base = 0;
+    FOR_EACH_LIST(mdxGeoset_t, geo, model->geosets) {
+        verts += geo->num_vertices;
+        elems += geo->num_triangles;
+    }
+    if (!model->geosets) return;
+    LPVERTEX vertices = ri.MemAlloc(verts * sizeof(*vertices));
+    USHORT *indices = ri.MemAlloc(elems * sizeof(*indices));
+    MDX_PackModelGeometry(model, vertices, indices);
+    R_Call(glGenBuffers, BZ_MDX_BUFFER_COUNT, model->buffers);
+    R_Call(glBindBuffer, GL_ARRAY_BUFFER, model->buffers[BZ_MDX_VERTEX_BUFFER]);
+    R_Call(glBufferData, GL_ARRAY_BUFFER, verts * sizeof(*vertices), vertices, GL_STATIC_DRAW);
+    base = 0;
+    FOR_EACH_LIST(mdxGeoset_t, geo, model->geosets) {
+        R_Call(glGenVertexArrays, 1, &geo->vertexArrayBuffer);
+        R_Call(glBindVertexArray, geo->vertexArrayBuffer);
+        R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, model->buffers[BZ_MDX_INDEX_BUFFER]);
+        FOR_LOOP(i, sizeof(attrs) / sizeof(*attrs)) {
+            R_Call(glEnableVertexAttribArray, attrs[i].attr);
+            R_Call(glVertexAttribPointer, attrs[i].attr, attrs[i].size, attrs[i].type, attrs[i].norm,
+                sizeof(VERTEX), (void *)(base * sizeof(VERTEX) + attrs[i].ofs));
+        }
+        base += geo->num_vertices;
+    }
+    /* Upload once after binding a VAO: core GL owns the element-buffer binding in the VAO. */
+    R_Call(glBufferData, GL_ELEMENT_ARRAY_BUFFER, elems * sizeof(*indices), indices, GL_STATIC_DRAW);
+    ri.MemFree(indices); ri.MemFree(vertices);
+}

--- a/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
@@ -508,10 +508,10 @@ static void MDLX_RenderGeoset(mdxModel_t const *model,
         LPCTEXTURE texture = MDLX_GetTexture(model, team, textureId, modeltex->replaceableID, overrideTexture);
         R_BindTexture(texture, 0);
         R_Call(glBindVertexArray, geoset->vertexArrayBuffer);
-        R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, *geoset->buffer);
+        /* The geoset VAO already binds the model-owned index buffer. */
         R_StatsDraw(GL_TRIANGLES, geoset->num_triangles, 1);
         R_ApplyShader(shader);
-        R_Call(glDrawElements, GL_TRIANGLES, geoset->num_triangles, GL_UNSIGNED_SHORT, NULL);
+        R_Call(glDrawElements, GL_TRIANGLES, geoset->num_triangles, GL_UNSIGNED_SHORT, (void *)(uintptr_t)geoset->indexofs);
     }
 
     R_Call(glEnable, GL_DEPTH_TEST);

--- a/games/warcraft-3/renderer/mdx/r_mdx_load.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_load.c
@@ -114,188 +114,6 @@ DWORD R_ModelFindBiggestGroup(mdxGeoset_t const *geoset) {
     return biggest;
 }
 
-static BYTE R_AddGeosetMatrixPaletteEntry(mdxGeoset_t *geoset, int matrix_id, DWORD *overflow_count, int *overflow_first) {
-    if (matrix_id < 0) {
-        matrix_id = 0;
-    }
-    FOR_LOOP(i, geoset->num_matrixPalette) {
-        if (geoset->matrixPalette[i] == matrix_id) {
-            return (BYTE)i;
-        }
-    }
-    if (geoset->num_matrixPalette >= MDX_MATRIX_PALETTE) {
-        if (!*overflow_count)
-            *overflow_first = matrix_id;
-        (*overflow_count)++;
-        return 0;
-    }
-    geoset->matrixPalette[geoset->num_matrixPalette] = matrix_id;
-    return (BYTE)geoset->num_matrixPalette++;
-}
-
-void R_SetupGeosetVertexBuffer(mdxGeoset_t *geoset) {
-    typedef BYTE matrixGroup_t[MAX_SKIN_BONES];
-    mdxVertexSkin_t *vertices = ri.MemAlloc(sizeof(mdxVertexSkin_t) * geoset->num_vertices);
-    DWORD matrixGroupCount = geoset->num_matrixGroupSizes > 0 && geoset->matrixGroupSizes && geoset->matrices
-        ? (DWORD)geoset->num_matrixGroupSizes
-        : 1;
-    matrixGroup_t *matrixGroups = ri.MemAlloc(sizeof(matrixGroup_t) * matrixGroupCount);
-    DWORD indexOffset = 0;
-    DWORD paletteOverflowCount = 0;
-    int paletteOverflowFirst = 0;
-    geoset->matrixPalette = ri.MemAlloc(sizeof(*geoset->matrixPalette) * MDX_MATRIX_PALETTE);
-    geoset->num_matrixPalette = 0;
-
-    FOR_LOOP(matrixGroupIndex, matrixGroupCount) {
-        memset(&matrixGroups[matrixGroupIndex], 0x00, sizeof(matrixGroup_t));
-        if (matrixGroupCount == 1 && (!geoset->matrixGroupSizes || !geoset->matrices || geoset->num_matrixGroupSizes <= 0)) {
-            matrixGroups[matrixGroupIndex][0] = R_AddGeosetMatrixPaletteEntry(geoset, 0, &paletteOverflowCount, &paletteOverflowFirst);
-            continue;
-        }
-        DWORD sourceGroupSize = geoset->matrixGroupSizes[matrixGroupIndex];
-        DWORD groupSize = MIN(sourceGroupSize, MAX_SKIN_BONES);
-        if (indexOffset >= (DWORD)geoset->num_matrices) {
-            groupSize = 0;
-        } else if (indexOffset + groupSize > (DWORD)geoset->num_matrices) {
-            groupSize = (DWORD)geoset->num_matrices - indexOffset;
-        }
-        FOR_LOOP(matrixIndex, groupSize) {
-            int matrix_id = geoset->matrices[indexOffset + matrixIndex];
-            matrixGroups[matrixGroupIndex][matrixIndex] = R_AddGeosetMatrixPaletteEntry(
-                geoset, matrix_id, &paletteOverflowCount, &paletteOverflowFirst);
-        }
-        /* Top-four filtering consumes four matrices but the next group still
-           starts after the complete file-shaped group. */
-        indexOffset += sourceGroupSize;
-    }
-    if (paletteOverflowCount) {
-        fprintf(stderr,
-                "MDX geoset uses more than %d unique matrices; %u matrix refs fell back to palette slot 0 (first node %d)\n",
-                MDX_MATRIX_PALETTE,
-                paletteOverflowCount,
-                paletteOverflowFirst);
-    }
-
-    FOR_LOOP(vertex, geoset->num_vertices) {
-        DWORD matrixGroupIndex = 0;
-        DWORD matrixGroupSize = 1;
-        BYTE leftover = 0xff;
-        BYTE leftoversize = 1;
-        if (geoset->vertexGroups && geoset->matrixGroupSizes && geoset->num_matrixGroupSizes > 0) {
-            matrixGroupIndex = (BYTE)geoset->vertexGroups[vertex];
-            if (matrixGroupIndex >= matrixGroupCount) {
-                matrixGroupIndex = matrixGroupCount - 1;
-            }
-            matrixGroupSize = MAX(1, geoset->matrixGroupSizes[matrixGroupIndex]);
-            if (matrixGroupSize > MAX_SKIN_BONES) {
-                matrixGroupSize = MAX_SKIN_BONES;
-            }
-            if (matrixGroupSize > geoset->num_matrices) {
-                matrixGroupSize = geoset->num_matrices;
-            }
-            leftoversize = matrixGroupSize;
-        }
-        BYTE *matrixGroup = matrixGroups[matrixGroupIndex];
-        /* Distribute equal weights across all bones in the group, then keep
-           the top 4 by weight (descending) and renormalize to sum=255. */
-        BYTE rawSkin[MAX_SKIN_BONES] = {0};
-        BYTE rawWeight[MAX_SKIN_BONES] = {0};
-        memcpy(rawSkin, matrixGroup, MAX_SKIN_BONES);
-        if (matrixGroupCount == 1 && matrixGroup[0] == 0) {
-            rawWeight[0] = 255;
-        } else {
-            FOR_LOOP(matrixIndex, matrixGroupSize) {
-                BYTE value = (float)leftover / (float)leftoversize;
-                rawWeight[matrixIndex] = value;
-                leftover = MAX(0, leftover - value);
-                leftoversize = MAX(1, leftoversize - 1);
-            }
-        }
-        /* Insertion-sort top 4 (weight desc) into the 4-slot skin/boneWeight. */
-        memset(vertices[vertex].skin, 0, 4);
-        memset(vertices[vertex].boneWeight, 0, 4);
-        FOR_LOOP(i, MAX_SKIN_BONES) {
-            if (!rawWeight[i]) continue;
-            FOR_LOOP(j, 4) {
-                if (rawWeight[i] > vertices[vertex].boneWeight[j]) {
-                    /* Shift lower entries down, dropping slot 3. */
-                    for (int k = 3; k > (int)j; k--) {
-                        vertices[vertex].skin[k] = vertices[vertex].skin[k - 1];
-                        vertices[vertex].boneWeight[k] = vertices[vertex].boneWeight[k - 1];
-                    }
-                    vertices[vertex].skin[j] = rawSkin[i];
-                    vertices[vertex].boneWeight[j] = rawWeight[i];
-                    break;
-                }
-            }
-        }
-        /* Renormalize top-4 weights to sum=255. */
-        DWORD wsum = 0;
-        FOR_LOOP(j, 4) wsum += vertices[vertex].boneWeight[j];
-        if (wsum && wsum != 255) {
-            DWORD acc = 0;
-            FOR_LOOP(j, 4) {
-                DWORD w = vertices[vertex].boneWeight[j] * 255 / wsum;
-                vertices[vertex].boneWeight[j] = (BYTE)w;
-                acc += w;
-            }
-            /* Fix rounding remainder in the highest-weight slot. */
-            if (acc < 255) vertices[vertex].boneWeight[0] += (BYTE)(255 - acc);
-        }
-    }
-    R_Call(glGenVertexArrays, 1, &geoset->vertexArrayBuffer);
-    R_Call(glBindVertexArray, geoset->vertexArrayBuffer);
-    R_Call(glGenBuffers, MAX_MDLX_BUFFERS, geoset->buffer);
-    R_Call(glBindBuffer, GL_ARRAY_BUFFER, geoset->buffer[1]);
-    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(VECTOR3) * geoset->num_vertices, geoset->vertices, GL_STATIC_DRAW);
-    R_Call(glVertexAttribPointer, attrib_position, 3, GL_FLOAT, GL_FALSE, 0, 0);
-    R_Call(glEnableVertexAttribArray, attrib_position);
-
-    R_Call(glBindBuffer, GL_ARRAY_BUFFER, geoset->buffer[2]);
-    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(VECTOR2) * geoset->num_texcoord, geoset->texcoord, GL_STATIC_DRAW);
-    R_Call(glVertexAttribPointer, attrib_texcoord, 2, GL_FLOAT, GL_FALSE, 0, 0);
-    R_Call(glEnableVertexAttribArray, attrib_texcoord);
-
-    R_Call(glBindBuffer, GL_ARRAY_BUFFER, geoset->buffer[3]);
-    R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(VECTOR3) * geoset->num_normals, geoset->normals, GL_STATIC_DRAW);
-    R_Call(glVertexAttribPointer, attrib_normal, 3, GL_FLOAT, GL_FALSE, 0, 0);
-    R_Call(glEnableVertexAttribArray, attrib_normal);
-
-    R_Call(glBindBuffer, GL_ARRAY_BUFFER, geoset->buffer[4]);
-
-    R_Call(glEnableVertexAttribArray, attrib_skin1);
-    R_Call(glEnableVertexAttribArray, attrib_boneWeight1);
-
-    R_Call(glVertexAttribPointer, attrib_skin1, 4, GL_UNSIGNED_BYTE, GL_FALSE, sizeof(mdxVertexSkin_t), FOFS(mdxVertexSkin_s, skin[0]));
-    R_Call(glVertexAttribPointer, attrib_boneWeight1, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(mdxVertexSkin_t), FOFS(mdxVertexSkin_s, boneWeight[0]));
-
-    R_Call(glBufferData, GL_ARRAY_BUFFER, geoset->num_vertices * sizeof(mdxVertexSkin_t), vertices, GL_STATIC_DRAW);
-
-    /* MDX models have no per-vertex colour data.  The unified model shader
-     * multiplies the sampled texture by v_color (i_color attribute), so we
-     * supply a white (255,255,255,255) buffer to make it a no-op. */
-    {
-        typedef BYTE color4_t[4];
-        color4_t *whiteColors = ri.MemAlloc(sizeof(color4_t) * geoset->num_vertices);
-        FOR_LOOP(i, geoset->num_vertices) {
-            whiteColors[i][0] = 255;
-            whiteColors[i][1] = 255;
-            whiteColors[i][2] = 255;
-            whiteColors[i][3] = 255;
-        }
-        R_Call(glBindBuffer, GL_ARRAY_BUFFER, geoset->buffer[5]);
-        R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(color4_t) * geoset->num_vertices, whiteColors, GL_STATIC_DRAW);
-        R_Call(glEnableVertexAttribArray, attrib_color);
-        R_Call(glVertexAttribPointer, attrib_color, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, 0);
-        ri.MemFree(whiteColors);
-    }
-
-    R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, geoset->buffer[0]);
-    R_Call(glBufferData, GL_ELEMENT_ARRAY_BUFFER, sizeof(USHORT) * geoset->num_triangles, geoset->triangles, GL_STATIC_DRAW);
-            
-    ri.MemFree(vertices);
-    ri.MemFree(matrixGroups);
-}
 
 void R_ReleaseModelNode(mdxNode_t *node) {
     SAFE_DELETE(node->translation, ri.MemFree);
@@ -399,7 +217,6 @@ void ReadGeoset(LPSIZEBUF buffer, mdxGeoset_t *geoset) {
                 break;
         }
     };
-    R_SetupGeosetVertexBuffer(geoset);
 }
 
 void ReadKeyTrack(LPSIZEBUF buffer, MODELKEYTRACKDATATYPE dataType, mdxKeyTrack_t **output) {
@@ -894,6 +711,7 @@ mdxModel_t *R_LoadModelMDLX(void *data, DWORD size) {
             geoset->geosetAnim = geosetAnim;
         }
     }
+    MDX_BuildBuffers(model);
     model->bounds = MDX_CalculateBounds(model);
     return model;
 }
@@ -906,7 +724,6 @@ void MDLX_ReleaseModelNode(mdxNode_t *node) {
 
 void MDLX_ReleaseModelGeoset(mdxGeoset_t *geoset) {
     R_Call(glDeleteVertexArrays, 1, &geoset->vertexArrayBuffer);
-    R_Call(glDeleteBuffers, MAX_MDLX_BUFFERS, geoset->buffer);
 
     SAFE_DELETE(geoset->next, MDLX_ReleaseModelGeoset);
     SAFE_DELETE(geoset->vertices, ri.MemFree);
@@ -980,6 +797,7 @@ void MDLX_ReleaseModelLight(mdxLight_t *light) {
 
 void MDLX_Release(mdxModel_t *model) {
     SAFE_DELETE(model->geosets, MDLX_ReleaseModelGeoset);
+    R_Call(glDeleteBuffers, BZ_MDX_BUFFER_COUNT, model->buffers);
     SAFE_DELETE(model->materials, MDLX_ReleaseModelMaterial);
     SAFE_DELETE(model->textureAnims, MDLX_ReleaseModelTextureAnim);
     SAFE_DELETE(model->bones, MDLX_ReleaseModelBone);

--- a/games/warcraft-3/renderer/w3m/r_war3map_ground.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_ground.c
@@ -299,11 +299,8 @@ LPMAPLAYER R_BuildMapSegmentLayer(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD laye
 }
 
 LPMAPLAYER R_BuildGroundLayerGlobal(LPCWAR3MAP map, DWORD layer) {
-    static LPVERTEX whole_map_buffer = NULL;
-    static DWORD whole_map_capacity = 0;
     LPMAPLAYER mapLayer;
     PATHSTR zBuffer;
-    DWORD needed;
 
     if (g_groundTextures[layer] == NULL) {
         char groundID[5] = { 0 };
@@ -318,11 +315,8 @@ LPMAPLAYER R_BuildGroundLayerGlobal(LPCWAR3MAP map, DWORD layer) {
         }
     }
 
-    needed = map->width * map->height * 6;
-    if (needed > whole_map_capacity) {
-        whole_map_buffer = ri.MemAlloc(sizeof(VERTEX) * needed);
-        whole_map_capacity = needed;
-    }
+    /* Construction scratch must not remain resident (or leak when the next map is larger). */
+    LPVERTEX whole_map_buffer = ri.MemAlloc(sizeof(VERTEX) * (map->width - 1) * (map->height - 1) * 6);
 
     mapLayer = ri.MemAlloc(sizeof(MAPLAYER));
     mapLayer->texture = g_groundTextures[layer];
@@ -334,10 +328,14 @@ LPMAPLAYER R_BuildGroundLayerGlobal(LPCWAR3MAP map, DWORD layer) {
         }
     }
     mapLayer->num_vertices = (DWORD)(ground_current_vertex - whole_map_buffer);
-    if (mapLayer->num_vertices == 0) {
+    if (mapLayer->num_vertices)
+        mapLayer->buffer = R_MakeVertexArrayObject(whole_map_buffer, mapLayer->num_vertices);
+    ri.MemFree(whole_map_buffer);
+    ground_current_vertex = NULL;
+    if (!mapLayer->num_vertices) {
+        ri.MemFree(mapLayer);
         return NULL;
     }
-    mapLayer->buffer = R_MakeVertexArrayObject(whole_map_buffer, mapLayer->num_vertices);
     return mapLayer;
 }
 

--- a/games/warcraft-3/tests/test_server_net.c
+++ b/games/warcraft-3/tests/test_server_net.c
@@ -506,9 +506,9 @@ TEST(server_net, server_snapshot_ring_scales_to_client_capacity) {
     reset_server_state(4);
 
     SV_InitGame();
-
-    T_EQ(svs.num_client_entities, (DWORD)(test_ge.max_clients * MAX_PACKET_ENTITIES));
-    T_ASSERT(svs.num_client_entities < (DWORD)(UPDATE_BACKUP * test_ge.max_clients * MAX_PACKET_ENTITIES));
+    /* History is required; the old test omitted it before the per-frame packet budget was reduced. */
+    T_EQ(svs.num_client_entities, (DWORD)(test_ge.max_clients * MAX_PACKET_ENTITIES * UPDATE_BACKUP));
+    T_ASSERT(svs.num_client_entities < (DWORD)(UPDATE_BACKUP * test_ge.max_clients * MAX_GAME_ENTITIES));
     T_ASSERT(svs.client_entities != NULL);
 }
 

--- a/games/warcraft-3/tests/test_ui_fdf.c
+++ b/games/warcraft-3/tests/test_ui_fdf.c
@@ -325,6 +325,15 @@ TEST(ui_fdf, parse_single_frame_definition) {
     T_NULL(root->Parent);
 }
 
+TEST(ui_fdf, compact_pool_preserves_capacity_and_reports_exhaustion) {
+    LPFRAMEDEF last = NULL;
+    reset_ui_state();
+    FOR_LOOP(i, MAX_UI_CLASSES - 1) last = UI_Spawn(FT_FRAME, NULL);
+    T_NOT_NULL(last); T_ASSERT(last == &frames[MAX_UI_CLASSES - 1]);
+    T_NULL(UI_Spawn(FT_FRAME, NULL));
+    T_ASSERT(sizeof(FRAMEPOINT) <= sizeof(void *) + 8);
+}
+
 TEST(ui_fdf, parse_nested_parent_child_relationship) {
     LPFRAMEDEF root;
     LPFRAMEDEF child;

--- a/games/world-of-warcraft/renderer/m2/r_m2.c
+++ b/games/world-of-warcraft/renderer/m2/r_m2.c
@@ -19,9 +19,8 @@ typedef struct m2KnownTexture_s {
 static m2KnownTexture_t *m2_known_textures;
 
 typedef struct m2ModelBatch_s {
-	LPBUFFER buffer;
 	LPTEXTURE texture;
-	DWORD num_vertices;
+	DRAWELEMENTS draw;
 	DWORD texture_type;
 	WORD bone_count;
 	WORD bone_combo_index;
@@ -44,6 +43,7 @@ struct m2Model_s {
     BOX3 geometry_bounds;
     DWORD flags;
     /* Renderer-owned state that has no representation in the M2 file. */
+    LPBUFFER buffer;
     m2ModelBatch_t *batches;
     DWORD num_batches;
 };
@@ -57,6 +57,8 @@ typedef struct {
     m2Box_t bounding_box;
 } m2GeometryInfo_t;
 
+typedef struct { LPCVERTEX vertices; DWORD num_vertices; DWORD const *indices; DWORD num_indices; } M2BUFFERDATA;
+
 static MODELPROG * m2_shader;
 static MATRIX4 m2_bone_matrices[M2_MAX_BONES];
 
@@ -65,6 +67,16 @@ static MODELPROG * M2_Shader(void) {
         m2_shader = R_ModelShader();
     }
     return m2_shader;
+}
+
+/* Concatenate the old batch-expanded geometry so one model still owns exactly one VBO and one EBO. */
+static LPBUFFER M2_MakeBuffer(M2BUFFERDATA const *data) {
+    LPBUFFER buffer = R_MakeVertexArrayObject(data->vertices, data->num_vertices);
+    R_Call(glBindVertexArray, buffer->vao);
+    R_Call(glGenBuffers, 1, &buffer->ibo);
+    R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, buffer->ibo);
+    R_Call(glBufferData, GL_ELEMENT_ARRAY_BUFFER, data->num_indices * sizeof(*data->indices), data->indices, GL_STATIC_DRAW);
+    return buffer;
 }
 
 static void M2_LogFallback(LPCSTR modelFilename, LPCSTR reason) {
@@ -78,6 +90,7 @@ static void M2_LogFallback(LPCSTR modelFilename, LPCSTR reason) {
 
 static m2Model_t *M2_CreateFallbackModel(LPCSTR modelFilename, LPCSTR reason) {
     static VERTEX vertices[12];
+    static DWORD indices[12];
     static BOOL initialized;
     m2Model_t *model;
     m2ModelBatch_t *batch;
@@ -103,12 +116,14 @@ static m2Model_t *M2_CreateFallbackModel(LPCSTR modelFilename, LPCSTR reason) {
             vertices[i].normal = (VECTOR3){ 0.0f, 0.0f, 1.0f };
             vertices[i].texcoord = (VECTOR2){ 0.0f, 0.0f };
             vertices[i].color = color;
+            indices[i] = i;
         }
         initialized = true;
     }
 
     model = ri.MemAlloc(sizeof(*model));
     memset(model, 0, sizeof(*model));
+    snprintf(model->filename, sizeof(model->filename), "%s", modelFilename ? modelFilename : "<null>");
     model->bounds = (BOX3){
         .min = { -14.0f, -14.0f, 0.0f },
         .max = { 14.0f, 14.0f, 42.0f },
@@ -116,9 +131,9 @@ static m2Model_t *M2_CreateFallbackModel(LPCSTR modelFilename, LPCSTR reason) {
     model->geometry_bounds = model->bounds;
     batch = ri.MemAlloc(sizeof(*batch));
     memset(batch, 0, sizeof(*batch));
-    batch->buffer = R_MakeVertexArrayObject(vertices, 12);
+    model->buffer = M2_MakeBuffer(&(M2BUFFERDATA){ vertices, 12, indices, 12 });
     batch->texture = tr.texture[TEX_WHITE];
-    batch->num_vertices = 12;
+    batch->draw.count = 12;
     model->batches = batch;
     model->num_batches = 1;
     return model;
@@ -1328,10 +1343,7 @@ static BOOL M2_SkinPath(LPCSTR model_path, LPSTR out, DWORD out_size) {
 static VERTEX M2_MakeVertex(m2VertexDisk_t const *src) {
     VERTEX out;
     memset(&out, 0, sizeof(out));
-    out.position = src->pos;
-    out.normal = src->normal;
-    out.texcoord = src->tex_coords[0];
-    out.color = COLOR32_WHITE;
+    out.position = src->pos; out.normal = src->normal; out.texcoord = src->tex_coords[0]; out.color = COLOR32_WHITE;
     memcpy(out.skin, src->bone_indices, sizeof(src->bone_indices));
     memcpy(out.boneWeight, src->bone_weights, sizeof(src->bone_weights));
     return out;
@@ -1573,6 +1585,8 @@ m2Model_t *R_LoadModelM2(LPCSTR modelFilename, void *buffer, DWORD size, BOOL *b
     m2Batch_t const *batches;
     m2Ubyte4_t const *skin_bones;
     m2Model_t *model;
+    VERTEX *verts;
+    DWORD *indices;
     DWORD batch_count;
     DWORD section_count;
     DWORD skin_vertex_count;
@@ -1583,6 +1597,7 @@ m2Model_t *R_LoadModelM2(LPCSTR modelFilename, void *buffer, DWORD size, BOOL *b
     DWORD version;
     m2FormatDef_t const *format;
     DWORD base_offset = 0;
+    DWORD total_indices = 0, vertex_offset = 0;
 
     if (buffer_owned) *buffer_owned = false;
 
@@ -1652,6 +1667,12 @@ m2Model_t *R_LoadModelM2(LPCSTR modelFilename, void *buffer, DWORD size, BOOL *b
         SAFE_DELETE(skin_data, ri.FS_FreeFile);
         return M2_CreateFallbackModel(modelFilename, using_legacy_view ? "invalid legacy embedded view" : "missing skin profile");
     }
+    FOR_LOOP(i, skin_vertex_count) {
+        if (skin_vertices[i] >= (DWORD)geom.vertices.size) {
+            SAFE_DELETE(skin_data, ri.FS_FreeFile);
+            return M2_CreateFallbackModel(modelFilename, "skin vertex lookup exceeds model vertices");
+        }
+    }
 
     model = ri.MemAlloc(sizeof(*model));
     memset(model, 0, sizeof(*model));
@@ -1679,6 +1700,29 @@ m2Model_t *R_LoadModelM2(LPCSTR modelFilename, void *buffer, DWORD size, BOOL *b
 		}
 	}
 
+    /* Preserve the old batch-expanded vertex interpretation while sharing the two GL buffers. */
+    FOR_LOOP(i, batch_count) {
+        m2Batch_t const *batch = &batches[i];
+        DWORD start, count;
+        if (batch->skin_section_index >= section_count) continue;
+        if (using_legacy_view) {
+            m2SkinSectionLegacy_t const *section = &((m2SkinSectionLegacy_t const *)sections)[batch->skin_section_index];
+            start = section->index_start; count = section->index_count;
+        } else {
+            m2SkinSection_t const *section = &((m2SkinSection_t const *)sections)[batch->skin_section_index];
+            start = section->index_start; count = section->index_count;
+        }
+        if (count && m2_validate_skin_vertex_range(skin_vertices, skin_vertex_count, skin_indices,
+            skin_index_count, (DWORD)geom.vertices.size, start, count)) total_indices += count;
+    }
+    verts = total_indices ? ri.MemAlloc(sizeof(*verts) * total_indices) : NULL;
+    indices = total_indices ? ri.MemAlloc(sizeof(*indices) * total_indices) : NULL;
+    if (total_indices && (!verts || !indices)) {
+        SAFE_DELETE(verts, ri.MemFree); SAFE_DELETE(indices, ri.MemFree); SAFE_DELETE(skin_data, ri.FS_FreeFile);
+        M2_FreeModelData(model); ri.MemFree(model);
+        return M2_CreateFallbackModel(modelFilename, "could not pack shared batch geometry");
+    }
+
 	FOR_LOOP(i, batch_count) {
 		m2Batch_t const *batch = &batches[i];
         DWORD index_start;
@@ -1686,7 +1730,6 @@ m2Model_t *R_LoadModelM2(LPCSTR modelFilename, void *buffer, DWORD size, BOOL *b
         WORD bone_count;
         WORD bone_combo_index;
         WORD section_id = 0;
-        VERTEX *verts;
         m2ModelBatch_t *out;
         BYTE alphamode;
         if (batch->skin_section_index >= section_count) {
@@ -1714,24 +1757,17 @@ m2Model_t *R_LoadModelM2(LPCSTR modelFilename, void *buffer, DWORD size, BOOL *b
             fprintf(stderr, "M2: section %u has an invalid skin index/vertex range\n", section_id);
             continue;
         }
-        verts = ri.MemAlloc(sizeof(*verts) * index_count);
-        if (!verts) {
-            continue;
-        }
         FOR_LOOP(j, index_count) {
-            DWORD sidx = skin_indices[index_start + j];
-            DWORD vidx = skin_vertices[sidx];
-            verts[j] = M2_MakeVertex(&m2_vertices[vidx]);
-            if (skin_bones) {
-                memcpy(verts[j].skin, skin_bones[sidx].v, sizeof(skin_bones[sidx].v));
-            }
+            DWORD sidx = skin_indices[index_start + j], vidx = skin_vertices[sidx];
+            verts[vertex_offset + j] = M2_MakeVertex(&m2_vertices[vidx]);
+            if (skin_bones) memcpy(verts[vertex_offset + j].skin, skin_bones[sidx].v, sizeof(skin_bones[sidx].v));
+            indices[vertex_offset + j] = vertex_offset + j;
         }
         alphamode = batch->material_index < material_count ? m2_blend_mode(materials[batch->material_index * 2 + 1]) : 0;
         out = ri.MemAlloc(sizeof(*out));
         memset(out, 0, sizeof(*out));
-        out->buffer = R_MakeVertexArrayObject(verts, index_count);
+        out->draw = (DRAWELEMENTS){ index_count, vertex_offset * sizeof(*indices) };
         out->texture = M2_TextureForBatch(m2_base, m2_size, &geom, batch, modelFilename, true, &out->texture_type);
-        out->num_vertices = index_count;
         out->bone_count = bone_count;
         out->bone_combo_index = bone_combo_index;
         out->section_id = section_id;
@@ -1740,15 +1776,18 @@ m2Model_t *R_LoadModelM2(LPCSTR modelFilename, void *buffer, DWORD size, BOOL *b
         out->alphamode = alphamode;
         ADD_TO_LIST(out, model->batches);
         model->num_batches++;
-        ri.MemFree(verts);
+        vertex_offset += index_count;
     }
 
     SAFE_DELETE(skin_data, ri.FS_FreeFile);
     if (!model->batches) {
+        SAFE_DELETE(verts, ri.MemFree); SAFE_DELETE(indices, ri.MemFree);
         M2_FreeModelData(model);
         ri.MemFree(model);
         return M2_CreateFallbackModel(modelFilename, using_legacy_view ? "legacy view produced no batches" : "skin produced no batches");
     }
+    model->buffer = M2_MakeBuffer(&(M2BUFFERDATA){ verts, vertex_offset, indices, vertex_offset });
+    ri.MemFree(indices); ri.MemFree(verts);
     return model;
 }
 
@@ -2111,7 +2150,7 @@ void M2_RenderModel(renderEntity_t const *entity, m2Model_t const *model, LPCMAT
 #endif
 		R_BindTexture(tr.texture[TEX_WHITE], 2);
 		R_ApplyShader(shader);
-		R_DrawBuffer(batch->buffer, batch->num_vertices);
+		R_DrawIndexedBuffer32(model->buffer, &batch->draw);
 	}
 	R_SetAlphaKeyState(false);
 	if (outfit)
@@ -2175,7 +2214,7 @@ void M2_RenderInstanced(m2Model_t const *model, LPCINSTANCEBUFFER instances, DWO
 #endif
 		R_BindTexture(tr.texture[TEX_WHITE], 2);
 		R_ApplyShader(shader);
-		R_DrawBufferInstanced(batch->buffer, batch->num_vertices, instances);
+		R_DrawIndexedBuffer32Instanced(model->buffer, &batch->draw, instances);
 	}
 	R_SetAlphaKeyState(false);
 }
@@ -2276,10 +2315,10 @@ void M2_Release(m2Model_t *model) {
     batch = model->batches;
     while (batch) {
         m2ModelBatch_t *next = batch->next;
-        R_ReleaseVertexArrayObject(batch->buffer);
         ri.MemFree(batch);
         batch = next;
     }
+    R_ReleaseVertexArrayObject(model->buffer);
     /* A recycled model allocation must never inherit an atlas cached for the old owner at the same address. */
     FOR_LOOP(i, M2_CHARACTER_COMPOSITE_CACHE_SIZE)
         if (m2_character_composite_keys[i].owner == model) m2_character_composite_keys[i].occupied = false;

--- a/games/world-of-warcraft/renderer/m2/r_m2_utils.h
+++ b/games/world-of-warcraft/renderer/m2/r_m2_utils.h
@@ -35,6 +35,7 @@ typedef struct {
     DWORD sequence_stride, bone_stride, attachment_stride, camera_stride, particle_stride, ribbon_stride;
 } m2FormatDef_t;
 
+
 typedef struct {
     FLOAT value[3], midpoint, lifespan;
 } M2PARTICLECURVE;
@@ -128,6 +129,7 @@ static BOOL m2_validate_skin_vertex_range(WORD const *skin_vertices, DWORD skin_
     }
     return true;
 }
+
 
 static BYTE const *m2_find_chunk(BYTE const *data, DWORD size, DWORD fourcc, LPDWORD chunk_size) {
     DWORD offset = 0;

--- a/renderer/r_buffer.c
+++ b/renderer/r_buffer.c
@@ -144,13 +144,10 @@ void R_ReleaseInstanceBuffer(LPINSTANCEBUFFER buffer) {
     memset(buffer, 0, sizeof(*buffer));
 }
 
-/* Rebind one model batch and its persistent instance stream to the shared VAO. */
-void R_DrawBufferInstanced(LPCBUFFER buffer, DWORD num_vertices, LPCINSTANCEBUFFER instances) {
-    if (!buffer || !num_vertices || !instances || !instances->vbo || !instances->count) return;
-    if (!r_instanced_vao) {
-        R_Call(glGenVertexArrays, 1, &r_instanced_vao);
-    }
-
+/* Both array and indexed draws share one transient VAO for their persistent instance stream. */
+static BOOL R_BindInstancedBuffer(LPCBUFFER buffer, LPCINSTANCEBUFFER instances) {
+    if (!buffer || !instances || !instances->vbo || !instances->count) return false;
+    if (!r_instanced_vao) R_Call(glGenVertexArrays, 1, &r_instanced_vao);
     R_Call(glBindVertexArray, r_instanced_vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, buffer->vbo);
     R_Call(glEnableVertexAttribArray, attrib_position);
@@ -166,20 +163,43 @@ void R_DrawBufferInstanced(LPCBUFFER buffer, DWORD num_vertices, LPCINSTANCEBUFF
     R_Call(glVertexAttribPointer, attrib_boneWeight1, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(struct vertex), FOFS(vertex, boneWeight[0]));
     R_Call(glVertexAttribPointer, attrib_normal, 3, GL_FLOAT, GL_FALSE, sizeof(struct vertex), FOFS(vertex, normal));
 
-    /* Instance matrices were uploaded once at ADT-window construction, not once per frame. */
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, instances->vbo);
-    for (int i = 0; i < 4; i++) {
+    FOR_LOOP(i, 4) {
         R_Call(glEnableVertexAttribArray, attrib_instance + i);
-        R_Call(glVertexAttribPointer, attrib_instance + i, 4, GL_FLOAT, GL_FALSE, sizeof(MATRIX4), (void *)(i * 4 * sizeof(float)));
+        R_Call(glVertexAttribPointer, attrib_instance + i, 4, GL_FLOAT, GL_FALSE,
+            sizeof(MATRIX4), (void *)(i * 4 * sizeof(float)));
         R_Call(glVertexAttribDivisor, attrib_instance + i, 1);
     }
+    return true;
+}
 
+static void R_ResetInstancedBuffer(void) { FOR_LOOP(i, 4) R_Call(glVertexAttribDivisor, attrib_instance + i, 0); }
+
+/* Rebind one model batch and its persistent instance stream to the shared VAO. */
+void R_DrawBufferInstanced(LPCBUFFER buffer, DWORD num_vertices, LPCINSTANCEBUFFER instances) {
+    if (!num_vertices || !R_BindInstancedBuffer(buffer, instances)) return;
     R_StatsDraw(GL_TRIANGLES, num_vertices, instances->count);
     R_Call(glDrawArraysInstanced, GL_TRIANGLES, 0, num_vertices, instances->count);
+    R_ResetInstancedBuffer();
+}
 
-    for (int i = 0; i < 4; i++) {
-        R_Call(glVertexAttribDivisor, attrib_instance + i, 0);
-    }
+/* M2 sections share model geometry while each visible group keeps its authored index range. */
+void R_DrawIndexedBuffer16Instanced(LPCBUFFER buffer, LPCDRAWELEMENTS draw, LPCINSTANCEBUFFER instances) {
+    if (!draw || !draw->count || !R_BindInstancedBuffer(buffer, instances)) return;
+    R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, buffer->ibo);
+    R_StatsDraw(GL_TRIANGLES, draw->count, instances->count);
+    R_Call(glDrawElementsInstanced, GL_TRIANGLES, draw->count, GL_UNSIGNED_SHORT,
+        (void *)(uintptr_t)draw->offset, instances->count);
+    R_ResetInstancedBuffer();
+}
+
+void R_DrawIndexedBuffer32Instanced(LPCBUFFER buffer, LPCDRAWELEMENTS draw, LPCINSTANCEBUFFER instances) {
+    if (!draw || !draw->count || !R_BindInstancedBuffer(buffer, instances)) return;
+    R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, buffer->ibo);
+    R_StatsDraw(GL_TRIANGLES, draw->count, instances->count);
+    R_Call(glDrawElementsInstanced, GL_TRIANGLES, draw->count, GL_UNSIGNED_INT,
+        (void *)(uintptr_t)draw->offset, instances->count);
+    R_ResetInstancedBuffer();
 }
 
 /* Free the lazily-created shared VAO; owners release their immutable instance VBOs. */

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -108,6 +108,9 @@ struct render_buffer {
     DWORD ibo;
 };
 
+typedef struct DRAWELEMENTS { DWORD count, offset; } DRAWELEMENTS, *LPDRAWELEMENTS;
+typedef DRAWELEMENTS const *LPCDRAWELEMENTS;
+
 typedef struct INSTANCEBUFFER {
     DWORD vbo;
     DWORD count;
@@ -400,12 +403,16 @@ VERTEX *R_AddWireBox(VERTEX *buffer, LPCBOX3 box, COLOR32 color);
 LPBUFFER R_MakeVertexArrayObject(LPCVERTEX vertices, DWORD size);
 LPBUFFER R_MakeIndexedVertexArrayObject(LPCVERTEX vertices, DWORD num_vertices, DWORD const *indices, DWORD num_indices);
 void R_DrawBuffer(LPCBUFFER buffer, DWORD num_vertices);
+void R_DrawIndexedBuffer16(LPCBUFFER buffer, LPCDRAWELEMENTS draw);
+void R_DrawIndexedBuffer32(LPCBUFFER buffer, LPCDRAWELEMENTS draw);
 void R_DrawBufferCopies(LPCBUFFER buffer, DWORD num_vertices, DWORD num_instances);
 void R_DrawIndexedBuffer(LPCBUFFER buffer, DWORD num_indices);
 BOOL R_MakeInstanceBuffer(LPINSTANCEBUFFER buffer, LPCMATRIX4 matrices, DWORD count);
 BOOL R_UpdateInstanceBuffer(LPINSTANCEBUFFER buffer, LPCMATRIX4 matrices, DWORD count);
 void R_ReleaseInstanceBuffer(LPINSTANCEBUFFER buffer);
 void R_DrawBufferInstanced(LPCBUFFER buffer, DWORD num_vertices, LPCINSTANCEBUFFER instances);
+void R_DrawIndexedBuffer16Instanced(LPCBUFFER buffer, LPCDRAWELEMENTS draw, LPCINSTANCEBUFFER instances);
+void R_DrawIndexedBuffer32Instanced(LPCBUFFER buffer, LPCDRAWELEMENTS draw, LPCINSTANCEBUFFER instances);
 void R_ShutdownDrawBufferInstanced(void);
 
 // r_draw.c

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -725,6 +725,19 @@ void R_DrawBuffer(LPCBUFFER buffer, DWORD num_vertices) {
     R_Call(glDrawArrays, GL_TRIANGLES, 0, num_vertices);
 }
 
+/* Model-owned element buffers retain per-section ranges as byte offsets. */
+void R_DrawIndexedBuffer16(LPCBUFFER buffer, LPCDRAWELEMENTS draw) {
+    R_Call(glBindVertexArray, buffer->vao);
+    R_StatsDraw(GL_TRIANGLES, draw->count, 1);
+    R_Call(glDrawElements, GL_TRIANGLES, draw->count, GL_UNSIGNED_SHORT, (void *)(uintptr_t)draw->offset);
+}
+
+void R_DrawIndexedBuffer32(LPCBUFFER buffer, LPCDRAWELEMENTS draw) {
+    R_Call(glBindVertexArray, buffer->vao);
+    R_StatsDraw(GL_TRIANGLES, draw->count, 1);
+    R_Call(glDrawElements, GL_TRIANGLES, draw->count, GL_UNSIGNED_INT, (void *)(uintptr_t)draw->offset);
+}
+
 /* Static procedural batches need only gl_InstanceID; their shared VAO has no per-instance stream. */
 void R_DrawBufferCopies(LPCBUFFER buffer, DWORD num_vertices, DWORD num_instances) {
     R_Call(glBindVertexArray, buffer->vao);

--- a/renderer/r_shader.c
+++ b/renderer/r_shader.c
@@ -465,6 +465,8 @@ const shader_desc_t sd_model = {
 static char shader_defines_buf[256];
 static LPCSTR R_ShaderDefines(BOOL instancing) {
     int n = 0;
+    /* Each variant owns its defines; the old retained instancing after the grass program compiled first. */
+    shader_defines_buf[0] = '\0';
     if (instancing)
         n += snprintf(shader_defines_buf + n, sizeof(shader_defines_buf) - n, "#define BZ_USE_INSTANCING 1\n");
 #ifdef USE_SHADOWMAPS

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -237,6 +237,21 @@ TEST(net, loopback_multiple_packets_in_order) {
     T_EQ(NET_GetPacket(NS_SERVER, &from, &msg), 0);
 }
 
+TEST(net, loopback_grows_without_reordering_pending_packets) {
+    static BYTE payload[65536], msg_buf[MAX_MSGLEN];
+    static sizeBuf_t msg = { msg_buf, MAX_MSGLEN, 0, 0 };
+    netadr_t adr = loopback_adr(), from;
+    drain_loopback(NS_SERVER);
+    FOR_LOOP(packet, 6) {
+        memset(payload, packet, sizeof(payload));
+        NET_SendPacket(NS_CLIENT, sizeof(payload), payload, adr);
+    }
+    FOR_LOOP(packet, 6) {
+        T_EQ(NET_GetPacket(NS_SERVER, &from, &msg), (int)sizeof(payload));
+        T_EQ(msg.data[0], packet); T_EQ(msg.data[sizeof(payload)-1], packet);
+    }
+}
+
 TEST(net, loopback_server_to_client) {
     static BYTE   msg_buf[MAX_MSGLEN];
     static sizeBuf_t msg = { msg_buf, MAX_MSGLEN, 0, 0 };

--- a/tests/test_renderer_model.c
+++ b/tests/test_renderer_model.c
@@ -352,6 +352,11 @@ TEST(renderer_bones, instanced_shader_uses_the_same_palette_contract) {
     T_NOT_NULL(strstr(shader_src, "int boneIdx = int(a_skin1[i]) + int(u_firstBoneLookupIndex);"));
 }
 
+TEST(renderer_shader, normal_model_defines_do_not_inherit_instancing) {
+    T_NOT_NULL(strstr(R_ShaderDefines(true), "#define BZ_USE_INSTANCING 1\n"));
+    T_NULL(strstr(R_ShaderDefines(false), "BZ_USE_INSTANCING"));
+}
+
 static HANDLE shader_alloc(long size) { return shader_test.memory = test_alloc(size); }
 
 /* Each case starts with empty caches and independent driver counters. */

--- a/tests/test_renderer_model.c
+++ b/tests/test_renderer_model.c
@@ -2,6 +2,7 @@
 #include "renderer/r_local.h"
 #include "renderer/r_emit.h"
 #include "games/warcraft-3/renderer/w3m/r_war3map.h"
+#include "games/warcraft-3/renderer/mdx/r_mdx.h"
 #include "renderer/r_shader.h"
 #include <stdarg.h>
 #include <stdlib.h>
@@ -188,6 +189,25 @@ static void reset_registry(void) {
     ri.MemAlloc = test_alloc; ri.MemFree = test_free; ri.error = test_error;
     load_count = release_count = register_count = 0;
     fail_load = touch_during_registration = false;
+}
+
+
+TEST(renderer_model, mdx_geometry_packs_two_geosets_into_model_ranges) {
+    VECTOR3 pos[] = {{1,2,3}, {4,5,6}, {7,8,9}}, normals[] = {{0,0,1}, {0,1,0}, {1,0,0}};
+    VECTOR2 uv[] = {{0,0}, {1,0}, {0,1}};
+    short first_idx[] = {0,1,0}, second_idx[] = {0};
+    mdxGeoset_t second = {.vertices=pos+2,.normals=normals+2,.texcoord=uv+2,.triangles=second_idx,
+        .num_vertices=1,.num_normals=1,.num_texcoord=1,.num_triangles=1};
+    mdxGeoset_t first = {.vertices=pos,.normals=normals,.texcoord=uv,.triangles=first_idx,
+        .num_vertices=2,.num_normals=2,.num_texcoord=2,.num_triangles=3,.next=&second};
+    mdxModel_t model = {.geosets=&first}; VERTEX vertices[3]; USHORT indices[4];
+    ri.MemAlloc = test_alloc; ri.MemFree = test_free;
+    MDX_PackModelGeometry(&model, vertices, indices);
+    T_FEQ(vertices[2].position.x, 7, 0.001f);
+    T_EQ(vertices[0].color.r, 255); T_EQ(vertices[0].color.g, 255);
+    T_EQ(vertices[0].color.b, 255); T_EQ(vertices[0].color.a, 255);
+    T_EQ(indices[2], 0); T_EQ(indices[3], 0); T_EQ((int)first.indexofs, 0); T_EQ((int)second.indexofs, 6);
+    ri.MemFree(first.matrixPalette); ri.MemFree(second.matrixPalette);
 }
 
 TEST(renderer_model, filename_cache_hit_and_miss) {


### PR DESCRIPTION
## Summary

Performance optimization pass targeting renderer buffer allocation, memory layout, and shader state management across WC3, WoW (M2), and SC2 (M3) model rendering.

## Changes

### Packed model index buffers and indexed draws
Pack per-division/batch index data into shared model element buffers and use byte-offset indexed draws.
- **M3**: adds `m3_pack_division_faces` and `indexofs`; creates and uploads a single EBO per model
- **M2**: rewrites loading to concatenate batch-expanded geometry into one VBO+EBO (`M2_MakeBuffer`, `DRAWELEMENTS`); switches rendering to `R_DrawIndexedBuffer{16,32}` / instanced variants
- Adds unit test for M3 division packing; adjusts fallbacks/cleanup to match new buffer ownership model
- Updated renderer helpers: `r_buffer.c`, `r_main.c`, `r_local.h`

### Layout memory reduction
Optimizes `stb_fdf` layout parsing to reduce per-frame memory usage in WC3 FDF frame trees.

### Shader define leak fix
Resets `shader_defines_buf` at the start of `R_ShaderDefines` so per-variant defines don't persist between compiles. Fixes a bug where `BZ_USE_INSTANCING` set by an earlier grass/instanced compile leaked into normal M2 shaders (making `u_model` -1 and producing rendering corruption).
- Adds unit test: `renderer_shader.normal_model_defines_do_not_inherit_instancing`

## Files changed

27 files, +634 / -300

Key files:
- `games/warcraft-3/renderer/mdx/r_mdx_buffer.c` (new) — M2/MDX buffer packing
- `games/world-of-warcraft/renderer/m2/r_m2.c` — M2 indexed draws
- `games/starcraft-2/renderer/m3/r_m3_load.c` — M3 EBO packing
- `renderer/r_shader.c` — shader define reset fix
- `games/warcraft-3/common/stb_fdf.h` — layout memory optimization

## Testing

- Unit tests: M3 division packing, shader define isolation
- Manual verification: `make test` (WC3 + WoW engine tests)