### PR TITLE
Speed up full test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | Diagnostic tools (mpqtool, dbctool, mdxtool, text renderer, profiler) | [docs/diagnostic-tools.md](docs/diagnostic-tools.md) |
 | Vendored Lua 5.4 and the libxml2-free XML parser (`common/tinyxml.h`) | [docs/vendored-dependencies.md](docs/vendored-dependencies.md) |
 | UI screen authoring, FDF conventions, ConsoleUI, stb_fdf.h | [docs/ui-authoring.md](docs/ui-authoring.md) |
+| Test-suite performance measurement and parallel execution | [docs/test-performance.md](docs/test-performance.md) |
 | WoW character display, DBC/skin-section/component-texture rules | [docs/wow-character.md](docs/wow-character.md) |
 | WoW grass: active paths, wind-sway math, phase decorrelation, density formula, constants | [docs/games/world-of-warcraft/GRASS_TECH.md](docs/games/world-of-warcraft/GRASS_TECH.md) |
 | WoW magic schools, damage types, buffs/debuffs, CC, status effects | [docs/games/world-of-warcraft/magic-and-effects.md](docs/games/world-of-warcraft/magic-and-effects.md) |

--- a/Makefile
+++ b/Makefile
@@ -181,8 +181,11 @@ $(1): $(2) | $$(BIN_DIR) install-share
 endef
 
 define test_schema
-$(1): $(2) | $$(BIN_DIR)
+
+$(4): $(2) $(5) | $$(BIN_DIR)
 	@$$(CC) $(3) -o $(4) $(5) $$(RPATH) $$(LDFLAGS) $(6)
+
+$(1): $(4)
 	@$(4) $(7)
 endef
 

--- a/docs/test-performance.md
+++ b/docs/test-performance.md
@@ -1,0 +1,49 @@
+# Test Performance
+
+## Execution Contract
+
+The aggregate `test` target runs independent standalone, engine, and game-suite targets. Each `test_schema` target now has two stages: a persistent binary target and a test execution target. The binary depends on its compiled source list, so source edits rebuild it while repeated test runs execute without recompiling.
+
+The aggregate target runs the suites concurrently through recursive Make. `TEST_JOBS` controls the concurrency and defaults to 16; this was fastest on the local 8-core macOS machine in the measurements below.
+
+## Benchmark
+
+Measured on `main` at commit `ac44fc12` before the change:
+
+| Run | Tests | Wall time |
+| --- | ---: | ---: |
+| Initial `make test` including builds | 1,396 | 52.30 s |
+| Repeat `make test` with existing build | 1,396 | 28.22 s |
+
+After incremental binaries and parallel suite execution:
+
+| Run | Tests | Wall time |
+| --- | ---: | ---: |
+| First run after rule migration | 1,396 | 5.13 s |
+| Steady-state run, `TEST_JOBS=16` | 1,396 | 4.79 s |
+| Plain `make test` using the default | 1,396 | 5.65 s |
+
+The final runs passed all 17 suite summaries. The default run processes about 1,235 tests per 5 seconds, exceeding the 1,000-tests-per-5-seconds target. With `TEST_JOBS=16`, throughput is about 1,457 tests per 5 seconds. Compared with the repeatable pre-change run, default wall time improved by 80%.
+
+## Diagnostic Workflow
+
+Run the full suite with timing:
+
+```sh
+/usr/bin/time -p make test TEST_JOBS=16
+```
+
+On macOS, `xctrace` requires the full Xcode developer directory when Command Line Tools is active:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xctrace record \
+  --template 'Time Profiler' --time-limit 10s --output build/test.trace --launch -- \
+  build/bin/openwarcraft3-tests -data build/tests +dedicated 1 +test '*'
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xctrace export \
+  --input build/test.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="time-profile"]' \
+  > build/test-time-profile.xml
+build/bin/xctraceprof --top 30 build/test-time-profile.xml
+```
+
+The final engine-test profile sampled `Test_Run` and showed `__bzero` as the largest leaf symbol, followed by JASS setup and test-specific work. This profile covers the engine-backed WC3 process; aggregate wall timing is required for the full multi-suite target.

--- a/games/warcraft-3/game.mk
+++ b/games/warcraft-3/game.mk
@@ -136,6 +136,8 @@ TEST_UI_SRCS := \
 	$(WC3_TEST_DIR)/stb_fdf_impl.c \
 	tests/test_tool_common.c
 
+TEST_JOBS ?= 16
+
  test: test-assets $(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB) | $(BIN_DIR)
 	@$(CC) $(TEST_CFLAGS) -DBZ_TESTS -o $(BIN_DIR)/test_openwarcraft3$(EXE_EXT) \
 		tests/test_runner.c tests/test_compat.c tests/test_net.c tests/test_tool_common.c \
@@ -143,23 +145,11 @@ TEST_UI_SRCS := \
 		common/net.c common/msg.c client/cl_parse.c client/cl_scrn.c client/cl_layout.c \
 		$(RPATH) $(LDFLAGS) -lsheet -lshared -lm
 	@$(BIN_DIR)/test_openwarcraft3$(EXE_EXT)
-	@# Propagate sub-suite failures; the old ignored-error prefix made a red suite report success.
-	@$(MAKE) test-commands
-	@$(MAKE) test-jass-build
-	@$(MAKE) test-galaxy
-	@$(MAKE) test-server-net
-	@$(MAKE) test-renderer-model
-	@$(MAKE) test-renderer-shadows
-	@$(MAKE) test-sc2
-	@$(MAKE) test-wow-appearance
-	@$(MAKE) test-wow-engine
-	@$(MAKE) test-wow-game
-	@$(MAKE) test-wow-entities
-	@$(MAKE) test-wow-abilities
-	@$(MAKE) test-wow-ui
-	@$(MAKE) test-wow-wmo
-	@$(MAKE) test-ui
-	@$(MAKE) test-wc3-engine
+	@# Run independent suites concurrently while preserving recursive-make failure propagation.
+	@$(MAKE) -j$(TEST_JOBS) test-commands test-jass-build test-galaxy test-server-net \
+		test-renderer-model test-renderer-shadows test-sc2 test-wow-appearance \
+		test-wow-engine test-wow-game test-wow-entities test-wow-abilities test-wow-ui \
+		test-wow-wmo test-ui test-wc3-engine
 
 $(eval $(call test_schema,test-commands,test-assets $(SHARED_LIB) $(SHEET_LIB),$(TEST_CFLAGS),$(BIN_DIR)/test_commands$(EXE_EXT),tests/test_runner.c $(WC3_TEST_DIR)/test_commands.c client/cl_screenshot.c common/common.c common/cmd.c common/cvar.c common/msg.c common/net.c common/mpq.c,-lsheet -lshared -lm -lz $(NET_LIBS),))
 $(eval $(call test_schema,test-server-net,test-assets $(SHARED_LIB) $(SHEET_LIB),$(TEST_CFLAGS),$(BIN_DIR)/test_server_net$(EXE_EXT),tests/test_runner.c $(WC3_TEST_DIR)/test_server_net.c $(WC3_TEST_DIR)/test_client_stubs.c server/sv_init.c server/sv_lan.c server/sv_main.c server/sv_lobby.c server/sv_send.c common/net.c common/msg.c,-lsheet -lshared -lm $(NET_LIBS),))


### PR DESCRIPTION
## Summary
- run independent test suites concurrently with configurable `TEST_JOBS` (default 16)
- make standalone test binaries incremental while tracking their source dependencies
- document the benchmark and `xctrace` profiling workflow

## Performance
- baseline on main: 28.22s for 1,396 tests
- steady-state result: 4.48s for 1,408 tests
- exceeds 1,000 tests per 5 seconds
- approximately 84% lower wall time versus the baseline

## Validation
- `make test` passed: 17 suite summaries, 1,408 tests
- first run after rebasing: 15.96s due to rebuilds; repeat run: 4.48s
- `git diff --check` passed