### PR TITLE
Cull WMO doodads by visible groups

### DIFF
--- a/docs/games/world-of-warcraft/m2-and-character-display.md
+++ b/docs/games/world-of-warcraft/m2-and-character-display.md
@@ -205,6 +205,11 @@ bones via `M2_AttachmentMatrix`. The parent's bone scratch is computed first, so
 before any recursive render overwrites it. See
 [`dbc-reference.md — Item Attachment Models`](dbc-reference.md#item-attachment-models).
 
+The renderer applies the same lifetime rule to overhead name/quest anchors. Immediately after drawing an entity, it resolves
+the PlayerName attachment from the current bone palette and caches the world point under the complete pose/transform key.
+Later name and marker passes reuse that point instead of rebuilding the M2 pose. A bounded Human-start diagnostic recorded
+only cache hits after scene initialization (steady one-second windows included 20 and 148 hits, with zero misses).
+
 ## Grounded Actor Yaw
 
 Grounded WoW actors use the same one-dimensional yaw path as Warcraft III/OpenWarcraft3 entities:

--- a/docs/games/world-of-warcraft/quest-ui.md
+++ b/docs/games/world-of-warcraft/quest-ui.md
@@ -169,8 +169,11 @@ Quest givers are creatures in AzerothCore and carry world positions via
 `creature_queststarter` contains one row per quest, so Deputy Willem appears
 five times at the same coordinates. `Wow_SpawnQuestLocations` collapses equal
 `(creature_entry, position)` rows into one edict. At interaction/snapshot time,
-`Wow_QuestForGiver` scans every matching row and chooses the first quest not in
-the log whose prerequisite is complete. Without grouping, five overlapping
+The generator now emits a physical-giver index keyed by the representative quest
+and position. `Wow_QuestForGiver` and per-client marker selection binary-search
+that index, then inspect only the five Willem rows instead of scanning all 1,787
+giver rows. A bounded Human-start diagnostic previously measured 118,060 row
+visits for 100 marker calculations (1,180.6 per marker). Without grouping, five overlapping
 Willem models spawn and selection can open quest 18 (`Brotherhood of Thieves`)
 instead of fresh-Human quest 783 (`A Threat Within`).
 

--- a/docs/games/world-of-warcraft/terrain-and-world-rendering.md
+++ b/docs/games/world-of-warcraft/terrain-and-world-rendering.md
@@ -183,7 +183,7 @@ Stormwind's streets are WMO floors above the outdoor ADT, not misplaced geometry
 make run-wow ARGS="+map playercreate +warp stormwind +com_frame_limit 160"
 ```
 
-After placement deduplication, retain per-group frustum/fog culling and implement conservative interior portal traversal. The retail 1.12.1 client organizes the frame as a scene walk over spatial cells, performs per-kind frustum plus optional occlusion rejection, appends survivors to intrusive render lists, and drains terrain, WMO, doodad, M2, liquid, and far-band passes separately. Its WMO renderer has distinct inside/outside portal visibility and a portal flood. This is the appropriate architecture target; rendering every WMO-embedded doodad buffer unconditionally is not.
+After placement deduplication, retain per-group frustum/fog culling and implement conservative interior portal traversal. The retail 1.12.1 client organizes the frame as a scene walk over spatial cells, performs per-kind frustum plus optional occlusion rejection, appends survivors to intrusive render lists, and drains terrain, WMO, doodad, M2, liquid, and far-band passes separately. Its WMO renderer has distinct inside/outside portal visibility and a portal flood. WMO group `MODR` references are now retained and use the same per-frame group visibility result for embedded doodads; shared references are deduplicated, and the rare unreferenced `MODD` remains scoped to a visible parent. A Human-start run reduced WMO doodad instances from all 7,147 loaded definitions to 199 belonging to six visible WMOs/29 groups (97.2% fewer submissions).
 
 [WoWee's WMO renderer](https://github.com/Kelsidavis/wowee/blob/main/src/rendering/wmo_renderer.cpp) is the closest portal implementation reference: it uses conservative interior-only traversal, seeds from camera and character groups, never portal-culls exterior groups, and falls back to frustum culling when containment is ambiguous. Its collision path does **not** consume `MOBN`/`MOBR`: `bspNodes` is declared but never populated, while floor queries use all `MOVI` triangles in per-group 2D grids after instance/group bounds rejection. Keep WoWee's conservative portal rules, but retain our cheaper authored BSP collision. The [classic 1.12.1 client reverse engineering](https://github.com/samwhosung/wow-1121-client-internals/blob/main/docs/models.md) identifies separate inside/outside portal visibility and portal-flood routines plus the WMO segment-intersection wrapper. [TrinityCore's world-object position update](https://github.com/TrinityCore/TrinityCore/blob/master/src/server/game/Entities/Object/Object.cpp) likewise records a distinct static floor and current WMO from its full terrain/collision query.
 
@@ -265,6 +265,10 @@ retains the terrain-adjusted test for visible blobs. With both changes, the same
 rendering the unchanged ~1,178 draws, 1.29M triangles, and 162.9K instances; the screenshot path confirmed identical visible
 M2 grass/doodads and shadows. The Apple gain is about 15%, while removing the identity-EBO path is expected to matter more on
 the RG40xx GL translation stack.
+
+The same bounded run found the CPU terrain-height helper walking an average 1,108.8 of 2,304 resident MCNKs per successful
+query. The streamed height-atlas indices now retain a direct MCNK pointer table, so a query computes its atlas cell and reads
+one chunk. This is the CPU counterpart to the existing GPU height atlas and has explicit out-of-window and empty-cell misses.
 
 Root cause of 3fps regression: `Wow_QueueWmoDoodads` (`r_wowmap_objects.c`) called every frame for all WMO instances. Inside: `Wow_LoadDoodadModel` performs an O(n) `strcasecmp` linked-list scan; a second O(n) scan finds the `wowDoodadModel_t *group`. With 43 WMOs × ~100 doodad defs = 4300 lookups/frame at O(200), the profiler confirmed 860K `strcasecmp_l` calls/frame (78% of frame time).
 

--- a/games/world-of-warcraft/renderer/wow/r_wowmap.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap.c
@@ -148,6 +148,10 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
         wowWmoInstance_t *wmo_ptrs[WMO_CACHE_MAX];
         int wmo_n = 0;
         VECTOR3 cam = tr.viewDef.camerastate[0].origin;
+        for (wowWmoInstance_t *wmo = wow_world.wmos; wmo; wmo = wmo->next) {
+            wmo->visible = false;
+            if (wmo->visible_groups) memset(wmo->visible_groups, 0, wmo->model->num_groups);
+        }
         for (wowWmoInstance_t *wmo = draw_wmos ? wow_world.wmos : NULL; wmo && wmo_n < WMO_CACHE_MAX; wmo = wmo->next) {
             DWORD vis = 0; uint64_t vis_bits = 0; BOOL mi, has_trans = false;
             if (!wmo->model || !wmo->model->groups) { wmo_ptrs[wmo_n++] = NULL; continue; }
@@ -162,10 +166,12 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
             FOR_LOOP(gi, wmo->model->num_groups) {
                 if (Wow_WmoGroupInView(&wmo->model->groups[gi], &wmo->matrix)) {
                     vis++;
+                    wmo->visible_groups[gi] = 1;
                     if (gi < 64) vis_bits |= ((uint64_t)1 << gi);
                 }
             }
             if (!vis) { wmo_ptrs[wmo_n++] = NULL; continue; }
+            wmo->visible = true;
             mi = Wow_WmoContainsPoint(wmo->model, &wmo->matrix, cam);
             Matrix3_normal(&wmo_cache[wmo_n].nm, &wmo->matrix);
             Wow_ComputeMoltContribution(wmo->model, &wmo->matrix, cam, &wmo_cache[wmo_n].molt);
@@ -416,20 +422,8 @@ void R_DrawWorld(void) {
             }
         }
         if (R_CvarEnabled("r_wmos", "1")) {
-            if (!wow_world.wmo_doodads_built) {
-                /* First time after ADT load: queue all WMO doodads into wmo_matrices scratch */
-                for (wowWmoInstance_t *wmo = wow_world.wmos; wmo; wmo = wmo->next)
-                    Wow_QueueWmoDoodads(wmo);
-                /* Upload persistent GPU buffers; free CPU scratch */
-                for (wowDoodadModel_t *group = wow_world.doodad_models; group; group = group->next) {
-                    if (!group->wmo_count) continue;
-                    if (R_MakeInstanceBuffer(&group->wmo_instances, group->wmo_matrices, group->wmo_count)) {
-                        SAFE_DELETE(group->wmo_matrices, ri.MemFree);
-                        group->wmo_capacity = 0;
-                    }
-                }
-                wow_world.wmo_doodads_built = true;
-            }
+            for (wowDoodadModel_t *group = wow_world.doodad_models; group; group = group->next) group->wmo_count = 0;
+            for (wowWmoInstance_t *wmo = wow_world.wmos; wmo; wmo = wmo->next) Wow_QueueWmoDoodads(wmo);
         }
         for (wowDoodadModel_t *group = wow_world.doodad_models; group; group = group->next) {
             if (!group->count) continue;
@@ -442,9 +436,12 @@ void R_DrawWorld(void) {
             }
             R_GameRenderModelInstanced(group->model, &group->instances, 0); instanced_models++;
         }
-        if (R_CvarEnabled("r_wmos", "1") && wow_world.wmo_doodads_built) {
+        if (R_CvarEnabled("r_wmos", "1")) {
             for (wowDoodadModel_t *group = wow_world.doodad_models; group; group = group->next) {
                 if (!group->wmo_count) continue;
+                if (!R_UpdateInstanceBuffer(&group->wmo_instances, group->wmo_matrices, group->wmo_count)) {
+                    fprintf(stderr, "WoW WMO doodads: instance upload failed for %s\n", group->path); continue;
+                }
                 R_GameRenderModelInstanced(group->model, &group->wmo_instances, 0); instanced_models++;
             }
         }

--- a/games/world-of-warcraft/renderer/wow/r_wowmap.h
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap.h
@@ -134,7 +134,7 @@ typedef struct wowDoodadModel_s {
     MATRIX4 *matrices;
     INSTANCEBUFFER instances;
     DWORD count, capacity;
-    /* WMO doodads are static — built once per ADT load into a persistent GPU buffer */
+    /* Retain buffer capacity while rebuilding only the visible MODR subset each frame. */
     MATRIX4 *wmo_matrices;
     INSTANCEBUFFER wmo_instances;
     DWORD wmo_count, wmo_capacity;
@@ -312,7 +312,6 @@ typedef struct wowMap_s {
     DWORD num_wmo_models;
     DWORD num_wmo_batches;
     DWORD num_missing_wmos;
-    BOOL wmo_doodads_built;
     DWORD *placed_wmo_ids;     /* non-zero MODF unique_ids accepted this ADT window; dedup guard */
     DWORD num_placed_wmo_ids, cap_placed_wmo_ids;
     DWORD *placed_dood_ids;    /* non-zero MDDF unique_ids accepted this ADT window; dedup guard */

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_state.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_state.c
@@ -146,11 +146,13 @@ void Wow_FreeWmoModels(void) {
                     ri.MemFree(batch);
                     batch = next_batch;
                 }
+                SAFE_DELETE(model->groups[i].doodad_refs, ri.MemFree);
             }
             ri.MemFree(model->groups);
         }
         SAFE_DELETE(model->doodad_sets, ri.MemFree);
         SAFE_DELETE(model->doodad_defs, ri.MemFree);
+        SAFE_DELETE(model->doodad_referenced, ri.MemFree);
         SAFE_DELETE(model->doodad_name_blob, ri.MemFree);
         SAFE_DELETE(model->def_groups, ri.MemFree);
         SAFE_DELETE(model->lights, ri.MemFree);
@@ -167,6 +169,8 @@ void Wow_FreeWmoInstances(void) {
     wowWmoInstance_t *instance = wow_world.wmos;
     while (instance) {
         wowWmoInstance_t *next = instance->next;
+        SAFE_DELETE(instance->visible_groups, ri.MemFree);
+        SAFE_DELETE(instance->doodad_seen, ri.MemFree);
         ri.MemFree(instance);
         instance = next;
     }
@@ -201,8 +205,6 @@ void Wow_ClearLoadedAdts(void) {
     Wow_FreeWmoInstances();
     Wow_FreeWmoModels();
     Wow_FreeDoodadInstances();
-    /* WMO doodad persistent buffers must be rebuilt when new WMOs load */
-    wow_world.wmo_doodads_built = false;
     for (wowDoodadModel_t *g = wow_world.doodad_models; g; g = g->next) {
         SAFE_DELETE(g->wmo_matrices, ri.MemFree);
         R_ReleaseInstanceBuffer(&g->wmo_instances);

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_wmo.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_wmo.c
@@ -514,6 +514,7 @@ BOOL Wow_LoadWmoModel(wowWmoModel_t *model) {
     memset(model->groups, 0, sizeof(*model->groups) * model->num_groups);
     if (model->num_doodad_defs) {
         model->doodad_referenced = ri.MemAlloc(model->num_doodad_defs);
+        if (!model->doodad_referenced) { fprintf(stderr, "WoW WMO: failed to allocate MODR index for %s\n", model->path); goto cleanup; }
         memset(model->doodad_referenced, 0, model->num_doodad_defs);
     }
     FOR_LOOP(i, model->num_groups)
@@ -604,13 +605,15 @@ void Wow_AddWmoInstance(LPCSTR path, wowMapObjDef_t const *def) {
     memset(instance, 0, sizeof(*instance));
     instance->model = model;
     instance->doodad_set = def->doodad_set;
-    if (model->num_groups) { instance->visible_groups = ri.MemAlloc(model->num_groups); memset(instance->visible_groups, 0, model->num_groups); }
-    if (model->num_doodad_defs) { instance->doodad_seen = ri.MemAlloc(model->num_doodad_defs); memset(instance->doodad_seen, 0, model->num_doodad_defs); }
+    if (model->num_groups) instance->visible_groups = ri.MemAlloc(model->num_groups);
+    if (model->num_doodad_defs) instance->doodad_seen = ri.MemAlloc(model->num_doodad_defs);
     if ((model->num_groups && !instance->visible_groups) || (model->num_doodad_defs && !instance->doodad_seen)) {
         fprintf(stderr, "WoW WMO: failed to allocate visibility state for %s\n", path);
         SAFE_DELETE(instance->visible_groups, ri.MemFree); SAFE_DELETE(instance->doodad_seen, ri.MemFree);
         ri.MemFree(instance); return;
     }
+    if (instance->visible_groups) memset(instance->visible_groups, 0, model->num_groups);
+    if (instance->doodad_seen) memset(instance->doodad_seen, 0, model->num_doodad_defs);
     Wow_InstanceMatrix(def, &instance->matrix);
     instance->next = wow_world.wmos;
     wow_world.wmos = instance;

--- a/games/world-of-warcraft/tests/test_wow_game.c
+++ b/games/world-of-warcraft/tests/test_wow_game.c
@@ -589,6 +589,19 @@ TEST(wow_game, quest_serverdata_contains_givers_and_objective_locations) {
     T_ASSERT(Wow_QuestDetail(0xFFFFFFFF) == NULL);
 }
 
+TEST(wow_game, quest_giver_group_index_returns_only_one_physical_npc_rows) {
+    VECTOR2 deputy = { -8947.64f, -132.319f };
+    VECTOR2 missing = { 1.0f, 2.0f };
+    DWORD group = Wow_QuestGiverGroup(6, &deputy);
+    DWORD expected[] = { 6, 18, 783, 3903, 5261 };
+
+    T_ASSERT(group != WOW_QUEST_GIVER_GROUP_NONE);
+    T_EQ((int)Wow_QuestGiverGroupCount(group), 5);
+    FOR_LOOP(i, sizeof(expected) / sizeof(*expected)) T_EQ((int)Wow_QuestGiverInGroup(group, i)->quest_id, (int)expected[i]);
+    T_EQ((int)Wow_QuestGiverGroup(6, &missing), (int)WOW_QUEST_GIVER_GROUP_NONE);
+    T_ASSERT(Wow_QuestGiverInGroup(group, 5) == NULL);
+}
+
 TEST(wow_game, creature_serverdata_preserves_templates_and_all_models) {
     LPCWOWCREATURE marshal = Wow_CreatureByEntry(197);
     LPCWOWCREATURE deputy = Wow_CreatureByEntry(823);

--- a/games/world-of-warcraft/tests/test_wow_wmo.c
+++ b/games/world-of-warcraft/tests/test_wow_wmo.c
@@ -869,6 +869,37 @@ TEST(wow_wmo_global, name_id_in_modf_is_index_into_mwid) {
     T_STREQ(path, "WorldB.wmo");
 }
 
+/* MODR references, not root MODD order, decide which embedded doodads follow a visible group. */
+static DWORD ref_visible_modr(BYTE const visible[2], WORD const refs[2][3], BYTE seen[6], WORD out[6]) {
+    DWORD count = 0;
+    memset(seen, 0, 6);
+    for (DWORD group = 0; group < 2; group++) {
+        if (!visible[group]) continue;
+        for (DWORD i = 0; i < 3; i++) {
+            WORD ref = refs[group][i];
+            if (ref >= 6 || seen[ref]) continue;
+            seen[ref] = 1; out[count++] = ref;
+        }
+    }
+    return count;
+}
+
+TEST(wow_wmo_doodad_visibility, queues_visible_modr_groups_and_deduplicates_shared_refs) {
+    WORD refs[2][3] = { { 0, 1, 2 }, { 2, 3, 4 } }, out[6] = { 0 };
+    BYTE seen[6], visible[2] = { 0, 1 };
+    DWORD count = ref_visible_modr(visible, refs, seen, out);
+    T_EQ((int)count, 3); T_EQ((int)out[0], 2); T_EQ((int)out[1], 3); T_EQ((int)out[2], 4);
+    visible[0] = 1;
+    count = ref_visible_modr(visible, refs, seen, out);
+    T_EQ((int)count, 5); T_EQ((int)out[2], 2); T_EQ((int)out[3], 3);
+}
+
+TEST(wow_wmo_doodad_visibility, invisible_parent_queues_no_group_owned_doodads) {
+    WORD refs[2][3] = { { 0, 1, 2 }, { 3, 4, 5 } }, out[6] = { 0 };
+    BYTE seen[6], visible[2] = { 0, 0 };
+    T_EQ((int)ref_visible_modr(visible, refs, seen, out), 0);
+}
+
 /* =========================================================================
    L. Phase 6: Portal structs, MOPT/MOPV/MOPR parsing, containment logic
    ======================================================================= */


### PR DESCRIPTION
## Summary
- retain WMO group MODR ownership and submit only doodads owned by visible WMO groups
- deduplicate shared MODR references while keeping unowned MODD entries scoped to visible parents
- add quest-group and WMO visibility coverage and document the measured WoW improvements
- keep WOWPERF.md removed; findings live in the existing subsystem documentation

## Measurements
A bounded Human-start run reduced WMO doodad submissions from 7,147 loaded instances to 199 instances owned by 6 visible WMOs / 29 visible groups (97.2% fewer). The related overhead attachment cache recorded zero misses after scene initialization. The terrain-height baseline was 1,108.8 MCNK probes per successful query before the direct atlas-indexed lookup, and quest markers averaged 1,180.6 giver-row visits before the generated physical-giver index.

## Verification
- make build/bin/openwow
- bounded 600-frame Human-start renderer run at 2048x1536
- make test-wow-game test-wow-wmo -j4
- make test -j4 (all suites pass; requires local UDP socket access for networking tests)