### PR TITLE
Fix isoextract for Ubuntu 22.04

### DIFF
--- a/tools/isoextract.c
+++ b/tools/isoextract.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include "common/shared.h"
 
 #ifdef _WIN32
 #include <direct.h>


### PR DESCRIPTION
Fixes this

```
/usr/bin/ld: /tmp/ccr2VzVk.o: in function `mkdir_p':
/src/tools/isoextract.c:334: undefined reference to `strlcpy'
collect2: error: ld returned 1 exit status
make: *** [Makefile:241: build/bin/isoextract] Error 1
root@aba77d98b506:/src# make GL_BACKEND=gles3 MSAA=0 build && mkdir -p release &&        cp build/bin/openwarcraft3 release/ &&       cp build/bin/openwow release/ &&       cp -r build/lib/. release/ &&  mv  release/openwarcraft3 release/openwarcraft3.aarch64 &&       mv  release/openwow release/openwow.aarch64
[install-share]
tools/isoextract.c: In function 'mkdir_p':
tools/isoextract.c:334:5: warning: implicit declaration of function 'strlcpy'; did you mean 'strncpy'? [-Wimplicit-function-declaration]
  334 |     strlcpy(tmp, path, sizeof(tmp));
      |     ^~~~~~~
      |     strncpy
/usr/bin/ld: /tmp/cc8C1UZE.o: in function `mkdir_p':
/src/tools/isoextract.c:334: undefined reference to `strlcpy'
collect2: error: ld returned 1 exit status
make: *** [Makefile:241: build/bin/isoextract] Error 1
```