### PR TITLE
wc3: Add health bar on mouse hover units

### DIFF
--- a/client/cl_input_w3.c
+++ b/client/cl_input_w3.c
@@ -211,9 +211,33 @@ void CL_InputModeMouseButton(SDL_MouseButtonEvent const *button, BOOL down) {
     CL_EndPan();
 }
 
+static BOOL CL_CanHoverHealthEntity(DWORD entnum) {
+    LPCENTITYSTATE state;
+
+    if (!entnum || entnum >= MAX_CLIENT_ENTITIES) {
+        return false;
+    }
+    state = &cl.ents[entnum].current;
+    return state->model &&
+           state->stats[ENT_HEALTH] > 0 &&
+           (state->flags & EF_HOVER_HEALTH) &&
+           !(state->flags & EF_NOT_SELECTABLE);
+}
+
 void CL_InputModeMouseMotion(SDL_MouseMotionEvent const *motion) {
+    DWORD entnum = 0;
+
     if (!motion) {
         return;
+    }
+    if (CL_GameplayInputReady() &&
+        !CL_MouseOverGameplayUI() &&
+        re.TraceEntity(&cl.viewDef, (float)motion->x, (float)motion->y, &entnum) &&
+        CL_CanHoverHealthEntity(entnum))
+    {
+        cl.hover_entity = entnum;
+    } else {
+        cl.hover_entity = 0;
     }
     if (camera_drag.active) {
         CL_UpdatePan(motion->x, motion->y);

--- a/client/cl_input_w3.c
+++ b/client/cl_input_w3.c
@@ -212,12 +212,10 @@ void CL_InputModeMouseButton(SDL_MouseButtonEvent const *button, BOOL down) {
 }
 
 static BOOL CL_CanHoverHealthEntity(DWORD entnum) {
-    LPCENTITYSTATE state;
-
     if (!entnum || entnum >= MAX_CLIENT_ENTITIES) {
         return false;
     }
-    state = &cl.ents[entnum].current;
+    LPCENTITYSTATE const state = &cl.ents[entnum].current;
     return state->model &&
            state->stats[ENT_HEALTH] > 0 &&
            (state->flags & EF_HOVER_HEALTH) &&

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -93,13 +93,27 @@ static void SCR_UpdateSystemCursor(BOOL game_cursor_active) {
     }
 }
 
+static COLOR32 SCR_CursorTint(void) {
+    DWORD const entnum = cl.hover_entity;
+
+    if (entnum && entnum < MAX_CLIENT_ENTITIES) {
+        LPCENTITYSTATE state = &cl.ents[entnum].current;
+        if ((state->flags & (EF_HOVER_HEALTH | EF_HOSTILE)) ==
+            (EF_HOVER_HEALTH | EF_HOSTILE))
+        {
+            return MAKE(COLOR32, 255, 0, 0, 255);
+        }
+    }
+    return COLOR32_WHITE;
+}
+
 static void SCR_DrawCursor(void) {
     int const x = (int)mouse.origin.x, y = (int)mouse.origin.y;
     BOOL drawn = false;
 
     if (Cvar_Integer("r_cursor", 0) == 1) {
         VECTOR2 const pos = SCR_ScreenToUI(x, y);
-        drawn = re.DrawCursor(pos.x, pos.y);
+        drawn = re.DrawCursor(pos.x, pos.y, SCR_CursorTint());
     }
     SCR_UpdateSystemCursor(drawn);
 }

--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -238,6 +238,7 @@ static void V_AddClientEntity(centity_t const *ent) {
     if (ent->current.flags & EF_HAS_QUEST) re.flags |= RF_HAS_QUEST;
     if (ent->current.flags & EF_QUEST_COMPLETE) re.flags |= RF_QUEST_COMPLETE;
     if (ent->current.flags & EF_HOSTILE) re.flags |= RF_HOSTILE;
+    if (ent->current.flags & EF_NEUTRAL) re.flags |= RF_NEUTRAL;
     if (ent->current.flags & EF_NOT_SELECTABLE) re.flags |= RF_NOT_SELECTABLE;
     re.radius = ent->current.radius;
     re.number = ent->current.number;

--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -509,6 +509,7 @@ void V_RenderView(void) {
         cl.viewDef.rdflags |= RDF_SHOW_ALL_HEALTHBARS; /* ALT: bars on every unit */
     }
     cl.viewDef.player = cl.playerstate.number;
+    cl.viewDef.hover_entity = cl.hover_entity;
     
 #if !defined(WOW) && !defined(SC2)
     {

--- a/client/tr_public.h
+++ b/client/tr_public.h
@@ -144,6 +144,7 @@ typedef struct {
 #endif
     BYTE health;   /* current HP fraction, 0-255 (0 = dead/no bar) */
     BYTE mana;     /* current mana fraction, 0-255 (0 = no mana bar) */
+    COLOR32 tint;  /* optional per-instance model RGBA; alpha 0 = unmodified/white */
 } renderEntity_t;
 
 typedef struct {
@@ -216,7 +217,7 @@ typedef struct {
     void (*DrawMinimap)(LPCRECT screen);
     void (*DrawLoadingIndicator)(LPCRECT rect, DWORD time, COLOR32 color);
     void (*DrawSprite)(LPCMODEL model, LPCSTR anim, float x, float y);
-    bool (*DrawCursor)(float x, float y);
+    bool (*DrawCursor)(float x, float y, COLOR32 tint);
     bool (*SetEntityAnimFrame)(LPCMODEL model, LPCSTR anim, renderEntity_t *entity);
     void (*DrawText)(LPCDRAWTEXT drawText);
     VECTOR2 (*GetTextSize)(LPCDRAWTEXT drawText);

--- a/common/msg.c
+++ b/common/msg.c
@@ -47,7 +47,7 @@ netField_t entityStateFields[] = {
 #endif
     { NETF(entityState_t, image), NFT_SHORT },
     { NETF(entityState_t, player), NFT_BYTE },
-    { NETF(entityState_t, flags), NFT_BYTE },
+    { NETF(entityState_t, flags), NFT_SHORT },
     { NETF(entityState_t, renderfx), NFT_BYTE },
     { NETF(entityState_t, ability), NFT_BYTE },
 #ifdef WOW

--- a/common/shared.h
+++ b/common/shared.h
@@ -200,6 +200,7 @@ enum {
     FLAG(EF_QUEST_COMPLETE, 5), /* quest is ready to turn in — tint "?" yellow */
     FLAG(EF_HOSTILE, 6),        /* entity is hostile — renderer shows red nameplate */
     FLAG(EF_NOT_SELECTABLE, 7), /* render entity, but exclude it from world/box selection */
+    FLAG(EF_HOVER_HEALTH, 8),   /* client may expose this entity's health on world hover */
 };
 
 enum {
@@ -472,7 +473,7 @@ typedef struct entityState_s {
     USHORT sound;
     DWORD frame;
     BYTE event;
-    BYTE flags;
+    USHORT flags;
     BYTE renderfx;
     BYTE ability;
     DWORD splat;

--- a/common/shared.h
+++ b/common/shared.h
@@ -181,7 +181,7 @@ enum {
     FLAG(RF_FOW_BLOCKER, 10),
     FLAG(RF_PORTRAIT_LIGHTING, 11),
     FLAG(RF_FOW_REVEALER, 12),
-    FLAG(RF_HOSTILE, 13),
+    FLAG(RF_HOSTILE, 13),      /* hostile relationship presentation */
     FLAG(RF_HOVERED, 14),
     FLAG(RF_ORTHO_CAMERA, 15), /* HUD model: use orthographic camera (console chrome) */
     FLAG(RF_GROUND_EFFECT, 15),
@@ -189,6 +189,7 @@ enum {
     FLAG(RF_HAS_QUEST, 17),    /* show overhead "?" sprite */
     FLAG(RF_QUEST_COMPLETE, 18), /* tint "?" sprite yellow */
     FLAG(RF_NOT_SELECTABLE, 19), /* render normally but exclude from world hit/box selection */
+    FLAG(RF_NEUTRAL, 20),        /* neutral/passive relationship presentation */
 };
 
 enum {
@@ -198,9 +199,10 @@ enum {
     FLAG(EF_MOUNTED, 3),        /* WoW: entity is riding a mount */
     FLAG(EF_HAS_QUEST, 4),      /* entity has a quest in progress — show "?" sprite */
     FLAG(EF_QUEST_COMPLETE, 5), /* quest is ready to turn in — tint "?" yellow */
-    FLAG(EF_HOSTILE, 6),        /* entity is hostile — renderer shows red nameplate */
+    FLAG(EF_HOSTILE, 6),        /* hostile relationship to this snapshot recipient */
     FLAG(EF_NOT_SELECTABLE, 7), /* render entity, but exclude it from world/box selection */
     FLAG(EF_HOVER_HEALTH, 8),   /* client may expose this entity's health on world hover */
+    FLAG(EF_NEUTRAL, 9),        /* neutral/passive relationship to this snapshot recipient */
 };
 
 enum {

--- a/docs/architecture/model-shader.md
+++ b/docs/architecture/model-shader.md
@@ -110,6 +110,15 @@ The instanced model shader receives the complete effect state in `uGrassParams`,
 
 The instance transform is declared as one `in mat4 i_instance`. OpenGL assigns its four columns to consecutive attribute locations beginning at `attrib_instance`; buffer setup still describes those four columns because the vertex API operates per location.
 
+## Per-instance model tint
+
+`renderEntity_t.tint` is optional RGBA modulation for an individual rendered model; alpha zero means the normal white/unmodified value.
+WC3's authored MDX cursor uses this to tint only the transient cursor instance without changing the shared model, BLP textures, or
+authored geoset animation. The MDX path multiplies the instance tint into the evaluated geoset colour before assigning the existing
+`u_geosetColor` state. This deliberately avoids introducing a second shader colour uniform for the same multiplicative concept.
+A white tint therefore preserves texture/geoset colour and alpha, while a red `(255,0,0,255)` tint preserves authored alpha and
+modulates only RGB.
+
 ## Extension rule
 
 Do not add a special count value, a second uniform family, or a per-game shader branch when an existing entry can encode the state. Extend the common schema only when authoritative data requires another value. If the common representation is genuinely incapable of expressing a title's behavior, document the exact constraint before adding an exception.

--- a/docs/architecture/network.md
+++ b/docs/architecture/network.md
@@ -136,7 +136,9 @@ openwarcraft3 -data=/path/to/Warcraft3 -connect=192.168.1.10:27910
 
 `entityState_t.flags` is a `USHORT` serialized as `NFT_SHORT` by `common/msg.c`. Engine-level bits describe generic client
 presentation/interaction capabilities; game modules decide when to set them in server-authored snapshots. `EF_HOVER_HEALTH` means the
-client may expose the entity's health through world-hover presentation. Any new field, flag, or packed value in `entityState_t` requires
+client may expose the entity's health through world-hover presentation. `EF_HOSTILE` and `EF_NEUTRAL` are recipient-relative
+presentation relationships; when neither is set, game-specific renderers may treat the entity as friendly. Any new field, flag, or
+packed value in `entityState_t` requires
 a `MSG_WriteDeltaEntity`/`MSG_ReadDeltaEntity` round-trip test in `tests/test_net.c`.
 
 ## Key files

--- a/docs/architecture/network.md
+++ b/docs/architecture/network.md
@@ -132,6 +132,13 @@ openwarcraft3 -data=/path/to/Warcraft3 -connect=192.168.1.10:27910
 `+map` and `-connect` are mutually exclusive.  Omitting both (with a valid
 `-data`) starts the client menu.
 
+## Entity snapshot flags
+
+`entityState_t.flags` is a `USHORT` serialized as `NFT_SHORT` by `common/msg.c`. Engine-level bits describe generic client
+presentation/interaction capabilities; game modules decide when to set them in server-authored snapshots. `EF_HOVER_HEALTH` means the
+client may expose the entity's health through world-hover presentation. Any new field, flag, or packed value in `entityState_t` requires
+a `MSG_WriteDeltaEntity`/`MSG_ReadDeltaEntity` round-trip test in `tests/test_net.c`.
+
 ## Key files
 
 | File | Purpose |

--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -161,6 +161,12 @@ The presentation path is:
 TraceEntity -> cl.hover_entity -> cl.viewDef.hover_entity -> R_DrawHealthBars
 ```
 
+The same hover entity drives the ground selection-preview splat in `renderer/r_ents.c`. `G_CustomizeEntity` derives the
+recipient-relative relationship from WC3 alliance state: non-passive allies are `EF_HOSTILE`, passive allies without shared control are
+`EF_NEUTRAL`, and own/shared-control units carry neither relationship flag. The renderer maps those states to faint red, yellow, and
+green rings respectively, using the normal selection-circle size/texture choice and half-alpha hover presentation. Selection remains a
+separate state and suppresses the hover preview while the full selected-unit circle is visible.
+
 An August 2026 regression had working world picking and working selected-unit health bars, but active gameplay never copied
 `cl.hover_entity` into `cl.viewDef.hover_entity`; the renderer therefore always saw hover entity 0. Targeted runtime logs confirmed the
 entity number at input, view, renderer, and health-bar filtering before the fix. Keep the active-view assignment in `V_RenderView`.

--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -167,6 +167,12 @@ recipient-relative relationship from WC3 alliance state: non-passive allies are 
 green rings respectively, using the normal selection-circle size/texture choice and half-alpha hover presentation. Selection remains a
 separate state and suppresses the hover preview while the full selected-unit circle is visible.
 
+The authored WC3 cursor reuses that recipient-relative hover state without changing cursor assets. While the current hover entity carries
+both `EF_HOVER_HEALTH` and `EF_HOSTILE`, `client/cl_scrn.c` submits a red per-instance tint to the renderer; clearing/changing hover
+submits white, restoring the cursor's original artwork. This step intentionally leaves non-hostile cursors untinted and does not change
+the cursor animation sequence. `MDLX_DrawSpriteTinted` stores the tint on the transient cursor render entity, and the MDX renderer folds
+it into the existing geoset-color shader value so texture alpha and authored geoset/material colour remain independent.
+
 An August 2026 regression had working world picking and working selected-unit health bars, but active gameplay never copied
 `cl.hover_entity` into `cl.viewDef.hover_entity`; the renderer therefore always saw hover entity 0. Targeted runtime logs confirmed the
 entity number at input, view, renderer, and health-bar filtering before the fix. Keep the active-view assignment in `V_RenderView`.

--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -148,6 +148,24 @@ parallel width/stride.
 Overhead resource bars use two fixed slots in `renderer/r_ents.c`: mana keeps the lower/original slot, and health occupies the slot
 above it. Without mana, health still sits one bar height above the projected model point.
 
+### World-unit hover health
+
+WC3 world hover is presentation-only and remains separate from selection. `client/cl_input_w3.c` ray-picks the world on mouse motion,
+then accepts only snapshot entities carrying the generic `EF_HOVER_HEALTH` capability. `G_CustomizeEntity` authors that bit per client
+for living `SVF_MONSTER` units/buildings that are selectable and actively visible. This stricter visibility check intentionally differs
+from `G_FowPlayerCanSeeEntity`: explored buildings may remain networked while shrouded, but must not expose current HP through hover.
+
+The presentation path is:
+
+```text
+TraceEntity -> cl.hover_entity -> cl.viewDef.hover_entity -> R_DrawHealthBars
+```
+
+An August 2026 regression had working world picking and working selected-unit health bars, but active gameplay never copied
+`cl.hover_entity` into `cl.viewDef.hover_entity`; the renderer therefore always saw hover entity 0. Targeted runtime logs confirmed the
+entity number at input, view, renderer, and health-bar filtering before the fix. Keep the active-view assignment in `V_RenderView`.
+The investigative logs were removed after confirmation.
+
 ## Verification
 
 Focused deterministic checks:

--- a/games/starcraft-2/renderer/r_game.c
+++ b/games/starcraft-2/renderer/r_game.c
@@ -426,7 +426,7 @@ void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
 
 /* TODO: SC2 authored cursor assets are not wired to the renderer yet;
  * returning false keeps SDL's native platform cursor visible. */
-bool R_GameDrawCursor(float x, float y) {
-    (void)x; (void)y;
+bool R_GameDrawCursor(float x, float y, COLOR32 tint) {
+    (void)x; (void)y; (void)tint;
     return false;
 }

--- a/games/warcraft-3/game/g_fow.c
+++ b/games/warcraft-3/game/g_fow.c
@@ -825,6 +825,31 @@ static BOOL G_FowPlayerFogDisabled(DWORD player) {
     return client && (client->ps.rdflags & RDF_NOFOG);
 }
 
+/* Hover information is interactive gameplay state, so unlike explored
+ * scenery it is exposed only while the entity is actively visible. */
+BOOL G_FowPlayerCanHoverEntity(DWORD player, LPCEDICT ent) {
+    DWORD x, y, index;
+    fowPlayerGrid_t const *grid;
+
+    if (!ent || player >= MAX_PLAYERS || !G_FowReady()) {
+        return true;
+    }
+    if (ent->s.player < MAX_PLAYERS && G_FowSharedVision(player, ent->s.player)) {
+        return true;
+    }
+    if (G_FowPlayerFogDisabled(player)) {
+        return true;
+    }
+    x = G_FowWorldToCellX(ent->s.origin.x);
+    y = G_FowWorldToCellY(ent->s.origin.y);
+    if (x == FOW_INVALID_CELL || y == FOW_INVALID_CELL) {
+        return false;
+    }
+    index = y * level.fow.width + x;
+    grid = &level.fow.players[player];
+    return grid->visible && grid->visible[index] != 0;
+}
+
 BOOL G_FowPlayerCanSeeEntity(DWORD player, LPCEDICT ent) {
     DWORD x, y, index;
     fowPlayerGrid_t const *grid;

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -819,6 +819,7 @@ void G_FowUpdate(void);
 void G_FowSendDeltas(void);
 void G_FowSendFull(LPEDICT ent);
 BOOL G_FowPlayerCanSeeEntity(DWORD player, LPCEDICT ent);
+BOOL G_FowPlayerCanHoverEntity(DWORD player, LPCEDICT ent);
 void G_FogModifierStart(LPFOGMODIFIER mod);
 void G_FogModifierStop(LPFOGMODIFIER mod);
 DWORD G_FowWorldToCellX(FLOAT x);

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -472,15 +472,28 @@ static void G_ClientBegin(LPEDICT edict) {
 /* Selection voices are local feedback; suppress them in snapshots for clients
  * that did not select this entity while leaving world sounds unchanged. */
 static void G_CustomizeEntity(DWORD player, LPCEDICT ent, LPENTITYSTATE state) {
-    if ((ent->svflags & SVF_MONSTER) &&
+    BOOL const hoverable = (ent->svflags & SVF_MONSTER) &&
         !(ent->svflags & SVF_DEADMONSTER) &&
         ent->health.value > 0.0f &&
         !(state->flags & EF_NOT_SELECTABLE) &&
-        G_FowPlayerCanHoverEntity(player, ent))
-    {
+        G_FowPlayerCanHoverEntity(player, ent);
+
+    state->flags &= ~(EF_HOVER_HEALTH | EF_HOSTILE | EF_NEUTRAL);
+    if (hoverable) {
+        DWORD const owner = ent->s.player;
+        BOOL const same_owner = owner == player;
+        BOOL const valid_players = player < MAX_PLAYERS && owner < MAX_PLAYERS;
+        BOOL const passive_ally = valid_players &&
+            (level.alliances[player][owner] & (1 << ALLIANCE_PASSIVE));
+        BOOL const shared_control = valid_players &&
+            (level.alliances[player][owner] & (1 << ALLIANCE_SHARED_CONTROL));
+
         state->flags |= EF_HOVER_HEALTH;
-    } else {
-        state->flags &= ~EF_HOVER_HEALTH;
+        if (!same_owner && !passive_ally) {
+            state->flags |= EF_HOSTILE;
+        } else if (!same_owner && !shared_control) {
+            state->flags |= EF_NEUTRAL;
+        }
     }
 
     if (state->event == EV_ACK && !(ent->selected & (1 << player))) {

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -481,7 +481,6 @@ static void G_CustomizeEntity(DWORD player, LPCEDICT ent, LPENTITYSTATE state) {
     state->flags &= ~(EF_HOVER_HEALTH | EF_HOSTILE | EF_NEUTRAL);
     if (hoverable) {
         DWORD const owner = ent->s.player;
-        BOOL const same_owner = owner == player;
         BOOL const valid_players = player < MAX_PLAYERS && owner < MAX_PLAYERS;
         BOOL const passive_ally = valid_players &&
             (level.alliances[player][owner] & (1 << ALLIANCE_PASSIVE));
@@ -489,9 +488,9 @@ static void G_CustomizeEntity(DWORD player, LPCEDICT ent, LPENTITYSTATE state) {
             (level.alliances[player][owner] & (1 << ALLIANCE_SHARED_CONTROL));
 
         state->flags |= EF_HOVER_HEALTH;
-        if (!same_owner && !passive_ally) {
+        if (owner != player && !passive_ally) {
             state->flags |= EF_HOSTILE;
-        } else if (!same_owner && !shared_control) {
+        } else if (owner != player && !shared_control) {
             state->flags |= EF_NEUTRAL;
         }
     }

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -472,6 +472,17 @@ static void G_ClientBegin(LPEDICT edict) {
 /* Selection voices are local feedback; suppress them in snapshots for clients
  * that did not select this entity while leaving world sounds unchanged. */
 static void G_CustomizeEntity(DWORD player, LPCEDICT ent, LPENTITYSTATE state) {
+    if ((ent->svflags & SVF_MONSTER) &&
+        !(ent->svflags & SVF_DEADMONSTER) &&
+        ent->health.value > 0.0f &&
+        !(state->flags & EF_NOT_SELECTABLE) &&
+        G_FowPlayerCanHoverEntity(player, ent))
+    {
+        state->flags |= EF_HOVER_HEALTH;
+    } else {
+        state->flags &= ~EF_HOVER_HEALTH;
+    }
+
     if (state->event == EV_ACK && !(ent->selected & (1 << player))) {
         state->event = EV_NONE;
         state->sound = 0;

--- a/games/warcraft-3/game/tests/t_api.c
+++ b/games/warcraft-3/game/tests/t_api.c
@@ -163,6 +163,33 @@ TEST(wc3_api, customize_entity_hides_ack_from_other_players) {
     T_EQ(state.sound, 0);
 }
 
+TEST(wc3_api, customize_entity_marks_live_unit_hoverable) {
+    entityState_t state = { .number = 7, .model = 11 };
+    edict_t ent = { .svflags = SVF_MONSTER, .s = { .player = 3 } };
+    ent.health.value = 100.0f;
+
+    globals.CustomizeEntity(3, &ent, &state);
+    T_ASSERT(state.flags & EF_HOVER_HEALTH);
+}
+
+TEST(wc3_api, customize_entity_rejects_non_unit_hover_health) {
+    entityState_t state = { .number = 7, .model = 11, .flags = EF_HOVER_HEALTH };
+    edict_t ent = { .s = { .player = 3 } };
+    ent.health.value = 100.0f;
+
+    globals.CustomizeEntity(3, &ent, &state);
+    T_ASSERT(!(state.flags & EF_HOVER_HEALTH));
+}
+
+TEST(wc3_api, customize_entity_rejects_dead_or_unselectable_unit_hover_health) {
+    entityState_t state = { .number = 7, .model = 11, .flags = EF_NOT_SELECTABLE | EF_HOVER_HEALTH };
+    edict_t ent = { .svflags = SVF_MONSTER | SVF_DEADMONSTER, .s = { .player = 3 } };
+    ent.health.value = 100.0f;
+
+    globals.CustomizeEntity(3, &ent, &state);
+    T_ASSERT(!(state.flags & EF_HOVER_HEALTH));
+}
+
 /* =========================================================================
  * Player — color
  * ========================================================================= */

--- a/games/warcraft-3/game/tests/t_api.c
+++ b/games/warcraft-3/game/tests/t_api.c
@@ -170,6 +170,44 @@ TEST(wc3_api, customize_entity_marks_live_unit_hoverable) {
 
     globals.CustomizeEntity(3, &ent, &state);
     T_ASSERT(state.flags & EF_HOVER_HEALTH);
+    T_ASSERT(!(state.flags & EF_HOSTILE));
+    T_ASSERT(!(state.flags & EF_NEUTRAL));
+}
+
+TEST(wc3_api, customize_entity_marks_enemy_hover_relation_hostile) {
+    entityState_t state = { .number = 7, .model = 11 };
+    edict_t ent = { .svflags = SVF_MONSTER, .s = { .player = 2 } };
+    ent.health.value = 100.0f;
+
+    globals.CustomizeEntity(0, &ent, &state);
+    T_ASSERT(state.flags & EF_HOVER_HEALTH);
+    T_ASSERT(state.flags & EF_HOSTILE);
+    T_ASSERT(!(state.flags & EF_NEUTRAL));
+}
+
+TEST(wc3_api, customize_entity_marks_passive_ally_hover_relation_neutral) {
+    entityState_t state = { .number = 7, .model = 11 };
+    edict_t ent = { .svflags = SVF_MONSTER, .s = { .player = 1 } };
+    ent.health.value = 100.0f;
+    G_SetPlayerAlliance(test_player(0), test_player(1), ALLIANCE_PASSIVE, true);
+
+    globals.CustomizeEntity(0, &ent, &state);
+    T_ASSERT(state.flags & EF_HOVER_HEALTH);
+    T_ASSERT(!(state.flags & EF_HOSTILE));
+    T_ASSERT(state.flags & EF_NEUTRAL);
+}
+
+TEST(wc3_api, customize_entity_marks_shared_control_hover_relation_friendly) {
+    entityState_t state = { .number = 7, .model = 11 };
+    edict_t ent = { .svflags = SVF_MONSTER, .s = { .player = 1 } };
+    ent.health.value = 100.0f;
+    G_SetPlayerAlliance(test_player(0), test_player(1), ALLIANCE_PASSIVE, true);
+    G_SetPlayerAlliance(test_player(0), test_player(1), ALLIANCE_SHARED_CONTROL, true);
+
+    globals.CustomizeEntity(0, &ent, &state);
+    T_ASSERT(state.flags & EF_HOVER_HEALTH);
+    T_ASSERT(!(state.flags & EF_HOSTILE));
+    T_ASSERT(!(state.flags & EF_NEUTRAL));
 }
 
 TEST(wc3_api, customize_entity_rejects_non_unit_hover_health) {
@@ -182,12 +220,15 @@ TEST(wc3_api, customize_entity_rejects_non_unit_hover_health) {
 }
 
 TEST(wc3_api, customize_entity_rejects_dead_or_unselectable_unit_hover_health) {
-    entityState_t state = { .number = 7, .model = 11, .flags = EF_NOT_SELECTABLE | EF_HOVER_HEALTH };
+    entityState_t state = { .number = 7, .model = 11,
+        .flags = EF_NOT_SELECTABLE | EF_HOVER_HEALTH | EF_HOSTILE | EF_NEUTRAL };
     edict_t ent = { .svflags = SVF_MONSTER | SVF_DEADMONSTER, .s = { .player = 3 } };
     ent.health.value = 100.0f;
 
     globals.CustomizeEntity(3, &ent, &state);
     T_ASSERT(!(state.flags & EF_HOVER_HEALTH));
+    T_ASSERT(!(state.flags & EF_HOSTILE));
+    T_ASSERT(!(state.flags & EF_NEUTRAL));
 }
 
 /* =========================================================================

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -597,6 +597,8 @@ TEST(wc3_game, fow_static_scenery_persists_after_unit_vision_leaves) {
     T_ASSERT(!G_FowPlayerCanSeeEntity(0, unseen));
     T_ASSERT(G_FowPlayerCanSeeEntity(0, unit));
     T_ASSERT(G_FowPlayerCanSeeEntity(0, building));
+    T_ASSERT(G_FowPlayerCanHoverEntity(0, unit));
+    T_ASSERT(G_FowPlayerCanHoverEntity(0, building));
     revealer->s.renderfx |= RF_HIDDEN;
     G_FowUpdate();
 
@@ -604,6 +606,8 @@ TEST(wc3_game, fow_static_scenery_persists_after_unit_vision_leaves) {
     T_ASSERT(!G_FowPlayerCanSeeEntity(0, unseen));
     T_ASSERT(!G_FowPlayerCanSeeEntity(0, unit));
     T_ASSERT(G_FowPlayerCanSeeEntity(0, building));
+    T_ASSERT(!G_FowPlayerCanHoverEntity(0, unit));
+    T_ASSERT(!G_FowPlayerCanHoverEntity(0, building));
     G_FowShutdown();
 }
 

--- a/games/warcraft-3/renderer/mdx/r_mdx.h
+++ b/games/warcraft-3/renderer/mdx/r_mdx.h
@@ -393,5 +393,6 @@ bool MDLX_TraceModel(renderEntity_t const *ent, LPCLINE3 line);
 bool MDLX_ExtractCamera(mdxModel_t const *model, DWORD frame, float aspect, LPMATRIX4 output, LPMATRIX4 light);
 bool MDLX_SetEntityAnimationFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity);
 void MDLX_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y);
+void MDLX_DrawSpriteTinted(LPCMODEL model, LPCSTR anim, float x, float y, COLOR32 tint);
 
 #endif

--- a/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
@@ -448,6 +448,7 @@ static void MDLX_RenderGeoset(mdxModel_t const *model,
                              LPCTEXTURE overrideTexture,
                              BOOL forceUnshaded,
                              DWORD frame,
+                             LPCVECTOR4 tint,
                              bool blendedPass)
 {
     BOOL force_two_sided = model && !model->cameras;
@@ -459,6 +460,11 @@ static void MDLX_RenderGeoset(mdxModel_t const *model,
     }
 
     geosetColor = MDLX_EvaluateGeosetColor(model, geoset, frame);
+    {
+        FLOAT *component = &geosetColor.x;
+        FLOAT const *factor = &tint->x;
+        FOR_LOOP(i, 4) component[i] *= factor[i];
+    }
     MDLX_BindGeosetMatrixPalette(model, geoset);
     shader->state.layerAlpha = 1.0f;
     shader->state.geosetColor = (VECTOR4){ geosetColor.x, geosetColor.y, geosetColor.z, geosetColor.w };
@@ -619,6 +625,11 @@ static void MDLX_RenderGeosets(const renderEntity_t *entity,
                                const mdxModel_t *model)
 {
     BOOL forceUnshaded = (entity->flags & RF_NO_LIGHTING) != 0;
+    COLOR32 const color = entity->tint.a ? entity->tint : COLOR32_WHITE;
+    VECTOR4 const tint = {
+        BYTE2FLOAT(color.r), BYTE2FLOAT(color.g),
+        BYTE2FLOAT(color.b), BYTE2FLOAT(color.a)
+    };
     DWORD geosetCount = 0;
     DWORD drawCount = 0;
     mdxGeosetDrawOrder_t stackDrawOrder[MDLX_STACK_DRAW_ORDER];
@@ -632,7 +643,7 @@ static void MDLX_RenderGeosets(const renderEntity_t *entity,
         }
         material = MDLX_GetMaterialAtIndex(geoset, model);
         if (MDLX_MaterialHasPass(material, false)) {
-            MDLX_RenderGeoset(model, geoset, material, entity->team&TEAM_MASK, entity->skin, forceUnshaded, entity->frame, false);
+            MDLX_RenderGeoset(model, geoset, material, entity->team&TEAM_MASK, entity->skin, forceUnshaded, entity->frame, &tint, false);
         }
     }
 
@@ -649,7 +660,7 @@ static void MDLX_RenderGeosets(const renderEntity_t *entity,
             if (MDLX_IsGeosetVisible(model, geoset, entity->frame) &&
                 MDLX_MaterialHasPass(material, true))
             {
-                MDLX_RenderGeoset(model, geoset, material, entity->team&TEAM_MASK, entity->skin, forceUnshaded, entity->frame, true);
+                MDLX_RenderGeoset(model, geoset, material, entity->team&TEAM_MASK, entity->skin, forceUnshaded, entity->frame, &tint, true);
             }
         }
         return;
@@ -678,7 +689,7 @@ static void MDLX_RenderGeosets(const renderEntity_t *entity,
 
     FOR_LOOP(i, drawCount) {
         mdxGeoset_t const *geoset = drawOrder[i].geoset;
-        MDLX_RenderGeoset(model, geoset, drawOrder[i].material, entity->team&TEAM_MASK, entity->skin, forceUnshaded, entity->frame, true);
+        MDLX_RenderGeoset(model, geoset, drawOrder[i].material, entity->team&TEAM_MASK, entity->skin, forceUnshaded, entity->frame, &tint, true);
     }
 
     if (drawOrder != stackDrawOrder) {

--- a/games/warcraft-3/renderer/mdx/r_mdx_render.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_render.c
@@ -174,7 +174,7 @@ bool MDLX_SetEntityAnimationFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *e
     return true;
 }
 
-void MDLX_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
+void MDLX_DrawSpriteTinted(LPCMODEL model, LPCSTR anim, float x, float y, COLOR32 tint) {
     renderEntity_t entity;
     viewDef_t viewdef;
     bool const fdf_sprite_coords = anim && anim[0] == '#' && anim[1] == '!';
@@ -193,6 +193,7 @@ void MDLX_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     memset(&viewdef, 0, sizeof(viewdef));
     entity.scale = 1;
     entity.model = model;
+    entity.tint = tint.a ? tint : COLOR32_WHITE;
     DWORD seq_len = seq->interval[1] - seq->interval[0];
     if (seq_len == 0) seq_len = 1;
     entity.frame = seq->interval[0] + (tr.viewDef.time % seq_len);
@@ -218,6 +219,10 @@ void MDLX_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     R_RenderShadowMap();
 #endif
     R_RenderView();
+}
+
+void MDLX_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
+    MDLX_DrawSpriteTinted(model, anim, x, y, COLOR32_WHITE);
 }
 
 void MDLX_Init(void) {

--- a/games/warcraft-3/renderer/r_game.c
+++ b/games/warcraft-3/renderer/r_game.c
@@ -386,7 +386,7 @@ void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
 }
 
 /* Warcraft III can replace the platform cursor with its authored animated MDX cursor. */
-bool R_GameDrawCursor(float x, float y) {
+bool R_GameDrawCursor(float x, float y, COLOR32 tint) {
     renderEntity_t probe = {0};
 
     if (!cursor_model && !cursor_load_attempted) {
@@ -399,6 +399,6 @@ bool R_GameDrawCursor(float x, float y) {
         }
     }
     if (!cursor_model) return false;
-    MDLX_DrawSprite(cursor_model, "Normal", x, y);
+    MDLX_DrawSpriteTinted(cursor_model, "Normal", x, y, tint);
     return true;
 }

--- a/games/warcraft-3/tests/test_client_stubs.c
+++ b/games/warcraft-3/tests/test_client_stubs.c
@@ -18,6 +18,8 @@ refExport_t re;
 uiExport_t ui;
 mouseEvent_t mouse;
 DWORD test_fow_upload_calls;
+DWORD test_cursor_draw_calls;
+COLOR32 test_cursor_tint;
 
 typedef struct { char name[64]; char value[128]; } mockCvar_t;
 static mockCvar_t mock_cvars[32];
@@ -38,7 +40,12 @@ void test_client_stubs_set_cvar(LPCSTR name, LPCSTR value) {
 static size2_t mock_GetWindowSize(void) { return MAKE(size2_t, 1024, 768); }
 static void mock_DrawLoadingIndicator(LPCRECT rect, DWORD time, COLOR32 color) { (void)rect; (void)time; (void)color; }
 static void mock_DrawFill(LPCRECT rect, COLOR32 color) { (void)rect; (void)color; }
-static bool mock_DrawCursor(float x, float y) { (void)x; (void)y; return true; }
+static bool mock_DrawCursor(float x, float y, COLOR32 tint) {
+    (void)x; (void)y;
+    test_cursor_draw_calls++;
+    test_cursor_tint = tint;
+    return true;
+}
 static void mock_SetFogOfWarData(DWORD width, DWORD height, BYTE const *data) {
     (void)width; (void)height; (void)data; test_fow_upload_calls++;
 }
@@ -81,6 +88,8 @@ void test_client_stubs_init(void) {
     memset(&ui, 0, sizeof(ui));
     memset(&mouse, 0, sizeof(mouse));
     test_fow_upload_calls = 0;
+    test_cursor_draw_calls = 0;
+    test_cursor_tint = COLOR32_WHITE;
     re.GetWindowSize = mock_GetWindowSize;
     re.DrawLoadingIndicator = mock_DrawLoadingIndicator;
     re.DrawFill = mock_DrawFill;

--- a/games/world-of-warcraft/renderer/r_game.c
+++ b/games/world-of-warcraft/renderer/r_game.c
@@ -578,7 +578,7 @@ void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
 }
 
 /* WoW context cursors are native SDL cursors owned by cl_input_wow.c. */
-bool R_GameDrawCursor(float x, float y) {
-    (void)x; (void)y;
+bool R_GameDrawCursor(float x, float y, COLOR32 tint) {
+    (void)x; (void)y; (void)tint;
     return false;
 }

--- a/renderer/r_ents.c
+++ b/renderer/r_ents.c
@@ -430,10 +430,15 @@ static void R_RenderHoverHighlight(renderEntity_t const *entity) {
     if (entity->flags & RF_SELECTED) {
         return; /* selection circle already visible, skip hover */
     }
-    COLOR32 color = (entity->flags & RF_HOSTILE)
-        ? MAKE(COLOR32, 255, 80, 80, 160)   /* red for hostile */
-        : MAKE(COLOR32, 80, 200, 80, 160);   /* green for friendly */
-    float radius = entity->radius;
+    COLOR32 color;
+    if (entity->flags & RF_HOSTILE) {
+        color = MAKE(COLOR32, 255, 80, 80, 128);   /* enemy: faint red */
+    } else if (entity->flags & RF_NEUTRAL) {
+        color = MAKE(COLOR32, 255, 220, 80, 128);  /* neutral/passive ally: faint yellow */
+    } else {
+        color = MAKE(COLOR32, 80, 200, 80, 128);   /* own/shared-control: faint green */
+    }
+    float radius = R_GameSelectionRadius(entity);
     FOR_LOOP(i, NUM_SELECTION_CIRCLES) {
         if ((radius * 2) > selCircles[i])
             continue;

--- a/renderer/r_game.h
+++ b/renderer/r_game.h
@@ -54,7 +54,7 @@ BOOL R_GameEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out);
 bool R_GameExtractEntityCamera(renderEntity_t const *entity, float aspect, viewDef_t *viewdef);
 bool R_GameSetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity);
 void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y);
-bool R_GameDrawCursor(float x, float y);
+bool R_GameDrawCursor(float x, float y, COLOR32 tint);
 w3TerrainArt_t const *R_GameTerrainArt(DWORD id);
 w3CliffType_t const *R_GameCliffType(DWORD id);
 

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -869,7 +869,7 @@ void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
 }
 
 /* Cursor presentation is game-owned; the client only supplies UI coordinates. */
-bool R_DrawCursor(float x, float y) { return R_GameDrawCursor(x, y); }
+bool R_DrawCursor(float x, float y, COLOR32 tint) { return R_GameDrawCursor(x, y, tint); }
 
 bool R_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity) {
     return R_GameSetEntityAnimFrame(model, anim, entity);

--- a/renderer/r_stdout.c
+++ b/renderer/r_stdout.c
@@ -342,7 +342,8 @@ static void RStd_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
 }
 
 /* stdout has no game-native cursor renderer; the client leaves SDL's platform cursor visible. */
-static bool RStd_DrawCursor(float x, float y) {
+static bool RStd_DrawCursor(float x, float y, COLOR32 tint) {
+    (void)tint;
     printf("draw_cursor x=%.6f y=%.6f unsupported\n", x, y);
     return false;
 }

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -836,8 +836,8 @@ TEST(net, entity_delta_preserves_large_wc3_radii) {
     }
 }
 
-/* Dead destructable remains use the last available entity-state flag bit, so
- * guard its snapshot round trip explicitly. */
+/* Dead destructable remains rely on EF_NOT_SELECTABLE surviving snapshots, so
+ * guard its round trip explicitly. */
 TEST(net, entity_delta_preserves_not_selectable_flag) {
     BYTE buf[256];
     sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
@@ -852,6 +852,24 @@ TEST(net, entity_delta_preserves_not_selectable_flag) {
 
     T_EQ(number, 9);
     T_ASSERT(out.flags & EF_NOT_SELECTABLE);
+}
+
+/* Hover-health eligibility occupies the first bit above the legacy byte-sized
+ * entity flags, so guard both the widened field and delta serialization. */
+TEST(net, entity_delta_preserves_hover_health_flag) {
+    BYTE buf[256];
+    sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
+    entityState_t from = { 0 }, to = { .number = 9, .model = 1, .flags = EF_HOVER_HEALTH }, out = { 0 };
+    DWORD bits = 0;
+    int number;
+
+    MSG_WriteDeltaEntity(&sb, &from, &to, true);
+    sb.readcount = 0;
+    number = MSG_ReadEntityBits(&sb, &bits);
+    MSG_ReadDeltaEntity(&sb, &out, number, bits);
+
+    T_EQ(number, 9);
+    T_ASSERT(out.flags & EF_HOVER_HEALTH);
 }
 
 /* Sound events must travel with the entity snapshot so the client can resolve

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -37,6 +37,8 @@ void SCR_UpdateScreen(DWORD msec);
 extern BOOL scr_initialized;
 void test_client_stubs_clear_cvars(void);
 extern DWORD test_fow_upload_calls;
+extern DWORD test_cursor_draw_calls;
+extern COLOR32 test_cursor_tint;
 
 static RECT test_scroll_rects[3], test_scroll_uvs[3];
 static LPCTEXTURE test_scroll_tex[3];
@@ -68,6 +70,36 @@ TEST(net, no_refresh_preserves_client_loop_without_screen_submission) {
     T_EQ(test_begin_frames, 0); T_EQ(test_end_frames, 0);
     test_client_stubs_set_cvar("r_norefresh", "0"); SCR_UpdateScreen(16);
     T_EQ(test_begin_frames, 1); T_EQ(test_end_frames, 1);
+    scr_initialized = false;
+}
+
+
+/* Authored cursors use recipient-relative hover state for presentation only:
+ * hostile WC3 hover is red, and clearing hover restores the original artwork. */
+TEST(client_screen, cursor_tint_is_red_only_while_hovering_hostile_unit) {
+    test_client_stubs_init(); test_client_stubs_clear_cvars();
+    cls.state = ca_active; cls.key_dest = key_game; scr_initialized = true;
+    test_client_stubs_set_cvar("r_hud", "0");
+    test_client_stubs_set_cvar("scr_showfps", "0");
+    test_client_stubs_set_cvar("r_cursor", "1");
+    re.BeginFrame = capture_begin_frame; re.EndFrame = capture_end_frame;
+
+    cl.hover_entity = 7;
+    cl.ents[7].current.flags = EF_HOVER_HEALTH | EF_HOSTILE;
+    SCR_UpdateScreen(16);
+    T_EQ(test_cursor_draw_calls, 1);
+    T_EQ(test_cursor_tint.r, 255);
+    T_EQ(test_cursor_tint.g, 0);
+    T_EQ(test_cursor_tint.b, 0);
+    T_EQ(test_cursor_tint.a, 255);
+
+    cl.hover_entity = 0;
+    SCR_UpdateScreen(16);
+    T_EQ(test_cursor_draw_calls, 2);
+    T_EQ(test_cursor_tint.r, 255);
+    T_EQ(test_cursor_tint.g, 255);
+    T_EQ(test_cursor_tint.b, 255);
+    T_EQ(test_cursor_tint.a, 255);
     scr_initialized = false;
 }
 

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -872,6 +872,23 @@ TEST(net, entity_delta_preserves_hover_health_flag) {
     T_ASSERT(out.flags & EF_HOVER_HEALTH);
 }
 
+/* Neutral hover-ring presentation is also recipient-authored snapshot state. */
+TEST(net, entity_delta_preserves_neutral_flag) {
+    BYTE buf[256];
+    sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
+    entityState_t from = { 0 }, to = { .number = 9, .model = 1, .flags = EF_NEUTRAL }, out = { 0 };
+    DWORD bits = 0;
+    int number;
+
+    MSG_WriteDeltaEntity(&sb, &from, &to, true);
+    sb.readcount = 0;
+    number = MSG_ReadEntityBits(&sb, &bits);
+    MSG_ReadDeltaEntity(&sb, &out, number, bits);
+
+    T_EQ(number, 9);
+    T_ASSERT(out.flags & EF_NEUTRAL);
+}
+
 /* Sound events must travel with the entity snapshot so the client can resolve
  * the server-assigned CS_SOUNDS index and fire the one-shot exactly once. */
 TEST(net, entity_delta_preserves_sound_event) {


### PR DESCRIPTION
Allows hovering on enemy units and buildings to see their health

also colours the hover ring and cursor based on if its an enemy (and neutral for hover rings)