### PR TITLE
wc3: replace SLK sheet-cache with direct typed-array loading

### DIFF
--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -589,8 +589,7 @@ void CL_Init(void) {
         .FS_MmapFile = FS_MmapFile,
         .FS_MunmapFile = FS_MunmapFile,
         .FileExtract = FS_ExtractFile,
-        .ReadSheet = FS_ParseSLK,
-        .FindSheetCell = FS_FindSheetCell,
+        .LoadSlkCache = Stb_SlkCacheLoad,
         .CvarString = Cvar_String,
         .error = CON_printf,
     });

--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -589,7 +589,7 @@ void CL_Init(void) {
         .FS_MmapFile = FS_MmapFile,
         .FS_MunmapFile = FS_MunmapFile,
         .FileExtract = FS_ExtractFile,
-        .LoadSlkCache = Stb_SlkCacheLoad,
+        .LoadSlk = Stb_SlkLoad,
         .CvarString = Cvar_String,
         .error = CON_printf,
     });

--- a/client/tr_public.h
+++ b/client/tr_public.h
@@ -94,7 +94,7 @@ typedef struct {
     
     HANDLE (*MemAlloc)(long size);
     void (*MemFree)(HANDLE);
-    BOOL (*LoadSlkCache)(stbSlkCache_t *cache, LPCSTR filename, slkField_t const *schema, DWORD row_stride);
+    DWORD (*LoadSlk)(LPCSTR filename, slkField_t const *schema, void **dest, DWORD row_stride);
     LPCSTR (*CvarString)(LPCSTR name, LPCSTR fallback);
     void (*error)(LPCSTR fmt, ...);
 } refImport_t;

--- a/client/tr_public.h
+++ b/client/tr_public.h
@@ -81,6 +81,7 @@ typedef struct drawBackdrop_s {
 typedef drawText_t const *LPCDRAWTEXT;
 typedef drawImage_t const *LPCDRAWIMAGE;
 typedef drawBackdrop_t const *LPCDRAWBACKDROP;
+#include "games/warcraft-3/common/stb_slk.h"
 
 typedef struct {
     // Quake 3-style file API: renderer is archive-agnostic
@@ -93,8 +94,7 @@ typedef struct {
     
     HANDLE (*MemAlloc)(long size);
     void (*MemFree)(HANDLE);
-    sheetRow_t *(*ReadSheet)(LPCSTR sheetFilename);
-    LPCSTR (*FindSheetCell)(sheetRow_t *sheet, LPCSTR row, LPCSTR column);
+    BOOL (*LoadSlkCache)(stbSlkCache_t *cache, LPCSTR filename, slkField_t const *schema, DWORD row_stride);
     LPCSTR (*CvarString)(LPCSTR name, LPCSTR fallback);
     void (*error)(LPCSTR fmt, ...);
 } refImport_t;

--- a/common/common.h
+++ b/common/common.h
@@ -1,6 +1,8 @@
 #ifndef __common_h__
 #define __common_h__
 
+#include <stddef.h>
+
 #include "shared.h"
 #include "net.h"
 #include "mpq.h"
@@ -204,11 +206,6 @@ typedef struct {
 } SHEETHOST;
 
 void FS_SetSheetHost(SHEETHOST const *host);
-sheetRow_t *FS_ParseINI(LPCSTR fileName);
-sheetRow_t *FS_ParseSLK(LPCSTR fileName);
-sheetRow_t *FS_ParseSLK_Buffer(LPCSTR buffer);
-LPCSTR FS_FindSheetCell(sheetRow_t *sheet, LPCSTR row, LPCSTR column);
-sheetRow_t *FS_GetParsedSheetTail(void);
 
 void CL_Init(void);
 void CL_Frame(DWORD msec);

--- a/common/shared.h
+++ b/common/shared.h
@@ -877,17 +877,6 @@ typedef struct {
     VECTOR2 pushedTextOffset;
 } uiGlueTextButton_t;
 
-typedef struct sheetField_s {
-    LPCSTR name, value;
-    struct sheetField_s *next;
-} sheetField_t;
-
-typedef struct sheetRow_s {
-    LPCSTR name;
-    struct sheetField_s *fields;
-    struct sheetRow_s *next;
-} sheetRow_t;
-
 typedef struct {
     LPSTR tok;
     LPCSTR str;

--- a/docs/wc3-data-model.md
+++ b/docs/wc3-data-model.md
@@ -2,6 +2,19 @@
 
 Read this when working on unit stats, combat, abilities, hero systems, pathfinding, or any code that reads from SLK/metadata tables.
 
+## SLK And INI Loading
+
+WC3 table loading follows the same boundary as `stb_dbc.h`: callers declare a `slkField_t` schema and own an
+`stbSlkCache_t` containing only decoded typed rows. `Stb_SlkCacheLoad` and `Stb_SlkCacheLoadBuffer` perform file parsing
+and decoding; `Stb_SlkCacheFind` resolves an explicitly declared FOURCC row key; `Stb_SlkCacheFree` releases owned
+strings and rows. The row key is a normal schema entry with an empty column name and `STB_SLK_FOURCC`; the loader never
+writes an implicit key into byte zero.
+
+INI files with fixed row layouts use `Stb_IniCacheDecode` into an `stbSlkCache_t`. Dynamic dictionaries such as skin,
+miscellaneous, command, and ability text files remain `stbIniCache_t` values queried through `Stb_IniCacheFind`.
+`sheetRow_t`, fields, linked lists, and append operations are private implementation details of
+`games/warcraft-3/sheet/sheet.c` and must not cross the parser boundary.
+
 ## The Base-vs-Computed Column Trap
 
 Several UnitBalance.slk columns exist in both a **base** form and a **computed** (real) form. The base column is the editor-entered value; the computed column includes bonuses (hero attributes, etc.). Always read the computed column at runtime — base values are 0 or wrong for heroes.

--- a/games/warcraft-3/common/stb_slk.h
+++ b/games/warcraft-3/common/stb_slk.h
@@ -2,27 +2,12 @@
  * stb_slk.h — Schema-driven SLK / INI row decoder for Warcraft III.
  *
  * Mirrors stb_dbc.h's stbDbcField_t / Stb_DbcParseRows pattern but for
- * string-keyed columnar data (sheetRow_t linked lists produced by
- * FS_ParseSLK / FS_ParseINI).  Source readers still own file I/O and the
- * linked-list representation; this header converts that representation into
- * typed C structs for direct struct-field access instead of per-call
- * FS_FindSheetCell + atoi / atof.
- *
- * Typical use — decode:
- *
- *   static slkField_t const balance_schema[] = {
- *       { "realHP",    offsetof(UnitBalance_t, realHP),    BZ_FIELD_FLOAT },
- *       { "spd",       offsetof(UnitBalance_t, spd),       BZ_FIELD_FLOAT },
- *       { "regenType", offsetof(UnitBalance_t, regenType), BZ_FIELD_CSTR  },
- *   };
- *   UnitBalance_t row = {0};
- *   FS_SLKDecodeRow(slk_row, balance_schema,
- *       sizeof(balance_schema)/sizeof(balance_schema[0]), &row);
+ * string-keyed columnar data decoded through slkField_t DDX schemas.
  *
  * Typical use — index (after decoding all rows into a flat array `rows`):
  *
  *   slkIndex_t idx = {0};
- *   FS_SLKBuildIndex(&idx, head, rows, n, sizeof(UnitBalance_t));
+ *   FS_SLKBuildIndex(&idx, rows, n, sizeof(UnitBalance_t));
  *   UnitBalance_t *r = FS_SLKLookup(&idx, unit_fourcc);
  *
  * The index uses a sorted key array with binary search; callers must
@@ -46,69 +31,40 @@
 #define STB_SLK_STR    BZ_FIELD_CSTR   /* owned string; freed with FS_SLKFreeRows */
 #define STB_SLK_FOURCC BZ_FIELD_FOURCC /* 4-char text → DWORD via memcpy (LE)   */
 
-/* -------------------------------------------------------------------------
- * Schema entry — one SLK column → one struct field.
- * Mirrors stbDbcField_t but with a string column key.
- * -------------------------------------------------------------------------*/
-typedef struct {
+/* Schema entry — one SLK/INI key → one struct field. */
+typedef struct slkField_s {
     LPCSTR        column;  /* SLK column header (Y=1 text) or INI key name */
     ptrdiff_t     offset;  /* offsetof(RowStruct, field)                   */
     bzFieldType_t type;
     LPCSTR        id;      /* optional four-character object-data field ID */
 } slkField_t;
 
-/* -------------------------------------------------------------------------
- * FS_SLKDecodeRow — fill one struct from a sheetRow_t using a schema.
- *
- * schema is NULL-terminated (last entry has .column == NULL), following the
- * Quake 2 zero-sentinel field-table convention.  For each field in `row`,
- * a linear scan finds the first matching schema entry (case-insensitive) and
- * writes the converted value into *out at the given offset.  Unmatched row
- * fields are silently ignored; unmatched schema entries leave the struct
- * field at its initialised value (caller should zero the struct first).
- * -------------------------------------------------------------------------*/
-static inline void FS_SLKDecodeRow(sheetRow_t const *row,
-                                   slkField_t const *schema,
-                                   void *out) {
-    if (!row || !schema || !out) return;
-    for (slkField_t const *s = schema; s->column; s++) {
-        if (*s->column) continue;
-        if (s->type == BZ_FIELD_CSTR) {
-            size_t len = strlen(row->name); LPSTR value = (LPSTR)malloc(len + 1);
-            if (!value) { fprintf(stderr, "SLK: out of memory copying row name '%s'\n", row->name); continue; }
-            memcpy(value, row->name, len + 1); *(LPSTR *)((BYTE *)out + s->offset) = value;
-        }
-    }
-    FOR_EACH_LIST(sheetField_t const, f, row->fields) {
-        for (slkField_t const *s = schema; s->column; s++) {
-            if (strcasecmp(f->name, s->column)) continue;
-            BYTE *dst = (BYTE *)out + s->offset;
-            switch (s->type) {
-            case BZ_FIELD_U32:
-                *(DWORD *)dst = f->value ? (DWORD)atoi(f->value) : 0; break;
-            case BZ_FIELD_FLOAT:
-                *(FLOAT *)dst = f->value ? (FLOAT)atof(f->value) : 0.f; break;
-            case BZ_FIELD_BOOL:
-                *(BOOL *)dst = f->value &&
-                    (atoi(f->value) != 0 || !strcmp(f->value, "TRUE")); break;
-            case BZ_FIELD_CSTR: {
-                size_t len = f->value ? strlen(f->value) : 0;
-                LPSTR value = (LPSTR)malloc(len + 1);
-                if (!value) { fprintf(stderr, "SLK: out of memory copying field '%s'\n", f->name); break; }
-                memcpy(value, f->value ? f->value : "", len + 1);
-                free(*(void **)dst); *(LPSTR *)dst = value; break;
-            }
-            case BZ_FIELD_FOURCC: {
-                DWORD k = 0;
-                if (f->value) { size_t n = strlen(f->value); memcpy(&k, f->value, n < 4 ? n : 4); }
-                *(DWORD *)dst = k; break;
-            }
-            default: break;
-            }
-            break; /* matched — move to next field */
-        }
-    }
-}
+/* Stateful typed-table cache, matching stbDbcCache_t ownership.  `source` is
+ * parser-private; consumers only read decoded rows or query the index. */
+typedef struct {
+    void *source;
+    void *rows;
+    slkField_t const *schema;
+    DWORD count, row_stride;
+    ptrdiff_t key_offset;
+    BOOL has_key;
+} stbSlkCache_t;
+
+/* INI files are runtime-keyed dictionaries, so keep their parser state opaque
+ * and expose lookup rather than pretending every file has a fixed row type. */
+typedef struct { void *source; } stbIniCache_t;
+
+#define STB_SLK_ROW(cache, T, idx) \
+    ((T const *)((BYTE const *)(cache).rows + (size_t)(idx) * (cache).row_stride))
+
+BOOL Stb_SlkCacheLoad(stbSlkCache_t *cache, LPCSTR filename, slkField_t const *schema, DWORD row_stride);
+BOOL Stb_SlkCacheLoadBuffer(stbSlkCache_t *cache, LPCSTR buffer, slkField_t const *schema, DWORD row_stride);
+BOOL Stb_IniCacheLoad(stbIniCache_t *cache, LPCSTR filename);
+BOOL Stb_IniCacheLoadFiles(stbIniCache_t *cache, LPCSTR const *filenames);
+BOOL Stb_IniCacheDecode(stbIniCache_t const *ini, stbSlkCache_t *cache,
+                        slkField_t const *schema, DWORD row_stride);
+LPCSTR Stb_IniCacheFind(stbIniCache_t const *cache, LPCSTR section, LPCSTR key);
+void Stb_IniCacheFree(stbIniCache_t *cache);
 
 /* -------------------------------------------------------------------------
  * FOURCC key helpers — convert a 4-char unit-code string to a DWORD for
@@ -138,18 +94,22 @@ static inline void FS_SLKFreeRows(slkField_t const *schema, void *rows, DWORD co
     free(rows);
 }
 
+static inline void Stb_SlkCacheFree(stbSlkCache_t *cache) {
+    if (!cache) return;
+    FS_SLKFreeRows(cache->schema, cache->rows, cache->count, cache->row_stride);
+    memset(cache, 0, sizeof(*cache));
+}
+
 /* -------------------------------------------------------------------------
  * Sorted lookup index — parallel key[] / row[] arrays for binary search.
  * Not heap-owning: rows[] points into the caller's decoded array.
  * -------------------------------------------------------------------------*/
 typedef struct { DWORD *keys; void **rows; DWORD count; } slkIndex_t;
 
-/* Build the sorted index from a decoded row array `rows_base` (flat, stride
- * bytes between rows) paired with the original sheetRow_t list (for keys).
- * Assumes one-to-one correspondence between `head` and `rows_base[0..n-1]`. */
-static inline void FS_SLKBuildIndex(slkIndex_t *idx, sheetRow_t const *head,
-                                    void *rows_base, DWORD n, size_t stride) {
-    if (!idx || !head || !rows_base || !n) return;
+/* Build the sorted index from a decoded row array whose first field is its
+ * FOURCC key.  Typed SLK rows own their identity; parser rows stay private. */
+static inline void FS_SLKBuildIndex(slkIndex_t *idx, void *rows_base, DWORD n, size_t stride) {
+    if (!idx || !rows_base || !n) return;
     idx->keys = (DWORD *)malloc(n * sizeof(DWORD));
     idx->rows = (void **)malloc(n * sizeof(void *));
     if (!idx->keys || !idx->rows) {
@@ -158,14 +118,11 @@ static inline void FS_SLKBuildIndex(slkIndex_t *idx, sheetRow_t const *head,
         idx->keys = NULL; idx->rows = NULL; idx->count = 0;
         return;
     }
-    DWORD i = 0;
-    FOR_EACH_LIST(sheetRow_t const, r, head) {
-        if (i >= n) break;
-        idx->keys[i] = FS_SLKKey(r->name);
+    FOR_LOOP(i, n) {
         idx->rows[i] = (BYTE *)rows_base + i * stride;
-        i++;
+        idx->keys[i] = *(DWORD *)idx->rows[i];
     }
-    idx->count = i;
+    idx->count = n;
     /* Sort both arrays together by key using an index-sort. */
     /* Simple insertion sort — ~1000 units, negligible at load time. */
     for (DWORD j = 1; j < idx->count; j++) {
@@ -189,6 +146,15 @@ static inline void *FS_SLKLookup(slkIndex_t const *idx, DWORD key) {
         if      (idx->keys[mid] < key) lo = mid + 1;
         else if (idx->keys[mid] > key) hi = mid;
         else return idx->rows[mid];
+    }
+    return NULL;
+}
+
+static inline void *Stb_SlkCacheFind(stbSlkCache_t const *cache, DWORD key) {
+    if (!cache || !cache->rows || !cache->has_key) return NULL;
+    FOR_LOOP(i, cache->count) {
+        BYTE *row = (BYTE *)cache->rows + i * cache->row_stride;
+        if (*(DWORD *)(row + cache->key_offset) == key) return row;
     }
     return NULL;
 }

--- a/games/warcraft-3/common/stb_slk.h
+++ b/games/warcraft-3/common/stb_slk.h
@@ -39,30 +39,18 @@ typedef struct slkField_s {
     LPCSTR        id;      /* optional four-character object-data field ID */
 } slkField_t;
 
-/* Stateful typed-table cache, matching stbDbcCache_t ownership.  `source` is
- * parser-private; consumers only read decoded rows or query the index. */
-typedef struct {
-    void *source;
-    void *rows;
-    slkField_t const *schema;
-    DWORD count, row_stride;
-    ptrdiff_t key_offset;
-    BOOL has_key;
-} stbSlkCache_t;
-
 /* INI files are runtime-keyed dictionaries, so keep their parser state opaque
  * and expose lookup rather than pretending every file has a fixed row type. */
 typedef struct { void *source; } stbIniCache_t;
 
-#define STB_SLK_ROW(cache, T, idx) \
-    ((T const *)((BYTE const *)(cache).rows + (size_t)(idx) * (cache).row_stride))
-
-BOOL Stb_SlkCacheLoad(stbSlkCache_t *cache, LPCSTR filename, slkField_t const *schema, DWORD row_stride);
-BOOL Stb_SlkCacheLoadBuffer(stbSlkCache_t *cache, LPCSTR buffer, slkField_t const *schema, DWORD row_stride);
+/* Load SLK from file → allocate *dest, return count (0 on failure). */
+DWORD Stb_SlkLoad(LPCSTR filename, slkField_t const *schema, void **dest, DWORD row_stride);
+/* Load SLK from in-memory buffer → allocate *dest, return count (0 on failure). */
+DWORD Stb_SlkLoadBuffer(LPCSTR buffer, slkField_t const *schema, void **dest, DWORD row_stride);
 BOOL Stb_IniCacheLoad(stbIniCache_t *cache, LPCSTR filename);
 BOOL Stb_IniCacheLoadFiles(stbIniCache_t *cache, LPCSTR const *filenames);
-BOOL Stb_IniCacheDecode(stbIniCache_t const *ini, stbSlkCache_t *cache,
-                        slkField_t const *schema, DWORD row_stride);
+/* Decode an INI cache into a typed row array → allocate *dest, return count. */
+DWORD Stb_IniDecode(stbIniCache_t const *ini, slkField_t const *schema, void **dest, DWORD row_stride);
 LPCSTR Stb_IniCacheFind(stbIniCache_t const *cache, LPCSTR section, LPCSTR key);
 void Stb_IniCacheFree(stbIniCache_t *cache);
 
@@ -92,12 +80,6 @@ static inline void FS_SLKFreeRows(slkField_t const *schema, void *rows, DWORD co
         }
     }
     free(rows);
-}
-
-static inline void Stb_SlkCacheFree(stbSlkCache_t *cache) {
-    if (!cache) return;
-    FS_SLKFreeRows(cache->schema, cache->rows, cache->count, cache->row_stride);
-    memset(cache, 0, sizeof(*cache));
 }
 
 /* -------------------------------------------------------------------------
@@ -146,15 +128,6 @@ static inline void *FS_SLKLookup(slkIndex_t const *idx, DWORD key) {
         if      (idx->keys[mid] < key) lo = mid + 1;
         else if (idx->keys[mid] > key) hi = mid;
         else return idx->rows[mid];
-    }
-    return NULL;
-}
-
-static inline void *Stb_SlkCacheFind(stbSlkCache_t const *cache, DWORD key) {
-    if (!cache || !cache->rows || !cache->has_key) return NULL;
-    FOR_LOOP(i, cache->count) {
-        BYTE *row = (BYTE *)cache->rows + i * cache->row_stride;
-        if (*(DWORD *)(row + cache->key_offset) == key) return row;
     }
     return NULL;
 }

--- a/games/warcraft-3/game/g_items.c
+++ b/games/warcraft-3/game/g_items.c
@@ -19,7 +19,7 @@ DWORD G_ItemTypeFromClass(LPCSTR cls) {
 }
 
 static FLOAT G_MiscVectorValue(LPCSTR name, DWORD index) {
-    LPCSTR value = FS_FindSheetCell(game.config.misc, "Misc", name);
+    LPCSTR value = Stb_IniCacheFind(&game.config.misc, "Misc", name);
     if (!value) {
         return 0;
     }
@@ -92,7 +92,7 @@ void SP_SpawnItem(LPEDICT self) {
     }
     self->s.radius = self->ItemData->selectionSize;
 #ifndef USE_SHADOWMAPS
-    self->s.shadow = G_LoadShadowTexture(FS_FindSheetCell(game.config.misc, "Misc", "ItemShadowFile"), false);
+    self->s.shadow = G_LoadShadowTexture(Stb_IniCacheFind(&game.config.misc, "Misc", "ItemShadowFile"), false);
     self->s.shadow_rect = ShadowPackRect(
         G_MiscVectorValue("ItemShadowOffset", 0),
         G_MiscVectorValue("ItemShadowOffset", 1),

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -7,6 +7,7 @@
 
 #include "common/common.h"
 #include "common/stb_fdf.h"
+#include "common/stb_slk.h"
 #include "server/game.h"
 #include "g_shared.h"
 #include "g_unitrow.h"
@@ -671,8 +672,8 @@ struct game_locals {
     DWORD num_abilities;
     LPGAMECLIENT clients;
     struct {
-        sheetRow_t *theme;
-        sheetRow_t *misc;
+        stbIniCache_t theme;
+        stbIniCache_t misc;
     } config;
     struct {
         FLOAT attackHalfAngle;
@@ -990,13 +991,13 @@ LPCSTR UnitMetaString(LPEDICT, DWORD);
 LONG UnitMetaInteger(LPEDICT, DWORD);
 BOOL UnitMetaBoolean(LPEDICT, DWORD);
 FLOAT UnitMetaReal(LPEDICT, DWORD);
-sheetRow_t *G_SheetTail(sheetRow_t *rows);
 
 void InitUnitData(void);
 void ShutdownUnitData(void);
 #ifdef BZ_TESTS
-sheetRow_t *G_SetSLKRows(LPCSTR, sheetRow_t *);
-sheetRow_t *G_SetProfileRows(sheetRow_t *);
+typedef struct { LPCSTR text; stbSlkCache_t cache; } slkTestData_t;
+slkTestData_t *G_SetSLKRows(LPCSTR, slkTestData_t *);
+slkTestData_t *G_SetProfileRows(slkTestData_t *);
 #endif
 void G_RegisterSelectSounds(LPEDICT, LPCSTR);
 

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -995,7 +995,7 @@ FLOAT UnitMetaReal(LPEDICT, DWORD);
 void InitUnitData(void);
 void ShutdownUnitData(void);
 #ifdef BZ_TESTS
-typedef struct { LPCSTR text; stbSlkCache_t cache; } slkTestData_t;
+typedef struct { LPCSTR text; void *rows; DWORD count; } slkTestData_t;
 slkTestData_t *G_SetSLKRows(LPCSTR, slkTestData_t *);
 slkTestData_t *G_SetProfileRows(slkTestData_t *);
 #endif

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -57,26 +57,12 @@ LPCSTR miscdata_files[] = {
 };
 
 static void InitMiscValue(LPCSTR name, FLOAT *dest) {
-    LPCSTR strvalue = FS_FindSheetCell(game.config.misc, "Misc", name);
+    LPCSTR strvalue = Stb_IniCacheFind(&game.config.misc, "Misc", name);
     *dest = strvalue ? atof(strvalue) : 0;
 }
 
 static void InitConstants(void) {
-    sheetRow_t *miscTail = NULL;
-
-    for (LPCSTR *config = miscdata_files; *config; config++) {
-        sheetRow_t *current = FS_ParseINI(*config);
-        if (current) {
-            sheetRow_t *currentTail = G_SheetTail(current);
-
-            if (miscTail) {
-                miscTail->next = current;
-            } else {
-                game.config.misc = current;
-            }
-            miscTail = currentTail;
-        }
-    }
+    Stb_IniCacheLoadFiles(&game.config.misc, miscdata_files);
     InitMiscValue("AttackHalfAngle", &game.constants.attackHalfAngle);
     InitMiscValue("MaxCollisionRadius", &game.constants.maxCollisionRadius);
     InitMiscValue("DecayTime", &game.constants.decayTime);
@@ -166,7 +152,7 @@ static void G_InitGame(void) {
 
     game.max_clients = globals.max_clients;
     game.clients = gi.MemAlloc(game.max_clients * sizeof(GAMECLIENT));
-    game.config.theme = FS_ParseINI("UI\\war3skins.txt");
+    Stb_IniCacheLoad(&game.config.theme, "UI\\war3skins.txt");
     InitConstants();
     InitUnitData();
     InitAbilities();
@@ -185,6 +171,7 @@ static void G_ShutdownGame(void) {
     globals.num_edicts = 0;
 
     ShutdownUnitData();
+    Stb_IniCacheFree(&game.config.theme); Stb_IniCacheFree(&game.config.misc);
     SAFE_DELETE(game.clients, gi.MemFree);
 }
 
@@ -330,7 +317,7 @@ static void G_RunFrame(void) {
 static LPCSTR G_GetThemeValue(LPCSTR filename) {
     LPCSTR skinned = NULL;
     if (!strstr(filename, "\\")) {
-        skinned = FS_FindSheetCell(game.config.theme, "Default", filename);
+        skinned = Stb_IniCacheFind(&game.config.theme, "Default", filename);
     }
     return skinned ? skinned : filename;
 }

--- a/games/warcraft-3/game/g_metadata.c
+++ b/games/warcraft-3/game/g_metadata.c
@@ -706,7 +706,6 @@ static slkField_t const dest_schema[] = {
  * =========================================================================*/
 UnitBalance_t *g_UnitBalance; DWORD g_UnitBalanceCount; static slkIndex_t balance_idx;
 UnitProfile_t *g_UnitProfile; DWORD g_UnitProfileCount; static slkIndex_t profile_idx;
-static stbSlkCache_t profile_cache;
 UnitData_t *g_UnitData; DWORD g_UnitDataCount; static slkIndex_t data_idx;
 UnitUI_t *g_UnitUI; DWORD g_UnitUICount; static slkIndex_t ui_idx;
 UnitWeapons_t *g_UnitWeapons; DWORD g_UnitWeaponsCount; static slkIndex_t weapons_idx;
@@ -725,7 +724,6 @@ typedef struct {
     void **rows;
     DWORD *count;
     slkIndex_t *idx;
-    stbSlkCache_t cache;
 } slkStore_t;
 
 static slkStore_t slk_stores[] = {
@@ -742,13 +740,6 @@ static slkStore_t slk_stores[] = {
     { "DestructableData", "Units\\DestructableData.slk", dest_schema, sizeof(*g_DestructableData), (void **)&g_DestructableData, &g_DestructableDataCount, &dest_idx },
 };
 
-/* Keep legacy exported arrays as borrowed views of the owning typed cache. */
-static void ApplySLKCache(slkStore_t *store) {
-    FS_SLKFreeIndex(store->idx);
-    *store->rows = store->cache.rows; *store->count = store->cache.count;
-    if (store->idx) FS_SLKBuildIndex(store->idx, store->cache.rows, store->cache.count, store->row_size);
-}
-
 /* Tests replace a typed table and restore its original parser-owned source. */
 #ifdef BZ_TESTS
 slkTestData_t *G_SetSLKRows(LPCSTR slk, slkTestData_t *data) {
@@ -757,12 +748,15 @@ slkTestData_t *G_SetSLKRows(LPCSTR slk, slkTestData_t *data) {
         if (!strcmp(slk, store->name)) {
             slkTestData_t *old = calloc(1, sizeof(*old));
             if (!old) return NULL;
-            old->cache = store->cache;
-            if (!data->cache.rows && !Stb_SlkCacheLoadBuffer(&data->cache, data->text, store->schema, store->row_size)) {
-                free(old); return NULL;
+            old->rows = *store->rows; old->count = *store->count;
+            if (!data->rows) {
+                data->count = Stb_SlkLoadBuffer(data->text, store->schema, &data->rows, store->row_size);
+                if (!data->count) { free(old); return NULL; }
             }
-            store->cache = data->cache; ApplySLKCache(store);
-            memset(&data->cache, 0, sizeof(data->cache));
+            FS_SLKFreeIndex(store->idx);
+            *store->rows = data->rows; *store->count = data->count;
+            if (store->idx) FS_SLKBuildIndex(store->idx, *store->rows, *store->count, store->row_size);
+            data->rows = NULL; data->count = 0;
             return old;
         }
     }
@@ -773,14 +767,15 @@ slkTestData_t *G_SetSLKRows(LPCSTR slk, slkTestData_t *data) {
 slkTestData_t *G_SetProfileRows(slkTestData_t *data) {
     slkTestData_t *old = calloc(1, sizeof(*old));
     if (!old) return NULL;
-    old->cache = profile_cache;
-    if (!data->cache.rows && !Stb_SlkCacheLoadBuffer(&data->cache, data->text, profile_schema, sizeof(*g_UnitProfile))) {
-        free(old); return NULL;
+    old->rows = g_UnitProfile; old->count = g_UnitProfileCount;
+    if (!data->rows) {
+        data->count = Stb_SlkLoadBuffer(data->text, profile_schema, &data->rows, sizeof(*g_UnitProfile));
+        if (!data->count) { free(old); return NULL; }
     }
-    FS_SLKFreeIndex(&profile_idx); profile_cache = data->cache;
-    memset(&data->cache, 0, sizeof(data->cache));
-    g_UnitProfile = profile_cache.rows; g_UnitProfileCount = profile_cache.count;
-    FS_SLKBuildIndex(&profile_idx, profile_cache.rows, profile_cache.count, profile_cache.row_stride);
+    FS_SLKFreeIndex(&profile_idx);
+    g_UnitProfile = data->rows; g_UnitProfileCount = data->count;
+    FS_SLKBuildIndex(&profile_idx, g_UnitProfile, g_UnitProfileCount, sizeof(*g_UnitProfile));
+    data->rows = NULL; data->count = 0;
     return old;
 }
 #endif
@@ -1247,25 +1242,26 @@ void InitUnitData(void) {
         }
     }
     Stb_IniCacheLoadFiles(&profile_ini, profile_files);
-    Stb_IniCacheDecode(&profile_ini, &profile_cache, profile_schema, sizeof(*g_UnitProfile));
-    g_UnitProfile = profile_cache.rows; g_UnitProfileCount = profile_cache.count;
-    FS_SLKBuildIndex(&profile_idx, profile_cache.rows, profile_cache.count, sizeof(*g_UnitProfile));
+    g_UnitProfileCount = Stb_IniDecode(&profile_ini, profile_schema, (void **)&g_UnitProfile, sizeof(*g_UnitProfile));
+    Stb_IniCacheFree(&profile_ini);
+    FS_SLKBuildIndex(&profile_idx, g_UnitProfile, g_UnitProfileCount, sizeof(*g_UnitProfile));
 
     FOR_LOOP(i, sizeof(slk_stores) / sizeof(*slk_stores)) {
         slkStore_t *store = slk_stores + i;
-        if (!Stb_SlkCacheLoad(&store->cache, store->path, store->schema, store->row_size))
-            fprintf(stderr, "SLK: failed to load '%s'\n", store->path);
-        ApplySLKCache(store);
+        *store->count = Stb_SlkLoad(store->path, store->schema, store->rows, store->row_size);
+        if (!*store->count) fprintf(stderr, "SLK: failed to load '%s'\n", store->path);
+        if (store->idx) FS_SLKBuildIndex(store->idx, *store->rows, *store->count, store->row_size);
     }
 }
 
 void ShutdownUnitData(void) {
-    FS_SLKFreeIndex(&profile_idx); Stb_SlkCacheFree(&profile_cache);
+    FS_SLKFreeIndex(&profile_idx);
+    FS_SLKFreeRows(profile_schema, g_UnitProfile, g_UnitProfileCount, sizeof(*g_UnitProfile));
     g_UnitProfile = NULL; g_UnitProfileCount = 0;
     FOR_LOOP(i, sizeof(slk_stores) / sizeof(*slk_stores)) {
         slkStore_t *store = slk_stores + i;
         FS_SLKFreeIndex(store->idx);
-        Stb_SlkCacheFree(&store->cache);
+        FS_SLKFreeRows(store->schema, *store->rows, *store->count, store->row_size);
         *store->rows = NULL; *store->count = 0;
     }
     FOR_LOOP(i, abilityConfigTableCount) Stb_IniCacheFree(abilityConfigTables + i);

--- a/games/warcraft-3/game/g_metadata.c
+++ b/games/warcraft-3/game/g_metadata.c
@@ -2,46 +2,6 @@
 #include "common/stb_slk.h"
 #include "g_unitrow.h"
 
-typedef struct sheet_tail_cache_entry_s {
-    sheetRow_t *rows;
-    sheetRow_t *tail;
-    struct sheet_tail_cache_entry_s *next;
-} sheet_tail_cache_entry_t;
-
-static sheet_tail_cache_entry_t *sheet_tail_cache = NULL;
-
-sheetRow_t *G_SheetTail(sheetRow_t *rows)
-{
-    sheet_tail_cache_entry_t *entry;
-    sheet_tail_cache_entry_t *new_entry;
-    sheetRow_t *tail;
-
-    if (!rows) {
-        return NULL;
-    }
-
-    for (entry = sheet_tail_cache; entry; entry = entry->next) {
-        if (entry->rows == rows) {
-            return entry->tail;
-        }
-    }
-
-    tail = rows;
-    while (tail->next) {
-        tail = tail->next;
-    }
-
-    new_entry = (sheet_tail_cache_entry_t *)malloc(sizeof(*new_entry));
-    if (!new_entry) {
-        return tail;
-    }
-    new_entry->rows = rows;
-    new_entry->tail = tail;
-    new_entry->next = sheet_tail_cache;
-    sheet_tail_cache = new_entry;
-    return tail;
-}
-
 LPCSTR config_files[] = {
     "Units\\OrcAbilityStrings.txt",
     "Units\\HumanUnitFunc.txt",
@@ -107,30 +67,10 @@ LPCSTR profile_files[] = {
     NULL
 };
 
-static sheetRow_t *abilityConfigs = NULL;
-static sheetRow_t *abilityConfigsTail = NULL;
-static sheetRow_t *commandFuncConfig = NULL;
-static sheetRow_t *commandStringsConfig = NULL;
-static sheetRow_t *abilityConfigTables[64];
+static stbIniCache_t abilityConfigTables[64];
+static stbIniCache_t *commandFuncConfig;
+static stbIniCache_t *commandStringsConfig;
 static DWORD abilityConfigTableCount = 0;
-
-static void AppendSheetRows(sheetRow_t **head, sheetRow_t **tail, sheetRow_t *rows)
-{
-    sheetRow_t *rows_tail;
-
-    if (!rows) {
-        return;
-    }
-
-    rows_tail = G_SheetTail(rows);
-
-    if (*tail) {
-        (*tail)->next = rows;
-    } else {
-        *head = rows;
-    }
-    *tail = rows_tail;
-}
 
 static unitMeta_t const *G_FindMetaData(unitMeta_t const *metadatas, DWORD id) {
     for (unitMeta_t const *d = metadatas; d->id; d++) {
@@ -164,6 +104,7 @@ static void warn_unregistered_field(DWORD id) {
  * DDX schemas — one entry per SLK column consumed at runtime.
  * =========================================================================*/
 static slkField_t const profile_schema[] = {
+    { "",              offsetof(UnitProfile_t, id),                STB_SLK_FOURCC },
     { "Name",          offsetof(UnitProfile_t, name),              STB_SLK_STR,   "unam" },
     { "Propernames",   offsetof(UnitProfile_t, properNames),       STB_SLK_STR,   "upro" },
     { "Builds",        offsetof(UnitProfile_t, builds),            STB_SLK_STR,   "ubui" },
@@ -225,6 +166,7 @@ static slkField_t const profile_schema[] = {
 };
 
 static slkField_t const balance_schema[] = {
+    { "",                 offsetof(UnitBalance_t, id),              STB_SLK_FOURCC },
     { "sortBalance",      offsetof(UnitBalance_t, sortBalance),     STB_SLK_STR   },
     { "sort2",            offsetof(UnitBalance_t, sort2),           STB_SLK_STR   },
     { "comment(s)",       offsetof(UnitBalance_t, comments),        STB_SLK_STR   },
@@ -288,6 +230,7 @@ static slkField_t const balance_schema[] = {
 };
 
 static slkField_t const data_schema[] = {
+    { "",                   offsetof(UnitData_t, id),               STB_SLK_FOURCC },
     { "sort",               offsetof(UnitData_t, sort),             STB_SLK_STR   },
     { "comment(s)",         offsetof(UnitData_t, comments),         STB_SLK_STR   },
     { "version",            offsetof(UnitData_t, version),          STB_SLK_INT   },
@@ -330,6 +273,7 @@ static slkField_t const data_schema[] = {
 };
 
 static slkField_t const ui_schema[] = {
+    { "",                 offsetof(UnitUI_t, id),               STB_SLK_FOURCC },
     { "sortUI",           offsetof(UnitUI_t, sortUI),           STB_SLK_STR   },
     { "InBeta",           offsetof(UnitUI_t, InBeta),           STB_SLK_BOOL  },
     { "file",             offsetof(UnitUI_t, modelFile),        STB_SLK_STR   },
@@ -389,6 +333,7 @@ static slkField_t const ui_schema[] = {
 };
 
 static slkField_t const weapons_schema[] = {
+    { "",              offsetof(UnitWeapons_t, id),            STB_SLK_FOURCC },
     { "sortWeap",       offsetof(UnitWeapons_t, sortWeap),      STB_SLK_STR   },
     { "sort2",          offsetof(UnitWeapons_t, sort2),         STB_SLK_STR   },
     { "comment(s)",     offsetof(UnitWeapons_t, comments),      STB_SLK_STR   },
@@ -469,6 +414,7 @@ static slkField_t const weapons_schema[] = {
 };
 
 static slkField_t const abil_schema[] = {
+    { "",             offsetof(UnitAbilities_t, id),          STB_SLK_FOURCC },
     { "sortAbil",     offsetof(UnitAbilities_t, sortAbil),     STB_SLK_STR  },
     { "comment(s)",   offsetof(UnitAbilities_t, comments),     STB_SLK_STR  },
     { "abilList",     offsetof(UnitAbilities_t, abilList),     STB_SLK_STR  },
@@ -481,6 +427,7 @@ static slkField_t const abil_schema[] = {
 #define AB_F(NAME, FIELD, LEVEL, TYPE) { NAME, offsetof(AbilityData_t, FIELD[LEVEL]), TYPE }
 #define AB_D(NAME, LEVEL, SLOT) { NAME, offsetof(AbilityData_t, data[LEVEL][SLOT]), STB_SLK_FLOAT }
 static slkField_t const ability_schema[] = {
+    { "",            offsetof(AbilityData_t, id),          STB_SLK_FOURCC },
     { "code",        offsetof(AbilityData_t, code),        STB_SLK_FOURCC },
     { "uberAlias",   offsetof(AbilityData_t, uberAlias),   STB_SLK_FOURCC }, /* ROC */
     { "comments",    offsetof(AbilityData_t, comments),    STB_SLK_STR    },
@@ -544,6 +491,7 @@ static slkField_t const ability_schema[] = {
 
 #define DOOD_VERT(NAME, VERTEX, CHANNEL) { NAME, offsetof(Doodads_t, vert[VERTEX][CHANNEL]), STB_SLK_INT }
 static slkField_t const doodad_schema[] = {
+    { "",                  offsetof(Doodads_t, id),                STB_SLK_FOURCC },
     { "category",          offsetof(Doodads_t, category),          STB_SLK_STR   },
     { "tilesets",          offsetof(Doodads_t, tilesets),          STB_SLK_STR   },
     { "tilesetSpecific",   offsetof(Doodads_t, tilesetSpecific),   STB_SLK_BOOL  },
@@ -597,6 +545,7 @@ static slkField_t const doodad_schema[] = {
 #undef DOOD_VERT
 
 static slkField_t const uber_schema[] = {
+    { "",           offsetof(UberSplatData_t, id),         STB_SLK_FOURCC },
     { "Name",       offsetof(UberSplatData_t, Name),       STB_SLK_STR   },
     { "comment",    offsetof(UberSplatData_t, comment),    STB_SLK_STR   },
     { "Dir",        offsetof(UberSplatData_t, Dir),        STB_SLK_STR   },
@@ -650,6 +599,7 @@ static slkField_t const sound_schema[] = {
 };
 
 static slkField_t const item_schema[] = {
+    { "",            offsetof(ItemData_t, id),          STB_SLK_FOURCC },
     { "scriptname",  offsetof(ItemData_t, scriptname),  STB_SLK_STR   },
     { "version",     offsetof(ItemData_t, version),     STB_SLK_INT   },
     { "InBeta",      offsetof(ItemData_t, InBeta),      STB_SLK_BOOL  },
@@ -689,6 +639,7 @@ static slkField_t const item_schema[] = {
 };
 
 static slkField_t const dest_schema[] = {
+    { "",                 offsetof(DestructableData_t, id),               STB_SLK_FOURCC },
     { "category",         offsetof(DestructableData_t, category),         STB_SLK_STR   },
     { "tilesets",         offsetof(DestructableData_t, tilesets),         STB_SLK_STR   },
     { "comment",          offsetof(DestructableData_t, comment),          STB_SLK_STR   },
@@ -755,9 +706,7 @@ static slkField_t const dest_schema[] = {
  * =========================================================================*/
 UnitBalance_t *g_UnitBalance; DWORD g_UnitBalanceCount; static slkIndex_t balance_idx;
 UnitProfile_t *g_UnitProfile; DWORD g_UnitProfileCount; static slkIndex_t profile_idx;
-#ifdef BZ_TESTS
-static sheetRow_t *profile_source;
-#endif
+static stbSlkCache_t profile_cache;
 UnitData_t *g_UnitData; DWORD g_UnitDataCount; static slkIndex_t data_idx;
 UnitUI_t *g_UnitUI; DWORD g_UnitUICount; static slkIndex_t ui_idx;
 UnitWeapons_t *g_UnitWeapons; DWORD g_UnitWeaponsCount; static slkIndex_t weapons_idx;
@@ -776,9 +725,7 @@ typedef struct {
     void **rows;
     DWORD *count;
     slkIndex_t *idx;
-#ifdef BZ_TESTS
-    sheetRow_t *source;
-#endif
+    stbSlkCache_t cache;
 } slkStore_t;
 
 static slkStore_t slk_stores[] = {
@@ -795,96 +742,27 @@ static slkStore_t slk_stores[] = {
     { "DestructableData", "Units\\DestructableData.slk", dest_schema, sizeof(*g_DestructableData), (void **)&g_DestructableData, &g_DestructableDataCount, &dest_idx },
 };
 
-/* Decode `head` rows into a typed flat array and build a sorted FOURCC index.
- * Rebuilds *rows_out (freeing any old allocation) from the NULL-terminated schema.
- * Called both at startup and when a test replaces one typed table's source. */
-static void RebuildDDXFromRows(slkIndex_t *idx, slkField_t const *schema,
-                               void **rows_out, DWORD *count_out, size_t row_size,
-                               sheetRow_t const *head) {
-    FS_SLKFreeIndex(idx); FS_SLKFreeRows(schema, *rows_out, *count_out, row_size); *rows_out = NULL; *count_out = 0;
-    if (!head) return;
-    DWORD n = 0; FOR_EACH_LIST(sheetRow_t const, r, head) n++;
-    *rows_out = calloc(n, row_size);
-    if (!*rows_out) { fprintf(stderr, "SLK: OOM for %u rows\n", n); return; }
-    *count_out = n;
-    DWORD i = 0;
-    FOR_EACH_LIST(sheetRow_t const, r, head) {
-        BYTE *row = (BYTE *)*rows_out + i++ * row_size;
-        *(DWORD *)row = FS_SLKKey(r->name);
-        FS_SLKDecodeRow(r, schema, row);
-    }
-    FS_SLKBuildIndex(idx, head, *rows_out, n, row_size);
-}
-
-/* Profile data is split across Func/Strings INIs. Decode each metadata field
- * through the combined list so the typed row preserves first-definition wins. */
-static void RebuildProfileDDX(sheetRow_t const *head) {
-    FS_SLKFreeIndex(&profile_idx); FS_SLKFreeRows(profile_schema, g_UnitProfile, g_UnitProfileCount, sizeof(*g_UnitProfile));
-    g_UnitProfile = NULL; g_UnitProfileCount = 0;
-    DWORD capacity = 0; FOR_EACH_LIST(sheetRow_t const, row, head) capacity++;
-    if (!capacity) return;
-    /* Allocate before duplicate detection; the old count pass dereferenced the still-NULL output array. */
-    g_UnitProfile = calloc(capacity, sizeof(*g_UnitProfile));
-    if (!g_UnitProfile) { fprintf(stderr, "Profile DDX: OOM for %u rows\n", capacity); return; }
-    DWORD out = 0;
-    FOR_EACH_LIST(sheetRow_t const, row, head) {
-        DWORD id = FS_SLKKey(row->name); BOOL found = false;
-        FOR_LOOP(i, out) if (g_UnitProfile[i].id == id) { found = true; break; }
-        if (found) continue;
-        UnitProfile_t *profile = g_UnitProfile + out++;
-        profile->id = id;
-        for (slkField_t const *field = profile_schema; field->column; field++) {
-            LPCSTR value = FS_FindSheetCell((sheetRow_t *)head, row->name, field->column);
-            if (!value) continue;
-            sheetField_t source_field = { field->column, value, NULL };
-            sheetRow_t source_row = { row->name, &source_field, NULL };
-            slkField_t source_schema[] = { *field, { NULL, 0, 0, 0 } };
-            FS_SLKDecodeRow(&source_row, source_schema, profile);
-        }
-    }
-    g_UnitProfileCount = out;
-    profile_idx.keys = malloc(g_UnitProfileCount * sizeof(*profile_idx.keys));
-    profile_idx.rows = malloc(g_UnitProfileCount * sizeof(*profile_idx.rows));
-    if (!profile_idx.keys || !profile_idx.rows) { fprintf(stderr, "Profile DDX: OOM building index\n"); FS_SLKFreeIndex(&profile_idx); return; }
-    profile_idx.count = g_UnitProfileCount;
-    FOR_LOOP(i, profile_idx.count) { profile_idx.keys[i] = g_UnitProfile[i].id; profile_idx.rows[i] = g_UnitProfile + i; }
-    for (DWORD i = 1; i < profile_idx.count; i++) {
-        DWORD key = profile_idx.keys[i], j = i; void *row = profile_idx.rows[i];
-        while (j && profile_idx.keys[j - 1] > key) { profile_idx.keys[j] = profile_idx.keys[j - 1]; profile_idx.rows[j] = profile_idx.rows[j - 1]; j--; }
-        profile_idx.keys[j] = key; profile_idx.rows[j] = row;
-    }
-}
-
-/* Parse SLK from disk, decode and index it, and warn once per column that has
- * no DDX schema entry. The raw rows remain parser-owned source data. */
-static sheetRow_t *ParseSLKInto(LPCSTR path, slkIndex_t *idx, slkField_t const *schema, size_t row_size,
-                                void **rows_out, DWORD *count_out) {
-    sheetRow_t *head = FS_ParseSLK(path);
-    if (!head) { fprintf(stderr, "SLK: failed to load '%s'\n", path); return NULL; }
-    RebuildDDXFromRows(idx, schema, rows_out, count_out, row_size, head);
-    /* Warn once per first-row column not covered by the schema (dev aid). */
-    if (head && head->fields) {
-        FOR_EACH_LIST(sheetField_t const, f, head->fields) {
-            bool found = false;
-            for (slkField_t const *s = schema; s->column; s++)
-                if (!strcasecmp(f->name, s->column)) { found = true; break; }
-            if (!found)
-                fprintf(stderr, "SLK DDX: column '%s' in '%s' has no schema entry\n",
-                        f->name, path);
-        }
-    }
-    return head;
+/* Keep legacy exported arrays as borrowed views of the owning typed cache. */
+static void ApplySLKCache(slkStore_t *store) {
+    FS_SLKFreeIndex(store->idx);
+    *store->rows = store->cache.rows; *store->count = store->cache.count;
+    if (store->idx) FS_SLKBuildIndex(store->idx, store->cache.rows, store->cache.count, store->row_size);
 }
 
 /* Tests replace a typed table and restore its original parser-owned source. */
 #ifdef BZ_TESTS
-sheetRow_t *G_SetSLKRows(LPCSTR slk, sheetRow_t *table) {
+slkTestData_t *G_SetSLKRows(LPCSTR slk, slkTestData_t *data) {
     FOR_LOOP(i, sizeof(slk_stores) / sizeof(*slk_stores)) {
         slkStore_t *store = slk_stores + i;
         if (!strcmp(slk, store->name)) {
-            sheetRow_t *old = store->source;
-            store->source = table;
-            RebuildDDXFromRows(store->idx, store->schema, store->rows, store->count, store->row_size, table);
+            slkTestData_t *old = calloc(1, sizeof(*old));
+            if (!old) return NULL;
+            old->cache = store->cache;
+            if (!data->cache.rows && !Stb_SlkCacheLoadBuffer(&data->cache, data->text, store->schema, store->row_size)) {
+                free(old); return NULL;
+            }
+            store->cache = data->cache; ApplySLKCache(store);
+            memset(&data->cache, 0, sizeof(data->cache));
             return old;
         }
     }
@@ -892,9 +770,17 @@ sheetRow_t *G_SetSLKRows(LPCSTR slk, sheetRow_t *table) {
     return NULL;
 }
 
-sheetRow_t *G_SetProfileRows(sheetRow_t *table) {
-    sheetRow_t *old = profile_source;
-    profile_source = table; RebuildProfileDDX(table);
+slkTestData_t *G_SetProfileRows(slkTestData_t *data) {
+    slkTestData_t *old = calloc(1, sizeof(*old));
+    if (!old) return NULL;
+    old->cache = profile_cache;
+    if (!data->cache.rows && !Stb_SlkCacheLoadBuffer(&data->cache, data->text, profile_schema, sizeof(*g_UnitProfile))) {
+        free(old); return NULL;
+    }
+    FS_SLKFreeIndex(&profile_idx); profile_cache = data->cache;
+    memset(&data->cache, 0, sizeof(data->cache));
+    g_UnitProfile = profile_cache.rows; g_UnitProfileCount = profile_cache.count;
+    FS_SLKBuildIndex(&profile_idx, profile_cache.rows, profile_cache.count, profile_cache.row_stride);
     return old;
 }
 #endif
@@ -1343,22 +1229,16 @@ BOOL G_UnitIsBuilding(DWORD id) {
 }
 
 void InitUnitData(void) {
-    sheetRow_t *Profile = NULL;
-    sheetRow_t *profileTail = NULL;
+    stbIniCache_t profile_ini = { 0 };
 
-    abilityConfigs = NULL;
-    abilityConfigsTail = NULL;
     commandFuncConfig = NULL;
     commandStringsConfig = NULL;
     abilityConfigTableCount = 0;
     
     for (LPCSTR *config = config_files; *config; config++) {
-        sheetRow_t *current = FS_ParseINI(*config);
-        if (current) {
-            if (abilityConfigTableCount < sizeof(abilityConfigTables) / sizeof(*abilityConfigTables)) {
-                abilityConfigTables[abilityConfigTableCount++] = current;
-            }
-            AppendSheetRows(&abilityConfigs, &abilityConfigsTail, current);
+        if (abilityConfigTableCount < sizeof(abilityConfigTables) / sizeof(*abilityConfigTables) &&
+            Stb_IniCacheLoad(abilityConfigTables + abilityConfigTableCount, *config)) {
+            stbIniCache_t *current = abilityConfigTables + abilityConfigTableCount++;
             if (!strcmp(*config, "Units\\CommandFunc.txt")) {
                 commandFuncConfig = current;
             } else if (!strcmp(*config, "Units\\CommandStrings.txt")) {
@@ -1366,54 +1246,29 @@ void InitUnitData(void) {
             }
         }
     }
-    for (LPCSTR *config = profile_files; *config; config++) {
-        sheetRow_t *current = FS_ParseINI(*config);
-        if (current) {
-            AppendSheetRows(&Profile, &profileTail, current);
-        }
-    }
-    RebuildProfileDDX(Profile);
-#ifdef BZ_TESTS
-    profile_source = Profile;
-#endif
+    Stb_IniCacheLoadFiles(&profile_ini, profile_files);
+    Stb_IniCacheDecode(&profile_ini, &profile_cache, profile_schema, sizeof(*g_UnitProfile));
+    g_UnitProfile = profile_cache.rows; g_UnitProfileCount = profile_cache.count;
+    FS_SLKBuildIndex(&profile_idx, profile_cache.rows, profile_cache.count, sizeof(*g_UnitProfile));
 
     FOR_LOOP(i, sizeof(slk_stores) / sizeof(*slk_stores)) {
         slkStore_t *store = slk_stores + i;
-        sheetRow_t *source = ParseSLKInto(store->path, store->idx, store->schema, store->row_size, store->rows, store->count);
-    #ifdef BZ_TESTS
-        store->source = source;
-    #else
-        (void)source;
-    #endif
+        if (!Stb_SlkCacheLoad(&store->cache, store->path, store->schema, store->row_size))
+            fprintf(stderr, "SLK: failed to load '%s'\n", store->path);
+        ApplySLKCache(store);
     }
 }
 
 void ShutdownUnitData(void) {
-    FS_SLKFreeIndex(&profile_idx); FS_SLKFreeRows(profile_schema, g_UnitProfile, g_UnitProfileCount, sizeof(*g_UnitProfile));
+    FS_SLKFreeIndex(&profile_idx); Stb_SlkCacheFree(&profile_cache);
     g_UnitProfile = NULL; g_UnitProfileCount = 0;
     FOR_LOOP(i, sizeof(slk_stores) / sizeof(*slk_stores)) {
         slkStore_t *store = slk_stores + i;
         FS_SLKFreeIndex(store->idx);
-        FS_SLKFreeRows(store->schema, *store->rows, *store->count, store->row_size);
+        Stb_SlkCacheFree(&store->cache);
         *store->rows = NULL; *store->count = 0;
-    #ifdef BZ_TESTS
-        store->source = NULL;
-    #endif
     }
-}
-
-static LPCSTR FindConfigField(sheetRow_t *sheet, LPCSTR row, LPCSTR column) {
-    FOR_EACH_LIST(sheetRow_t const, srow, sheet) {
-        if (strcmp(srow->name, row)) {
-            continue;
-        }
-        FOR_EACH_LIST(sheetField_t const, scolumn, srow->fields) {
-            if (!strcasecmp(scolumn->name, column)) {
-                return scolumn->value;
-            }
-        }
-    }
-    return NULL;
+    FOR_LOOP(i, abilityConfigTableCount) Stb_IniCacheFree(abilityConfigTables + i);
 }
 
 LPCSTR FindConfigValue(LPCSTR category, LPCSTR field) {
@@ -1421,13 +1276,13 @@ LPCSTR FindConfigValue(LPCSTR category, LPCSTR field) {
 
     if (!strncmp(category, "Cmd", 3)) {
         if (commandFuncConfig) {
-            value = FindConfigField(commandFuncConfig, category, field);
+            value = Stb_IniCacheFind(commandFuncConfig, category, field);
             if (value) {
                 return value;
             }
         }
         if (commandStringsConfig) {
-            value = FindConfigField(commandStringsConfig, category, field);
+            value = Stb_IniCacheFind(commandStringsConfig, category, field);
             if (value) {
                 return value;
             }
@@ -1435,7 +1290,7 @@ LPCSTR FindConfigValue(LPCSTR category, LPCSTR field) {
     }
 
     FOR_LOOP(i, abilityConfigTableCount) {
-        value = FindConfigField(abilityConfigTables[i], category, field);
+        value = Stb_IniCacheFind(abilityConfigTables + i, category, field);
         if (value) {
             return value;
         }

--- a/games/warcraft-3/game/hud/hud_write.c
+++ b/games/warcraft-3/game/hud/hud_write.c
@@ -253,8 +253,8 @@ BZ_HOST_HIDDEN DWORD UI_LoadTexture(LPCSTR path, BOOL forcewrap) {
 
 BZ_HOST_HIDDEN LPCSTR Theme_String(LPCSTR key, LPCSTR def) {
     LPCSTR value = NULL;
-    if (key && !strstr(key, "\\") && game.config.theme) {
-        value = FS_FindSheetCell(game.config.theme, "Default", key);
+    if (key && !strstr(key, "\\") && game.config.theme.source) {
+        value = Stb_IniCacheFind(&game.config.theme, "Default", key);
     }
     return value ? value : def;
 }

--- a/games/warcraft-3/game/hud/hud_write.c
+++ b/games/warcraft-3/game/hud/hud_write.c
@@ -274,10 +274,10 @@ static LPCSTR Theme_PlayerRaceCategory(DWORD race) {
 LPCSTR Theme_PlayerString(LPGAMECLIENT client, LPCSTR key, LPCSTR def) {
     LPCSTR category, value;
 
-    if (!key || strstr(key, "\\") || !game.config.theme) return def;
+    if (!key || strstr(key, "\\") || !game.config.theme.source) return def;
     category = Theme_PlayerRaceCategory(client ? client->ps.race : kPlayerRaceNone);
-    value = FS_FindSheetCell(game.config.theme, category, key);
-    if (!value && strcmp(category, "Default")) value = FS_FindSheetCell(game.config.theme, "Default", key);
+    value = Stb_IniCacheFind(&game.config.theme, category, key);
+    if (!value && strcmp(category, "Default")) value = Stb_IniCacheFind(&game.config.theme, "Default", key);
     return value ? value : def;
 }
 

--- a/games/warcraft-3/game/m_unit.c
+++ b/games/warcraft-3/game/m_unit.c
@@ -416,7 +416,7 @@ void G_RecomputeHeroStats(LPEDICT ent) {
  * - SetHeroLevel works by granting enough XP to reach the level; XP is the
  *   source of truth and level only ever increases. */
 DWORD G_MaxHeroLevel(void) {
-    LPCSTR const v = FS_FindSheetCell(game.config.misc, "Misc", "MaxHeroLevel");
+    LPCSTR const v = Stb_IniCacheFind(&game.config.misc, "Misc", "MaxHeroLevel");
     DWORD const m = v ? (DWORD)atoi(v) : 0;
     return m > 0 ? m : 10;
 }
@@ -480,13 +480,13 @@ void G_HeroSetXP(LPEDICT ent, DWORD xp) {
  * 100,120,160,220,300 (heroes), HeroFactorXP=80,70,60,50,0 (diminishing % when
  * the hero outlevels the victim by N), BuildingKillsGiveExp=0. */
 static FLOAT G_MiscNum(LPCSTR key, FLOAT fallback) {
-    LPCSTR const v = FS_FindSheetCell(game.config.misc, "Misc", key);
+    LPCSTR const v = Stb_IniCacheFind(&game.config.misc, "Misc", key);
     return (v && *v) ? (FLOAT)atof(v) : fallback;
 }
 
 /* n-th (0-based) comma-separated entry of a Misc list, clamped to the last. */
 static FLOAT G_MiscListNum(LPCSTR key, DWORD n, FLOAT fallback) {
-    LPCSTR v = FS_FindSheetCell(game.config.misc, "Misc", key);
+    LPCSTR v = Stb_IniCacheFind(&game.config.misc, "Misc", key);
     if (!v || !*v) {
         return fallback;
     }

--- a/games/warcraft-3/game/skills/s_spell.c
+++ b/games/warcraft-3/game/skills/s_spell.c
@@ -22,8 +22,8 @@ static umove_t spell_effect_birth = { "birth", NULL, G_FreeEdict };
 static LPCSTR S_SpellThemeString(LPCSTR key, LPCSTR def) {
     LPCSTR value = NULL;
 
-    if (key && !strstr(key, "\\") && game.config.theme) {
-        value = FS_FindSheetCell(game.config.theme, "Default", key);
+    if (key && !strstr(key, "\\") && game.config.theme.source) {
+        value = Stb_IniCacheFind(&game.config.theme, "Default", key);
     }
     return value ? value : def;
 }

--- a/games/warcraft-3/game/tests/t_combat.c
+++ b/games/warcraft-3/game/tests/t_combat.c
@@ -1,7 +1,7 @@
 #ifdef BZ_TESTS
 /* Forward declarations — defined in t_slk.c, compiled together in unity build. */
-sheetRow_t *parse_slk_string(const char *slk_text);
-void free_slk_rows(sheetRow_t *rows);
+slkTestData_t *parse_slk_string(const char *slk_text);
+void free_slk_rows(slkTestData_t *rows);
 /*
  * test_combat.c — Tests for combat, animation, ability lookup, resources,
  *                 build queue, and quest system.
@@ -765,8 +765,8 @@ static const char slk_ability_helpers_roc[] =
 
 /* ROC and TFT store the same semantic ability slots under different headers. */
 TEST(wc3_combat, ability_data_resolves_roc_and_tft_columns) {
-    sheetRow_t *rows = parse_slk_string(slk_ability_helpers_roc);
-    sheetRow_t *old_abilities = G_SetSLKRows("AbilityData", rows);
+    slkTestData_t *rows = parse_slk_string(slk_ability_helpers_roc);
+    slkTestData_t *old_abilities = G_SetSLKRows("AbilityData", rows);
     T_FEQ(AB_Data("Ahar", 1, 1), 1.0f, 0.01f);
     T_FEQ(AB_Data("Ahar", 1, 2), 10.0f, 0.01f);
     T_FEQ(S_SpellData(MAKEFOURCC('A','h','a','r'), 1, 3), 10.0f, 0.01f);
@@ -785,8 +785,8 @@ TEST(wc3_combat, ability_data_resolves_roc_and_tft_columns) {
  * Agld globals initialized immediately before it. */
 TEST(wc3_combat, overlay_mine_does_not_reset_basic_mine_data) {
     extern FLOAT MAX_GOLD, MINING_DURATION, MINING_CAPACITY;
-    sheetRow_t *rows = parse_slk_string(slk_ability_helpers_roc);
-    sheetRow_t *old_abilities = G_SetSLKRows("AbilityData", rows);
+    slkTestData_t *rows = parse_slk_string(slk_ability_helpers_roc);
+    slkTestData_t *old_abilities = G_SetSLKRows("AbilityData", rows);
     a_goldmine.init("Agld", &a_goldmine);
     T_FEQ(MAX_GOLD, 12500.0f, 0.01f);
     T_FEQ(MINING_DURATION, 1.0f, 0.01f);
@@ -797,8 +797,8 @@ TEST(wc3_combat, overlay_mine_does_not_reset_basic_mine_data) {
 }
 
 TEST(wc3_combat, spell_helpers_read_slk_fields) {
-    sheetRow_t *rows = parse_slk_string(slk_ability_helpers);
-    sheetRow_t *old_abilities = G_SetSLKRows("AbilityData", rows);
+    slkTestData_t *rows = parse_slk_string(slk_ability_helpers);
+    slkTestData_t *old_abilities = G_SetSLKRows("AbilityData", rows);
     DWORD thunder = MAKEFOURCC('A', 'H', 't', 'b');
     DWORD water = MAKEFOURCC('A', 'H', 'w', 'e');
 
@@ -818,8 +818,8 @@ TEST(wc3_combat, spell_helpers_read_slk_fields) {
 }
 
 TEST(wc3_combat, spell_mana_and_cooldown) {
-    sheetRow_t *rows = parse_slk_string(slk_ability_helpers);
-    sheetRow_t *old_abilities = G_SetSLKRows("AbilityData", rows);
+    slkTestData_t *rows = parse_slk_string(slk_ability_helpers);
+    slkTestData_t *old_abilities = G_SetSLKRows("AbilityData", rows);
     DWORD thunder = MAKEFOURCC('A', 'H', 't', 'b');
     LPEDICT caster = make_combat_unit(MAKEFOURCC('h','p','e','a'), 250.0f, 0.0f, 0.0f);
     caster->mana.value = 100.0f;

--- a/games/warcraft-3/game/tests/t_destructable.c
+++ b/games/warcraft-3/game/tests/t_destructable.c
@@ -15,8 +15,8 @@ void setup_test_world(void);
 BOOL unit_issuetargetorder(LPEDICT self, LPCSTR order, LPEDICT target);
 void T_Damage(LPEDICT target, LPEDICT attacker, int damage);
 BOOL run_test_jass(LPCSTR src);
-sheetRow_t *parse_slk_string(const char *slk_text);
-void free_slk_rows(sheetRow_t *rows);
+slkTestData_t *parse_slk_string(const char *slk_text);
+void free_slk_rows(slkTestData_t *rows);
 
 typedef struct {
     WORD width;
@@ -531,11 +531,11 @@ TEST(wc3_destructable, scripted_lifecycle_natives_use_authoritative_state) {
         "C;Y2;X4;K100\n"
         "C;Y2;X5;K16\n"
         "E\n";
-    sheetRow_t *rows = parse_slk_string(slk);
+    slkTestData_t *rows = parse_slk_string(slk);
     LPEDICT dest;
 
     setup_test_world();
-    sheetRow_t *saved = G_SetSLKRows("DestructableData", rows);
+    slkTestData_t *saved = G_SetSLKRows("DestructableData", rows);
     T_ASSERT(run_test_jass(
         "globals\n"
         "  destructable scriptedDest = null\n"

--- a/games/warcraft-3/game/tests/t_slk.c
+++ b/games/warcraft-3/game/tests/t_slk.c
@@ -1,7 +1,7 @@
 /*
  * t_slk.c — In-engine SLK data reading and unit-stat tests.
  *
- * Part 1 (pure functions): FS_FindSheetCell linked-list traversal tests.
+ * Part 1 (pure functions): typed cache decode and lookup tests.
  * Part 2 (unit stats): real archive data for hpea/hfoo.
  * Part 3 (typed table replacement): G_SetSLKRows tests mana/armor edge cases.
  */
@@ -13,173 +13,80 @@
 
 void setup_test_world(void);
 
-/* parse_slk_string / free_slk_rows: defined in test_harness.c, reproduced
- * here so t_slk.c is self-contained without the old harness. */
-#define MAX_SLK_COLS 64
-#define MAX_SLK_LINE 512
-
-sheetRow_t *parse_slk_string(const char *slk_text) {
-    if (!slk_text) return NULL;
-    typedef struct raw_cell { int x, y; char *text; struct raw_cell *next; } raw_cell_t;
-    raw_cell_t *cells = NULL, *cells_tail = NULL;
-    int max_row = 0, max_col = 0;
-    sheetRow_t *head = NULL, *tail = NULL;
-
-    const char *p = slk_text;
-    while (*p) {
-        char line[MAX_SLK_LINE];
-        int  len = 0;
-        while (*p && *p != '\n' && len < MAX_SLK_LINE - 1)
-            line[len++] = *p++;
-        if (*p == '\n') p++;
-        line[len] = '\0';
-
-        if (line[0] != 'C' && line[0] != 'F') continue;
-
-        char tokens[MAX_SLK_LINE] = {0};
-        memcpy(tokens, line, len + 1);
-        for (int i = 0; tokens[i]; i++)
-            if (tokens[i] == ';') tokens[i] = '\0';
-
-        int cx = 0, cy = 0;
-        char *kval = NULL;
-        const char *tok = tokens;
-        tok += strlen(tok) + 1;
-        while (*tok) {
-            if (*tok == 'X') cx = atoi(tok + 1);
-            else if (*tok == 'Y') cy = atoi(tok + 1);
-            else if (*tok == 'K') kval = (char *)(tok + 1);
-            tok += strlen(tok) + 1;
-        }
-        if (!kval) continue;
-
-        char text[MAX_SLK_LINE] = {0};
-        int ti = 0;
-        for (const char *c = kval; *c; c++) {
-            if (*c == '"' || *c == '\r' || *c == '\n') continue;
-            text[ti++] = *c;
-        }
-        text[ti] = '\0';
-
-        raw_cell_t *cell = malloc(sizeof(*cell));
-        cell->x    = cx;
-        cell->y    = cy;
-        cell->text = strdup(text);
-        cell->next = NULL;
-        if (!cells) cells = cell; else cells_tail->next = cell;
-        cells_tail = cell;
-
-        if (cy > max_row) max_row = cy;
-        if (cx > max_col) max_col = cx;
-    }
-    if (!cells || max_row < 2) goto cleanup;
-
-    char *col_names[MAX_SLK_COLS] = {NULL};
-    for (raw_cell_t *c = cells; c; c = c->next) {
-        if (c->y == 1 && c->x < MAX_SLK_COLS)
-            col_names[c->x] = c->text;
-    }
-
-    for (int row = 2; row <= max_row; row++) {
-        char *row_key = NULL;
-        for (raw_cell_t *c = cells; c; c = c->next) {
-            if (c->y == row && c->x == 1) { row_key = c->text; break; }
-        }
-        if (!row_key) continue;
-
-        sheetRow_t *sr = malloc(sizeof(*sr));
-        sr->name   = strdup(row_key);
-        sr->fields = NULL;
-        sr->next   = NULL;
-
-        for (raw_cell_t *c = cells; c; c = c->next) {
-            if (c->y != row || c->x <= 1 || c->x >= MAX_SLK_COLS) continue;
-            if (!col_names[c->x]) continue;
-            sheetField_t *sf = malloc(sizeof(*sf));
-            sf->name  = strdup(col_names[c->x]);
-            sf->value = strdup(c->text);
-            sf->next  = sr->fields;
-            sr->fields = sf;
-        }
-
-        if (!head) head = sr; else tail->next = sr;
-        tail = sr;
-    }
-
-cleanup:
-    for (raw_cell_t *c = cells; c; ) {
-        raw_cell_t *nx = c->next;
-        free(c->text);
-        free(c);
-        c = nx;
-    }
-    return head;
+slkTestData_t *parse_slk_string(const char *slk_text) {
+    static slkField_t const schema[] = { { NULL, 0, 0 } };
+    stbSlkCache_t cache = { 0 };
+    slkTestData_t *data;
+    if (!Stb_SlkCacheLoadBuffer(&cache, slk_text, schema, sizeof(DWORD))) return NULL;
+    Stb_SlkCacheFree(&cache);
+    data = calloc(1, sizeof(*data));
+    if (data) data->text = slk_text;
+    return data;
 }
 
-void free_slk_rows(sheetRow_t *rows) {
-    while (rows) {
-        sheetRow_t *next_row = rows->next;
-        free((void *)rows->name);
-        for (sheetField_t *f = rows->fields; f; ) {
-            sheetField_t *nf = f->next;
-            free((void *)f->name);
-            free((void *)f->value);
-            free(f);
-            f = nf;
-        }
-        free(rows);
-        rows = next_row;
-    }
+void free_slk_rows(slkTestData_t *data) {
+    if (!data) return;
+    Stb_SlkCacheFree(&data->cache); free(data);
+}
+
+static LPCSTR find_slk_value(slkTestData_t const *data, LPCSTR row, LPCSTR column) {
+    typedef struct { DWORD id; LPCSTR value; } row_t;
+    slkField_t schema[] = {
+        { "", offsetof(row_t, id), STB_SLK_FOURCC },
+        { column, offsetof(row_t, value), STB_SLK_STR },
+        { NULL, 0, 0 }
+    };
+    stbSlkCache_t cache = { 0 };
+    row_t const *found;
+    bool has_value;
+    static char value[1024];
+    if (!data || !Stb_SlkCacheLoadBuffer(&cache, data->text, schema, sizeof(row_t))) return NULL;
+    found = Stb_SlkCacheFind(&cache, FS_SLKKey(row));
+    has_value = found && found->value;
+    if (has_value) snprintf(value, sizeof(value), "%s", found->value);
+    Stb_SlkCacheFree(&cache);
+    return has_value ? value : NULL;
 }
 
 /* -----------------------------------------------------------------------
- * 1.  FS_FindSheetCell
+ * 1.  Typed cache lookup
  * --------------------------------------------------------------------- */
 
 TEST(wc3_slk, find_cell_existing_row_and_column) {
-    sheetField_t f = {"spd", "270", NULL};
-    sheetRow_t   r = {"hpea", &f, NULL};
-    T_STREQ(FS_FindSheetCell(&r, "hpea", "spd"), "270");
+    slkTestData_t *rows = parse_slk_string("C;Y1;X1;K\"id\"\nC;Y1;X2;K\"spd\"\nC;Y2;X1;K\"hpea\"\nC;Y2;X2;K\"270\"\nE\n");
+    T_STREQ(find_slk_value(rows, "hpea", "spd"), "270");
 }
 
 TEST(wc3_slk, find_cell_missing_row_returns_null) {
-    sheetField_t f = {"spd", "270", NULL};
-    sheetRow_t   r = {"hpea", &f, NULL};
-    T_NULL(FS_FindSheetCell(&r, "hfoo", "spd"));
+    slkTestData_t *rows = parse_slk_string("C;Y1;X1;K\"id\"\nC;Y1;X2;K\"spd\"\nC;Y2;X1;K\"hpea\"\nC;Y2;X2;K\"270\"\nE\n");
+    T_NULL(find_slk_value(rows, "hfoo", "spd"));
 }
 
 TEST(wc3_slk, find_cell_missing_column_returns_null) {
-    sheetField_t f = {"spd", "270", NULL};
-    sheetRow_t   r = {"hpea", &f, NULL};
-    T_NULL(FS_FindSheetCell(&r, "hpea", "hp"));
+    slkTestData_t *rows = parse_slk_string("C;Y1;X1;K\"id\"\nC;Y1;X2;K\"spd\"\nC;Y2;X1;K\"hpea\"\nC;Y2;X2;K\"270\"\nE\n");
+    T_NULL(find_slk_value(rows, "hpea", "hp"));
 }
 
 TEST(wc3_slk, find_cell_case_insensitive_column) {
-    sheetField_t f = {"RealHP", "250", NULL};
-    sheetRow_t   r = {"hpea", &f, NULL};
-    T_STREQ(FS_FindSheetCell(&r, "hpea", "realHP"), "250");
-    T_STREQ(FS_FindSheetCell(&r, "hpea", "REALHP"), "250");
+    slkTestData_t *rows = parse_slk_string("C;Y1;X1;K\"id\"\nC;Y1;X2;K\"RealHP\"\nC;Y2;X1;K\"hpea\"\nC;Y2;X2;K\"250\"\nE\n");
+    T_STREQ(find_slk_value(rows, "hpea", "realHP"), "250");
+    T_STREQ(find_slk_value(rows, "hpea", "REALHP"), "250");
 }
 
 TEST(wc3_slk, find_cell_multiple_rows) {
-    sheetField_t fa = {"spd", "270", NULL};
-    sheetField_t fb = {"spd", "300", NULL};
-    sheetRow_t   rb = {"hfoo", &fb, NULL};
-    sheetRow_t   ra = {"hpea", &fa, &rb};
-    T_STREQ(FS_FindSheetCell(&ra, "hpea", "spd"), "270");
-    T_STREQ(FS_FindSheetCell(&ra, "hfoo", "spd"), "300");
+    slkTestData_t *rows = parse_slk_string("C;Y1;X1;K\"id\"\nC;Y1;X2;K\"spd\"\nC;Y2;X1;K\"hpea\"\nC;Y2;X2;K\"270\"\nC;Y3;X1;K\"hfoo\"\nC;Y3;X2;K\"300\"\nE\n");
+    T_STREQ(find_slk_value(rows, "hpea", "spd"), "270");
+    T_STREQ(find_slk_value(rows, "hfoo", "spd"), "300");
 }
 
 TEST(wc3_slk, find_cell_multiple_fields) {
-    sheetField_t fb = {"realHP", "250", NULL};
-    sheetField_t fa = {"spd",    "270", &fb};
-    sheetRow_t   r  = {"hpea", &fa, NULL};
-    T_STREQ(FS_FindSheetCell(&r, "hpea", "spd"),    "270");
-    T_STREQ(FS_FindSheetCell(&r, "hpea", "realHP"), "250");
+    slkTestData_t *rows = parse_slk_string("C;Y1;X1;K\"id\"\nC;Y1;X2;K\"spd\"\nC;Y1;X3;K\"realHP\"\nC;Y2;X1;K\"hpea\"\nC;Y2;X2;K\"270\"\nC;Y2;X3;K\"250\"\nE\n");
+    T_STREQ(find_slk_value(rows, "hpea", "spd"), "270");
+    T_STREQ(find_slk_value(rows, "hpea", "realHP"), "250");
 }
 
 TEST(wc3_slk, find_cell_null_sheet_returns_null) {
-    T_NULL(FS_FindSheetCell(NULL, "hpea", "spd"));
+    T_NULL(find_slk_value(NULL, "hpea", "spd"));
 }
 
 TEST(wc3_slk, typed_strings_are_owned_and_alias_safe) {
@@ -189,24 +96,29 @@ TEST(wc3_slk, typed_strings_are_owned_and_alias_safe) {
         { "name", offsetof(testRow_t, name), STB_SLK_STR },
         { NULL, 0, 0 }
     };
-    char first[] = "Footman", second[] = "Knight";
-    sheetField_t alias = { "name", second, NULL };
-    sheetField_t field = { "Name", first, &alias };
-    sheetRow_t source = { "hfoo", &field, NULL };
-    testRow_t *rows = calloc(1, sizeof(*rows));
+    char src[] =
+        "C;Y1;X1;K\"id\"\n"
+        "C;Y1;X2;K\"Name\"\n"
+        "C;Y1;X3;K\"name\"\n"
+        "C;Y2;X1;K\"hfoo\"\n"
+        "C;Y2;X2;K\"Footman\"\n"
+        "C;Y2;X3;K\"Knight\"\n"
+        "E\n";
+    stbSlkCache_t cache = { 0 };
+    LPSTR alias = strstr(src, "Knight");
 
-    FS_SLKDecodeRow(&source, schema, rows);
-    first[0] = 'X'; second[0] = 'Y';
-    T_STREQ(rows->name, "Knight");
-    FS_SLKFreeRows(schema, rows, 1, sizeof(*rows));
+    T_ASSERT(Stb_SlkCacheLoadBuffer(&cache, src, schema, sizeof(testRow_t)));
+    testRow_t const *rows = cache.rows;
+    T_EQ(cache.count, 1);
+    T_NOT_NULL(alias);
+    alias[0] = 'Y';
+    T_STREQ(rows[0].name, "Knight");
+    Stb_SlkCacheFree(&cache);
 }
 
 TEST(wc3_slk, profile_ddx_and_fourcc_metadata_share_typed_row) {
-    sheetField_t homing = { "MissileHoming", "TRUE", NULL };
-    sheetField_t speed = { "Missilespeed", "900", &homing };
-    sheetField_t name = { "Name", "Rifleman", &speed };
-    sheetRow_t row = { "hrif", &name, NULL };
-    sheetRow_t *old = G_SetProfileRows(&row);
+    slkTestData_t *row = parse_slk_string("C;Y1;X1;K\"id\"\nC;Y1;X2;K\"Name\"\nC;Y1;X3;K\"Missilespeed\"\nC;Y1;X4;K\"MissileHoming\"\nC;Y2;X1;K\"hrif\"\nC;Y2;X2;K\"Rifleman\"\nC;Y2;X3;K\"900\"\nC;Y2;X4;K\"TRUE\"\nE\n");
+    slkTestData_t *old = G_SetProfileRows(row);
     DWORD id = MAKEFOURCC('h','r','i','f');
     edict_t unit = { .class_id = id };
     G_BindEntityData(&unit);
@@ -259,41 +171,40 @@ static const char slk_two_units[] =
     "E\n";
 
 TEST(wc3_slk, parse_returns_non_null) {
-    sheetRow_t *rows = parse_slk_string(slk_two_units);
+    slkTestData_t *rows = parse_slk_string(slk_two_units);
     T_NOT_NULL(rows);
     free_slk_rows(rows);
 }
 
 TEST(wc3_slk, parse_row_names) {
-    sheetRow_t *rows = parse_slk_string(slk_two_units);
+    slkTestData_t *rows = parse_slk_string(slk_two_units);
     T_NOT_NULL(rows);
-    T_STREQ(rows->name, "hpea");
-    T_NOT_NULL(rows->next);
-    T_STREQ(rows->next->name, "hfoo");
+    T_STREQ(find_slk_value(rows, "hpea", "spd"), "270");
+    T_STREQ(find_slk_value(rows, "hfoo", "spd"), "270");
     free_slk_rows(rows);
 }
 
 TEST(wc3_slk, parse_field_values) {
-    sheetRow_t *rows = parse_slk_string(slk_two_units);
+    slkTestData_t *rows = parse_slk_string(slk_two_units);
     T_NOT_NULL(rows);
-    T_STREQ(FS_FindSheetCell(rows, "hpea", "spd"),    "270");
-    T_STREQ(FS_FindSheetCell(rows, "hpea", "realHP"), "250");
-    T_STREQ(FS_FindSheetCell(rows, "hpea", "bldtm"),  "45");
-    T_STREQ(FS_FindSheetCell(rows, "hfoo", "realHP"), "420");
-    T_STREQ(FS_FindSheetCell(rows, "hfoo", "bldtm"),  "60");
+    T_STREQ(find_slk_value(rows, "hpea", "spd"),    "270");
+    T_STREQ(find_slk_value(rows, "hpea", "realHP"), "250");
+    T_STREQ(find_slk_value(rows, "hpea", "bldtm"),  "45");
+    T_STREQ(find_slk_value(rows, "hfoo", "realHP"), "420");
+    T_STREQ(find_slk_value(rows, "hfoo", "bldtm"),  "60");
     free_slk_rows(rows);
 }
 
 TEST(wc3_slk, parse_missing_cell_returns_null) {
-    sheetRow_t *rows = parse_slk_string(slk_two_units);
+    slkTestData_t *rows = parse_slk_string(slk_two_units);
     T_NOT_NULL(rows);
-    T_NULL(FS_FindSheetCell(rows, "hkni", "spd"));
-    T_NULL(FS_FindSheetCell(rows, "hpea", "armor"));
+    T_NULL(find_slk_value(rows, "hkni", "spd"));
+    T_NULL(find_slk_value(rows, "hpea", "armor"));
     free_slk_rows(rows);
 }
 
 TEST(wc3_slk, parse_empty_string_returns_null) {
-    sheetRow_t *rows = parse_slk_string("ID;PWXL\nE\n");
+    slkTestData_t *rows = parse_slk_string("ID;PWXL\nE\n");
     T_NULL(rows);
 }
 
@@ -354,8 +265,8 @@ TEST(wc3_slk, weapon_columns_decode_into_attack_records) {
         "C;Y1;X1;K\"unitWeaponID\"\nC;Y1;X2;K\"dmgplus1\"\nC;Y1;X3;K\"dmgplus2\"\n"
         "C;Y1;X4;K\"rangeN1\"\nC;Y1;X5;K\"rangeN2\"\n"
         "C;Y2;X1;K\"hfoo\"\nC;Y2;X2;K12\nC;Y2;X3;K34\nC;Y2;X4;K90\nC;Y2;X5;K600\nE\n";
-    sheetRow_t *rows = parse_slk_string(slk);
-    sheetRow_t *saved = G_SetSLKRows("UnitWeapons", rows);
+    slkTestData_t *rows = parse_slk_string(slk);
+    slkTestData_t *saved = G_SetSLKRows("UnitWeapons", rows);
     UnitWeapons_t const *weapons = G_UnitWeapons(MAKEFOURCC('h','f','o','o'));
     T_ASSERT(weapons == g_UnitWeapons);
     T_EQ(weapons->attack1.damageBase, 12); T_EQ(weapons->attack2.damageBase, 34);
@@ -389,9 +300,9 @@ TEST(wc3_slk, mana_uses_realM_not_manaN) {
         "C;Y3;X3;K\"200\"\n"
         "C;Y3;X4;K\"75\"\n"
         "E\n";
-    sheetRow_t *rows = parse_slk_string(slk_mana);
+    slkTestData_t *rows = parse_slk_string(slk_mana);
     T_NOT_NULL(rows);
-    sheetRow_t *saved_mana = G_SetSLKRows("UnitBalance", rows);
+    slkTestData_t *saved_mana = G_SetSLKRows("UnitBalance", rows);
 
     T_FEQ(G_UnitBalance(MAKEFOURCC('E','w','a','r'))->maxMana, 225.0f, 0.01f);
     T_FEQ(G_UnitBalance(MAKEFOURCC('E','w','a','r'))->initialMana, 100.0f, 0.01f);
@@ -419,9 +330,9 @@ TEST(wc3_slk, armor_uses_realdef_not_def) {
         "C;Y3;X3;K\"2\"\n"
         "C;Y3;X4;K\"270\"\n"
         "E\n";
-    sheetRow_t *rows = parse_slk_string(slk_armor);
+    slkTestData_t *rows = parse_slk_string(slk_armor);
     T_NOT_NULL(rows);
-    sheetRow_t *saved_arm = G_SetSLKRows("UnitBalance", rows);
+    slkTestData_t *saved_arm = G_SetSLKRows("UnitBalance", rows);
 
     T_FEQ(G_UnitBalance(MAKEFOURCC('E','w','a','r'))->armor, 4.0f, 0.01f);
     T_FEQ(G_UnitBalance(MAKEFOURCC('h','f','o','o'))->armor, 2.0f, 0.01f);
@@ -441,14 +352,14 @@ static int capture_spawn_image(LPCSTR name) {
 TEST(wc3_slk, destructable_texture_preserves_extension_and_absent_sentinel) {
     static LPCSTR const names[] = { "_", "", "ReplaceableTextures\\Cliff\\Cliff0.tga",
                                    "ReplaceableTextures\\LordaeronTree\\LordaeronSummerTree" };
-    sheetRow_t *saved = NULL;
+    slkTestData_t *saved = NULL;
     int (*old_index)(LPCSTR) = gi.ImageIndex;
     setup_test_world();
     gi.ImageIndex = capture_spawn_image;
     FOR_LOOP(i, sizeof(names) / sizeof(names[0])) {
         char slk[1024];
         snprintf(slk, sizeof(slk), "ID;PWXL;N;E\nC;Y1;X1;K\"ID\"\nC;Y1;X2;K\"file\"\nC;Y1;X3;K\"texFile\"\nC;Y1;X4;K\"targType\"\nC;Y2;X1;K\"LT05\"\nC;Y2;X2;K\"Cliff\"\nC;Y2;X3;K\"%s\"\nC;Y2;X4;K\"debris\"\nE\n", names[i]);
-        sheetRow_t *rows = parse_slk_string(slk);
+        slkTestData_t *rows = parse_slk_string(slk);
         if (!saved) saved = G_SetSLKRows("DestructableData", rows);
         else G_SetSLKRows("DestructableData", rows);
         edict_t ent = { .class_id = MAKEFOURCC('L','T','0','5') };
@@ -468,8 +379,8 @@ TEST(wc3_slk, doodad_fields_use_typed_row) {
         "ID;PWXL;N;E\n"
         "C;Y1;X1;K\"doodID\"\nC;Y1;X2;K\"dir\"\nC;Y1;X3;K\"file\"\n"
         "C;Y2;X1;K\"LTlt\"\nC;Y2;X2;K\"Doodads\\Terrain\"\nC;Y2;X3;K\"Tree\"\nE\n";
-    sheetRow_t *rows = parse_slk_string(slk);
-    sheetRow_t *saved = G_SetSLKRows("Doodads", rows);
+    slkTestData_t *rows = parse_slk_string(slk);
+    slkTestData_t *saved = G_SetSLKRows("Doodads", rows);
     Doodads_t const *row = G_Doodad(MAKEFOURCC('L','T','l','t'));
     T_EQ(row->id, MAKEFOURCC('L','T','l','t'));
     T_STREQ(row->dir, "Doodads\\Terrain"); T_STREQ(row->file, "Tree");
@@ -481,16 +392,15 @@ TEST(wc3_slk, uber_splat_fields_use_typed_row) {
         "ID;PWXL;N;E\n"
         "C;Y1;X1;K\"Name\"\nC;Y1;X2;K\"Dir\"\nC;Y1;X3;K\"file\"\nC;Y1;X4;K\"Scale\"\n"
         "C;Y2;X1;K\"HMtp\"\nC;Y2;X2;K\"Splats\"\nC;Y2;X3;K\"TownHall\"\nC;Y2;X4;K4\nE\n";
-    sheetRow_t *rows = parse_slk_string(slk);
-    sheetRow_t *saved = G_SetSLKRows("UberSplatData", rows);
+    slkTestData_t *rows = parse_slk_string(slk);
+    slkTestData_t *saved = G_SetSLKRows("UberSplatData", rows);
     UberSplatData_t const *row = G_UberSplat(MAKEFOURCC('H','M','t','p'));
     T_STREQ(row->Dir, "Splats"); T_STREQ(row->file, "TownHall"); T_FEQ(row->Scale, 4.0f, 0.01f);
     G_SetSLKRows("UberSplatData", saved); free_slk_rows(rows);
 }
 
 /* -----------------------------------------------------------------------
- * 5.  Production SLK buffer parser (FS_ParseSLK_Buffer)
- *     These tests exercise the real parser path, not parse_slk_string.
+ * 5.  Production SLK buffer parser through Stb_SlkCacheLoadBuffer
  * --------------------------------------------------------------------- */
 
 /* Omitted Y uses stateful current row; ROC tables rely on this heavily. */
@@ -501,9 +411,9 @@ TEST(wc3_slk, prod_stateful_y) {
         "C;Y2;X1;K\"hero\"\n"
         "C;X2;K\"500\"\n"   /* Y omitted: Y=2 carries from previous C */
         "E\n";
-    sheetRow_t *rows = FS_ParseSLK_Buffer(src);
+    slkTestData_t *rows = parse_slk_string(src);
     T_NOT_NULL(rows);
-    T_STREQ(FS_FindSheetCell(rows, "hero", "HP"), "500");
+    T_STREQ(find_slk_value(rows, "hero", "HP"), "500");
 }
 
 /* Multiple columns populated using only omitted Y (stateful row context). */
@@ -516,10 +426,10 @@ TEST(wc3_slk, prod_stateful_xy) {
         "C;X2;K\"500\"\n"   /* Y=2 carries; X=2: HP */
         "C;X3;K\"200\"\n"   /* Y=2 carries; X=3: MP */
         "E\n";
-    sheetRow_t *rows = FS_ParseSLK_Buffer(src);
+    slkTestData_t *rows = parse_slk_string(src);
     T_NOT_NULL(rows);
-    T_STREQ(FS_FindSheetCell(rows, "mage", "HP"), "500");
-    T_STREQ(FS_FindSheetCell(rows, "mage", "MP"), "200");
+    T_STREQ(find_slk_value(rows, "mage", "HP"), "500");
+    T_STREQ(find_slk_value(rows, "mage", "MP"), "200");
 }
 
 /* F record advances X without creating a cell; next C inherits the updated X. */
@@ -531,9 +441,9 @@ TEST(wc3_slk, prod_f_advances_x) {
         "F;X2\n"            /* advance X to 2, no K → no cell */
         "C;Y2;K\"400\"\n"   /* X=2 from F, Y=2 explicit: HP=400 */
         "E\n";
-    sheetRow_t *rows = FS_ParseSLK_Buffer(src);
+    slkTestData_t *rows = parse_slk_string(src);
     T_NOT_NULL(rows);
-    T_STREQ(FS_FindSheetCell(rows, "mage", "HP"), "400");
+    T_STREQ(find_slk_value(rows, "mage", "HP"), "400");
 }
 
 /* B record dimension bounds are advisory; wrong values must not corrupt output. */
@@ -545,9 +455,9 @@ TEST(wc3_slk, prod_b_record_advisory) {
         "C;Y2;X1;K\"unit\"\n"
         "C;Y2;X2;K\"300\"\n"
         "E\n";
-    sheetRow_t *rows = FS_ParseSLK_Buffer(src);
+    slkTestData_t *rows = parse_slk_string(src);
     T_NOT_NULL(rows);
-    T_STREQ(FS_FindSheetCell(rows, "unit", "HP"), "300");
+    T_STREQ(find_slk_value(rows, "unit", "HP"), "300");
 }
 
 /* Semicolons inside a quoted K value must not split the field. */
@@ -558,9 +468,9 @@ TEST(wc3_slk, prod_quoted_semicolon) {
         "C;Y2;X1;K\"itm1\"\n"
         "C;Y2;X2;K\"foo;bar\"\n"  /* semicolon inside quotes */
         "E\n";
-    sheetRow_t *rows = FS_ParseSLK_Buffer(src);
+    slkTestData_t *rows = parse_slk_string(src);
     T_NOT_NULL(rows);
-    T_STREQ(FS_FindSheetCell(rows, "itm1", "path"), "foo;bar");
+    T_STREQ(find_slk_value(rows, "itm1", "path"), "foo;bar");
 }
 
 /* "" inside a quoted K value decodes to a single literal double-quote. */
@@ -571,9 +481,9 @@ TEST(wc3_slk, prod_quote_escape) {
         "C;Y2;X1;K\"obj1\"\n"
         "C;Y2;X2;K\"foo\"\"bar\"\n"  /* SLK: K"foo""bar" → foo"bar */
         "E\n";
-    sheetRow_t *rows = FS_ParseSLK_Buffer(src);
+    slkTestData_t *rows = parse_slk_string(src);
     T_NOT_NULL(rows);
-    T_STREQ(FS_FindSheetCell(rows, "obj1", "note"), "foo\"bar");
+    T_STREQ(find_slk_value(rows, "obj1", "note"), "foo\"bar");
 }
 
 /* Cells with Y=0 must be skipped; valid rows below must still parse. */
@@ -585,10 +495,10 @@ TEST(wc3_slk, prod_zero_y_ignored) {
         "C;Y2;X1;K\"unit\"\n"
         "C;Y2;X2;K\"100\"\n"
         "E\n";
-    sheetRow_t *rows = FS_ParseSLK_Buffer(src);
+    slkTestData_t *rows = parse_slk_string(src);
     T_NOT_NULL(rows);
-    T_STREQ(FS_FindSheetCell(rows, "unit", "HP"), "100");
-    T_NULL(rows->next); /* only one data row; the Y=0 cell must not add a row */
+    T_STREQ(find_slk_value(rows, "unit", "HP"), "100");
+    T_NULL(find_slk_value(rows, "BAD", "HP"));
 }
 
 /* File without an ID;PWXL magic line is parsed without error. */
@@ -599,9 +509,9 @@ TEST(wc3_slk, prod_no_magic_line) {
         "C;Y2;X1;K\"foo\"\n"
         "C;Y2;X2;K\"270\"\n"
         "E\n";
-    sheetRow_t *rows = FS_ParseSLK_Buffer(src);
+    slkTestData_t *rows = parse_slk_string(src);
     T_NOT_NULL(rows);
-    T_STREQ(FS_FindSheetCell(rows, "foo", "spd"), "270");
+    T_STREQ(find_slk_value(rows, "foo", "spd"), "270");
 }
 
 #endif /* BZ_TESTS */

--- a/games/warcraft-3/game/tests/t_slk.c
+++ b/games/warcraft-3/game/tests/t_slk.c
@@ -15,10 +15,11 @@ void setup_test_world(void);
 
 slkTestData_t *parse_slk_string(const char *slk_text) {
     static slkField_t const schema[] = { { NULL, 0, 0 } };
-    stbSlkCache_t cache = { 0 };
+    void *rows = NULL;
+    DWORD count = Stb_SlkLoadBuffer(slk_text, schema, &rows, sizeof(DWORD));
     slkTestData_t *data;
-    if (!Stb_SlkCacheLoadBuffer(&cache, slk_text, schema, sizeof(DWORD))) return NULL;
-    Stb_SlkCacheFree(&cache);
+    if (!count) return NULL;
+    FS_SLKFreeRows(schema, rows, count, sizeof(DWORD));
     data = calloc(1, sizeof(*data));
     if (data) data->text = slk_text;
     return data;
@@ -26,7 +27,7 @@ slkTestData_t *parse_slk_string(const char *slk_text) {
 
 void free_slk_rows(slkTestData_t *data) {
     if (!data) return;
-    Stb_SlkCacheFree(&data->cache); free(data);
+    free(data->rows); free(data);
 }
 
 static LPCSTR find_slk_value(slkTestData_t const *data, LPCSTR row, LPCSTR column) {
@@ -36,15 +37,21 @@ static LPCSTR find_slk_value(slkTestData_t const *data, LPCSTR row, LPCSTR colum
         { column, offsetof(row_t, value), STB_SLK_STR },
         { NULL, 0, 0 }
     };
-    stbSlkCache_t cache = { 0 };
-    row_t const *found;
-    bool has_value;
+    row_t *rows = NULL;
+    DWORD count, key;
     static char value[1024];
-    if (!data || !Stb_SlkCacheLoadBuffer(&cache, data->text, schema, sizeof(row_t))) return NULL;
-    found = Stb_SlkCacheFind(&cache, FS_SLKKey(row));
-    has_value = found && found->value;
-    if (has_value) snprintf(value, sizeof(value), "%s", found->value);
-    Stb_SlkCacheFree(&cache);
+    bool has_value = false;
+    if (!data) return NULL;
+    count = Stb_SlkLoadBuffer(data->text, schema, (void **)&rows, sizeof(row_t));
+    if (!count) return NULL;
+    key = FS_SLKKey(row);
+    FOR_LOOP(i, count) {
+        if (rows[i].id == key && rows[i].value) {
+            snprintf(value, sizeof(value), "%s", rows[i].value);
+            has_value = true; break;
+        }
+    }
+    FS_SLKFreeRows(schema, rows, count, sizeof(row_t));
     return has_value ? value : NULL;
 }
 
@@ -104,16 +111,15 @@ TEST(wc3_slk, typed_strings_are_owned_and_alias_safe) {
         "C;Y2;X2;K\"Footman\"\n"
         "C;Y2;X3;K\"Knight\"\n"
         "E\n";
-    stbSlkCache_t cache = { 0 };
+    testRow_t *rows = NULL;
     LPSTR alias = strstr(src, "Knight");
+    DWORD count = Stb_SlkLoadBuffer(src, schema, (void **)&rows, sizeof(testRow_t));
 
-    T_ASSERT(Stb_SlkCacheLoadBuffer(&cache, src, schema, sizeof(testRow_t)));
-    testRow_t const *rows = cache.rows;
-    T_EQ(cache.count, 1);
+    T_ASSERT(count == 1);
     T_NOT_NULL(alias);
     alias[0] = 'Y';
     T_STREQ(rows[0].name, "Knight");
-    Stb_SlkCacheFree(&cache);
+    FS_SLKFreeRows(schema, rows, count, sizeof(testRow_t));
 }
 
 TEST(wc3_slk, profile_ddx_and_fourcc_metadata_share_typed_row) {
@@ -400,7 +406,7 @@ TEST(wc3_slk, uber_splat_fields_use_typed_row) {
 }
 
 /* -----------------------------------------------------------------------
- * 5.  Production SLK buffer parser through Stb_SlkCacheLoadBuffer
+ * 5.  Production SLK buffer parser through Stb_SlkLoadBuffer
  * --------------------------------------------------------------------- */
 
 /* Omitted Y uses stateful current row; ROC tables rely on this heavily. */

--- a/games/warcraft-3/game/tests/t_spell.c
+++ b/games/warcraft-3/game/tests/t_spell.c
@@ -6,8 +6,8 @@
 LPEDICT alloc_test_unit(DWORD class_id, FLOAT x, FLOAT y);
 void reset_entities(void);
 void setup_test_world(void);
-sheetRow_t *parse_slk_string(const char *slk_text);
-void free_slk_rows(sheetRow_t *rows);
+slkTestData_t *parse_slk_string(const char *slk_text);
+void free_slk_rows(slkTestData_t *rows);
 
 static const char slk_spell_data[] =
 	"ID;PWXL;N;EBB;Y2;X11\n"
@@ -142,16 +142,16 @@ TEST(wc3_spell, spell_unit_id_from_slk) {
 		"C;Y2;X2;K\"AHwe\"\n"
 		"C;Y2;X3;K\"hwat\"\n"
 		"E\n";
-	sheetRow_t *rows = parse_slk_string(slk);
-	sheetRow_t *old = G_SetSLKRows("AbilityData", rows);
+	slkTestData_t *rows = parse_slk_string(slk);
+	slkTestData_t *old = G_SetSLKRows("AbilityData", rows);
 	T_EQ((int)S_SpellUnitId(MAKEFOURCC('A','H','w','e'), 1), (int)MAKEFOURCC('h','w','a','t'));
 	G_SetSLKRows("AbilityData", old);
 	free_slk_rows(rows);
 }
 
 TEST(wc3_spell, hero_duration_uses_herodur_col) {
-	sheetRow_t *rows = parse_slk_string(slk_spell_data);
-	sheetRow_t *old = G_SetSLKRows("AbilityData", rows);
+	slkTestData_t *rows = parse_slk_string(slk_spell_data);
+	slkTestData_t *old = G_SetSLKRows("AbilityData", rows);
 	T_FEQ(S_SpellDuration(MAKEFOURCC('A','H','t','b'), 1, true), 3.0f, 0.01f);
 	T_FEQ(S_SpellDuration(MAKEFOURCC('A','H','t','b'), 1, false), 5.0f, 0.01f);
 	G_SetSLKRows("AbilityData", old);

--- a/games/warcraft-3/game/tests/t_unit.c
+++ b/games/warcraft-3/game/tests/t_unit.c
@@ -25,8 +25,8 @@ BOOL unit_issueorder(LPEDICT self, LPCSTR order, LPCVECTOR2 point);
 BOOL unit_issueimmediateorder(LPEDICT self, LPCSTR order);
 BOOL unit_additem(LPEDICT edict, LPEDICT item);
 BOOL unit_additemtoslot(LPEDICT edict, LPEDICT item, DWORD slot);
-sheetRow_t *parse_slk_string(LPCSTR slk_text);
-void free_slk_rows(sheetRow_t *rows);
+slkTestData_t *parse_slk_string(LPCSTR slk_text);
+void free_slk_rows(slkTestData_t *rows);
 
 /* Reset the entity pool between tests. */
 static void reset_test_entities(void) {
@@ -86,8 +86,8 @@ TEST(wc3_unit, selection_sound_registration_caches_all_responses) {
         "C;Y2;X3;K\"Units\\Human\\Footman\\\"\n"
         "E\n";
     LPEDICT ent = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0, 0);
-    sheetRow_t *sounds = parse_slk_string(slk);
-    sheetRow_t *old = G_SetSLKRows("UnitAckSounds", sounds);
+    slkTestData_t *sounds = parse_slk_string(slk);
+    slkTestData_t *old = G_SetSLKRows("UnitAckSounds", sounds);
     G_RegisterSelectSounds(ent, "Footman");
     T_EQ(ent->sound.num_select, 4);
     FOR_LOOP(i, ent->sound.num_select) T_ASSERT(ent->sound.select[i]);

--- a/games/warcraft-3/renderer/r_game.c
+++ b/games/warcraft-3/renderer/r_game.c
@@ -27,8 +27,8 @@ static slkField_t const cliff_schema[] = {
     { "", offsetof(w3CliffType_t, id), STB_SLK_FOURCC },
     { "texDir", offsetof(w3CliffType_t, texDir), STB_SLK_STR },
     { "texFile", offsetof(w3CliffType_t, texFile), STB_SLK_STR },
-    { "groundTile", offsetof(w3CliffType_t, groundTile), STB_SLK_STR },
-    { "upperTile", offsetof(w3CliffType_t, upperTile), STB_SLK_STR },
+    { "groundTile", offsetof(w3CliffType_t, groundTile), STB_SLK_FOURCC },
+    { "upperTile", offsetof(w3CliffType_t, upperTile), STB_SLK_FOURCC },
     { "rampModelDir", offsetof(w3CliffType_t, rampModelDir), STB_SLK_STR },
     { "cliffModelDir", offsetof(w3CliffType_t, cliffModelDir), STB_SLK_STR },
     { NULL, 0, 0 },
@@ -97,8 +97,6 @@ void R_GameLoadAssets(void) {
 
 void R_GameInit(void) {
     cursor_model = NULL; cursor_load_attempted = false;
-    g_terrain_rows = NULL; g_terrain_count = 0; memset(&g_terrain_idx, 0, sizeof(g_terrain_idx));
-    g_cliff_rows   = NULL; g_cliff_count   = 0; memset(&g_cliff_idx,   0, sizeof(g_cliff_idx));
     MDLX_Init();
 }
 

--- a/games/warcraft-3/renderer/r_game.c
+++ b/games/warcraft-3/renderer/r_game.c
@@ -1,6 +1,7 @@
 #include "renderer/r_game.h"
 #include "mdx/r_mdx.h"
 #include "w3m/r_war3map.h"
+#include "common/stb_slk.h"
 
 void R_RegisterMap(LPCSTR mapFileName);
 void R_DrawWorld(void);
@@ -15,9 +16,22 @@ static LPCSTR selCirclesNames[NUM_SELECTION_CIRCLES] = {
     "ReplaceableTextures\\Selection\\SelectionCircleLarge.blp",
 };
 
-static LPCSTR sheetNames[SHEET_COUNT] = {
-    "TerrainArt\\Terrain.slk",
-    "TerrainArt\\CliffTypes.slk",
+static slkField_t const terrain_schema[] = {
+    { "", offsetof(w3TerrainArt_t, id), STB_SLK_FOURCC },
+    { "dir", offsetof(w3TerrainArt_t, dir), STB_SLK_STR },
+    { "file", offsetof(w3TerrainArt_t, file), STB_SLK_STR },
+    { NULL, 0, 0 },
+};
+
+static slkField_t const cliff_schema[] = {
+    { "", offsetof(w3CliffType_t, id), STB_SLK_FOURCC },
+    { "texDir", offsetof(w3CliffType_t, texDir), STB_SLK_STR },
+    { "texFile", offsetof(w3CliffType_t, texFile), STB_SLK_STR },
+    { "groundTile", offsetof(w3CliffType_t, groundTile), STB_SLK_STR },
+    { "upperTile", offsetof(w3CliffType_t, upperTile), STB_SLK_STR },
+    { "rampModelDir", offsetof(w3CliffType_t, rampModelDir), STB_SLK_STR },
+    { "cliffModelDir", offsetof(w3CliffType_t, cliffModelDir), STB_SLK_STR },
+    { NULL, 0, 0 },
 };
 
 static LPCSTR modelNames[MODEL_COUNT] = {
@@ -27,6 +41,8 @@ static LPCSTR modelNames[MODEL_COUNT] = {
 static LPCSTR const cursor_model_name = "UI\\Cursor\\HumanCursor.mdx";
 static LPMODEL cursor_model;
 static BOOL cursor_load_attempted;
+static stbSlkCache_t g_terrain;
+static stbSlkCache_t g_cliff;
 
 typedef struct {
     LPMODEL model;
@@ -55,9 +71,13 @@ void R_GameLoadAssets(void) {
     FOR_LOOP(i, MODEL_COUNT) {
         tr.model[i] = R_LoadModel(modelNames[i]);
     }
-    FOR_LOOP(i, SHEET_COUNT) {
-        tr.sheet[i] = ri.ReadSheet(sheetNames[i]);
-    }
+    Stb_SlkCacheFree(&g_terrain);
+    if (!ri.LoadSlkCache(&g_terrain, "TerrainArt\\Terrain.slk", terrain_schema, sizeof(w3TerrainArt_t)))
+        fprintf(stderr, "Renderer: failed to load TerrainArt\\Terrain.slk\n");
+    Stb_SlkCacheFree(&g_cliff);
+    if (!ri.LoadSlkCache(&g_cliff, "TerrainArt\\CliffTypes.slk", cliff_schema, sizeof(w3CliffType_t)))
+        fprintf(stderr, "Renderer: failed to load TerrainArt\\CliffTypes.slk\n");
+
     FOR_LOOP(i, NUM_SELECTION_CIRCLES) {
         tr.texture[TEX_SELECTION_CIRCLE+i] = R_LoadTexture(selCirclesNames[i]);
     }
@@ -73,13 +93,27 @@ void R_GameLoadAssets(void) {
 
 void R_GameInit(void) {
     cursor_model = NULL; cursor_load_attempted = false;
+    memset(&g_terrain, 0, sizeof(g_terrain)); memset(&g_cliff, 0, sizeof(g_cliff));
     MDLX_Init();
 }
 
 void R_GameShutdown(void) {
     /* R_ShutdownModels runs first and owns the cached model allocation; only clear our borrowed handle here. */
     cursor_model = NULL; cursor_load_attempted = false;
+    Stb_SlkCacheFree(&g_terrain); Stb_SlkCacheFree(&g_cliff);
     MDLX_Shutdown();
+}
+
+w3TerrainArt_t const *R_GameTerrainArt(DWORD id) {
+    static w3TerrainArt_t zero;
+    w3TerrainArt_t *row = Stb_SlkCacheFind(&g_terrain, id);
+    return row ? row : &zero;
+}
+
+w3CliffType_t const *R_GameCliffType(DWORD id) {
+    static w3CliffType_t zero;
+    w3CliffType_t *row = Stb_SlkCacheFind(&g_cliff, id);
+    return row ? row : &zero;
 }
 
 void R_GameSetupTextureMatrix(void) {

--- a/games/warcraft-3/renderer/r_game.c
+++ b/games/warcraft-3/renderer/r_game.c
@@ -41,8 +41,8 @@ static LPCSTR modelNames[MODEL_COUNT] = {
 static LPCSTR const cursor_model_name = "UI\\Cursor\\HumanCursor.mdx";
 static LPMODEL cursor_model;
 static BOOL cursor_load_attempted;
-static stbSlkCache_t g_terrain;
-static stbSlkCache_t g_cliff;
+static w3TerrainArt_t *g_terrain_rows; static DWORD g_terrain_count; static slkIndex_t g_terrain_idx;
+static w3CliffType_t *g_cliff_rows;   static DWORD g_cliff_count;   static slkIndex_t g_cliff_idx;
 
 typedef struct {
     LPMODEL model;
@@ -71,12 +71,16 @@ void R_GameLoadAssets(void) {
     FOR_LOOP(i, MODEL_COUNT) {
         tr.model[i] = R_LoadModel(modelNames[i]);
     }
-    Stb_SlkCacheFree(&g_terrain);
-    if (!ri.LoadSlkCache(&g_terrain, "TerrainArt\\Terrain.slk", terrain_schema, sizeof(w3TerrainArt_t)))
-        fprintf(stderr, "Renderer: failed to load TerrainArt\\Terrain.slk\n");
-    Stb_SlkCacheFree(&g_cliff);
-    if (!ri.LoadSlkCache(&g_cliff, "TerrainArt\\CliffTypes.slk", cliff_schema, sizeof(w3CliffType_t)))
-        fprintf(stderr, "Renderer: failed to load TerrainArt\\CliffTypes.slk\n");
+    FS_SLKFreeIndex(&g_terrain_idx);
+    FS_SLKFreeRows(terrain_schema, g_terrain_rows, g_terrain_count, sizeof(w3TerrainArt_t));
+    g_terrain_count = ri.LoadSlk("TerrainArt\\Terrain.slk", terrain_schema, (void **)&g_terrain_rows, sizeof(w3TerrainArt_t));
+    if (!g_terrain_count) fprintf(stderr, "Renderer: failed to load TerrainArt\\Terrain.slk\n");
+    FS_SLKBuildIndex(&g_terrain_idx, g_terrain_rows, g_terrain_count, sizeof(w3TerrainArt_t));
+    FS_SLKFreeIndex(&g_cliff_idx);
+    FS_SLKFreeRows(cliff_schema, g_cliff_rows, g_cliff_count, sizeof(w3CliffType_t));
+    g_cliff_count = ri.LoadSlk("TerrainArt\\CliffTypes.slk", cliff_schema, (void **)&g_cliff_rows, sizeof(w3CliffType_t));
+    if (!g_cliff_count) fprintf(stderr, "Renderer: failed to load TerrainArt\\CliffTypes.slk\n");
+    FS_SLKBuildIndex(&g_cliff_idx, g_cliff_rows, g_cliff_count, sizeof(w3CliffType_t));
 
     FOR_LOOP(i, NUM_SELECTION_CIRCLES) {
         tr.texture[TEX_SELECTION_CIRCLE+i] = R_LoadTexture(selCirclesNames[i]);
@@ -93,26 +97,32 @@ void R_GameLoadAssets(void) {
 
 void R_GameInit(void) {
     cursor_model = NULL; cursor_load_attempted = false;
-    memset(&g_terrain, 0, sizeof(g_terrain)); memset(&g_cliff, 0, sizeof(g_cliff));
+    g_terrain_rows = NULL; g_terrain_count = 0; memset(&g_terrain_idx, 0, sizeof(g_terrain_idx));
+    g_cliff_rows   = NULL; g_cliff_count   = 0; memset(&g_cliff_idx,   0, sizeof(g_cliff_idx));
     MDLX_Init();
 }
 
 void R_GameShutdown(void) {
     /* R_ShutdownModels runs first and owns the cached model allocation; only clear our borrowed handle here. */
     cursor_model = NULL; cursor_load_attempted = false;
-    Stb_SlkCacheFree(&g_terrain); Stb_SlkCacheFree(&g_cliff);
+    FS_SLKFreeIndex(&g_terrain_idx);
+    FS_SLKFreeRows(terrain_schema, g_terrain_rows, g_terrain_count, sizeof(w3TerrainArt_t));
+    g_terrain_rows = NULL; g_terrain_count = 0;
+    FS_SLKFreeIndex(&g_cliff_idx);
+    FS_SLKFreeRows(cliff_schema, g_cliff_rows, g_cliff_count, sizeof(w3CliffType_t));
+    g_cliff_rows = NULL; g_cliff_count = 0;
     MDLX_Shutdown();
 }
 
 w3TerrainArt_t const *R_GameTerrainArt(DWORD id) {
     static w3TerrainArt_t zero;
-    w3TerrainArt_t *row = Stb_SlkCacheFind(&g_terrain, id);
+    w3TerrainArt_t *row = FS_SLKLookup(&g_terrain_idx, id);
     return row ? row : &zero;
 }
 
 w3CliffType_t const *R_GameCliffType(DWORD id) {
     static w3CliffType_t zero;
-    w3CliffType_t *row = Stb_SlkCacheFind(&g_cliff, id);
+    w3CliffType_t *row = FS_SLKLookup(&g_cliff_idx, id);
     return row ? row : &zero;
 }
 

--- a/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
@@ -42,7 +42,6 @@ static LPVERTEX R_CliffBakeVertex(rCliffBakeList_t *list) {
 
 #include "r_war3map.h"
 #include "../mdx/r_mdx.h"
-#include "common/stb_slk.h"
 
 #define SAME_TILE 852063
 #define NO_CLIFF MAKEFOURCC('C','L','n','o')
@@ -56,8 +55,8 @@ typedef struct {
     DWORD cliff;
     LPCSTR texDir;
     LPCSTR texFile;
-    LPCSTR groundTile;
-    LPCSTR upperTile;
+    DWORD groundTile;
+    DWORD upperTile;
     LPCSTR rampModelDir;
     LPCSTR cliffModelDir;
 } cliffData_t;
@@ -202,14 +201,16 @@ static void R_MakeCliff(LPCWAR3MAP map, DWORD x, DWORD y, cliffData_t const *dat
         }
     }
     
-    FOR_LOOP(gindx, map->num_grounds) {
-//        DWORD tile = *(DWORD *)(IS_FOURCC(data->groundTile) ? data->groundTile : data->upperTile);
-        if (map->grounds[gindx] == *(DWORD *)data->groundTile) {
-            ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, x+1, y+1))->ground = gindx;
-            ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, x, y+1))->ground = gindx;
-            ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, x+1, y))->ground = gindx;
-            ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, x, y))->ground = gindx;
-            break;
+    DWORD const ground_key = data->groundTile ? data->groundTile : data->upperTile;
+    if (ground_key) {
+        FOR_LOOP(gindx, map->num_grounds) {
+            if (map->grounds[gindx] == ground_key) {
+                ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, x+1, y+1))->ground = gindx;
+                ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, x, y+1))->ground = gindx;
+                ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, x+1, y))->ground = gindx;
+                ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, x, y))->ground = gindx;
+                break;
+            }
         }
     }
 
@@ -274,10 +275,7 @@ LPMAPLAYER R_BuildMapSegmentCliffs(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD cli
     }
 
     LPMAPLAYER mapLayer = ri.MemAlloc(sizeof(MAPLAYER));
-    char cliffID_str[5] = { 0 };
-    w3CliffType_t const *row;
-    memcpy(cliffID_str, &cliffID, 4);
-    row = R_GameCliffType(FS_SLKKey(cliffID_str));
+    w3CliffType_t const *row = R_GameCliffType(cliffID);
     cliffData_t data = {
         .cliff = cliff,
         .texDir = row->texDir,

--- a/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
@@ -42,6 +42,7 @@ static LPVERTEX R_CliffBakeVertex(rCliffBakeList_t *list) {
 
 #include "r_war3map.h"
 #include "../mdx/r_mdx.h"
+#include "common/stb_slk.h"
 
 #define SAME_TILE 852063
 #define NO_CLIFF MAKEFOURCC('C','L','n','o')
@@ -274,15 +275,17 @@ LPMAPLAYER R_BuildMapSegmentCliffs(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD cli
 
     LPMAPLAYER mapLayer = ri.MemAlloc(sizeof(MAPLAYER));
     char cliffID_str[5] = { 0 };
+    w3CliffType_t const *row;
     memcpy(cliffID_str, &cliffID, 4);
+    row = R_GameCliffType(FS_SLKKey(cliffID_str));
     cliffData_t data = {
         .cliff = cliff,
-        .texDir = ri.FindSheetCell(tr.sheet[SHEET_CLIFF], cliffID_str, "texDir"),
-        .texFile = ri.FindSheetCell(tr.sheet[SHEET_CLIFF], cliffID_str, "texFile"),
-        .groundTile = ri.FindSheetCell(tr.sheet[SHEET_CLIFF], cliffID_str, "groundTile"),
-        .upperTile = ri.FindSheetCell(tr.sheet[SHEET_CLIFF], cliffID_str, "upperTile"),
-        .rampModelDir = ri.FindSheetCell(tr.sheet[SHEET_CLIFF], cliffID_str, "rampModelDir"),
-        .cliffModelDir = ri.FindSheetCell(tr.sheet[SHEET_CLIFF], cliffID_str, "cliffModelDir"),
+        .texDir = row->texDir,
+        .texFile = row->texFile,
+        .groundTile = row->groundTile,
+        .upperTile = row->upperTile,
+        .rampModelDir = row->rampModelDir,
+        .cliffModelDir = row->cliffModelDir,
     };
     mapLayer->type = MAPLAYERTYPE_CLIFF;
     cliffs_current_vertex = cliffs_vertex_buffer;

--- a/games/warcraft-3/renderer/w3m/r_war3map_ground.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_ground.c
@@ -1,5 +1,4 @@
 #include "r_war3map.h"
-#include "common/stb_slk.h"
 
 #define MAX_MAP_LAYERS 16
 #define WATER(INDEX) \
@@ -271,10 +270,7 @@ LPMAPLAYER R_BuildMapSegmentLayer(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD laye
     LPMAPLAYER mapLayer = ri.MemAlloc(sizeof(MAPLAYER));
     PATHSTR zBuffer;
     if (g_groundTextures[layer] == NULL) {
-        char groundID[5] = { 0 };
-        w3TerrainArt_t const *terrain;
-        memcpy(groundID, &map->grounds[layer], 4);
-        terrain = R_GameTerrainArt(FS_SLKKey(groundID));
+        w3TerrainArt_t const *terrain = R_GameTerrainArt(map->grounds[layer]);
         if (terrain->file && terrain->dir) {
             snprintf(zBuffer, sizeof(zBuffer), "%s\\%s.blp", terrain->dir, terrain->file);
             g_groundTextures[layer] = R_LoadTexture(zBuffer);
@@ -300,10 +296,7 @@ LPMAPLAYER R_BuildGroundLayerGlobal(LPCWAR3MAP map, DWORD layer) {
     PATHSTR zBuffer;
 
     if (g_groundTextures[layer] == NULL) {
-        char groundID[5] = { 0 };
-        w3TerrainArt_t const *terrain;
-        memcpy(groundID, &map->grounds[layer], 4);
-        terrain = R_GameTerrainArt(FS_SLKKey(groundID));
+        w3TerrainArt_t const *terrain = R_GameTerrainArt(map->grounds[layer]);
         if (terrain->file && terrain->dir) {
             sprintf(zBuffer, "%s\\%s.blp", terrain->dir, terrain->file);
             g_groundTextures[layer] = R_LoadTexture(zBuffer);

--- a/games/warcraft-3/renderer/w3m/r_war3map_ground.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_ground.c
@@ -1,4 +1,5 @@
 #include "r_war3map.h"
+#include "common/stb_slk.h"
 
 #define MAX_MAP_LAYERS 16
 #define WATER(INDEX) \
@@ -271,11 +272,11 @@ LPMAPLAYER R_BuildMapSegmentLayer(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD laye
     PATHSTR zBuffer;
     if (g_groundTextures[layer] == NULL) {
         char groundID[5] = { 0 };
+        w3TerrainArt_t const *terrain;
         memcpy(groundID, &map->grounds[layer], 4);
-        LPCSTR dir = ri.FindSheetCell(tr.sheet[SHEET_TERRAIN], groundID, "dir");
-        LPCSTR file = ri.FindSheetCell(tr.sheet[SHEET_TERRAIN], groundID, "file");
-        if (file && dir) {
-            snprintf(zBuffer, sizeof(zBuffer), "%s\\%s.blp", dir, file);
+        terrain = R_GameTerrainArt(FS_SLKKey(groundID));
+        if (terrain->file && terrain->dir) {
+            snprintf(zBuffer, sizeof(zBuffer), "%s\\%s.blp", terrain->dir, terrain->file);
             g_groundTextures[layer] = R_LoadTexture(zBuffer);
         } else {
             return NULL;
@@ -300,11 +301,11 @@ LPMAPLAYER R_BuildGroundLayerGlobal(LPCWAR3MAP map, DWORD layer) {
 
     if (g_groundTextures[layer] == NULL) {
         char groundID[5] = { 0 };
+        w3TerrainArt_t const *terrain;
         memcpy(groundID, &map->grounds[layer], 4);
-        LPCSTR dir = ri.FindSheetCell(tr.sheet[SHEET_TERRAIN], groundID, "dir");
-        LPCSTR file = ri.FindSheetCell(tr.sheet[SHEET_TERRAIN], groundID, "file");
-        if (file && dir) {
-            sprintf(zBuffer, "%s\\%s.blp", dir, file);
+        terrain = R_GameTerrainArt(FS_SLKKey(groundID));
+        if (terrain->file && terrain->dir) {
+            sprintf(zBuffer, "%s\\%s.blp", terrain->dir, terrain->file);
             g_groundTextures[layer] = R_LoadTexture(zBuffer);
         } else {
             return NULL;

--- a/games/warcraft-3/sheet/sheet.c
+++ b/games/warcraft-3/sheet/sheet.c
@@ -3,6 +3,7 @@
 #include <ctype.h>
 
 #include "common/common.h"
+#include "games/warcraft-3/common/stb_slk.h"
 
 #define MAX_INI_LINE 1024
 #define MAX_SHEET_COLUMNS 256
@@ -14,10 +15,26 @@ typedef struct SheetCell {
     LPSHEET next;
 } sheetCell_t;
 
-typedef struct sheet_cache_entry_s {
-    char *name;
+typedef struct sheet_field_s {
+    LPCSTR name, value;
+    struct sheet_field_s *next;
+} sheetField_t;
+
+typedef struct sheet_row_s {
+    LPCSTR name;
+    sheetField_t *fields;
+    struct sheet_row_s *next;
+} sheetRow_t;
+
+typedef struct sheet_table_s {
     sheetRow_t *rows;
     sheetRow_t *tail;
+    struct sheet_table_s *next;
+} sheetTable_t;
+
+typedef struct sheet_cache_entry_s {
+    char *name;
+    sheetTable_t *sheet;
     struct sheet_cache_entry_s *next;
 } sheet_cache_entry_t;
 
@@ -32,7 +49,6 @@ static LPSHEET previous_cell = cells;
 static sheetRow_t *current_row = rows;
 static sheetField_t *current_field = fields;
 static sheet_cache_entry_t *sheet_cache = NULL;
-static sheetRow_t *last_parsed_sheet_tail = NULL;
 
 static LPSTR SheetStoreTextRange(LPCSTR text, size_t len) {
     LPSTR out = current_text;
@@ -76,7 +92,7 @@ static void NormalizeSheetKey(const char *src, char *dst, size_t dst_size)
     dst[i] = '\0';
 }
 
-static sheetRow_t *SheetCacheLookup(LPCSTR fileName, sheetRow_t **tailOut)
+static sheetTable_t *SheetCacheLookup(LPCSTR fileName)
 {
     char key[256];
     sheet_cache_entry_t *entry;
@@ -84,24 +100,18 @@ static sheetRow_t *SheetCacheLookup(LPCSTR fileName, sheetRow_t **tailOut)
     NormalizeSheetKey(fileName, key, sizeof(key));
     for (entry = sheet_cache; entry; entry = entry->next) {
         if (!strcmp(entry->name, key)) {
-            if (tailOut) {
-                *tailOut = entry->tail;
-            }
-            return entry->rows;
+            return entry->sheet;
         }
-    }
-    if (tailOut) {
-        *tailOut = NULL;
     }
     return NULL;
 }
 
-static void SheetCacheStore(LPCSTR fileName, sheetRow_t *rows, sheetRow_t *tail)
+static void SheetCacheStore(LPCSTR fileName, sheetTable_t *sheet)
 {
     char key[256];
     sheet_cache_entry_t *entry;
 
-    if (!rows) {
+    if (!sheet) {
         return;
     }
 
@@ -116,10 +126,23 @@ static void SheetCacheStore(LPCSTR fileName, sheetRow_t *rows, sheetRow_t *tail)
         return;
     }
     memcpy(entry->name, key, strlen(key) + 1);
-    entry->rows = rows;
-    entry->tail = tail ? tail : rows;
+    entry->sheet = sheet;
     entry->next = sheet_cache;
     sheet_cache = entry;
+}
+
+static sheetTable_t *FS_MakeTable(sheetRow_t *rows, sheetRow_t *tail)
+{
+    sheetTable_t *table = (sheetTable_t *)malloc(sizeof(*table));
+
+    if (!table) {
+        fprintf(stderr, "Sheet: out of memory creating table handle\n");
+        return NULL;
+    }
+    table->rows = rows;
+    table->tail = tail;
+    table->next = NULL;
+    return table;
 }
 
 /* Scan one semicolon-delimited SLK record field from *p up to end.
@@ -182,7 +205,7 @@ static void FS_FillSheetCell(DWORD x, DWORD y, LPCSTR text) {
     current_cell++;
 }
 
-sheetRow_t *FS_MakeRowsFromSheet(LPSHEET sheet) {
+static sheetTable_t *FS_MakeRowsFromSheet(LPSHEET sheet) {
     LPCSTR columns[256] = { 0 };
     sheetRow_t *start = NULL;
     sheetRow_t *last_row = NULL;
@@ -250,11 +273,10 @@ sheetRow_t *FS_MakeRowsFromSheet(LPSHEET sheet) {
     }
 
     free(rows_by_number);
-    last_parsed_sheet_tail = last_row;
-    return start;
+    return FS_MakeTable(start, last_row);
 }
 
-sheetRow_t *FS_ParseSLK_Buffer(LPCSTR buffer)
+static sheetTable_t *FS_ParseSLK_Buffer(LPCSTR buffer)
 {
     LPSHEET start = current_cell;
     DWORD X = 1, Y = 1;
@@ -295,48 +317,43 @@ sheetRow_t *FS_ParseSLK_Buffer(LPCSTR buffer)
         previous_cell->next = NULL;
         return FS_MakeRowsFromSheet(start);
     }
-    last_parsed_sheet_tail = NULL;
     return NULL;
 }
 
 
-sheetRow_t *FS_ParseSLK(LPCSTR fileName) {
-    sheetRow_t *cachedTail = NULL;
-    sheetRow_t *cached = SheetCacheLookup(fileName, &cachedTail);
+static sheetTable_t *FS_ParseSLK(LPCSTR fileName) {
+    sheetTable_t *cached = SheetCacheLookup(fileName);
     LPSTR buffer;
-    sheetRow_t *rows;
+    sheetTable_t *sheet;
 
-    if (cached) {
-        last_parsed_sheet_tail = cachedTail;
-        return cached;
-    }
+    if (cached) return cached;
 
     buffer = FS_ReadFileIntoString(fileName);
     if (!buffer) {
         return NULL;
     }
-    rows = FS_ParseSLK_Buffer(buffer);
+    sheet = FS_ParseSLK_Buffer(buffer);
     FS_FreeFileString(buffer);
-    if (rows) {
-        SheetCacheStore(fileName, rows, last_parsed_sheet_tail);
-    }
-    return rows;
+    if (sheet) SheetCacheStore(fileName, sheet);
+    return sheet;
 }
 
-LPCSTR FS_FindSheetCell(sheetRow_t *sheet, LPCSTR row, LPCSTR column) {
-    FOR_EACH_LIST(sheetRow_t const, srow, sheet) {
-        if (strcmp(srow->name, row))
-            continue;
-        FOR_EACH_LIST(sheetField_t const, scolumn, srow->fields) {
-            if (strcasecmp(scolumn->name, column))
+static LPCSTR FS_FindSheetCell(sheetTable_t const *sheet, LPCSTR row, LPCSTR column) {
+    for (; sheet; sheet = sheet->next) {
+        FOR_EACH_LIST(sheetRow_t const, srow, sheet->rows) {
+            if (strcmp(srow->name, row))
                 continue;
-            return scolumn->value;
+            FOR_EACH_LIST(sheetField_t const, scolumn, srow->fields) {
+                if (strcasecmp(scolumn->name, column))
+                    continue;
+                return scolumn->value;
+            }
         }
     }
     return NULL;
 }
 
-static sheetRow_t *FS_ParseINI_Buffer(LPCSTR buffer) {
+static sheetTable_t *FS_ParseINI_Buffer(LPCSTR buffer) {
     LPCSTR p = buffer;
     sheetRow_t *start = current_row;
     sheetRow_t *section = NULL;
@@ -394,44 +411,190 @@ static sheetRow_t *FS_ParseINI_Buffer(LPCSTR buffer) {
             }
         }
     }
-    if (current_row != start) {
-        last_parsed_sheet_tail = section;
-        if (section) {
-            section->next = NULL;
-        }
-        return start;
-    }
-
-    last_parsed_sheet_tail = NULL;
-    return NULL;
+    if (current_row == start)
+        return NULL;
+    if (section)
+        section->next = NULL;
+    return FS_MakeTable(start, section);
 }
 
-sheetRow_t *FS_ParseINI(LPCSTR fileName) {
-    sheetRow_t *cachedTail = NULL;
-    sheetRow_t *cached = SheetCacheLookup(fileName, &cachedTail);
+static sheetTable_t *FS_ParseINI(LPCSTR fileName) {
+    sheetTable_t *cached = SheetCacheLookup(fileName);
     LPSTR buffer;
 
-    if (cached) {
-        last_parsed_sheet_tail = cachedTail;
-        return cached;
-    }
+    if (cached) return cached;
 
     buffer = FS_ReadFileIntoString(fileName);
     if (!buffer) {
         return NULL;
     }
 //    printf("%")
-    sheetRow_t *config = FS_ParseINI_Buffer(buffer);
+    sheetTable_t *config = FS_ParseINI_Buffer(buffer);
     if (!config) {
         fprintf(stderr, "Failed to parse %s\n", fileName);
     } else {
-        SheetCacheStore(fileName, config, last_parsed_sheet_tail);
+        SheetCacheStore(fileName, config);
     }
     FS_FreeFileString(buffer);
     return config;
 }
 
-sheetRow_t *FS_GetParsedSheetTail(void)
+static void FS_AppendSheetTable(sheetTable_t **head, sheetTable_t **tail, sheetTable_t *sheet)
 {
-    return last_parsed_sheet_tail;
+    if (!sheet)
+        return;
+    if (*tail)
+        (*tail)->next = sheet;
+    else
+        *head = sheet;
+    *tail = sheet;
+    while ((*tail)->next)
+        *tail = (*tail)->next;
+}
+
+static void SheetSetTypedField(BYTE *dst, bzFieldType_t type, LPCSTR value, LPCSTR field_name)
+{
+    switch (type) {
+    case BZ_FIELD_U32: *(DWORD *)dst = value ? (DWORD)atoi(value) : 0; break;
+    case BZ_FIELD_FLOAT: *(FLOAT *)dst = value ? (FLOAT)atof(value) : 0.f; break;
+    case BZ_FIELD_BOOL: *(BOOL *)dst = value && (atoi(value) != 0 || !strcasecmp(value, "TRUE")); break;
+    case BZ_FIELD_CSTR: {
+        size_t len = value ? strlen(value) : 0;
+        LPSTR str = (LPSTR)malloc(len + 1);
+        if (!str) { fprintf(stderr, "SLK: out of memory copying field '%s'\n", field_name ? field_name : ""); break; }
+        memcpy(str, value ? value : "", len + 1);
+        free(*(void **)dst);
+        *(LPSTR *)dst = str;
+        break;
+    }
+    case BZ_FIELD_FOURCC: {
+        DWORD key = 0;
+        if (value) {
+            size_t n = strlen(value);
+            memcpy(&key, value, n < 4 ? n : 4);
+        }
+        *(DWORD *)dst = key;
+        break;
+    }
+    default: break;
+    }
+}
+
+static void *FS_LoadSheetTyped(sheetTable_t const *sheet, slkField_t const *schema, size_t row_size, DWORD *count_out)
+{
+    DWORD capacity = 0, out_count = 0;
+    LPCSTR *seen_names;
+    BYTE *rows_out;
+
+    if (count_out)
+        *count_out = 0;
+    if (!sheet || !schema || !row_size)
+        return NULL;
+
+    for (sheetTable_t const *table = sheet; table; table = table->next)
+        FOR_EACH_LIST(sheetRow_t const, row, table->rows) if (row->name && row->name[0]) capacity++;
+    if (!capacity)
+        return NULL;
+
+    seen_names = (LPCSTR *)calloc(capacity, sizeof(*seen_names));
+    rows_out = (BYTE *)calloc(capacity, row_size);
+    if (!seen_names || !rows_out) {
+        fprintf(stderr, "SLK: out of memory allocating %u decoded rows\n", capacity);
+        free(seen_names);
+        free(rows_out);
+        return NULL;
+    }
+
+    for (sheetTable_t const *table = sheet; table; table = table->next) {
+        FOR_EACH_LIST(sheetRow_t const, row, table->rows) {
+            BYTE *dst;
+            bool seen = false;
+
+            if (!row->name || !row->name[0])
+                continue;
+            FOR_LOOP(i, out_count) {
+                if (!strcmp(seen_names[i], row->name)) {
+                    seen = true;
+                    break;
+                }
+            }
+            if (seen)
+                continue;
+
+            seen_names[out_count] = row->name;
+            dst = rows_out + out_count * row_size;
+
+            for (slkField_t const *field = schema; field->column; field++) {
+                LPCSTR value;
+                BYTE *field_dst = dst + field->offset;
+
+                if (!field->column[0]) {
+                    SheetSetTypedField(field_dst, field->type, row->name, field->column);
+                    continue;
+                }
+                value = FS_FindSheetCell(sheet, row->name, field->column);
+                if (!value)
+                    continue;
+                SheetSetTypedField(field_dst, field->type, value, field->column);
+            }
+            out_count++;
+        }
+    }
+
+    free(seen_names);
+    if (!out_count) {
+        free(rows_out);
+        return NULL;
+    }
+    if (count_out)
+        *count_out = out_count;
+    return rows_out;
+}
+
+static BOOL SheetDecodeCache(stbSlkCache_t *cache, sheetTable_t *source,
+                             slkField_t const *schema, DWORD row_stride) {
+    if (!cache || !source || !schema || !row_stride) return false;
+    cache->rows = FS_LoadSheetTyped(source, schema, row_stride, &cache->count);
+    if (!cache->rows) return false;
+    cache->source = source; cache->schema = schema; cache->row_stride = row_stride;
+    for (slkField_t const *field = schema; field->column; field++)
+        if (!field->column[0] && field->type == STB_SLK_FOURCC) {
+            cache->key_offset = field->offset; cache->has_key = true; break;
+        }
+    return true;
+}
+
+BOOL Stb_SlkCacheLoad(stbSlkCache_t *cache, LPCSTR filename, slkField_t const *schema, DWORD row_stride) {
+    return SheetDecodeCache(cache, FS_ParseSLK(filename), schema, row_stride);
+}
+
+BOOL Stb_SlkCacheLoadBuffer(stbSlkCache_t *cache, LPCSTR buffer, slkField_t const *schema, DWORD row_stride) {
+    return SheetDecodeCache(cache, FS_ParseSLK_Buffer(buffer), schema, row_stride);
+}
+
+BOOL Stb_IniCacheLoad(stbIniCache_t *cache, LPCSTR filename) {
+    if (!cache || !filename) return false;
+    cache->source = FS_ParseINI(filename);
+    return cache->source != NULL;
+}
+
+BOOL Stb_IniCacheLoadFiles(stbIniCache_t *cache, LPCSTR const *filenames) {
+    sheetTable_t *head = NULL, *tail = NULL;
+    if (!cache || !filenames) return false;
+    for (; *filenames; filenames++) FS_AppendSheetTable(&head, &tail, FS_ParseINI(*filenames));
+    cache->source = head;
+    return head != NULL;
+}
+
+BOOL Stb_IniCacheDecode(stbIniCache_t const *ini, stbSlkCache_t *cache,
+                        slkField_t const *schema, DWORD row_stride) {
+    return ini && SheetDecodeCache(cache, ini->source, schema, row_stride);
+}
+
+LPCSTR Stb_IniCacheFind(stbIniCache_t const *cache, LPCSTR section, LPCSTR key) {
+    return cache ? FS_FindSheetCell(cache->source, section, key) : NULL;
+}
+
+void Stb_IniCacheFree(stbIniCache_t *cache) {
+    if (cache) cache->source = NULL;
 }

--- a/games/warcraft-3/sheet/sheet.c
+++ b/games/warcraft-3/sheet/sheet.c
@@ -32,12 +32,6 @@ typedef struct sheet_table_s {
     struct sheet_table_s *next;
 } sheetTable_t;
 
-typedef struct sheet_cache_entry_s {
-    char *name;
-    sheetTable_t *sheet;
-    struct sheet_cache_entry_s *next;
-} sheet_cache_entry_t;
-
 // TODO: allocate these as needed, this is only PoC and will only work for 1 level
 static sheetCell_t cells[1024 * 1024] = { 0 };
 static sheetRow_t rows[1024 * 1024] = { 0 };
@@ -48,7 +42,6 @@ static LPSHEET current_cell = cells;
 static LPSHEET previous_cell = cells;
 static sheetRow_t *current_row = rows;
 static sheetField_t *current_field = fields;
-static sheet_cache_entry_t *sheet_cache = NULL;
 
 static LPSTR SheetStoreTextRange(LPCSTR text, size_t len) {
     LPSTR out = current_text;
@@ -70,65 +63,6 @@ static LPSTR SheetStoreTextRange(LPCSTR text, size_t len) {
     current_text[len] = '\0';
     current_text += len + 1;
     return out;
-}
-
-static void NormalizeSheetKey(const char *src, char *dst, size_t dst_size)
-{
-    size_t i = 0;
-
-    if (!src || !dst || dst_size == 0) {
-        return;
-    }
-
-    while (*src && i + 1 < dst_size) {
-        char ch = *src++;
-        if (ch == '/') {
-            ch = '\\';
-        } else if (ch >= 'A' && ch <= 'Z') {
-            ch = (char)(ch + 0x20);
-        }
-        dst[i++] = ch;
-    }
-    dst[i] = '\0';
-}
-
-static sheetTable_t *SheetCacheLookup(LPCSTR fileName)
-{
-    char key[256];
-    sheet_cache_entry_t *entry;
-
-    NormalizeSheetKey(fileName, key, sizeof(key));
-    for (entry = sheet_cache; entry; entry = entry->next) {
-        if (!strcmp(entry->name, key)) {
-            return entry->sheet;
-        }
-    }
-    return NULL;
-}
-
-static void SheetCacheStore(LPCSTR fileName, sheetTable_t *sheet)
-{
-    char key[256];
-    sheet_cache_entry_t *entry;
-
-    if (!sheet) {
-        return;
-    }
-
-    NormalizeSheetKey(fileName, key, sizeof(key));
-    entry = (sheet_cache_entry_t *)malloc(sizeof(sheet_cache_entry_t));
-    if (!entry) {
-        return;
-    }
-    entry->name = (char *)malloc(strlen(key) + 1);
-    if (!entry->name) {
-        free(entry);
-        return;
-    }
-    memcpy(entry->name, key, strlen(key) + 1);
-    entry->sheet = sheet;
-    entry->next = sheet_cache;
-    sheet_cache = entry;
 }
 
 static sheetTable_t *FS_MakeTable(sheetRow_t *rows, sheetRow_t *tail)
@@ -322,19 +256,11 @@ static sheetTable_t *FS_ParseSLK_Buffer(LPCSTR buffer)
 
 
 static sheetTable_t *FS_ParseSLK(LPCSTR fileName) {
-    sheetTable_t *cached = SheetCacheLookup(fileName);
-    LPSTR buffer;
+    LPSTR buffer = FS_ReadFileIntoString(fileName);
     sheetTable_t *sheet;
-
-    if (cached) return cached;
-
-    buffer = FS_ReadFileIntoString(fileName);
-    if (!buffer) {
-        return NULL;
-    }
+    if (!buffer) return NULL;
     sheet = FS_ParseSLK_Buffer(buffer);
     FS_FreeFileString(buffer);
-    if (sheet) SheetCacheStore(fileName, sheet);
     return sheet;
 }
 
@@ -419,22 +345,11 @@ static sheetTable_t *FS_ParseINI_Buffer(LPCSTR buffer) {
 }
 
 static sheetTable_t *FS_ParseINI(LPCSTR fileName) {
-    sheetTable_t *cached = SheetCacheLookup(fileName);
-    LPSTR buffer;
-
-    if (cached) return cached;
-
-    buffer = FS_ReadFileIntoString(fileName);
-    if (!buffer) {
-        return NULL;
-    }
-//    printf("%")
-    sheetTable_t *config = FS_ParseINI_Buffer(buffer);
-    if (!config) {
-        fprintf(stderr, "Failed to parse %s\n", fileName);
-    } else {
-        SheetCacheStore(fileName, config);
-    }
+    LPSTR buffer = FS_ReadFileIntoString(fileName);
+    sheetTable_t *config;
+    if (!buffer) return NULL;
+    config = FS_ParseINI_Buffer(buffer);
+    if (!config) fprintf(stderr, "Failed to parse %s\n", fileName);
     FS_FreeFileString(buffer);
     return config;
 }
@@ -551,25 +466,20 @@ static void *FS_LoadSheetTyped(sheetTable_t const *sheet, slkField_t const *sche
     return rows_out;
 }
 
-static BOOL SheetDecodeCache(stbSlkCache_t *cache, sheetTable_t *source,
-                             slkField_t const *schema, DWORD row_stride) {
-    if (!cache || !source || !schema || !row_stride) return false;
-    cache->rows = FS_LoadSheetTyped(source, schema, row_stride, &cache->count);
-    if (!cache->rows) return false;
-    cache->source = source; cache->schema = schema; cache->row_stride = row_stride;
-    for (slkField_t const *field = schema; field->column; field++)
-        if (!field->column[0] && field->type == STB_SLK_FOURCC) {
-            cache->key_offset = field->offset; cache->has_key = true; break;
-        }
-    return true;
+DWORD Stb_SlkLoad(LPCSTR filename, slkField_t const *schema, void **dest, DWORD row_stride) {
+    DWORD count = 0;
+    sheetTable_t *sheet = FS_ParseSLK(filename);
+    if (!sheet || !dest || !schema || !row_stride) return 0;
+    *dest = FS_LoadSheetTyped(sheet, schema, row_stride, &count);
+    return count;
 }
 
-BOOL Stb_SlkCacheLoad(stbSlkCache_t *cache, LPCSTR filename, slkField_t const *schema, DWORD row_stride) {
-    return SheetDecodeCache(cache, FS_ParseSLK(filename), schema, row_stride);
-}
-
-BOOL Stb_SlkCacheLoadBuffer(stbSlkCache_t *cache, LPCSTR buffer, slkField_t const *schema, DWORD row_stride) {
-    return SheetDecodeCache(cache, FS_ParseSLK_Buffer(buffer), schema, row_stride);
+DWORD Stb_SlkLoadBuffer(LPCSTR buffer, slkField_t const *schema, void **dest, DWORD row_stride) {
+    DWORD count = 0;
+    sheetTable_t *sheet = FS_ParseSLK_Buffer(buffer);
+    if (!sheet || !dest || !schema || !row_stride) return 0;
+    *dest = FS_LoadSheetTyped(sheet, schema, row_stride, &count);
+    return count;
 }
 
 BOOL Stb_IniCacheLoad(stbIniCache_t *cache, LPCSTR filename) {
@@ -586,9 +496,11 @@ BOOL Stb_IniCacheLoadFiles(stbIniCache_t *cache, LPCSTR const *filenames) {
     return head != NULL;
 }
 
-BOOL Stb_IniCacheDecode(stbIniCache_t const *ini, stbSlkCache_t *cache,
-                        slkField_t const *schema, DWORD row_stride) {
-    return ini && SheetDecodeCache(cache, ini->source, schema, row_stride);
+DWORD Stb_IniDecode(stbIniCache_t const *ini, slkField_t const *schema, void **dest, DWORD row_stride) {
+    DWORD count = 0;
+    if (!ini || !ini->source || !dest || !schema || !row_stride) return 0;
+    *dest = FS_LoadSheetTyped(ini->source, schema, row_stride, &count);
+    return count;
 }
 
 LPCSTR Stb_IniCacheFind(stbIniCache_t const *cache, LPCSTR section, LPCSTR key) {

--- a/games/warcraft-3/sheet/sheet.c
+++ b/games/warcraft-3/sheet/sheet.c
@@ -466,19 +466,40 @@ static void *FS_LoadSheetTyped(sheetTable_t const *sheet, slkField_t const *sche
     return rows_out;
 }
 
+/* Typed SLK rows are fully malloc-owned after FS_LoadSheetTyped — the static
+ * pools are only scratch space during parsing.  Reset cursors so they can be
+ * reused by the next load without exhausting the fixed-size arenas. */
+#define SHEET_POOL_SAVE() \
+    LPSHEET     _saved_cell  = current_cell;  \
+    LPSHEET     _saved_prev  = previous_cell; \
+    sheetRow_t *_saved_row   = current_row;   \
+    sheetField_t *_saved_fld = current_field; \
+    LPSTR       _saved_text  = current_text
+
+#define SHEET_POOL_RESTORE() \
+    current_cell  = _saved_cell;  \
+    previous_cell = _saved_prev;  \
+    current_row   = _saved_row;   \
+    current_field = _saved_fld;   \
+    current_text  = _saved_text
+
 DWORD Stb_SlkLoad(LPCSTR filename, slkField_t const *schema, void **dest, DWORD row_stride) {
+    SHEET_POOL_SAVE();
     DWORD count = 0;
     sheetTable_t *sheet = FS_ParseSLK(filename);
-    if (!sheet || !dest || !schema || !row_stride) return 0;
-    *dest = FS_LoadSheetTyped(sheet, schema, row_stride, &count);
+    if (sheet && dest && schema && row_stride)
+        *dest = FS_LoadSheetTyped(sheet, schema, row_stride, &count);
+    SHEET_POOL_RESTORE();
     return count;
 }
 
 DWORD Stb_SlkLoadBuffer(LPCSTR buffer, slkField_t const *schema, void **dest, DWORD row_stride) {
+    SHEET_POOL_SAVE();
     DWORD count = 0;
     sheetTable_t *sheet = FS_ParseSLK_Buffer(buffer);
-    if (!sheet || !dest || !schema || !row_stride) return 0;
-    *dest = FS_LoadSheetTyped(sheet, schema, row_stride, &count);
+    if (sheet && dest && schema && row_stride)
+        *dest = FS_LoadSheetTyped(sheet, schema, row_stride, &count);
+    SHEET_POOL_RESTORE();
     return count;
 }
 

--- a/games/warcraft-3/ui/ui_main.c
+++ b/games/warcraft-3/ui/ui_main.c
@@ -7,6 +7,7 @@
 
 #include "ui_local.h"
 #include "ui_screen.h"
+#include "common/stb_slk.h"
 #include "generated/loading_screen.h"
 
 /* Global import table filled by UI_GetAPI */
@@ -299,11 +300,12 @@ static void UI_EnterGameMode(void) {
 
 /* LoadingScreens rows describe the model/sequence; TFT adds an expansion category before the display label. */
 static DWORD UI_LoadCampaignLoadingModel(DWORD background, DWORD *sequence) {
-    sheetRow_t *data = FS_ParseINI("UI\\WorldEditData.txt");
+    static stbIniCache_t data;
+    if (!data.source) Stb_IniCacheLoad(&data, "UI\\WorldEditData.txt");
     char key[8];
     PATHSTR model;
     snprintf(key, sizeof(key), "%02u", (unsigned)background);
-    LPCSTR row = FS_FindSheetCell(data, "LoadingScreens", key);
+    LPCSTR row = Stb_IniCacheFind(&data, "LoadingScreens", key);
     if (!UI_ParseLoadingRow(row, sequence, model)) {
         fprintf(stderr, "UI: invalid LoadingScreens[%s]: %s\n", key, row ? row : "(missing)");
         return 0;

--- a/renderer/r_game.h
+++ b/renderer/r_game.h
@@ -13,8 +13,8 @@ typedef struct {
 	DWORD id;
 	LPCSTR texDir;
 	LPCSTR texFile;
-	LPCSTR groundTile;
-	LPCSTR upperTile;
+	DWORD groundTile;
+	DWORD upperTile;
 	LPCSTR rampModelDir;
 	LPCSTR cliffModelDir;
 } w3CliffType_t;

--- a/renderer/r_game.h
+++ b/renderer/r_game.h
@@ -3,6 +3,22 @@
 
 #include "r_local.h"
 
+typedef struct {
+	DWORD id;
+	LPCSTR dir;
+	LPCSTR file;
+} w3TerrainArt_t;
+
+typedef struct {
+	DWORD id;
+	LPCSTR texDir;
+	LPCSTR texFile;
+	LPCSTR groundTile;
+	LPCSTR upperTile;
+	LPCSTR rampModelDir;
+	LPCSTR cliffModelDir;
+} w3CliffType_t;
+
 void R_GameLoadAssets(void);
 void R_GameInit(void);
 void R_GameShutdown(void);
@@ -39,5 +55,7 @@ bool R_GameExtractEntityCamera(renderEntity_t const *entity, float aspect, viewD
 bool R_GameSetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity);
 void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y);
 bool R_GameDrawCursor(float x, float y);
+w3TerrainArt_t const *R_GameTerrainArt(DWORD id);
+w3CliffType_t const *R_GameCliffType(DWORD id);
 
 #endif

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -279,12 +279,6 @@ enum {
     MODEL_COUNT,
 };
 
-enum {
-    SHEET_TERRAIN,
-    SHEET_CLIFF,
-    SHEET_COUNT,
-};
-
 struct render_globals {
     viewDef_t viewDef;
     render_phase_t render_phase;    /* current whole-scene pass (solid / shadow-map / alpha); read by game renderers */
@@ -301,7 +295,6 @@ struct render_globals {
     LPBUFFER buffer[RBUF_COUNT];
     LPMODEL model[MODEL_COUNT];
     LPRENDERTARGET rt[RT_COUNT];
-    sheetRow_t *sheet[SHEET_COUNT];
     size2_t drawableSize;
     int msaa_samples;
     LPTEXTURE minimap;

--- a/tools/m3tool.c
+++ b/tools/m3tool.c
@@ -316,8 +316,7 @@ int main(int argc, char **argv) {
         .FileExtract = FS_ExtractFile,
         .MemAlloc = Tool_MemAlloc,
         .MemFree = Tool_MemFree,
-        .ReadSheet = FS_ParseSLK,
-        .FindSheetCell = FS_FindSheetCell,
+        .LoadSlkCache = Stb_SlkCacheLoad,
         .error = errorf,
     });
 

--- a/tools/m3tool.c
+++ b/tools/m3tool.c
@@ -316,7 +316,7 @@ int main(int argc, char **argv) {
         .FileExtract = FS_ExtractFile,
         .MemAlloc = Tool_MemAlloc,
         .MemFree = Tool_MemFree,
-        .LoadSlkCache = Stb_SlkCacheLoad,
+        .LoadSlk = Stb_SlkLoad,
         .error = errorf,
     });
 

--- a/tools/maptool.c
+++ b/tools/maptool.c
@@ -174,8 +174,7 @@ int main(int argc, char **argv) {
         .FS_FreeFile = Tool_FS_FreeFile,
         .MemAlloc = MemAlloc,
         .MemFree = MemFree,
-        .ReadSheet = FS_ParseSLK,
-        .FindSheetCell = FS_FindSheetCell,
+        .LoadSlkCache = Stb_SlkCacheLoad,
         .error = errorf,
     });
 

--- a/tools/maptool.c
+++ b/tools/maptool.c
@@ -174,7 +174,7 @@ int main(int argc, char **argv) {
         .FS_FreeFile = Tool_FS_FreeFile,
         .MemAlloc = MemAlloc,
         .MemFree = MemFree,
-        .LoadSlkCache = Stb_SlkCacheLoad,
+        .LoadSlk = Stb_SlkLoad,
         .error = errorf,
     });
 

--- a/tools/mdxtool.c
+++ b/tools/mdxtool.c
@@ -1309,8 +1309,7 @@ int main(int argc, char **argv) {
         .FS_FreeFile = Tool_FS_FreeFile,
         .MemAlloc = MemAlloc,
         .MemFree = MemFree,
-        .ReadSheet = FS_ParseSLK,
-        .FindSheetCell = FS_FindSheetCell,
+        .LoadSlkCache = Stb_SlkCacheLoad,
         .error = errorf,
     });
 

--- a/tools/mdxtool.c
+++ b/tools/mdxtool.c
@@ -1309,7 +1309,7 @@ int main(int argc, char **argv) {
         .FS_FreeFile = Tool_FS_FreeFile,
         .MemAlloc = MemAlloc,
         .MemFree = MemFree,
-        .LoadSlkCache = Stb_SlkCacheLoad,
+        .LoadSlk = Stb_SlkLoad,
         .error = errorf,
     });
 


### PR DESCRIPTION
## Summary

Replaces the intermediate `stbSlkCache_t` / `sheetRow_t` linked-list caching layer with a clean load-once API: `Stb_SlkLoad(path, schema, &dest, row_stride) → count`. SLK data is decoded directly into `malloc`-owned typed arrays at startup and never accessed again through the raw sheet layer.

### What changed

**API (`stb_slk.h`, `sheet.c`)**
- Removed `stbSlkCache_t`, `STB_SLK_ROW`, `Stb_SlkCacheLoad/Buffer`, `Stb_SlkCacheFree`, `Stb_SlkCacheFind`, `Stb_IniCacheDecode`
- New: `Stb_SlkLoad`, `Stb_SlkLoadBuffer`, `Stb_IniDecode` — all return `DWORD count`, write `void **dest`
- `sheet.c`: dropped `sheet_cache_entry_t` and the underlying parse-result cache entirely; SLK pool scratch is save/restored around each decode so fixed-size arenas are reused across loads rather than exhausted
- `sheet.c`: `FS_ParseSLK` / `FS_ParseINI` simplified — no cache lookup/store

**Game metadata (`g_metadata.c`)**
- `slkStore_t` loses its `stbSlkCache_t cache` field; `InitUnitData` loop becomes `Stb_SlkLoad → FS_SLKBuildIndex`
- `ShutdownUnitData` uses `FS_SLKFreeRows` directly
- `profile_cache` removed; `Stb_IniDecode` fills `g_UnitProfile` directly
- Test helpers (`G_SetSLKRows`, `G_SetProfileRows`) updated to `slkTestData_t { LPCSTR text; void *rows; DWORD count }`

**Renderer (`r_game.c`, `r_war3map_ground.c`, `r_war3map_cliffs.c`)**
- `stbSlkCache_t g_terrain/g_cliff` replaced with typed `w3TerrainArt_t *` / `w3CliffType_t *` + `slkIndex_t`; lookups use `FS_SLKLookup` (binary search) instead of the old linear scan
- `w3CliffType_t.groundTile` / `upperTile` changed from `LPCSTR` to `DWORD` (FOURCC) — eliminates the string cast at use sites
- Ground and cliff lookups pass the raw map DWORD ID directly instead of routing through `FS_SLKKey(char[5])`
- `tr_public.h`: `LoadSlkCache(stbSlkCache_t*, ...) → BOOL` → `LoadSlk(void**, ...) → DWORD`

**Bug fixes**
- `R_GameInit` was zeroing `g_terrain_rows`/`g_cliff_rows` *after* `R_GameLoadAssets` had populated them (both called from the same renderer-init function, 19 lines apart) — caused black terrain on every run
- `R_MakeCliff`: null-deref on `data->groundTile` when a cliff ID isn't in the SLK; fixed with `IS_FOURCC` fallback to `upperTile` and a guard before the dereference

## Test plan

- [ ] `make openwarcraft3-tests` passes (wc3_slk_* suite covers typed-table decode, index lookup, G_SetSLKRows/G_SetProfileRows round-trip)
- [ ] `make run-map` launches Human02.w3m: green Lordaeron terrain, cliffs, models all render correctly
- [ ] No crash on cliff tiles whose ID is absent from CliffTypes.slk