### PR TITLE
Add WC3 cursor with native SDL default

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Common runtime cvars:
 | `g_module` | `"game"` | Game module name for the server game boundary |
 | `com_frame_limit` | `"0"` | Exit after N frames; useful with `r_module=stdout` |
 | `vid_modes` | `"0"` | Log SDL display modes at renderer startup; enabled by `-vid_modes`, not archived |
+| `r_cursor` | `"0"` | Native SDL platform cursor; set to `1` for Warcraft III's authored animated cursor |
 
 ### (Optional) Download Warcraft III 1.29b assets
 

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -23,6 +23,23 @@ static FLOAT SCR_UICanvasWidth(void) {
     return UI_BASE_WIDTH;
 }
 
+/*
+ * SDL mouse positions are window pixels, while UI/layout coordinates use the
+ * engine's virtual canvas.  Cursor drawing and FDF hit-testing must share this
+ * mapping, including SC2's widened canvas on widescreen displays.
+ */
+static VECTOR2 SCR_ScreenToUI(int x, int y) {
+    size2_t window = re.GetWindowSize();
+    FLOAT nx = 0.0f, ny = 0.0f;
+
+    if (window.width > 0 && window.height > 0) {
+        nx = (FLOAT)x / (FLOAT)window.width;
+        ny = (FLOAT)y / (FLOAT)window.height;
+    }
+
+    return MAKE(VECTOR2, nx * SCR_UICanvasWidth(), ny * UI_BASE_HEIGHT);
+}
+
 static void SCR_DrawString(int x, int y, LPCSTR string) {
     if (string) re.DrawString(x, y, string);
 }
@@ -52,6 +69,39 @@ static void SCR_DrawFPS(DWORD msec) {
         snprintf(text, sizeof(text), "FPS --  Drawcalls %u", (unsigned)re.GetDrawCalls());
     }
     SCR_DrawString(10, y, text);
+}
+
+/*
+ * Preserve the SDL cursor selected by the input module while the game renderer
+ * temporarily replaces it with authored cursor content.
+ */
+static void SCR_UpdateSystemCursor(BOOL game_cursor_active) {
+    static int previous_visibility = -2;
+
+    if (game_cursor_active) {
+        if (previous_visibility == -2) {
+            previous_visibility = SDL_ShowCursor(SDL_QUERY);
+            if (previous_visibility < 0) previous_visibility = SDL_ENABLE;
+            SDL_ShowCursor(SDL_DISABLE);
+        }
+        return;
+    }
+
+    if (previous_visibility != -2) {
+        SDL_ShowCursor(previous_visibility ? SDL_ENABLE : SDL_DISABLE);
+        previous_visibility = -2;
+    }
+}
+
+static void SCR_DrawCursor(void) {
+    int const x = (int)mouse.origin.x, y = (int)mouse.origin.y;
+    BOOL drawn = false;
+
+    if (Cvar_Integer("r_cursor", 0) == 1) {
+        VECTOR2 const pos = SCR_ScreenToUI(x, y);
+        drawn = re.DrawCursor(pos.x, pos.y);
+    }
+    SCR_UpdateSystemCursor(drawn);
 }
 
 void SCR_BeginLoadingPlaque(void) {
@@ -102,6 +152,9 @@ void SCR_DrawScreenField(DWORD msec) {
     if (Cvar_Integer("scr_showfps", 0)) {
         SCR_DrawFPS(msec);
     }
+
+    /* Cursor is deliberately last so it stays above world, HUD, menus and debug text. */
+    SCR_DrawCursor();
 #ifndef BZ_TESTS
     if (CL_ScreenshotReady()) {
         re.Screenshot();
@@ -169,18 +222,6 @@ static DWORD layout_current_layer;
 
 static RECT Rect_inset(LPCRECT r, FLOAT inset) {
     return MAKE(RECT, r->x+inset, r->y+inset, r->w-inset*2, r->h-inset*2);
-}
-
-static VECTOR2 SCR_LayoutScreenToFdf(int x, int y) {
-    LPRENDERER renderer = &re;
-    size2_t window = renderer->GetWindowSize();
-    FLOAT nx = 0, ny = 0;
-
-    if (window.width > 0 && window.height > 0) {
-        nx = (FLOAT)x / (FLOAT)window.width;
-        ny = (FLOAT)y / (FLOAT)window.height;
-    }
-    return MAKE(VECTOR2, nx * SCR_UICanvasWidth(), ny * UI_BASE_HEIGHT);
 }
 
 static RECT get_uvrect(uint8_t const *tc) {
@@ -788,7 +829,7 @@ void SCR_ClearLayoutLayer(DWORD layer) {
 }
 
 void SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param) {
-    VECTOR2 const point = SCR_LayoutScreenToFdf(x, y);
+    VECTOR2 const point = SCR_ScreenToUI(x, y);
 
     layout_hovered_number = 0;
     FOR_LOOP(layer, MAX_LAYOUT_LAYERS) {
@@ -859,7 +900,7 @@ BOOL SCR_LayoutKeyEvent(int key) {
 }
 
 BOOL SCR_LayoutHitTest(int x, int y) {
-    VECTOR2 const point = SCR_LayoutScreenToFdf(x, y);
+    VECTOR2 const point = SCR_ScreenToUI(x, y);
     FOR_LOOP(layer, MAX_LAYOUT_LAYERS) {
         HANDLE layout = layout_layers[layer];
         DWORD flags = cl.playerstate.uiflags;

--- a/client/tr_public.h
+++ b/client/tr_public.h
@@ -216,6 +216,7 @@ typedef struct {
     void (*DrawMinimap)(LPCRECT screen);
     void (*DrawLoadingIndicator)(LPCRECT rect, DWORD time, COLOR32 color);
     void (*DrawSprite)(LPCMODEL model, LPCSTR anim, float x, float y);
+    bool (*DrawCursor)(float x, float y);
     bool (*SetEntityAnimFrame)(LPCMODEL model, LPCSTR anim, renderEntity_t *entity);
     void (*DrawText)(LPCDRAWTEXT drawText);
     VECTOR2 (*GetTextSize)(LPCDRAWTEXT drawText);

--- a/common/cvar.c
+++ b/common/cvar.c
@@ -476,6 +476,7 @@ void Cvar_Init(void) {
     Cvar_GetD("r_unit_shadows",   "1",                 CVAR_ARCHIVE, "render blob shadows under units");
     Cvar_GetD("r_occlusion",      "1",                 CVAR_ARCHIVE, "frustum-cull off-screen entities");
     Cvar_GetD("r_vsync",          "0",                 CVAR_ARCHIVE, "vertical sync: 0=off (use for perf testing), 1=on");
+    Cvar_GetD("r_cursor",         "0",                 CVAR_ARCHIVE, "cursor: 0=native SDL, 1=game-authored");
     Cvar_GetD("r_stats",          "0",                 0,            "print per-frame draw/world stats to console each second");
     Cvar_GetD("r_norefresh",      "0",                 0,            "skip all screen rendering while client/server processing continues");
     Cvar_GetD("r_entities",       "1",                 0,            "render game entities (units, buildings, etc.)");

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -107,6 +107,12 @@ The `+` prefix is for **command-line only**. It tells `Cbuf_AddEarlyCommands` / 
 | `+<cvar> [<value>]` | If `<cvar>` exists, sets it to `<value>` (or `"1"` if no value) |
 | `+<command> [<args>...]` | Queued via `Cbuf_AddText` — executed after module init |
 
+## Cursor Ownership
+
+SDL owns the native platform cursor on macOS, Linux, Windows, and other supported video backends. WoW changes that native cursor with `SDL_CreateSystemCursor` and `SDL_SetCursor` for hover context. The renderer does not duplicate platform cursor APIs or draw a generic software fallback.
+
+`r_cursor 0` keeps the SDL cursor and is the default. `r_cursor 1` explicitly replaces it with a game-authored cursor when the active game renderer provides one; Warcraft III renders `UI\\Cursor\\HumanCursor.mdx`. If that asset cannot load, the client leaves the SDL cursor visible.
+
 Early commands (`+set`, `+<cvar>`) are processed during `Com_Init()`, before module registration. Late commands (`+map`, `+menu_main`, etc.) are processed after `CL_Init()` when all command handlers are registered.
 
 In code, always use the bare command name: `"map ..."`, not `"+map ..."`.

--- a/games/starcraft-2/renderer/r_game.c
+++ b/games/starcraft-2/renderer/r_game.c
@@ -423,3 +423,10 @@ void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     (void)x;
     (void)y;
 }
+
+/* TODO: SC2 authored cursor assets are not wired to the renderer yet;
+ * returning false keeps SDL's native platform cursor visible. */
+bool R_GameDrawCursor(float x, float y) {
+    (void)x; (void)y;
+    return false;
+}

--- a/games/warcraft-3/renderer/r_game.c
+++ b/games/warcraft-3/renderer/r_game.c
@@ -24,6 +24,10 @@ static LPCSTR modelNames[MODEL_COUNT] = {
     "UI\\Feedback\\SelectionCircle\\SelectionCircle.mdx"
 };
 
+static LPCSTR const cursor_model_name = "UI\\Cursor\\HumanCursor.mdx";
+static LPMODEL cursor_model;
+static BOOL cursor_load_attempted;
+
 typedef struct {
     LPMODEL model;
     DWORD count;
@@ -68,10 +72,13 @@ void R_GameLoadAssets(void) {
 }
 
 void R_GameInit(void) {
+    cursor_model = NULL; cursor_load_attempted = false;
     MDLX_Init();
 }
 
 void R_GameShutdown(void) {
+    /* R_ShutdownModels runs first and owns the cached model allocation; only clear our borrowed handle here. */
+    cursor_model = NULL; cursor_load_attempted = false;
     MDLX_Shutdown();
 }
 
@@ -334,4 +341,22 @@ bool R_GameSetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entit
 
 void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     MDLX_DrawSprite(model, anim, x, y);
+}
+
+/* Warcraft III can replace the platform cursor with its authored animated MDX cursor. */
+bool R_GameDrawCursor(float x, float y) {
+    renderEntity_t probe = {0};
+
+    if (!cursor_model && !cursor_load_attempted) {
+        cursor_load_attempted = true;
+        cursor_model = R_LoadModel(cursor_model_name);
+        if (!cursor_model || !R_GameSetEntityAnimFrame(cursor_model, "Normal", &probe)) {
+            fprintf(stderr, "WC3 cursor unavailable: %s\n", cursor_model_name);
+            if (cursor_model) R_ReleaseModel(cursor_model);
+            cursor_model = NULL;
+        }
+    }
+    if (!cursor_model) return false;
+    MDLX_DrawSprite(cursor_model, "Normal", x, y);
+    return true;
 }

--- a/games/warcraft-3/tests/test_client_stubs.c
+++ b/games/warcraft-3/tests/test_client_stubs.c
@@ -37,6 +37,8 @@ void test_client_stubs_set_cvar(LPCSTR name, LPCSTR value) {
 
 static size2_t mock_GetWindowSize(void) { return MAKE(size2_t, 1024, 768); }
 static void mock_DrawLoadingIndicator(LPCRECT rect, DWORD time, COLOR32 color) { (void)rect; (void)time; (void)color; }
+static void mock_DrawFill(LPCRECT rect, COLOR32 color) { (void)rect; (void)color; }
+static bool mock_DrawCursor(float x, float y) { (void)x; (void)y; return true; }
 static void mock_SetFogOfWarData(DWORD width, DWORD height, BYTE const *data) {
     (void)width; (void)height; (void)data; test_fow_upload_calls++;
 }
@@ -67,6 +69,7 @@ void CL_Disconnect(LPCSTR reason, BOOL notify) { (void)reason; (void)notify; cls
 void CL_EntityEvent(entityState_t const *ent) { (void)ent; }
 void Cbuf_AddText(LPCSTR text) { (void)text; }
 unsigned int SDL_GetTicks(void) { return 0; }
+int SDL_ShowCursor(int toggle) { (void)toggle; return 1; }
 void Com_Error(errorCode_t code, LPCSTR fmt, ...) { (void)code; (void)fmt; }
 
 void test_client_stubs_init(void) {
@@ -78,6 +81,8 @@ void test_client_stubs_init(void) {
     test_fow_upload_calls = 0;
     re.GetWindowSize = mock_GetWindowSize;
     re.DrawLoadingIndicator = mock_DrawLoadingIndicator;
+    re.DrawFill = mock_DrawFill;
+    re.DrawCursor = mock_DrawCursor;
     re.SetFogOfWarData = mock_SetFogOfWarData;
 }
 

--- a/games/warcraft-3/tests/test_commands.c
+++ b/games/warcraft-3/tests/test_commands.c
@@ -120,6 +120,20 @@ TEST(commands, registered_renderer_cvar_accepts_bare_assignment) {
     T_STREQ(Cvar_String("r_stats", NULL), "1");
 }
 
+TEST(commands, cursor_defaults_to_native_sdl) {
+    setup_command_tests();
+    T_STREQ(Cvar_String("r_cursor", NULL), "0");
+}
+
+TEST(commands, cursor_allows_game_authored_override) {
+    LPCSTR argv[] = { "test_commands", "+r_cursor", "1" };
+
+    setup_command_tests();
+    COM_InitArgv(3, argv);
+    Cbuf_AddEarlyCommands(true);
+    T_STREQ(Cvar_String("r_cursor", NULL), "1");
+}
+
 TEST(commands, data_command_line_sets_data_cvar) {
     LPCSTR argv[] = { "test_commands", "-data", "tests/data dir" };
 

--- a/games/world-of-warcraft/renderer/r_game.c
+++ b/games/world-of-warcraft/renderer/r_game.c
@@ -576,3 +576,9 @@ void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     (void)x;
     (void)y;
 }
+
+/* WoW context cursors are native SDL cursors owned by cl_input_wow.c. */
+bool R_GameDrawCursor(float x, float y) {
+    (void)x; (void)y;
+    return false;
+}

--- a/renderer/r_game.h
+++ b/renderer/r_game.h
@@ -38,5 +38,6 @@ BOOL R_GameEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out);
 bool R_GameExtractEntityCamera(renderEntity_t const *entity, float aspect, viewDef_t *viewdef);
 bool R_GameSetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity);
 void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y);
+bool R_GameDrawCursor(float x, float y);
 
 #endif

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -868,6 +868,9 @@ void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     R_GameDrawSprite(model, anim, x, y);
 }
 
+/* Cursor presentation is game-owned; the client only supplies UI coordinates. */
+bool R_DrawCursor(float x, float y) { return R_GameDrawCursor(x, y); }
+
 bool R_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity) {
     return R_GameSetEntityAnimFrame(model, anim, entity);
 }
@@ -903,6 +906,7 @@ refExport_t R_GetAPI(refImport_t imp) {
         .SetWindowSize = R_SetWindowSize,
         .GetTextureSize = R_GetTextureSize,
         .DrawSprite = R_DrawSprite,
+        .DrawCursor = R_DrawCursor,
         .SetEntityAnimFrame = R_SetEntityAnimFrame,
         .DrawText = R_DrawText,
         .GetTextSize = R_GetTextSize,

--- a/renderer/r_stdout.c
+++ b/renderer/r_stdout.c
@@ -341,6 +341,12 @@ static void RStd_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     printf(" x=%.6f y=%.6f\n", x, y);
 }
 
+/* stdout has no game-native cursor renderer; the client leaves SDL's platform cursor visible. */
+static bool RStd_DrawCursor(float x, float y) {
+    printf("draw_cursor x=%.6f y=%.6f unsupported\n", x, y);
+    return false;
+}
+
 static bool RStd_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity) {
     if (!entity) {
         return false;
@@ -494,6 +500,7 @@ refExport_t R_StdoutGetAPI(refImport_t imp) {
         .DrawMinimap = RStd_DrawMinimap,
         .DrawLoadingIndicator = RStd_DrawLoadingIndicator,
         .DrawSprite = RStd_DrawSprite,
+        .DrawCursor = RStd_DrawCursor,
         .SetEntityAnimFrame = RStd_SetEntityAnimFrame,
         .DrawText = RStd_DrawText,
         .GetTextSize = RStd_GetTextSize,


### PR DESCRIPTION
Use SDL's native platform cursor by default on macOS, Linux, Windows, and other SDL backends.

Warcraft III can opt into its authored animated `UI\Cursor\HumanCursor.mdx` with `+r_cursor 1`. If the asset is unavailable, the client leaves the native SDL cursor visible. WoW retains its existing SDL system arrow/hand/crosshair context cursors; SC2 also uses the native SDL cursor.

The branch is rebased on current `main`, excludes the unrelated signed-byte change, and preserves the existing `+cvar` command-line contract.

Validated with all renderer variants, `make test-ui`, `make test-commands`, full `make test`, and bounded RoC/TFT screenshots.