### PR TITLE
wc3: Fix command-card ability dispatch for build menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 data model (SLK, unit stats, combat) | [docs/wc3-data-model.md](docs/wc3-data-model.md) |
 | WC3 JASS native coverage, callback contracts, state ownership | [docs/games/warcraft-3/jass-native-coverage.md](docs/games/warcraft-3/jass-native-coverage.md) |
 | WC3 gathering, immobile units, construction HUD, overhead bars | [docs/games/warcraft-3/economy-and-unit-presentation.md](docs/games/warcraft-3/economy-and-unit-presentation.md) |
+| WC3 building menu, placement validation, Human construction and power building | [docs/games/warcraft-3/building-construction.md](docs/games/warcraft-3/building-construction.md) |
 | WC3 inventory, world-item lifecycle, item UI presentation | [docs/games/warcraft-3/inventory-and-items.md](docs/games/warcraft-3/inventory-and-items.md) |
 | WC3 campaign loading lifecycle, texture references, unused FDF art, cliff transitions | [docs/games/warcraft-3/loading-and-assets.md](docs/games/warcraft-3/loading-and-assets.md) |
 | WC3 perf hot spots: MDX bone/geoset setup, shadow batching, client/server entity scans | [docs/games/warcraft-3/performance.md](docs/games/warcraft-3/performance.md) |

--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -311,15 +311,24 @@ static void CL_AddBuilding(void) {
     
     re.TraceLocation(&cl.viewDef, mouse.origin.x, mouse.origin.y, &ent.origin);
 
-    ent.origin.x = floor(ent.origin.x / 32) * 32;
-    ent.origin.y = floor(ent.origin.y / 32) * 32;
+    if (cl.cursorEntity->origin.x > 0.0f && cl.cursorEntity->origin.y > 0.0f) {
+        DWORD const path_width = (DWORD)cl.cursorEntity->origin.x;
+        DWORD const path_height = (DWORD)cl.cursorEntity->origin.y;
+        ent.origin.x = floorf(ent.origin.x / 64.0f) * 64.0f;
+        ent.origin.y = floorf(ent.origin.y / 64.0f) * 64.0f;
+        if (((path_width / 2) & 1) != 0) ent.origin.x += 32.0f;
+        if (((path_height / 2) & 1) != 0) ent.origin.y += 32.0f;
+    } else {
+        ent.origin.x = floorf(ent.origin.x / 32.0f) * 32.0f;
+        ent.origin.y = floorf(ent.origin.y / 32.0f) * 32.0f;
+    }
     ent.origin.z = CM_GetHeightAtPoint(ent.origin.x, ent.origin.y);
     ent.scale = cl.cursorEntity->scale;
+    ent.angle = cl.cursorEntity->angle;
+    ent.team = cl.cursorEntity->player;
     ent.frame = cl.cursorEntity->frame;
     ent.oldframe = cl.cursorEntity->frame;
     ent.model = cl.models[cl.cursorEntity->model];
-    
-    cl.cursorEntity->origin = ent.origin;
     
     view_state.entities[view_state.num_entities++] = ent;
 }

--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -311,9 +311,9 @@ static void CL_AddBuilding(void) {
     
     re.TraceLocation(&cl.viewDef, mouse.origin.x, mouse.origin.y, &ent.origin);
 
-    if (cl.cursorEntity->origin.x > 0.0f && cl.cursorEntity->origin.y > 0.0f) {
-        DWORD const path_width = (DWORD)cl.cursorEntity->origin.x;
-        DWORD const path_height = (DWORD)cl.cursorEntity->origin.y;
+    if (cl.cursorEntity->pathing_width && cl.cursorEntity->pathing_height) {
+        DWORD const path_width = cl.cursorEntity->pathing_width;
+        DWORD const path_height = cl.cursorEntity->pathing_height;
         ent.origin.x = floorf(ent.origin.x / 64.0f) * 64.0f;
         ent.origin.y = floorf(ent.origin.y / 64.0f) * 64.0f;
         if (((path_width / 2) & 1) != 0) ent.origin.x += 32.0f;

--- a/common/cmodel.h
+++ b/common/cmodel.h
@@ -46,6 +46,7 @@ BOOL CM_ClosestPathablePoint(LPCVECTOR2 location, LPVECTOR2 out);
 BOOL CM_ClosestPathablePointForRadius(LPCVECTOR2 location, FLOAT radius, LPVECTOR2 out);
 BOOL CM_PointIsPathableForRadius(LPCVECTOR2 location, FLOAT radius);
 BOOL CM_LineIsWalkable(LPCVECTOR2 a, LPCVECTOR2 b);
+BOOL CM_GetPathingFlagsAt(LPCVECTOR2 location, LPBYTE flags);
 BOX2 CM_GetWorldBounds(void);
 
 /* WoW-only: all WorldSafeLocs entries for the current map.  Populated during

--- a/common/msg.c
+++ b/common/msg.c
@@ -50,6 +50,8 @@ netField_t entityStateFields[] = {
     { NETF(entityState_t, flags), NFT_SHORT },
     { NETF(entityState_t, renderfx), NFT_BYTE },
     { NETF(entityState_t, ability), NFT_BYTE },
+    { NETF(entityState_t, pathing_width), NFT_SHORT },
+    { NETF(entityState_t, pathing_height), NFT_SHORT },
 #ifdef WOW
     /* WoW creature radii can be 0.5; NFT_ROUND serialized those as zero. WoW radii stay < 65.5 so the packed-float
      * range is ample. WC3 selection radii (buildings/destructables) exceed 65.5 and must keep NFT_ROUND. */

--- a/common/routing.c
+++ b/common/routing.c
@@ -478,6 +478,21 @@ BOOL CM_PointIsPathableForRadius(LPCVECTOR2 location, FLOAT radius) {
  * pathmap cells along the segment (Bresenham) and fail on the first obstacle.
  * O(cells on the line) — vastly cheaper than a full flow-field bake, so a unit
  * chasing a target in the open can steer directly instead of flood-filling. */
+
+BOOL CM_GetPathingFlagsAt(LPCVECTOR2 location, LPBYTE flags) {
+    VECTOR2 n;
+    int x, y;
+
+    if (flags) *flags = 0;
+    if (!location || !flags || !pathmap.original || !pathmap.width || !pathmap.height) return false;
+    n = CM_GetNormalizedMapPosition(location->x, location->y);
+    x = (int)floorf(n.x * pathmap.width);
+    y = (int)floorf(n.y * pathmap.height);
+    if (x < 0 || y < 0 || !is_valid_point((DWORD)x, (DWORD)y)) return false;
+    memcpy(flags, &pathmap.original[x + y * pathmap.width], sizeof(*flags));
+    return true;
+}
+
 BOOL CM_LineIsWalkable(LPCVECTOR2 a, LPCVECTOR2 b) {
     if (!a || !b || pathmap.width == 0 || pathmap.height == 0) {
         return false;

--- a/common/shared.h
+++ b/common/shared.h
@@ -480,6 +480,8 @@ typedef struct entityState_s {
     USHORT flags;
     BYTE renderfx;
     BYTE ability;
+    USHORT pathing_width;   /* authored cursor/building pathing texture width in 32-unit cells */
+    USHORT pathing_height;  /* authored cursor/building pathing texture height in 32-unit cells */
     DWORD splat;
 #ifdef WOW
     DWORD appearance;

--- a/docs/games/warcraft-3/building-construction.md
+++ b/docs/games/warcraft-3/building-construction.md
@@ -40,7 +40,7 @@ odd half-pathing-map dimension -> +32 on that axis
 no authored pathing texture -> 32-unit fallback grid
 ```
 
-The placement cursor carries its authored pathing-texture width/height in the cursor-only `entityState_t.origin.x/y` fields. `client/cl_view.c:CL_AddBuilding()` uses those dimensions for the same visual snap; those cursor metadata values are not world position.
+The placement cursor carries its authored pathing-texture width/height in dedicated `entityState_t.pathing_width` / `pathing_height` fields. `client/cl_view.c:CL_AddBuilding()` uses those dimensions for the same visual snap. The fields are delta-serialized and have an explicit network round-trip test; world-position fields remain world position only.
 
 `G_EvaluateBuildPlacement()` checks:
 
@@ -57,7 +57,7 @@ The common routing layer exposes `CM_GetPathingFlagsAt()` specifically so placem
 
 A declared pathing texture that fails to load is a placement failure. Do not silently degrade such a structure to a one-cell footprint; `M_LoadPathTex()` already reports the missing asset.
 
-Placement is checked once when the player confirms the ghost and again when the worker reaches the site. Resources are charged only after the arrival-time validation passes. Construction spawns at the stored snapped waypoint, not at the worker's current position.
+Placement is checked once when the player confirms the ghost and again when the worker reaches the site. Resources are charged only after the arrival-time validation passes. Construction spawns at the stored snapped waypoint, not at the worker's current position. Placement rejection uses the plain UI message `Unable to build there.`; requirement/resource failures remain separate command-state messages. `G_LevelString()` resolves only exact `TRIGSTR_<id>` tokens. Previously it parsed arbitrary UI text as trigger-string ID 0, so Human02's WTS entry 0 (the map name) replaced ordinary errors with `Human02`.
 
 The current client ghost snaps correctly but does not yet render the full per-cell green/red placement texture. Live units are therefore authoritative server blockers but are not painted into the preview.
 
@@ -73,7 +73,7 @@ construction.progress = 0
 life = 10% max life
 ```
 
-The building's birth animation is held until construction completes. The primary Peasant enters Human Repair and contributes `1.0` construction time. If that Peasant stops/dies/receives another behavior, no autonomous timer advances the paused structure. A later Human Repair worker can become the new primary worker.
+The building's birth animation is held until construction completes. Its authored pathing footprint is baked before the primary Peasant is relocated. Human Repair uses `SP_FindUnitExitPosition()` against that baked footprint and relinks the worker at the chosen point; selection radius is not a substitute for pathing geometry. This prevents the Lumber Mill case where the old `SP_FindEmptySpaceAround()` placed the Peasant inside cells that became blocked immediately after construction started. The primary Peasant then contributes `1.0` construction time. If that Peasant stops/dies/receives another behavior, no autonomous timer advances the paused structure. A later Human Repair worker can become the new primary worker.
 
 Additional `Arep` repairers use the ability's authored data:
 
@@ -98,10 +98,12 @@ This patch intentionally focuses on Human construction. The following clean-room
 
 - `war3map.w3u` modifications are not yet fully merged into the normalized typed unit rows, so map-local edits to `Builds`/requirements may still resolve through the base unit row;
 - the client does not yet draw a per-cell green/red pathing splat or mirror live-unit obstruction into that splat;
-- placement supports the currently decoded walk/build/blight flags, not every Warcraft compound placement type;
+- placement supports the currently decoded walk/build/blight flags, not every Warcraft compound placement type; unsupported tokens are reported to `stderr` instead of being silently discarded;
 - build cancellation after a structure has spawned does not yet have the retail partial-refund lifecycle;
 - Orc worker-inside, Night Elf worker/Ancient consumption, and Undead summon/release construction strategies remain legacy behavior;
-- normal completed-building Repair still uses the older simplified HP rate; DataA/DataB repair cost/time parity is separate from Human power-building DataC/DataD.
+- normal completed-building Repair still uses the older simplified HP rate; DataA/DataB repair cost/time parity is separate from Human power-building DataC/DataD;
+- the per-player technology table is intentionally bounded at `MAX_PLAYER_TECH_STATE`; exhaustion is reported as a warning and does not overwrite an existing entry;
+- `GetPlayerTechResearched` / `GetPlayerTechCount` currently have exact-rawcode semantics for both `specificonly` values because technology-equivalence groups are not represented yet.
 
 ## Verification
 
@@ -111,6 +113,8 @@ Focused automated checks after building:
 make test-wc3-engine WC3_PATTERN='wc3_building.*'
 make test-wc3-engine WC3_PATTERN='wc3_combat.*'
 make test-wc3-engine WC3_PATTERN='wc3_movement.*'
+make test-wc3-engine WC3_PATTERN='wc3_jass_map.player_technology_*'
+make test
 ```
 
 Runtime checks should cover at least:
@@ -124,3 +128,5 @@ Runtime checks should cover at least:
 7. One Peasant constructs at the base rate; stopping it pauses progress.
 8. A replacement Peasant resumes construction.
 9. Additional Peasants accelerate according to Repair `DataD` and consume incremental `DataC` costs.
+10. Build a Lumber Mill and then order its primary Peasant away; the worker must begin outside the baked footprint and move normally.
+11. Reject a blocked placement and verify the UI displays `Unable to build there.`, not the map name.

--- a/docs/games/warcraft-3/building-construction.md
+++ b/docs/games/warcraft-3/building-construction.md
@@ -1,0 +1,126 @@
+# Warcraft III Building Construction
+
+## Contract
+
+Human construction is server-authoritative. `UnitProfile.Builds` remains the source of which structures a worker can offer; a client cannot select an arbitrary unit rawcode and bypass that list. `games/warcraft-3/game/g_building.c` owns technology/resource availability, placement snapping/validation, and the common construction state used by Human Repair.
+
+The runtime developer override is:
+
+```sh
++set wc3_build_all 1
+```
+
+It makes every structure already present in the selected worker's final `Builds` list available regardless of technology maximums, `Requires`, gold, lumber, or food. It does **not** bypass `Builds`, building classification, map bounds, terrain/static pathing, live-unit occupancy, or build-on-target rules. This keeps the cheat useful for tech-tree testing without allowing invalid world placement.
+
+## Build-menu data flow
+
+```text
+UnitProfile.Builds
+    -> G_GetBuildCommandState
+       -> SetPlayerTechMaxAllowed state
+       -> Requires / Requiresamount
+       -> current gold/lumber/food
+    -> ui_builds
+       -> hidden at tech maximum
+       -> disabled with reason when requirements/resources fail
+       -> available otherwise
+```
+
+`SetPlayerTechMaxAllowed`, `GetPlayerTechMaxAllowed`, `AddPlayerTechResearched`, `SetPlayerTechResearched`, `GetPlayerTechResearched`, and `GetPlayerTechCount` now have game-state backing rather than no-op JASS stubs. W3I technology-availability entries initialize a player's matching technology maximum to zero before map script execution; map JASS can subsequently change that state.
+
+`G_GetPlayerTechCountValue()` counts researched levels plus live owned entities of the requested rawcode. In-progress structures therefore count against a maximum as soon as they exist.
+
+## Placement
+
+`G_SnapBuildingPoint()` implements the WC3 pathing-grid alignment used by both authoritative placement and the client ghost:
+
+```text
+base lattice = 64 world units
+odd half-pathing-map dimension -> +32 on that axis
+no authored pathing texture -> 32-unit fallback grid
+```
+
+The placement cursor carries its authored pathing-texture width/height in the cursor-only `entityState_t.origin.x/y` fields. `client/cl_view.c:CL_AddBuilding()` uses those dimensions for the same visual snap; those cursor metadata values are not world position.
+
+`G_EvaluateBuildPlacement()` checks:
+
+- building classification;
+- snapped pathing footprint inside the map path grid;
+- `UNBUILDABLE` and `UNWALKABLE` static pathing;
+- normalized `preventPlace` (`unwalkable`, `unbuildable`, `blighted`);
+- normalized `requirePlace` for the same supported flags;
+- static building/destructable footprints already baked into `pathmap.original`;
+- live unit-circle occupancy, excluding the builder;
+- exact build-on-target presence when `isBuildOn` requires a `canBuildOn` structure.
+
+The common routing layer exposes `CM_GetPathingFlagsAt()` specifically so placement can read the immutable terrain + baked-static pathing result without mutating movement's dynamic path map.
+
+A declared pathing texture that fails to load is a placement failure. Do not silently degrade such a structure to a one-cell footprint; `M_LoadPathTex()` already reports the missing asset.
+
+Placement is checked once when the player confirms the ghost and again when the worker reaches the site. Resources are charged only after the arrival-time validation passes. Construction spawns at the stored snapped waypoint, not at the worker's current position.
+
+The current client ghost snaps correctly but does not yet render the full per-cell green/red placement texture. Live units are therefore authoritative server blockers but are not painted into the preview.
+
+## Human construction and power building
+
+A successfully started Human structure uses explicit construction state on the building:
+
+```text
+construction.active = true
+construction.paused = true
+construction.primary_builder = original Peasant
+construction.progress = 0
+life = 10% max life
+```
+
+The building's birth animation is held until construction completes. The primary Peasant enters Human Repair and contributes `1.0` construction time. If that Peasant stops/dies/receives another behavior, no autonomous timer advances the paused structure. A later Human Repair worker can become the new primary worker.
+
+Additional `Arep` repairers use the ability's authored data:
+
+- `DataC` -> incremental power-build cost ratio;
+- `DataD` -> additional construction-time contribution.
+
+Each additional worker independently contributes:
+
+```text
+progress += frame_time * DataD
+```
+
+and accumulates incremental gold/lumber cost from the building's `goldRep` / `lumberRep`, build time, and `DataC`. An additional repairer stops when that incremental payment cannot be made. `+set wc3_build_all 1` suppresses those debug-time costs.
+
+Ordinary repair aliases remain separate and do not acquire Human power-building behavior automatically.
+
+Completion clears paused/constructing state, releases the held birth animation, restores full life, applies positive `foodMade`, publishes `EVENT_PLAYER_UNIT_CONSTRUCT_FINISH`, and refreshes resource/HUD state.
+
+## Known gaps
+
+This patch intentionally focuses on Human construction. The following clean-room-spec items remain incomplete:
+
+- `war3map.w3u` modifications are not yet fully merged into the normalized typed unit rows, so map-local edits to `Builds`/requirements may still resolve through the base unit row;
+- the client does not yet draw a per-cell green/red pathing splat or mirror live-unit obstruction into that splat;
+- placement supports the currently decoded walk/build/blight flags, not every Warcraft compound placement type;
+- build cancellation after a structure has spawned does not yet have the retail partial-refund lifecycle;
+- Orc worker-inside, Night Elf worker/Ancient consumption, and Undead summon/release construction strategies remain legacy behavior;
+- normal completed-building Repair still uses the older simplified HP rate; DataA/DataB repair cost/time parity is separate from Human power-building DataC/DataD.
+
+## Verification
+
+Focused automated checks after building:
+
+```sh
+make test-wc3-engine WC3_PATTERN='wc3_building.*'
+make test-wc3-engine WC3_PATTERN='wc3_combat.*'
+make test-wc3-engine WC3_PATTERN='wc3_movement.*'
+```
+
+Runtime checks should cover at least:
+
+1. Peasant Build submenu only exposes its `Builds` entries.
+2. A `SetPlayerTechMaxAllowed(..., 0)` structure disappears; `+set wc3_build_all 1` restores it.
+3. Missing `Requires` or resources disable the button; the cvar bypasses those gates.
+4. Farm/Barracks ghost and spawned structure use the same 64/32 alignment.
+5. Terrain, tree/building static pathing, map edges, and live units reject placement.
+6. Obstruction introduced while the Peasant walks causes arrival-time rejection without charging resources.
+7. One Peasant constructs at the base rate; stopping it pauses progress.
+8. A replacement Peasant resumes construction.
+9. Additional Peasants accelerate according to Repair `DataD` and consume incremental `DataC` costs.

--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -259,6 +259,10 @@ the server received `CmdBuild`, but pre-dispatch SLK normalization produced `Cmd
 unit's `trains` list. Peasants have a `Builds` list rather than a `trains` list, so the visible Build button appeared to do nothing.
 The investigative trace was removed after the root cause was confirmed.
 
+### Human building construction
+
+The command-card `CmdBuild` resolver is only the entry point. Authoritative build availability, WC3 grid snapping, placement/pathing validation, arrival-time revalidation, and Human Repair/power-building state live in [building-construction.md](building-construction.md). Use `+set wc3_build_all 1` to bypass tech/resource gates for structures already present in the selected worker's `Builds` list while retaining world-placement validation.
+
 ## Verification
 
 Focused deterministic checks:

--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -239,12 +239,33 @@ An August 2026 regression had working world picking and working selected-unit he
 entity number at input, view, renderer, and health-bar filtering before the fix. Keep the active-view assignment in `V_RenderView`.
 The investigative logs were removed after confirmation.
 
+### Command-card command resolution
+
+Command-card clicks carry the original command string from `hud/hud_commands.c` to `CLIENTCOMMAND(Button)` in `g_commands.c`.
+There are two command namespaces and they must not be normalized the same way:
+
+- engine commands such as `CmdBuild`, `CmdMove`, and `CmdAttack` are full strings registered directly in `skills/s_skills.c`;
+- WC3 ability commands are four-character rawcodes such as `Ahrp`, which must follow `AbilityData.slk:code` to the registered base
+  handler (for example `Ahrp -> Arep`).
+
+Use `FindAbilityForCommand()` at the command-card boundary. It preserves non-four-character engine command strings verbatim and only
+runs four-character rawcodes through `G_AbilityCodeName()`. Do not pass `Cmd*` names through `FS_SLKKey()`/`G_AbilityCodeName()`: the
+SLK key helper intentionally copies at most four bytes, so `CmdBuild` becomes `CmdB` and cannot match the registered `CmdBuild`
+handler. The same resolver supplies the command button's `active` ability index; mana-cost lookup remains rawcode-only because engine
+commands have no `AbilityData` row.
+
+The August 30, 2026 build-menu regression was confirmed by a bounded runtime trace: the client hit `onclick="button CmdBuild"` and
+the server received `CmdBuild`, but pre-dispatch SLK normalization produced `CmdB`, missed `a_build`, and fell through to the selected
+unit's `trains` list. Peasants have a `Builds` list rather than a `trains` list, so the visible Build button appeared to do nothing.
+The investigative trace was removed after the root cause was confirmed.
+
 ## Verification
 
 Focused deterministic checks:
 
 ```sh
 make test-wc3-engine WC3_PATTERN='wc3_movement.*'
+make test-wc3-engine WC3_PATTERN='wc3_combat.command_lookup_*'
 make test-wc3-engine WC3_PATTERN='wc3_combat.ability_data_resolves_roc_and_tft_columns'
 make test-wc3-engine WC3_PATTERN='wc3_unit.*'
 make test-wc3-engine WC3_PATTERN='wc3_game.hud_*'

--- a/docs/games/warcraft-3/jass-native-coverage.md
+++ b/docs/games/warcraft-3/jass-native-coverage.md
@@ -8,7 +8,7 @@ and map-script behavior, but do not replace the native declarations.
 ## Baseline
 
 The registry currently contains 836 callbacks. A conservative source audit
-classifies 476 as implemented and 360 as clear placeholders, for 56.9% overall
+classifies 482 as implemented and 354 as clear placeholders, for 57.7% overall
 coverage. This count treats a callback as a placeholder only when it ignores its
 arguments and unconditionally returns no value, zero, false, or a null handle.
 A working `returns nothing` callback also returns zero at the C ABI boundary, so
@@ -18,7 +18,7 @@ raw `return 0` counts are not meaningful.
 | --- | ---: | ---: | ---: |
 | `api_misc.h` | 317 | 190 | 127 |
 | `api_unit.h` | 144 | 82 | 62 |
-| `api_player.h` | 86 | 37 | 49 |
+| `api_player.h` | 86 | 43 | 43 |
 | `api_trigger.h` | 48 | 26 | 22 |
 | `api_camera.h` | 42 | 34 | 8 |
 | `api_sound.h` | 35 | 7 | 28 |
@@ -132,8 +132,7 @@ in the registry: `SetEnemyStartLocPrioCount`, `SetEnemyStartLocPrio`, and
 - `SetPlayerHandicap` and `SetPlayerHandicapXP` are percentages represented by
   real values; their getters must return the stored values, not normalized
   fractions unless runtime evidence demonstrates that contract.
-- Tech maximums, researched levels, and ability availability require keyed
-  per-player tables. They should not be packed into `ps.stats[]`.
+- Tech maximums and researched levels use the keyed `game.clients[].tech` table rather than `ps.stats[]`. `SetPlayerTechMaxAllowed`, `GetPlayerTechMaxAllowed`, `AddPlayerTechResearched`, `SetPlayerTechResearched`, `GetPlayerTechResearched`, and `GetPlayerTechCount` now round-trip through that state. W3I technology-unavailability entries seed a maximum of zero before map scripts may override it. Ability availability remains separate work.
 
 ## Trigger Context Contract
 

--- a/docs/games/warcraft-3/jass-native-coverage.md
+++ b/docs/games/warcraft-3/jass-native-coverage.md
@@ -132,7 +132,7 @@ in the registry: `SetEnemyStartLocPrioCount`, `SetEnemyStartLocPrio`, and
 - `SetPlayerHandicap` and `SetPlayerHandicapXP` are percentages represented by
   real values; their getters must return the stored values, not normalized
   fractions unless runtime evidence demonstrates that contract.
-- Tech maximums and researched levels use the keyed `game.clients[].tech` table rather than `ps.stats[]`. `SetPlayerTechMaxAllowed`, `GetPlayerTechMaxAllowed`, `AddPlayerTechResearched`, `SetPlayerTechResearched`, `GetPlayerTechResearched`, and `GetPlayerTechCount` now round-trip through that state. W3I technology-unavailability entries seed a maximum of zero before map scripts may override it. Ability availability remains separate work.
+- Tech maximums and researched levels use the keyed `game.clients[].tech` table rather than `ps.stats[]`. `SetPlayerTechMaxAllowed`, `GetPlayerTechMaxAllowed`, `AddPlayerTechResearched`, `SetPlayerTechResearched`, `GetPlayerTechResearched`, and `GetPlayerTechCount` round-trip through that state. W3I technology-unavailability entries seed a maximum of zero before map scripts may override it. The table is bounded by `MAX_PLAYER_TECH_STATE` and reports exhaustion rather than silently overwriting state. The bundled `game/common.txt` declares `GetPlayerTechResearched` as `boolean`, so it reports whether the exact rawcode has a researched level above zero; `GetPlayerTechCount` returns the exact-rawcode count/level. Both currently ignore technology-equivalence expansion when `specificonly` is false because equivalence groups are not represented yet. Ability availability remains separate work.
 
 ## Trigger Context Contract
 

--- a/docs/games/warcraft-3/readme.md
+++ b/docs/games/warcraft-3/readme.md
@@ -107,3 +107,5 @@ File formats, renderer notes, UI/FDF behavior, and gameplay coverage work used b
 - [ROC Ability Checklist](architecture/roc-ability-checklist.md)
 - [Cinematics](cinematics.md)
 - [Sounds](sounds.md)
+
+- [Building construction](building-construction.md) — build-menu availability, placement validation, Human construction, and power building.

--- a/games/warcraft-3/game/api/api_player.h
+++ b/games/warcraft-3/game/api/api_player.h
@@ -333,13 +333,20 @@ DWORD SetPlayerTechResearched(LPJASS j) {
 DWORD GetPlayerTechResearched(LPJASS j) {
     LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
     LONG techid = jass_checkinteger(j, 2);
-    (void)jass_checkboolean(j, 3);
-    return jass_pushinteger(j, whichPlayer ? G_GetPlayerTechResearchedLevel(PLAYER_CLIENT(whichPlayer), (DWORD)techid) : 0);
+    BOOL specificonly = jass_checkboolean(j, 3);
+    /* TODO: model Warcraft technology-equivalence groups. Until that data is
+     * represented, both specificonly modes address the exact rawcode only. */
+    (void)specificonly;
+    return jass_pushboolean(j, whichPlayer &&
+        G_GetPlayerTechResearchedLevel(PLAYER_CLIENT(whichPlayer), (DWORD)techid) > 0);
 }
 DWORD GetPlayerTechCount(LPJASS j) {
     LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
     LONG techid = jass_checkinteger(j, 2);
-    (void)jass_checkboolean(j, 3);
+    BOOL specificonly = jass_checkboolean(j, 3);
+    /* TODO: model Warcraft technology-equivalence groups. Until that data is
+     * represented, both specificonly modes address the exact rawcode only. */
+    (void)specificonly;
     return jass_pushinteger(j, whichPlayer ? G_GetPlayerTechCountValue(PLAYER_CLIENT(whichPlayer), (DWORD)techid) : 0);
 }
 DWORD SetPlayerAbilityAvailable(LPJASS j) {

--- a/games/warcraft-3/game/api/api_player.h
+++ b/games/warcraft-3/game/api/api_player.h
@@ -304,39 +304,43 @@ DWORD SetPlayerHandicapXP(LPJASS j) {
     return 0;
 }
 DWORD SetPlayerTechMaxAllowed(LPJASS j) {
-    //LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
-    //LONG techid = jass_checkinteger(j, 2);
-    //LONG maximum = jass_checkinteger(j, 3);
+    LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
+    LONG techid = jass_checkinteger(j, 2);
+    LONG maximum = jass_checkinteger(j, 3);
+    if (whichPlayer) G_SetPlayerTechMaxAllowed(PLAYER_CLIENT(whichPlayer), (DWORD)techid, maximum);
     return 0;
 }
 DWORD GetPlayerTechMaxAllowed(LPJASS j) {
-    //LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
-    //LONG techid = jass_checkinteger(j, 2);
-    return jass_pushinteger(j, 0);
+    LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
+    LONG techid = jass_checkinteger(j, 2);
+    LONG maximum = whichPlayer ? G_GetPlayerTechMaxAllowed(PLAYER_CLIENT(whichPlayer), (DWORD)techid) : -1;
+    return jass_pushinteger(j, maximum);
 }
 DWORD AddPlayerTechResearched(LPJASS j) {
-    //LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
-    //LONG techid = jass_checkinteger(j, 2);
-    //LONG levels = jass_checkinteger(j, 3);
+    LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
+    LONG techid = jass_checkinteger(j, 2);
+    LONG levels = jass_checkinteger(j, 3);
+    if (whichPlayer) G_AddPlayerTechResearched(PLAYER_CLIENT(whichPlayer), (DWORD)techid, levels);
     return 0;
 }
 DWORD SetPlayerTechResearched(LPJASS j) {
-    //LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
-    //LONG techid = jass_checkinteger(j, 2);
-    //LONG setToLevel = jass_checkinteger(j, 3);
+    LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
+    LONG techid = jass_checkinteger(j, 2);
+    LONG setToLevel = jass_checkinteger(j, 3);
+    if (whichPlayer) G_SetPlayerTechResearched(PLAYER_CLIENT(whichPlayer), (DWORD)techid, setToLevel);
     return 0;
 }
 DWORD GetPlayerTechResearched(LPJASS j) {
-    //LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
-    //LONG techid = jass_checkinteger(j, 2);
-    //BOOL specificonly = jass_checkboolean(j, 3);
-    return jass_pushboolean(j, 0);
+    LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
+    LONG techid = jass_checkinteger(j, 2);
+    (void)jass_checkboolean(j, 3);
+    return jass_pushinteger(j, whichPlayer ? G_GetPlayerTechResearchedLevel(PLAYER_CLIENT(whichPlayer), (DWORD)techid) : 0);
 }
 DWORD GetPlayerTechCount(LPJASS j) {
-    //LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
-    //LONG techid = jass_checkinteger(j, 2);
-    //BOOL specificonly = jass_checkboolean(j, 3);
-    return jass_pushinteger(j, 0);
+    LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
+    LONG techid = jass_checkinteger(j, 2);
+    (void)jass_checkboolean(j, 3);
+    return jass_pushinteger(j, whichPlayer ? G_GetPlayerTechCountValue(PLAYER_CLIENT(whichPlayer), (DWORD)techid) : 0);
 }
 DWORD SetPlayerAbilityAvailable(LPJASS j) {
     //LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");

--- a/games/warcraft-3/game/g_building.c
+++ b/games/warcraft-3/game/g_building.c
@@ -1,0 +1,405 @@
+#include "g_local.h"
+
+#define WC3_BUILD_CELL_SIZE 32.0f
+#define WC3_BUILD_GRID_SIZE 64.0f
+#define WC3_BUILD_START_LIFE 0.10f
+#define WC3_PATH_UNWALKABLE 0x02
+#define WC3_PATH_UNBUILDABLE 0x08
+#define WC3_PATH_BLIGHTED 0x20
+
+static BOOL G_StringHasPlacementType(LPCSTR list, LPCSTR type) {
+    char token[64];
+    LPCSTR p;
+
+    if (!list || !type || !*type) return false;
+    p = list;
+    while (*p) {
+        DWORD n = 0;
+        while (*p == ',' || *p == ' ' || *p == '\t') p++;
+        while (*p && *p != ',' && n + 1 < sizeof(token)) token[n++] = (char)tolower(*p++);
+        token[n] = '\0';
+        while (*p && *p != ',') p++;
+        if (*p == ',') p++;
+        if (!strcmp(token, type)) return true;
+    }
+    return false;
+}
+
+static BYTE G_PlacementFlags(LPCSTR list) {
+    BYTE flags = 0;
+    if (G_StringHasPlacementType(list, "unwalkable")) flags |= WC3_PATH_UNWALKABLE;
+    if (G_StringHasPlacementType(list, "unbuildable")) flags |= WC3_PATH_UNBUILDABLE;
+    if (G_StringHasPlacementType(list, "blighted")) flags |= WC3_PATH_BLIGHTED;
+    return flags;
+}
+
+static DWORD G_CsvToken(LPCSTR list, DWORD index, LPSTR out, DWORD out_size) {
+    DWORD current = 0;
+    LPCSTR p = list;
+
+    if (!out || !out_size) return 0;
+    out[0] = '\0';
+    if (!list) return 0;
+    while (*p) {
+        LPCSTR start;
+        DWORD len;
+        while (*p == ',' || *p == ' ' || *p == '\t') p++;
+        start = p;
+        while (*p && *p != ',') p++;
+        len = (DWORD)(p - start);
+        while (len && (start[len - 1] == ' ' || start[len - 1] == '\t')) len--;
+        if (current++ == index) {
+            len = MIN(len, out_size - 1);
+            memcpy(out, start, len);
+            out[len] = '\0';
+            return len;
+        }
+        if (*p == ',') p++;
+    }
+    return 0;
+}
+
+BOOL G_BuildAllEnabled(void) {
+    return gi.CvarString && atoi(gi.CvarString("wc3_build_all", "0")) != 0;
+}
+
+static LONG G_FindTechSlot(LPGAMECLIENT client, DWORD techid, BOOL create) {
+    LONG free_slot = -1;
+
+    if (!client || !techid) return -1;
+    FOR_LOOP(i, MAX_PLAYER_TECH_STATE) {
+        if (client->tech[i].id == techid) return (LONG)i;
+        if (!client->tech[i].id && free_slot < 0) free_slot = (LONG)i;
+    }
+    if (!create || free_slot < 0) return -1;
+    client->tech[free_slot].id = techid;
+    client->tech[free_slot].max_allowed = -1;
+    return free_slot;
+}
+
+void G_SetPlayerTechMaxAllowed(LPGAMECLIENT client, DWORD techid, LONG maximum) {
+    LONG slot = G_FindTechSlot(client, techid, true);
+    if (slot < 0) return;
+    client->tech[slot].max_allowed = MAX(0, maximum);
+}
+
+LONG G_GetPlayerTechMaxAllowed(LPGAMECLIENT client, DWORD techid) {
+    LONG slot = G_FindTechSlot(client, techid, false);
+    return slot < 0 ? -1 : client->tech[slot].max_allowed;
+}
+
+void G_SetPlayerTechResearched(LPGAMECLIENT client, DWORD techid, LONG level_value) {
+    LONG slot = G_FindTechSlot(client, techid, true);
+    if (slot < 0) return;
+    client->tech[slot].researched = MAX(0, level_value);
+}
+
+void G_AddPlayerTechResearched(LPGAMECLIENT client, DWORD techid, LONG levels) {
+    LONG slot = G_FindTechSlot(client, techid, true);
+    if (slot < 0) return;
+    client->tech[slot].researched = MAX(0, client->tech[slot].researched + levels);
+}
+
+LONG G_GetPlayerTechResearchedLevel(LPGAMECLIENT client, DWORD techid) {
+    LONG slot = G_FindTechSlot(client, techid, false);
+    return slot < 0 ? 0 : MAX(0, client->tech[slot].researched);
+}
+
+LONG G_GetPlayerTechCountValue(LPGAMECLIENT client, DWORD techid) {
+    LONG count = G_GetPlayerTechResearchedLevel(client, techid);
+    DWORD player;
+
+    if (!client || !techid) return 0;
+    player = client->ps.number;
+    FILTER_EDICTS(ent, ent->inuse && ent->class_id == techid && ent->s.player == player &&
+                         !(ent->svflags & SVF_DEADMONSTER)) {
+        count++;
+    }
+    return count;
+}
+
+BOOL G_WorkerCanBuild(LPEDICT worker, DWORD building_id) {
+    char token[64];
+    LPCSTR builds;
+
+    if (!worker || !building_id) return false;
+    builds = worker->UnitProfile ? worker->UnitProfile->builds : NULL;
+    if (!builds) return false;
+    for (DWORD i = 0; G_CsvToken(builds, i, token, sizeof(token)); i++) {
+        if (strlen(token) == 4 && !memcmp(token, &building_id, 4)) return true;
+    }
+    return false;
+}
+
+static LONG G_RequirementAmount(UnitProfile_t const *profile, DWORD index) {
+    char amount[32];
+    LONG value = 1;
+
+    if (!profile || !profile->requiresAmount ||
+        !G_CsvToken(profile->requiresAmount, index, amount, sizeof(amount))) return 1;
+    if (sscanf(amount, "%ld", &value) != 1) return 1;
+    return MAX(1, value);
+}
+
+static LONG G_PlayerRequirementCount(LPGAMECLIENT client, DWORD techid) {
+    LONG count = G_GetPlayerTechResearchedLevel(client, techid);
+    DWORD player;
+
+    if (!client || !techid) return 0;
+    player = client->ps.number;
+    FILTER_EDICTS(ent, ent->inuse && ent->class_id == techid && ent->s.player == player &&
+                         !(ent->svflags & SVF_DEADMONSTER) && !ent->construction.active) {
+        count++;
+    }
+    return count;
+}
+
+static BOOL G_RequirementsSatisfied(LPGAMECLIENT client, DWORD building_id, LPSTR reason, DWORD reason_size) {
+    UnitProfile_t const *profile = G_UnitProfile(building_id);
+    char requirement[64];
+
+    if (!profile->requires || !*profile->requires) return true;
+    for (DWORD i = 0; G_CsvToken(profile->requires, i, requirement, sizeof(requirement)); i++) {
+        DWORD rawcode;
+        LONG required;
+        if (strlen(requirement) != 4) continue;
+        memcpy(&rawcode, requirement, sizeof(rawcode));
+        required = G_RequirementAmount(profile, i);
+        if (G_PlayerRequirementCount(client, rawcode) < required) {
+            if (reason && reason_size) {
+                LPCSTR name = G_UnitProfile(rawcode)->name;
+                if (required > 1) {
+                    snprintf(reason, reason_size, "Requires %s x%ld",
+                             name && *name ? name : requirement, required);
+                } else {
+                    snprintf(reason, reason_size, "Requires %s",
+                             name && *name ? name : requirement);
+                }
+            }
+            return false;
+        }
+    }
+    return true;
+}
+
+static BOOL G_BuildResourcesAvailable(LPGAMECLIENT client, DWORD building_id, LPSTR reason, DWORD reason_size) {
+    UnitBalance_t const *b = G_UnitBalance(building_id);
+    LONG food_after;
+
+    if (!client) return false;
+    if (b->goldCost > (LONG)client->ps.stats[PLAYERSTATE_RESOURCE_GOLD]) {
+        if (reason && reason_size) snprintf(reason, reason_size, "Not enough gold");
+        return false;
+    }
+    if (b->lumberCost > (LONG)client->ps.stats[PLAYERSTATE_RESOURCE_LUMBER]) {
+        if (reason && reason_size) snprintf(reason, reason_size, "Not enough lumber");
+        return false;
+    }
+    food_after = (LONG)client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_USED] + MAX(0, b->foodUsed);
+    if (b->foodUsed > 0 && food_after > (LONG)client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP]) {
+        if (reason && reason_size) snprintf(reason, reason_size, "Not enough food");
+        return false;
+    }
+    return true;
+}
+
+buildCommandState_t G_GetBuildCommandState(LPGAMECLIENT client, LPEDICT worker, DWORD building_id,
+                                           LPSTR reason, DWORD reason_size) {
+    LONG maximum;
+
+    if (reason && reason_size) reason[0] = '\0';
+    if (!client || !G_WorkerCanBuild(worker, building_id)) return BUILD_COMMAND_ABSENT;
+    if (!G_UnitIsBuilding(building_id)) return BUILD_COMMAND_ABSENT;
+    if (G_BuildAllEnabled()) return BUILD_COMMAND_AVAILABLE;
+
+    maximum = G_GetPlayerTechMaxAllowed(client, building_id);
+    if (maximum >= 0 && G_GetPlayerTechCountValue(client, building_id) >= maximum) {
+        return BUILD_COMMAND_HIDDEN;
+    }
+    if (!G_RequirementsSatisfied(client, building_id, reason, reason_size)) {
+        return BUILD_COMMAND_DISABLED;
+    }
+    if (!G_BuildResourcesAvailable(client, building_id, reason, reason_size)) {
+        return BUILD_COMMAND_DISABLED;
+    }
+    return BUILD_COMMAND_AVAILABLE;
+}
+
+BOOL G_ChargeBuilding(LPGAMECLIENT client, DWORD building_id) {
+    UnitBalance_t const *b;
+
+    if (!client) return false;
+    if (G_BuildAllEnabled()) return true;
+    if (!G_BuildResourcesAvailable(client, building_id, NULL, 0)) return false;
+    b = G_UnitBalance(building_id);
+    client->ps.stats[PLAYERSTATE_RESOURCE_GOLD] -= MAX(0, b->goldCost);
+    client->ps.stats[PLAYERSTATE_RESOURCE_LUMBER] -= MAX(0, b->lumberCost);
+    client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_USED] += MAX(0, b->foodUsed);
+    return true;
+}
+
+void G_RefundBuilding(LPGAMECLIENT client, DWORD building_id) {
+    UnitBalance_t const *b;
+    if (!client || G_BuildAllEnabled()) return;
+    b = G_UnitBalance(building_id);
+    client->ps.stats[PLAYERSTATE_RESOURCE_GOLD] += MAX(0, b->goldCost);
+    client->ps.stats[PLAYERSTATE_RESOURCE_LUMBER] += MAX(0, b->lumberCost);
+    client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_USED] =
+        MAX(0, (LONG)client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_USED] - MAX(0, b->foodUsed));
+}
+
+void G_SnapBuildingPoint(DWORD building_id, LPVECTOR2 point) {
+    pathTex_t *pathtex;
+    UnitData_t const *data;
+
+    if (!point) return;
+    data = G_UnitData(building_id);
+    pathtex = M_LoadPathTex(data->pathingTexture);
+    if (!pathtex) {
+        point->x = floorf(point->x / WC3_BUILD_CELL_SIZE) * WC3_BUILD_CELL_SIZE;
+        point->y = floorf(point->y / WC3_BUILD_CELL_SIZE) * WC3_BUILD_CELL_SIZE;
+        return;
+    }
+    point->x = floorf(point->x / WC3_BUILD_GRID_SIZE) * WC3_BUILD_GRID_SIZE;
+    point->y = floorf(point->y / WC3_BUILD_GRID_SIZE) * WC3_BUILD_GRID_SIZE;
+    if (((pathtex->width / 2) & 1) != 0) point->x += WC3_BUILD_CELL_SIZE;
+    if (((pathtex->height / 2) & 1) != 0) point->y += WC3_BUILD_CELL_SIZE;
+    gi.MemFree(pathtex);
+}
+
+static BOOL G_PathCellUsed(pathTex_t const *pathtex, DWORD x, DWORD y) {
+    if (!pathtex) return true;
+    return pathtex->map[x + y * pathtex->width].b != 0;
+}
+
+static BOOL G_FindBuildOnTarget(DWORD building_id, LPCVECTOR2 point, LPEDICT *out) {
+    UnitData_t const *data = G_UnitData(building_id);
+    if (out) *out = NULL;
+    if (!data->isBuildOn) return true;
+    FILTER_EDICTS(ent, ent->inuse && G_UnitIsBuilding(ent->class_id) && ent->UnitData->canBuildOn) {
+        if (fabsf(ent->s.origin2.x - point->x) <= WC3_BUILD_CELL_SIZE &&
+            fabsf(ent->s.origin2.y - point->y) <= WC3_BUILD_CELL_SIZE) {
+            if (out) *out = ent;
+            return true;
+        }
+    }
+    return false;
+}
+
+static BOOL G_LiveUnitBlocksBuild(LPEDICT builder, LPEDICT build_on, LPCBOX2 footprint) {
+    FILTER_EDICTS(ent, ent->inuse && (ent->svflags & SVF_MONSTER) && !(ent->svflags & SVF_DEADMONSTER)) {
+        FLOAT x, y;
+        if (ent == builder || ent == build_on || ent->collision <= 0.0f) continue;
+        x = MAX(footprint->min.x, MIN(footprint->max.x, ent->s.origin2.x));
+        y = MAX(footprint->min.y, MIN(footprint->max.y, ent->s.origin2.y));
+        VECTOR2 nearest = { x, y };
+        if (Vector2_distance(&nearest, &ent->s.origin2) < ent->collision) return true;
+    }
+    return false;
+}
+
+buildPlacementResult_t G_EvaluateBuildPlacement(LPEDICT builder, DWORD building_id, LPCVECTOR2 requested,
+                                                LPVECTOR2 snapped) {
+    UnitBalance_t const *balance = G_UnitBalance(building_id);
+    UnitUI_t const *ui = G_UnitUI(building_id);
+    UnitData_t const *data = G_UnitData(building_id);
+    LPCSTR prevent = balance->preventPlace ? balance->preventPlace : ui->preventPlace;
+    LPCSTR require = balance->requirePlace ? balance->requirePlace : ui->requirePlace;
+    BYTE prevented = WC3_PATH_UNBUILDABLE | WC3_PATH_UNWALKABLE | G_PlacementFlags(prevent);
+    BYTE required = G_PlacementFlags(require);
+    pathTex_t *pathtex = NULL;
+    LPEDICT build_on = NULL;
+    DWORD width = 1, height = 1;
+    BOX2 footprint;
+    VECTOR2 point;
+
+    if (!requested || !G_UnitIsBuilding(building_id)) return PLACE_INVALID_BUILDING;
+    point = *requested;
+    G_SnapBuildingPoint(building_id, &point);
+    if (snapped) *snapped = point;
+
+    if (!G_FindBuildOnTarget(building_id, &point, &build_on)) return PLACE_REQUIRED_PARENT_MISSING;
+    pathtex = M_LoadPathTex(data->pathingTexture);
+    if (data->pathingTexture && strlen(data->pathingTexture) > 1 && !pathtex) {
+        return PLACE_INVALID_BUILDING;
+    }
+    if (pathtex) {
+        width = MAX(1, pathtex->width);
+        height = MAX(1, pathtex->height);
+    }
+    footprint.min.x = point.x - width * WC3_BUILD_CELL_SIZE * 0.5f;
+    footprint.min.y = point.y - height * WC3_BUILD_CELL_SIZE * 0.5f;
+    footprint.max.x = point.x + width * WC3_BUILD_CELL_SIZE * 0.5f;
+    footprint.max.y = point.y + height * WC3_BUILD_CELL_SIZE * 0.5f;
+
+    if (!build_on) {
+        FOR_LOOP(x, width) {
+            FOR_LOOP(y, height) {
+                VECTOR2 sample;
+                BYTE flags;
+                if (pathtex && !G_PathCellUsed(pathtex, x, y)) continue;
+                sample.x = point.x + ((FLOAT)x + 0.5f - (FLOAT)width * 0.5f) * WC3_BUILD_CELL_SIZE;
+                sample.y = point.y + ((FLOAT)y + 0.5f - (FLOAT)height * 0.5f) * WC3_BUILD_CELL_SIZE;
+                if (!CM_GetPathingFlagsAt(&sample, &flags)) {
+                    if (pathtex) gi.MemFree(pathtex);
+                    return PLACE_OUT_OF_BOUNDS;
+                }
+                if (flags & prevented) {
+                    if (pathtex) gi.MemFree(pathtex);
+                    return PLACE_TERRAIN_BLOCKED;
+                }
+                if ((flags & required) != required) {
+                    if (pathtex) gi.MemFree(pathtex);
+                    return PLACE_REQUIRED_PATHING_MISSING;
+                }
+            }
+        }
+    }
+    if (pathtex) gi.MemFree(pathtex);
+    if (G_LiveUnitBlocksBuild(builder, build_on, &footprint)) return PLACE_UNIT_BLOCKED;
+    return PLACE_OK;
+}
+
+FLOAT G_BuildApproachDistance(DWORD building_id) {
+    pathTex_t *pathtex = M_LoadPathTex(G_UnitData(building_id)->pathingTexture);
+    FLOAT result;
+    if (!pathtex) return MAX(WC3_BUILD_CELL_SIZE, G_UnitCollision(building_id));
+    result = MAX(pathtex->width, pathtex->height) * WC3_BUILD_CELL_SIZE * 0.5f;
+    gi.MemFree(pathtex);
+    return result;
+}
+
+BOOL G_StartHumanConstruction(LPEDICT builder, LPEDICT building) {
+    EDICTSTAT *hp;
+    if (!builder || !building || !G_UnitIsBuilding(building->class_id)) return false;
+    hp = &building->health;
+    building->construction.active = true;
+    building->construction.paused = true;
+    building->construction.primary_builder = builder;
+    building->construction.progress = 0.0f;
+    building->aiflags |= AI_HOLD_FRAME;
+    hp->value = MAX(1.0f, hp->max_value * WC3_BUILD_START_LIFE);
+    return true;
+}
+
+void G_CompleteConstruction(LPEDICT building) {
+    LPGAMECLIENT client;
+    if (!building || !building->construction.active) return;
+    client = G_GetPlayerClientByNumber(building->s.player);
+    building->construction.active = false;
+    building->construction.paused = false;
+    building->construction.primary_builder = NULL;
+    building->construction.progress = 0.0f;
+    building->aiflags &= ~AI_HOLD_FRAME;
+    building->health.value = building->health.max_value;
+    building->stand(building);
+    if (client && building->UnitBalance->foodMade > 0) {
+        client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP] += building->UnitBalance->foodMade;
+    }
+    G_PublishEvent(building, EVENT_PLAYER_UNIT_CONSTRUCT_FINISH);
+    if (client) {
+        LPEDICT clent = G_GetPlayerEntityByNumber(client->ps.number);
+        G_RefreshResourceBar(clent);
+        Get_Portrait_f(clent);
+    }
+}

--- a/games/warcraft-3/game/g_building.c
+++ b/games/warcraft-3/game/g_building.c
@@ -7,29 +7,37 @@
 #define WC3_PATH_UNBUILDABLE 0x08
 #define WC3_PATH_BLIGHTED 0x20
 
-static BOOL G_StringHasPlacementType(LPCSTR list, LPCSTR type) {
-    char token[64];
-    LPCSTR p;
+static BYTE G_PlacementFlags(LPCSTR list) {
+    BYTE flags = 0;
+    LPCSTR p = list;
 
-    if (!list || !type || !*type) return false;
-    p = list;
+    if (!list) return 0;
     while (*p) {
+        char token[64];
         DWORD n = 0;
+
         while (*p == ',' || *p == ' ' || *p == '\t') p++;
-        while (*p && *p != ',' && n + 1 < sizeof(token)) token[n++] = (char)tolower(*p++);
+        while (*p && *p != ',' && n + 1 < sizeof(token)) {
+            token[n++] = (char)tolower((unsigned char)*p++);
+        }
         token[n] = '\0';
         while (*p && *p != ',') p++;
         if (*p == ',') p++;
-        if (!strcmp(token, type)) return true;
-    }
-    return false;
-}
+        while (n && (token[n - 1] == ' ' || token[n - 1] == '\t')) token[--n] = '\0';
 
-static BYTE G_PlacementFlags(LPCSTR list) {
-    BYTE flags = 0;
-    if (G_StringHasPlacementType(list, "unwalkable")) flags |= WC3_PATH_UNWALKABLE;
-    if (G_StringHasPlacementType(list, "unbuildable")) flags |= WC3_PATH_UNBUILDABLE;
-    if (G_StringHasPlacementType(list, "blighted")) flags |= WC3_PATH_BLIGHTED;
+        if (!token[0]) continue;
+        if (!strcmp(token, "unwalkable")) {
+            flags |= WC3_PATH_UNWALKABLE;
+        } else if (!strcmp(token, "unbuildable")) {
+            flags |= WC3_PATH_UNBUILDABLE;
+        } else if (!strcmp(token, "blighted")) {
+            flags |= WC3_PATH_BLIGHTED;
+        } else {
+            /* TODO: decode the remaining Warcraft placement predicates from the
+             * authoritative unit data instead of silently treating them as no-op. */
+            fprintf(stderr, "G_PlacementFlags: unsupported placement type '%s'\n", token);
+        }
+    }
     return flags;
 }
 
@@ -71,7 +79,12 @@ static LONG G_FindTechSlot(LPGAMECLIENT client, DWORD techid, BOOL create) {
         if (client->tech[i].id == techid) return (LONG)i;
         if (!client->tech[i].id && free_slot < 0) free_slot = (LONG)i;
     }
-    if (!create || free_slot < 0) return -1;
+    if (!create) return -1;
+    if (free_slot < 0) {
+        fprintf(stderr, "G_FindTechSlot: player %u tech state capacity %u exhausted for 0x%08x\n",
+                (unsigned)client->ps.number, (unsigned)MAX_PLAYER_TECH_STATE, (unsigned)techid);
+        return -1;
+    }
     client->tech[free_slot].id = techid;
     client->tech[free_slot].max_allowed = -1;
     return free_slot;
@@ -137,7 +150,11 @@ static LONG G_RequirementAmount(UnitProfile_t const *profile, DWORD index) {
 
     if (!profile || !profile->requiresAmount ||
         !G_CsvToken(profile->requiresAmount, index, amount, sizeof(amount))) return 1;
-    if (sscanf(amount, "%ld", &value) != 1) return 1;
+    if (sscanf(amount, "%ld", &value) != 1) {
+        fprintf(stderr, "G_RequirementAmount: invalid Requiresamount token '%s' at index %u\n",
+                amount, (unsigned)index);
+        return 1;
+    }
     return MAX(1, value);
 }
 
@@ -162,7 +179,11 @@ static BOOL G_RequirementsSatisfied(LPGAMECLIENT client, DWORD building_id, LPST
     for (DWORD i = 0; G_CsvToken(profile->requires, i, requirement, sizeof(requirement)); i++) {
         DWORD rawcode;
         LONG required;
-        if (strlen(requirement) != 4) continue;
+        if (strlen(requirement) != 4) {
+            fprintf(stderr, "G_RequirementsSatisfied: unsupported requirement token '%s' for 0x%08x\n",
+                    requirement, (unsigned)building_id);
+            continue;
+        }
         memcpy(&rawcode, requirement, sizeof(rawcode));
         required = G_RequirementAmount(profile, i);
         if (G_PlayerRequirementCount(client, rawcode) < required) {

--- a/games/warcraft-3/game/g_building.c
+++ b/games/warcraft-3/game/g_building.c
@@ -150,7 +150,7 @@ static LONG G_RequirementAmount(UnitProfile_t const *profile, DWORD index) {
 
     if (!profile || !profile->requiresAmount ||
         !G_CsvToken(profile->requiresAmount, index, amount, sizeof(amount))) return 1;
-    if (sscanf(amount, "%ld", &value) != 1) {
+    if (sscanf(amount, "%d", &value) != 1) {
         fprintf(stderr, "G_RequirementAmount: invalid Requiresamount token '%s' at index %u\n",
                 amount, (unsigned)index);
         return 1;
@@ -190,7 +190,7 @@ static BOOL G_RequirementsSatisfied(LPGAMECLIENT client, DWORD building_id, LPST
             if (reason && reason_size) {
                 LPCSTR name = G_UnitProfile(rawcode)->name;
                 if (required > 1) {
-                    snprintf(reason, reason_size, "Requires %s x%ld",
+                    snprintf(reason, reason_size, "Requires %s x%d",
                              name && *name ? name : requirement, required);
                 } else {
                     snprintf(reason, reason_size, "Requires %s",

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -132,7 +132,7 @@ CLIENTCOMMAND(SmartPoint) {
 CLIENTCOMMAND(Button) {
     LPCSTR classname = argv[1];
     LPGAMECLIENT client = clent->client;
-    ability_t const *ability = FindAbilityByClassname(GetClassName(G_AbilityCodeName(classname)));
+    ability_t const *ability = FindAbilityForCommand(classname);
     if (ability && ability->cmd) {
         client->menu.ability_code = *((DWORD const *)classname);
         ability->cmd(clent);
@@ -269,7 +269,7 @@ CLIENTCOMMAND(Inventory) {
     abilities = FindConfigValue(GetClassName(item->class_id), "abilList");
     if (abilities && *abilities) {
         PARSE_LIST(abilities, ability_name, parse_segment) {
-            ability_t const *ability = FindAbilityByClassname(GetClassName(G_AbilityCodeName(ability_name)));
+            ability_t const *ability = FindAbilityForCommand(ability_name);
             if (ability && ability->cmd) {
                 client->menu.ability_code = *((DWORD const *)ability_name);
                 ability->cmd(clent);

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -961,6 +961,7 @@ buildPlacementResult_t G_EvaluateBuildPlacement(LPEDICT builder, DWORD building_
 FLOAT G_BuildApproachDistance(DWORD building_id);
 BOOL G_StartHumanConstruction(LPEDICT builder, LPEDICT building);
 void G_CompleteConstruction(LPEDICT building);
+BOOL G_UnitHasHumanRepair(LPEDICT ent);
 void G_SetPlayerTechMaxAllowed(LPGAMECLIENT client, DWORD techid, LONG maximum);
 LONG G_GetPlayerTechMaxAllowed(LPGAMECLIENT client, DWORD techid);
 void G_SetPlayerTechResearched(LPGAMECLIENT client, DWORD techid, LONG level_value);

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -32,6 +32,7 @@
 #define PLAYER_TEXT_BACKUP 16
 #define PLAYER_TEXT_MASK (PLAYER_TEXT_BACKUP - 1)
 #define MAX_START_PRIO 16 // slots; one possible priority entry per WC3 player start location
+#define MAX_PLAYER_TECH_STATE 128
 
 #define FILTER_EDICTS(ENT, CONDITION) \
 for (LPEDICT ENT = globals.edicts; \
@@ -70,6 +71,29 @@ KNOWN_AS(gevent_s, EVENT);
 KNOWN_AS(gtrigger_s, TRIGGER);
 KNOWN_AS(gquest_s, QUEST);
 KNOWN_AS(gquestitem_s, QUESTITEM);
+
+typedef enum {
+    BUILD_COMMAND_ABSENT,
+    BUILD_COMMAND_HIDDEN,
+    BUILD_COMMAND_DISABLED,
+    BUILD_COMMAND_AVAILABLE,
+} buildCommandState_t;
+
+typedef enum {
+    PLACE_OK,
+    PLACE_INVALID_BUILDING,
+    PLACE_TERRAIN_BLOCKED,
+    PLACE_UNIT_BLOCKED,
+    PLACE_REQUIRED_PATHING_MISSING,
+    PLACE_OUT_OF_BOUNDS,
+    PLACE_REQUIRED_PARENT_MISSING,
+} buildPlacementResult_t;
+
+typedef struct {
+    DWORD id;
+    LONG researched;
+    LONG max_allowed; /* -1 = unlimited/default */
+} playerTechState_t;
 
 typedef struct {
     BOOL (*on_entity_selected)(LPEDICT, LPEDICT);
@@ -318,6 +342,7 @@ struct client_s {
         BOOL race_selectable, on_score_screen;
         char name[MAX_PATHLEN];
     } jass;
+    playerTechState_t tech[MAX_PLAYER_TECH_STATE];
     char playerTextStorage[PLAYERTEXT_COUNT][PLAYER_TEXT_BACKUP][512];
     DWORD playerTextCursor[PLAYERTEXT_COUNT];
     LPCMAPPLAYER mapplayer;
@@ -541,6 +566,17 @@ struct edict_s {
     DWORD class_id;
     DWORD variation;
     DWORD build_project;
+    struct {
+        BOOL active;
+        BOOL paused;
+        LPEDICT primary_builder;
+        FLOAT progress;
+    } construction;
+    struct {
+        BOOL primary;
+        FLOAT gold_accum;
+        FLOAT lumber_accum;
+    } buildwork;
     DWORD spawn_time;
     DWORD harvested_lumber;
     DWORD harvested_gold;
@@ -915,6 +951,22 @@ LPCSTR GetClassName(DWORD);
 // g_unit_ui.c (Phase 8)
 BYTE G_GetCommandButtons(LPEDICT ent, gameCommandButton_t *buttons, BYTE max_buttons);
 BOOL G_BuildCommandButton(LPEDICT ent, LPCSTR code, BOOL research, DWORD level, gameCommandButton_t *button);
+BOOL G_BuildAllEnabled(void);
+BOOL G_WorkerCanBuild(LPEDICT worker, DWORD building_id);
+buildCommandState_t G_GetBuildCommandState(LPGAMECLIENT client, LPEDICT worker, DWORD building_id, LPSTR reason, DWORD reason_size);
+BOOL G_ChargeBuilding(LPGAMECLIENT client, DWORD building_id);
+void G_RefundBuilding(LPGAMECLIENT client, DWORD building_id);
+void G_SnapBuildingPoint(DWORD building_id, LPVECTOR2 point);
+buildPlacementResult_t G_EvaluateBuildPlacement(LPEDICT builder, DWORD building_id, LPCVECTOR2 requested, LPVECTOR2 snapped);
+FLOAT G_BuildApproachDistance(DWORD building_id);
+BOOL G_StartHumanConstruction(LPEDICT builder, LPEDICT building);
+void G_CompleteConstruction(LPEDICT building);
+void G_SetPlayerTechMaxAllowed(LPGAMECLIENT client, DWORD techid, LONG maximum);
+LONG G_GetPlayerTechMaxAllowed(LPGAMECLIENT client, DWORD techid);
+void G_SetPlayerTechResearched(LPGAMECLIENT client, DWORD techid, LONG level_value);
+void G_AddPlayerTechResearched(LPGAMECLIENT client, DWORD techid, LONG levels);
+LONG G_GetPlayerTechResearchedLevel(LPGAMECLIENT client, DWORD techid);
+LONG G_GetPlayerTechCountValue(LPGAMECLIENT client, DWORD techid);
 BOOL G_BuildInventoryItem(LPEDICT ent, LPEDICT item, BYTE slot, gameInventoryItem_t *out);
 BYTE G_GetInventory(LPEDICT ent, gameInventoryItem_t *items, BYTE max_items);
 BYTE G_GetBuildQueue(LPEDICT ent, gameQueueItem_t *queue, BYTE max_queue);
@@ -929,6 +981,7 @@ void G_UpdateClientInfoPanels(void);
 void G_RefreshResourceBar(LPEDICT);
 void G_UpdateClientResourceBars(void);
 void UI_AddCancelButton(LPEDICT);
+void UI_WriteCommandButtonFrame(gameCommandButton_t const *button);
 void UI_AddCommandButton(LPCSTR);
 void UI_AddCommandButtonExtended(LPCSTR code, BOOL research, DWORD level);
 void UI_WriteTooltipFrame(void);

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -902,6 +902,7 @@ void G_PushEntity3(LPEDICT ent, FLOAT distance, LPCVECTOR3 direction);
 
 // g_abilities.c
 ability_t const *FindAbilityByClassname(LPCSTR);
+ability_t const *FindAbilityForCommand(LPCSTR);
 ability_t const *GetAbilityByIndex(DWORD);
 DWORD FindAbilityIndex(LPCSTR);
 void InitAbilities(void);

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -409,10 +409,16 @@ void G_PublishMessage(LPEDICT actor, GAMEMSGTYPE type, LPEDICT target) {
 }
 
 LPCSTR G_LevelString(LPCSTR name) {
-    DWORD string_id = 0;
-    sscanf(name, "TRIGSTR_%d", &string_id);
+    unsigned int string_id;
+    char trailing;
+
+    if (!name || strncmp(name, "TRIGSTR_", 8) ||
+        sscanf(name, "TRIGSTR_%u%c", &string_id, &trailing) != 1 ||
+        !level.mapinfo) {
+        return name;
+    }
     FOR_EACH_LIST(mapTrigStr_t, trigstr, level.mapinfo->strings) {
-        if (trigstr->id == string_id) {
+        if (trigstr->id == (DWORD)string_id) {
             return trigstr->text;
         }
     }

--- a/games/warcraft-3/game/g_spawn.c
+++ b/games/warcraft-3/game/g_spawn.c
@@ -306,6 +306,7 @@ static void G_InitMapPlayer(LPEDICT clent, LPCMAPINFO mapinfo, DWORD playernum) 
     LPPLAYER ps = &clent->client->ps;
     G_SetClientConnected(clent, false);
     memset(&clent->client->jass, 0, sizeof(clent->client->jass));
+    memset(clent->client->tech, 0, sizeof(clent->client->tech));
     memset(ps, 0, sizeof(PLAYER));
     ps->number = playernum;
     ps->team = G_MapPlayerTeam(mapinfo, playernum);
@@ -323,6 +324,14 @@ static void G_InitMapPlayer(LPEDICT clent, LPCMAPINFO mapinfo, DWORD playernum) 
     clent->client->camera.state.fov = 50;
     clent->client->camera.state.target_distance = 1650;
     clent->client->camera.old_state = clent->client->camera.state;
+    if (mapinfo) {
+        FOR_LOOP(i, mapinfo->num_techAvailabilities) {
+            mapTechAvailability_t const *tech = mapinfo->techAvailabilities + i;
+            if (tech->playerFlags & (1u << playernum)) {
+                G_SetPlayerTechMaxAllowed(clent->client, tech->techID, 0);
+            }
+        }
+    }
     clent->client->mapplayer = player;
     clent->client->jass.controller = G_MapControl(player);
     clent->client->jass.race_pref = G_RacePreference(player);

--- a/games/warcraft-3/game/g_unit_ui.c
+++ b/games/warcraft-3/game/g_unit_ui.c
@@ -135,6 +135,8 @@ BOOL G_BuildCommandButton(LPEDICT ent, LPCSTR code, BOOL research, DWORD level, 
     LPCSTR tip;
     LPCSTR ubertip;
     LPCSTR hotkey;
+    ability_t const *ability;
+    DWORD ability_code = 0;
     DWORD x = UINT_MAX;
     DWORD y = UINT_MAX;
 
@@ -143,7 +145,13 @@ BOOL G_BuildCommandButton(LPEDICT ent, LPCSTR code, BOOL research, DWORD level, 
     }
 
     memset(button, 0, sizeof(*button));
-    base_code = GetClassName(G_AbilityCodeName(code));
+    ability = FindAbilityForCommand(code);
+    if (strlen(code) == 4) {
+        ability_code = G_AbilityCodeName(code);
+        base_code = GetClassName(ability_code);
+    } else {
+        base_code = code;
+    }
     art_code = G_CommandArtCode(ent, code);
     art = FindConfigValue(art_code, G_ResearchField(STR_ART, research));
     buttonpos = FindConfigValue(art_code, G_ResearchField(STR_BUTTONPOS, research));
@@ -164,10 +172,9 @@ BOOL G_BuildCommandButton(LPEDICT ent, LPCSTR code, BOOL research, DWORD level, 
     button->x = x == UINT_MAX ? 255 : (BYTE)MIN(x, 3);
     button->y = y == UINT_MAX ? 255 : (BYTE)MIN(y, 2);
     button->research = research ? 1 : 0;
-    button->active = (BYTE)FindAbilityIndex(base_code);
-    if (strlen(base_code) >= 4) {
-        button->manacost = S_SpellNumber(MAKEFOURCC(base_code[0], base_code[1], base_code[2], base_code[3]),
-                         ABILITY_NUMBER_COST, level);
+    button->active = (BYTE)GetAbilityIndex(ability);
+    if (ability_code) {
+        button->manacost = S_SpellNumber(ability_code, ABILITY_NUMBER_COST, level);
     }
     if (!button->art[0]) {
         fprintf(stderr,
@@ -201,7 +208,7 @@ static void G_AddCommandButton(LPEDICT ent,
 }
 
 static BOOL G_IsImplementedAbility(LPCSTR code) {
-    return FindAbilityByClassname(code) != NULL;
+    return FindAbilityForCommand(code) != NULL;
 }
 
 BYTE G_GetCommandButtons(LPEDICT ent, gameCommandButton_t *buttons, BYTE max_buttons) {
@@ -239,7 +246,7 @@ BYTE G_GetCommandButtons(LPEDICT ent, gameCommandButton_t *buttons, BYTE max_but
     } else if (a->abilList) {
         PARSE_LIST(a->abilList, abil, parse_segment) {
             DWORD const code = G_AbilityCodeName(abil);
-            if (G_IsImplementedAbility(GetClassName(code))) {
+            if (G_IsImplementedAbility(abil)) {
                 BYTE const idx = count;
                 G_AddCommandButton(ent, buttons, max_buttons, &count, abil, false, 0);
                 if (count > idx) buttons[idx].cooldown = S_SpellCooldownFraction(ent, code, 0);

--- a/games/warcraft-3/game/hud/hud_commands.c
+++ b/games/warcraft-3/game/hud/hud_commands.c
@@ -74,15 +74,15 @@ void UI_WriteCommandButtonFrame(gameCommandButton_t const *button) {
     FLOAT by = UI_BASE_HEIGHT - 0.1131f + (FLOAT)button->y * 0.0434f;
     memset(&frame, 0, sizeof(frame));
     frame.flags.type = FT_COMMANDBUTTON;
-    frame.color = COLOR32_WHITE;
+    frame.color = button->disabled ? (COLOR32){ 128, 128, 128, 255 } : COLOR32_WHITE;
     frame.tex.index = gi.ImageIndex(button->art);
     frame.stat = button->active;
     frame.value = button->cooldown;
-    frame.hotkey = (BYTE)button->hotkey;
+    frame.hotkey = button->disabled ? 0 : (BYTE)button->hotkey;
     UI_FormatTooltip(button->command, button->tooltip, button->ubertip, button->manacost, tooltip, sizeof(tooltip));
     frame.tooltip = tooltip;
     snprintf(onclick, sizeof(onclick), "%s %s", button->research ? "research" : "button", button->command);
-    frame.onclick = onclick;
+    frame.onclick = button->disabled ? NULL : onclick;
     UI_SetFrameRect(&frame, bx - 0.0195f, by - 0.0195f, 0.039f, 0.039f);
     UI_WriteProxyFrame(&frame, NULL, 0);
 }

--- a/games/warcraft-3/game/skills/s_build.c
+++ b/games/warcraft-3/game/skills/s_build.c
@@ -3,9 +3,20 @@
 void build_walk(LPEDICT ent);
 void build_build(LPEDICT ent);
 void repair_build(LPEDICT ent, LPEDICT building);
+void repair_build_primary(LPEDICT ent, LPEDICT building);
+
+static BOOL G_IsHumanBuilder(LPEDICT ent) {
+    return ent && ent->UnitData && ent->UnitData->race && !strcmp(ent->UnitData->race, STR_HUMAN);
+}
+
+static void G_BuildError(LPEDICT clent, LPCSTR text) {
+    if (!clent) return;
+    UI_ShowText(clent, &MAKE(VECTOR2, 0, 0), text && *text ? text : "Unable to build there.", 2.0f);
+}
 
 static void ai_build_walk(LPEDICT ent) {
-    if (M_DistanceToGoal(ent) <= unit_movedistance(ent)) {
+    FLOAT const reach = unit_movedistance(ent) + G_BuildApproachDistance(ent->build_project);
+    if (M_DistanceToGoal(ent) <= reach) {
         build_build(ent);
     } else {
         unit_changeangle(ent);
@@ -13,23 +24,7 @@ static void ai_build_walk(LPEDICT ent) {
     }
 }
 
-static void ai_build(LPEDICT ent) {
-    FLOAT const k = (FLOAT)FRAMETIME / ((FLOAT)ent->build->UnitBalance->buildTime * 1000.0f);
-    EDICTSTAT *hp = &ent->build->health;
-    hp->value += hp->max_value * k;
-    if (hp->value >= hp->max_value) {
-        LPEDICT clent = G_GetPlayerEntityByNumber(ent->s.player);
-
-        hp->value = hp->max_value;
-        G_PublishEvent(ent->build, EVENT_PLAYER_UNIT_CONSTRUCT_FINISH);
-        ent->build->stand(ent->build);
-        ent->stand(ent);
-        Get_Portrait_f(clent);
-    }
-}
-
 static umove_t build_move_walk = { "walk", ai_build_walk, NULL, &a_build };
-static umove_t build_move_stand = { "stand", ai_build, NULL, &a_build };
 
 static void FillUnitData(LPENTITYSTATE ent, DWORD unit_id, LPCSTR anim) {
     PATHSTR buffer = { 0 };
@@ -43,6 +38,16 @@ static void FillUnitData(LPENTITYSTATE ent, DWORD unit_id, LPCSTR anim) {
     ent->model = G_RegisterModel(buffer);
     ent->scale = ui->modelScale;
     ent->angle = -M_PI / 2;
+    {
+        pathTex_t *pathtex = M_LoadPathTex(G_UnitData(unit_id)->pathingTexture);
+        if (pathtex) {
+            /* Cursor-only metadata: preserve the authored footprint dimensions so
+             * the client uses the same 64/32 placement snap before confirmation. */
+            ent->origin.x = (FLOAT)pathtex->width;
+            ent->origin.y = (FLOAT)pathtex->height;
+            gi.MemFree(pathtex);
+        }
+    }
     LPCANIMATION animation = G_GetAnimation(ent->model, anim);
     if (animation) {
         ent->frame = animation->interval[0];
@@ -50,38 +55,81 @@ static void FillUnitData(LPENTITYSTATE ent, DWORD unit_id, LPCSTR anim) {
 }
 
 void build_build(LPEDICT ent) {
-    if (player_pay(G_GetPlayerByNumber(ent->s.player), ent->build_project)) {
-        LPEDICT building = SP_SpawnAtLocation(ent->build_project, ent->s.player, &ent->s.origin2);
-        repair_build(ent, building);
-//        VECTOR2 origin;
-//        FLOAT angle;
-//        M_SetMove(ent, &build_move_build);
-//        SP_FindEmptySpaceAround(building, ent->class_id, &origin, &angle);
-//        ent->s.origin2 = origin;
-//        ent->s.angle = angle - M_PI;
-//        ent->selected = 0;
-//        ent->build = building;
-        building->health.value = 0;
-        building->build = building;
-        G_PublishEvent(building, EVENT_PLAYER_UNIT_CONSTRUCT_START);
-        /* Bake the new building's footprint into the static pathmap so it
-         * becomes a hard obstacle for move-time collision and the flow field
-         * reroutes around it.  Units standing on the footprint are not pushed
-         * (WC3 does not push them either); they path out on their next order. */
-        CM_BakeStaticObstacles();
-        Get_Portrait_f(G_GetPlayerEntityByNumber(ent->s.player));
-    } else {
-        ent->stand(ent);
+    LPGAMECLIENT client;
+    VECTOR2 snapped;
+    buildPlacementResult_t placement;
+    buildCommandState_t state;
+    LPEDICT building;
+
+    if (!ent || !ent->goalentity || !ent->build_project) {
+        if (ent) ent->stand(ent);
+        return;
     }
+    client = G_GetPlayerClientByNumber(ent->s.player);
+    placement = G_EvaluateBuildPlacement(ent, ent->build_project, &ent->goalentity->s.origin2, &snapped);
+    state = G_GetBuildCommandState(client, ent, ent->build_project, NULL, 0);
+    if (placement != PLACE_OK || state != BUILD_COMMAND_AVAILABLE) {
+        G_BuildError(G_GetPlayerEntityByNumber(ent->s.player),
+                     placement == PLACE_OK ? "Unable to build: requirements changed." : "Unable to build there.");
+        ent->stand(ent);
+        return;
+    }
+    if (!G_ChargeBuilding(client, ent->build_project)) {
+        G_BuildError(G_GetPlayerEntityByNumber(ent->s.player), "Not enough resources.");
+        ent->stand(ent);
+        return;
+    }
+
+    building = SP_SpawnAtLocation(ent->build_project, ent->s.player, &snapped);
+    if (!building) {
+        G_RefundBuilding(client, ent->build_project);
+        ent->stand(ent);
+        return;
+    }
+
+    if (G_IsHumanBuilder(ent)) {
+        G_StartHumanConstruction(ent, building);
+        repair_build_primary(ent, building);
+    } else {
+        /* Other race lifecycles remain the legacy behavior until their
+         * worker-inside/summon construction strategies are implemented. */
+        repair_build(ent, building);
+        building->health.value = 0;
+    }
+    building->build = building;
+    G_PublishEvent(building, EVENT_PLAYER_UNIT_CONSTRUCT_START);
+    CM_BakeStaticObstacles();
+    G_RefreshResourceBar(G_GetPlayerEntityByNumber(ent->s.player));
+    Get_Portrait_f(G_GetPlayerEntityByNumber(ent->s.player));
 }
 
 BOOL build_menu_send_builder(LPEDICT clent, LPCVECTOR2 location) {
-    LPEDICT waypoint = Waypoint_add(location);
-    FOR_SELECTED_UNITS(clent->client, ent) {
-        ent->goalentity = waypoint;
-        ent->build_project = clent->build_project;
-        unit_setmove(ent, &build_move_walk);
+    LPEDICT builder;
+    VECTOR2 snapped;
+    buildPlacementResult_t placement;
+    buildCommandState_t state;
+    LPEDICT waypoint;
+    char reason[128];
+
+    if (!clent || !clent->client || !location || !clent->build_project) return false;
+    builder = G_GetMainSelectedUnit(clent->client);
+    if (!builder) return false;
+
+    state = G_GetBuildCommandState(clent->client, builder, clent->build_project, reason, sizeof(reason));
+    if (state != BUILD_COMMAND_AVAILABLE) {
+        G_BuildError(clent, reason[0] ? reason : "Unable to build that structure.");
+        return false;
     }
+    placement = G_EvaluateBuildPlacement(builder, clent->build_project, location, &snapped);
+    if (placement != PLACE_OK) {
+        G_BuildError(clent, "Unable to build there.");
+        return false;
+    }
+
+    waypoint = Waypoint_add(&snapped);
+    builder->goalentity = waypoint;
+    builder->build_project = clent->build_project;
+    unit_setmove(builder, &build_move_walk);
     entityState_t empty;
     memset(&empty, 0, sizeof(entityState_t));
     gi.Write(PF_BYTE, &(LONG){svc_cursor});
@@ -92,7 +140,21 @@ BOOL build_menu_send_builder(LPEDICT clent, LPCVECTOR2 location) {
 
 void build_menu_selectlocation(LPEDICT ent, DWORD building_id) {
     entityState_t cursor;
+    LPEDICT worker;
+    buildCommandState_t state;
+    char reason[128];
+
+    if (!ent || !ent->client) return;
+    worker = G_GetMainSelectedUnit(ent->client);
+    if (!worker || !G_WorkerCanBuild(worker, building_id)) return;
+    state = G_GetBuildCommandState(ent->client, worker, building_id, reason, sizeof(reason));
+    if (state != BUILD_COMMAND_AVAILABLE) {
+        G_BuildError(ent, reason[0] ? reason : "Unable to build that structure.");
+        return;
+    }
+
     FillUnitData(&cursor, building_id, "stand");
+    cursor.player = worker->s.player;
     UI_AddCancelButton(ent);
     gi.Write(PF_BYTE, &(LONG){svc_cursor});
     gi.Write(PF_ENTITY, &cursor);
@@ -103,11 +165,28 @@ void build_menu_selectlocation(LPEDICT ent, DWORD building_id) {
 
 void ui_builds(LPGAMECLIENT client) {
     LPEDICT ent = G_GetMainSelectedUnit(client);
-    LPCSTR builds = G_UnitProfile(ent->class_id)->builds;
-    if (!builds)
+    LPCSTR builds = ent ? G_UnitProfile(ent->class_id)->builds : NULL;
+    if (!ent || !builds)
         return;
     PARSE_LIST(builds, build, parse_segment) {
-        UI_AddCommandButton(build);
+        DWORD building_id = 0;
+        gameCommandButton_t button;
+        buildCommandState_t state;
+        char reason[128];
+        size_t used;
+
+        if (strlen(build) != 4) continue;
+        memcpy(&building_id, build, sizeof(building_id));
+        state = G_GetBuildCommandState(client, ent, building_id, reason, sizeof(reason));
+        if (state == BUILD_COMMAND_ABSENT || state == BUILD_COMMAND_HIDDEN) continue;
+        if (!G_BuildCommandButton(ent, build, false, 0, &button)) continue;
+        if (state == BUILD_COMMAND_DISABLED) {
+            button.disabled = 1;
+            used = strlen(button.ubertip);
+            snprintf(button.ubertip + used, sizeof(button.ubertip) - used,
+                     "%s|cffffcc00%s|r", used ? "|n" : "", reason);
+        }
+        UI_WriteCommandButtonFrame(&button);
     }
     UI_AddCommandButton(STR_CmdCancel);
     UI_WriteTooltipFrame();
@@ -116,11 +195,6 @@ void ui_builds(LPGAMECLIENT client) {
 void build_command(LPEDICT edict) {
     UI_WRITE_LAYER(edict, ui_builds, LAYER_COMMANDBAR);
     edict->client->menu.cmdbutton = build_menu_selectlocation;
-}
-
-void build_start(LPEDICT self, LPEDICT target) {
-//    self->goalentity = target;
-    unit_setmove(self, &build_move_stand);
 }
 
 ability_t a_build = {

--- a/games/warcraft-3/game/skills/s_build.c
+++ b/games/warcraft-3/game/skills/s_build.c
@@ -10,8 +10,12 @@ static BOOL G_IsHumanBuilder(LPEDICT ent) {
 }
 
 static void G_BuildError(LPEDICT clent, LPCSTR text) {
-    if (!clent) return;
-    UI_ShowText(clent, &MAKE(VECTOR2, 0, 0), text && *text ? text : "Unable to build there.", 2.0f);
+    if (!clent || !text || !*text) return;
+    UI_ShowText(clent, &MAKE(VECTOR2, 0, 0), text, 2.0f);
+}
+
+static void G_BuildPlacementError(LPEDICT clent) {
+    G_BuildError(clent, "Unable to build there.");
 }
 
 static void ai_build_walk(LPEDICT ent) {
@@ -41,10 +45,8 @@ static void FillUnitData(LPENTITYSTATE ent, DWORD unit_id, LPCSTR anim) {
     {
         pathTex_t *pathtex = M_LoadPathTex(G_UnitData(unit_id)->pathingTexture);
         if (pathtex) {
-            /* Cursor-only metadata: preserve the authored footprint dimensions so
-             * the client uses the same 64/32 placement snap before confirmation. */
-            ent->origin.x = (FLOAT)pathtex->width;
-            ent->origin.y = (FLOAT)pathtex->height;
+            ent->pathing_width = (USHORT)MIN(pathtex->width, USHRT_MAX);
+            ent->pathing_height = (USHORT)MIN(pathtex->height, USHRT_MAX);
             gi.MemFree(pathtex);
         }
     }
@@ -68,9 +70,13 @@ void build_build(LPEDICT ent) {
     client = G_GetPlayerClientByNumber(ent->s.player);
     placement = G_EvaluateBuildPlacement(ent, ent->build_project, &ent->goalentity->s.origin2, &snapped);
     state = G_GetBuildCommandState(client, ent, ent->build_project, NULL, 0);
-    if (placement != PLACE_OK || state != BUILD_COMMAND_AVAILABLE) {
-        G_BuildError(G_GetPlayerEntityByNumber(ent->s.player),
-                     placement == PLACE_OK ? "Unable to build: requirements changed." : "Unable to build there.");
+    if (placement != PLACE_OK) {
+        G_BuildPlacementError(G_GetPlayerEntityByNumber(ent->s.player));
+        ent->stand(ent);
+        return;
+    }
+    if (state != BUILD_COMMAND_AVAILABLE) {
+        G_BuildError(G_GetPlayerEntityByNumber(ent->s.player), "Unable to build: requirements changed.");
         ent->stand(ent);
         return;
     }
@@ -87,6 +93,10 @@ void build_build(LPEDICT ent) {
         return;
     }
 
+    /* The structure blocks pathing as soon as construction starts. Bake its
+     * authored footprint before relocating the worker so the egress search
+     * cannot choose a point that becomes blocked immediately afterward. */
+    CM_BakeStaticObstacles();
     if (G_IsHumanBuilder(ent)) {
         G_StartHumanConstruction(ent, building);
         repair_build_primary(ent, building);
@@ -98,7 +108,6 @@ void build_build(LPEDICT ent) {
     }
     building->build = building;
     G_PublishEvent(building, EVENT_PLAYER_UNIT_CONSTRUCT_START);
-    CM_BakeStaticObstacles();
     G_RefreshResourceBar(G_GetPlayerEntityByNumber(ent->s.player));
     Get_Portrait_f(G_GetPlayerEntityByNumber(ent->s.player));
 }
@@ -122,7 +131,7 @@ BOOL build_menu_send_builder(LPEDICT clent, LPCVECTOR2 location) {
     }
     placement = G_EvaluateBuildPlacement(builder, clent->build_project, location, &snapped);
     if (placement != PLACE_OK) {
-        G_BuildError(clent, "Unable to build there.");
+        G_BuildPlacementError(clent);
         return false;
     }
 

--- a/games/warcraft-3/game/skills/s_repair.c
+++ b/games/warcraft-3/game/skills/s_repair.c
@@ -110,19 +110,31 @@ static void ai_repair(LPEDICT ent) {
 
 static umove_t repair_move_build = { "stand work", ai_repair, NULL, &a_repair };
 
-static void repair_begin(LPEDICT ent, LPEDICT building, BOOL primary) {
+static BOOL repair_begin(LPEDICT ent, LPEDICT building, BOOL primary) {
     VECTOR2 origin;
     FLOAT angle;
-    if (!ent || !building) return;
+
+    if (!ent || !building) return false;
+    /* Human builders must leave the building's authored pathing footprint, not
+     * merely its selection/collision circle. The static footprint is baked by
+     * build_build() before this search. */
+    if (!SP_FindUnitExitPosition(building, ent, &origin, &angle)) {
+        if (primary && building->construction.primary_builder == ent) {
+            building->construction.primary_builder = NULL;
+        }
+        if (ent->stand) ent->stand(ent);
+        return false;
+    }
     unit_setmove(ent, &repair_move_build);
-    SP_FindEmptySpaceAround(building, ent->class_id, &origin, &angle);
     ent->s.origin2 = origin;
     ent->s.angle = angle - M_PI;
+    gi.LinkEntity(ent);
     ent->build = building;
     ent->buildwork.primary = primary;
     ent->buildwork.gold_accum = 0.0f;
     ent->buildwork.lumber_accum = 0.0f;
     if (primary) building->construction.primary_builder = ent;
+    return true;
 }
 
 void repair_build_primary(LPEDICT ent, LPEDICT building) {
@@ -141,7 +153,7 @@ void repair_build(LPEDICT ent, LPEDICT building) {
 }
 
 
-static BOOL repair_unit_has_human_repair(LPEDICT ent) {
+BOOL G_UnitHasHumanRepair(LPEDICT ent) {
     LPCSTR abilities;
 
     if (!ent || !ent->UnitAbilities) return false;
@@ -167,7 +179,7 @@ static BOOL repair_selecttarget(LPEDICT clent, LPEDICT target) {
         return false;
     }
     FOR_SELECTED_UNITS(clent->client, ent) {
-        if (repair_unit_has_human_repair(ent)) repair_build(ent, target);
+        if (G_UnitHasHumanRepair(ent)) repair_build(ent, target);
     }
     return true;
 }

--- a/games/warcraft-3/game/skills/s_repair.c
+++ b/games/warcraft-3/game/skills/s_repair.c
@@ -1,30 +1,156 @@
 #include "s_skills.h"
 
 static FLOAT repair_cost_factor;
+static FLOAT power_build_cost_ratio;
+static FLOAT power_build_time_ratio;
 
 void repair_build(LPEDICT ent, LPEDICT building);
+void repair_build_primary(LPEDICT ent, LPEDICT building);
+
+static BOOL repair_primary_active(LPEDICT building) {
+    LPEDICT worker;
+    if (!building) return false;
+    worker = building->construction.primary_builder;
+    return worker && worker->inuse && !(worker->svflags & SVF_DEADMONSTER) && worker->build == building &&
+           worker->currentmove && worker->currentmove->ability == &a_repair;
+}
+
+static BOOL repair_charge_power_cost(LPEDICT ent, LPEDICT building) {
+    LPGAMECLIENT client;
+    UnitBalance_t const *b;
+    FLOAT seconds;
+    LONG gold_due, lumber_due;
+
+    if (!ent || !building || ent->buildwork.primary || G_BuildAllEnabled()) return true;
+    client = G_GetPlayerClientByNumber(ent->s.player);
+    b = building->UnitBalance;
+    if (!client || b->buildTime <= 0 || power_build_cost_ratio <= 0.0f) return true;
+
+    seconds = (FLOAT)FRAMETIME / 1000.0f;
+    ent->buildwork.gold_accum += ((FLOAT)b->goldRep / (FLOAT)b->buildTime) * power_build_cost_ratio * seconds;
+    ent->buildwork.lumber_accum += ((FLOAT)b->lumberRep / (FLOAT)b->buildTime) * power_build_cost_ratio * seconds;
+    gold_due = (LONG)floorf(ent->buildwork.gold_accum);
+    lumber_due = (LONG)floorf(ent->buildwork.lumber_accum);
+    if (gold_due > (LONG)client->ps.stats[PLAYERSTATE_RESOURCE_GOLD] ||
+        lumber_due > (LONG)client->ps.stats[PLAYERSTATE_RESOURCE_LUMBER]) {
+        return false;
+    }
+    if (gold_due > 0) {
+        client->ps.stats[PLAYERSTATE_RESOURCE_GOLD] -= gold_due;
+        ent->buildwork.gold_accum -= gold_due;
+    }
+    if (lumber_due > 0) {
+        client->ps.stats[PLAYERSTATE_RESOURCE_LUMBER] -= lumber_due;
+        ent->buildwork.lumber_accum -= lumber_due;
+    }
+    if (gold_due || lumber_due) G_RefreshResourceBar(G_GetPlayerEntityByNumber(ent->s.player));
+    return true;
+}
 
 static void ai_repair(LPEDICT ent) {
-    FLOAT const k = (FLOAT)FRAMETIME / ((FLOAT)ent->build->UnitBalance->buildTime * 1000.0f);
-    EDICTSTAT *hp = &ent->build->health;
-    hp->value += hp->max_value * k;
+    LPEDICT building = ent ? ent->build : NULL;
+    EDICTSTAT *hp;
+
+    if (!building || !building->inuse) {
+        if (ent) ent->stand(ent);
+        return;
+    }
+    hp = &building->health;
+
+    if (building->construction.active) {
+        FLOAT ratio;
+        FLOAT duration;
+        FLOAT start_hp;
+        FLOAT fraction;
+
+        if (ent->buildwork.primary) {
+            if (building->construction.primary_builder != ent) {
+                ent->stand(ent);
+                return;
+            }
+            ratio = 1.0f;
+        } else {
+            if (power_build_time_ratio <= 0.0f) {
+                ent->stand(ent);
+                return;
+            }
+            ratio = power_build_time_ratio;
+        }
+        if (!repair_charge_power_cost(ent, building)) {
+            ent->stand(ent);
+            return;
+        }
+
+        duration = MAX(1.0f, (FLOAT)building->UnitBalance->buildTime * 1000.0f);
+        building->construction.progress += (FLOAT)FRAMETIME * ratio;
+        fraction = MIN(1.0f, building->construction.progress / duration);
+        start_hp = MAX(1.0f, hp->max_value * 0.10f);
+        hp->value = start_hp + (hp->max_value - start_hp) * fraction;
+        if (fraction >= 1.0f) {
+            G_CompleteConstruction(building);
+            ent->stand(ent);
+        }
+        return;
+    }
+
+    /* Completed-structure repair keeps the existing simple rate until the
+     * normal Repair DataA/DataB resource/time model is implemented. */
+    if (building->UnitBalance->buildTime <= 0) {
+        ent->stand(ent);
+        return;
+    }
+    hp->value += hp->max_value * (FLOAT)FRAMETIME /
+                 ((FLOAT)building->UnitBalance->buildTime * 1000.0f);
     if (hp->value >= hp->max_value) {
         hp->value = hp->max_value;
-        ent->build->stand(ent->build);
+        building->stand(building);
         ent->stand(ent);
     }
 }
 
 static umove_t repair_move_build = { "stand work", ai_repair, NULL, &a_repair };
 
-void repair_build(LPEDICT ent, LPEDICT building) {
+static void repair_begin(LPEDICT ent, LPEDICT building, BOOL primary) {
     VECTOR2 origin;
     FLOAT angle;
+    if (!ent || !building) return;
     unit_setmove(ent, &repair_move_build);
     SP_FindEmptySpaceAround(building, ent->class_id, &origin, &angle);
     ent->s.origin2 = origin;
     ent->s.angle = angle - M_PI;
     ent->build = building;
+    ent->buildwork.primary = primary;
+    ent->buildwork.gold_accum = 0.0f;
+    ent->buildwork.lumber_accum = 0.0f;
+    if (primary) building->construction.primary_builder = ent;
+}
+
+void repair_build_primary(LPEDICT ent, LPEDICT building) {
+    repair_begin(ent, building, true);
+}
+
+void repair_build(LPEDICT ent, LPEDICT building) {
+    BOOL primary = false;
+    if (building && building->construction.active) {
+        if (!repair_primary_active(building)) {
+            building->construction.primary_builder = NULL;
+            primary = true;
+        }
+    }
+    repair_begin(ent, building, primary);
+}
+
+
+static BOOL repair_unit_has_human_repair(LPEDICT ent) {
+    LPCSTR abilities;
+
+    if (!ent || !ent->UnitAbilities) return false;
+    abilities = ent->UnitAbilities->abilList;
+    if (!abilities) return false;
+    PARSE_LIST(abilities, ability_name, parse_segment) {
+        if (FindAbilityForCommand(ability_name) == &a_repair) return true;
+    }
+    return false;
 }
 
 static BOOL repair_selecttarget(LPEDICT clent, LPEDICT target) {
@@ -34,11 +160,14 @@ static BOOL repair_selecttarget(LPEDICT clent, LPEDICT target) {
     if (target->s.player != clent->client->ps.number) {
         return false;
     }
-    if (target->health.value >= target->health.max_value) {
+    if (target->health.value >= target->health.max_value && !target->construction.active) {
+        return false;
+    }
+    if (target->construction.active && power_build_time_ratio <= 0.0f && repair_primary_active(target)) {
         return false;
     }
     FOR_SELECTED_UNITS(clent->client, ent) {
-        repair_build(ent, target);
+        if (repair_unit_has_human_repair(ent)) repair_build(ent, target);
     }
     return true;
 }
@@ -49,7 +178,11 @@ static void repair_command(LPEDICT clent) {
 }
 
 void SP_ability_repair(LPCSTR classname, ability_t *self) {
-    repair_cost_factor = G_AbilityDataName(classname)->data[0][0];
+    AbilityData_t const *data = G_AbilityDataName(classname);
+    (void)self;
+    repair_cost_factor = data->data[0][0];
+    power_build_cost_ratio = data->data[0][2];
+    power_build_time_ratio = data->data[0][3];
 }
 
 ability_t a_repair = {

--- a/games/warcraft-3/game/skills/s_skills.c
+++ b/games/warcraft-3/game/skills/s_skills.c
@@ -105,6 +105,21 @@ ability_t const *FindAbilityByClassname(LPCSTR classname) {
     return NULL;
 }
 
+/* Command-card names use two namespaces. Engine commands (CmdBuild, CmdMove,
+ * etc.) are full strings registered directly in abilitylist. WC3 abilities are
+ * four-character rawcodes whose AbilityData alias may point at a base handler.
+ * Only rawcodes belong in the SLK resolver: passing CmdBuild through FS_SLKKey
+ * truncates it to CmdB and loses the registered build command. */
+ability_t const *FindAbilityForCommand(LPCSTR classname) {
+    if (!classname || !*classname) {
+        return NULL;
+    }
+    if (strlen(classname) != 4) {
+        return FindAbilityByClassname(classname);
+    }
+    return FindAbilityByClassname(GetClassName(G_AbilityCodeName(classname)));
+}
+
 DWORD FindAbilityIndex(LPCSTR classname) {
     FOR_LOOP(i, game.num_abilities) {
         if (!abilitylist[i].classname)

--- a/games/warcraft-3/game/tests/t_building.c
+++ b/games/warcraft-3/game/tests/t_building.c
@@ -261,7 +261,7 @@ TEST(wc3_building, plain_build_error_text_is_not_resolved_as_trigger_string_zero
     mapTrigStr_t zero = { .id = 0 };
 
     snprintf(zero.text, sizeof(zero.text), "Human02");
-    level.mapinfo->strings = &zero;
+    ((LPMAPINFO)level.mapinfo)->strings = &zero;
 
     T_STREQ(G_LevelString("Unable to build there."), "Unable to build there.");
     T_STREQ(G_LevelString("TRIGSTR_0"), "Human02");

--- a/games/warcraft-3/game/tests/t_building.c
+++ b/games/warcraft-3/game/tests/t_building.c
@@ -3,6 +3,28 @@
 #include "../g_local.h"
 
 LPEDICT alloc_test_unit(DWORD class_id, FLOAT x, FLOAT y);
+void setup_test_world(void);
+void repair_build_primary(LPEDICT ent, LPEDICT building);
+
+static DWORD building_stand_calls;
+static uiFrame_t building_command_frame;
+static BOOL building_command_frame_seen;
+
+static void building_test_stand(LPEDICT ent) {
+    (void)ent;
+    building_stand_calls++;
+}
+
+static int building_test_image_index(LPCSTR name) {
+    (void)name;
+    return 1;
+}
+
+static void building_capture_write(pfWriteType_t type, void const *value) {
+    if (type != PF_UIFRAME || !value) return;
+    building_command_frame = *(uiFrame_t const *)value;
+    building_command_frame_seen = true;
+}
 
 TEST(wc3_building, player_tech_state_tracks_max_and_researched_levels) {
     LPGAMECLIENT client = &game.clients[0];
@@ -47,6 +69,256 @@ TEST(wc3_building, building_charge_checks_and_deducts_resources) {
     T_ASSERT(G_ChargeBuilding(client, barracks));
     T_EQ(client->ps.stats[PLAYERSTATE_RESOURCE_GOLD], 0);
     T_EQ(client->ps.stats[PLAYERSTATE_RESOURCE_LUMBER], 0);
+}
+
+TEST(wc3_building, build_command_state_covers_available_hidden_disabled_and_absent) {
+    LPGAMECLIENT client = &game.clients[0];
+    LPEDICT worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    DWORD const barracks = MAKEFOURCC('h','b','a','r');
+    UnitProfile_t worker_profile = { .builds = "hbar" };
+    char reason[128];
+
+    worker->UnitProfile = &worker_profile;
+    client->ps.stats[PLAYERSTATE_RESOURCE_GOLD] = G_UnitBalance(barracks)->goldCost;
+    client->ps.stats[PLAYERSTATE_RESOURCE_LUMBER] = G_UnitBalance(barracks)->lumberCost;
+    client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP] = 100;
+
+    T_EQ(G_GetBuildCommandState(client, worker, barracks, reason, sizeof(reason)), BUILD_COMMAND_AVAILABLE);
+
+    G_SetPlayerTechMaxAllowed(client, barracks, 0);
+    T_EQ(G_GetBuildCommandState(client, worker, barracks, reason, sizeof(reason)), BUILD_COMMAND_HIDDEN);
+
+    memset(client->tech, 0, sizeof(client->tech));
+    client->ps.stats[PLAYERSTATE_RESOURCE_GOLD] = 0;
+    T_EQ(G_GetBuildCommandState(client, worker, barracks, reason, sizeof(reason)), BUILD_COMMAND_DISABLED);
+    T_STREQ(reason, "Not enough gold");
+
+    worker_profile.builds = "hfoo";
+    T_EQ(G_GetBuildCommandState(client, worker, barracks, reason, sizeof(reason)), BUILD_COMMAND_ABSENT);
+}
+
+TEST(wc3_building, disabled_command_button_is_inert_and_available_button_is_clickable) {
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    int (*old_image_index)(LPCSTR) = gi.ImageIndex;
+    gameCommandButton_t button;
+
+    memset(&button, 0, sizeof(button));
+    snprintf(button.command, sizeof(button.command), "CmdBuild");
+    snprintf(button.art, sizeof(button.art), "test");
+    button.hotkey = 'B';
+    button.x = 0;
+    button.y = 0;
+
+    gi.Write = building_capture_write;
+    gi.ImageIndex = building_test_image_index;
+
+    building_command_frame_seen = false;
+    button.disabled = 1;
+    UI_WriteCommandButtonFrame(&button);
+    T_ASSERT(building_command_frame_seen);
+    T_EQ(building_command_frame.flags.type, FT_COMMANDBUTTON);
+    T_EQ(building_command_frame.hotkey, 0);
+    T_NULL(building_command_frame.onclick);
+    T_EQ(building_command_frame.color.r, 128);
+    T_EQ(building_command_frame.color.g, 128);
+    T_EQ(building_command_frame.color.b, 128);
+
+    building_command_frame_seen = false;
+    button.disabled = 0;
+    UI_WriteCommandButtonFrame(&button);
+    T_ASSERT(building_command_frame_seen);
+    T_EQ(building_command_frame.hotkey, 'B');
+    T_NOT_NULL(building_command_frame.onclick);
+
+    gi.Write = old_write;
+    gi.ImageIndex = old_image_index;
+}
+
+TEST(wc3_building, tech_state_capacity_is_bounded_without_clobbering_existing_entries) {
+    LPGAMECLIENT client = &game.clients[0];
+
+    FOR_LOOP(i, MAX_PLAYER_TECH_STATE) {
+        DWORD const techid = 0x41000000u + i + 1;
+        G_SetPlayerTechMaxAllowed(client, techid, (LONG)i);
+    }
+    FOR_LOOP(i, MAX_PLAYER_TECH_STATE) {
+        DWORD const techid = 0x41000000u + i + 1;
+        T_EQ(G_GetPlayerTechMaxAllowed(client, techid), (LONG)i);
+    }
+
+    G_SetPlayerTechMaxAllowed(client, 0x42000001u, 7);
+    T_EQ(G_GetPlayerTechMaxAllowed(client, 0x42000001u), -1);
+    T_EQ(G_GetPlayerTechMaxAllowed(client, 0x41000001u), 0);
+}
+
+TEST(wc3_building, building_charge_rejects_short_gold_and_refund_restores_resources) {
+    LPGAMECLIENT client = &game.clients[0];
+    DWORD const barracks = MAKEFOURCC('h','b','a','r');
+    UnitBalance_t const *balance = G_UnitBalance(barracks);
+
+    client->ps.stats[PLAYERSTATE_RESOURCE_GOLD] = MAX(0, balance->goldCost - 1);
+    client->ps.stats[PLAYERSTATE_RESOURCE_LUMBER] = balance->lumberCost;
+    client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP] = 100;
+    T_ASSERT(!G_ChargeBuilding(client, barracks));
+
+    client->ps.stats[PLAYERSTATE_RESOURCE_GOLD] = balance->goldCost;
+    T_ASSERT(G_ChargeBuilding(client, barracks));
+    G_RefundBuilding(client, barracks);
+    T_EQ(client->ps.stats[PLAYERSTATE_RESOURCE_GOLD], balance->goldCost);
+    T_EQ(client->ps.stats[PLAYERSTATE_RESOURCE_LUMBER], balance->lumberCost);
+}
+
+TEST(wc3_building, placement_accepts_open_ground_rejects_live_unit_and_map_edge) {
+    LPEDICT builder;
+    LPEDICT blocker;
+    VECTOR2 requested = { 64.0f, 64.0f };
+    VECTOR2 snapped;
+    DWORD const barracks = MAKEFOURCC('h','b','a','r');
+
+    setup_test_world();
+    builder = alloc_test_unit(MAKEFOURCC('h','p','e','a'), -128, -128);
+
+    T_EQ(G_EvaluateBuildPlacement(builder, barracks, &requested, &snapped), PLACE_OK);
+
+    blocker = alloc_test_unit(MAKEFOURCC('h','f','o','o'), snapped.x, snapped.y);
+    blocker->svflags |= SVF_MONSTER;
+    blocker->collision = 16.0f;
+    T_EQ(G_EvaluateBuildPlacement(builder, barracks, &requested, &snapped), PLACE_UNIT_BLOCKED);
+
+    requested = (VECTOR2){ 100000.0f, 100000.0f };
+    T_EQ(G_EvaluateBuildPlacement(builder, barracks, &requested, &snapped), PLACE_OUT_OF_BOUNDS);
+}
+
+TEST(wc3_building, building_snap_without_authored_pathing_uses_32_unit_grid) {
+    VECTOR2 point = { 47.0f, 79.0f };
+
+    G_SnapBuildingPoint(MAKEFOURCC('h','p','e','a'), &point);
+
+    T_FEQ(point.x, 32.0f, 0.001f);
+    T_FEQ(point.y, 64.0f, 0.001f);
+}
+
+TEST(wc3_building, human_construction_start_sets_explicit_state_and_start_life) {
+    LPEDICT builder = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    LPEDICT building = alloc_test_unit(MAKEFOURCC('h','b','a','r'), 64, 64);
+
+    building->health.max_value = 1000.0f;
+    building->health.value = 1000.0f;
+
+    T_ASSERT(!G_StartHumanConstruction(builder, builder));
+    T_ASSERT(G_StartHumanConstruction(builder, building));
+    T_ASSERT(building->construction.active);
+    T_ASSERT(building->construction.paused);
+    T_ASSERT(building->construction.primary_builder == builder);
+    T_FEQ(building->construction.progress, 0.0f, 0.001f);
+    T_ASSERT(building->aiflags & AI_HOLD_FRAME);
+    T_FEQ(building->health.value, 100.0f, 0.001f);
+}
+
+TEST(wc3_building, completing_construction_clears_state_publishes_once_and_grants_food_once) {
+    LPGAMECLIENT client = &game.clients[0];
+    LPEDICT builder = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    LPEDICT building = alloc_test_unit(MAKEFOURCC('h','b','a','r'), 64, 64);
+    UnitBalance_t balance = *building->UnitBalance;
+
+    balance.foodMade = 6;
+    building->UnitBalance = &balance;
+    building->s.player = client->ps.number;
+    building->health.max_value = 1000.0f;
+    building->health.value = 400.0f;
+    building->construction.active = true;
+    building->construction.paused = true;
+    building->construction.primary_builder = builder;
+    building->construction.progress = 500.0f;
+    building->aiflags |= AI_HOLD_FRAME;
+    building->stand = building_test_stand;
+    client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP] = 10;
+    level.events.write = 0;
+    level.events.read = 0;
+    building_stand_calls = 0;
+
+    G_CompleteConstruction(building);
+
+    T_ASSERT(!building->construction.active);
+    T_ASSERT(!building->construction.paused);
+    T_NULL(building->construction.primary_builder);
+    T_FEQ(building->construction.progress, 0.0f, 0.001f);
+    T_ASSERT(!(building->aiflags & AI_HOLD_FRAME));
+    T_FEQ(building->health.value, building->health.max_value, 0.001f);
+    T_EQ(client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP], 16);
+    T_EQ(building_stand_calls, 1);
+    T_EQ(level.events.write, 1);
+    T_EQ(level.events.queue[0].type, EVENT_PLAYER_UNIT_CONSTRUCT_FINISH);
+    T_ASSERT(level.events.queue[0].edict == building);
+
+    G_CompleteConstruction(building);
+    T_EQ(client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP], 16);
+    T_EQ(building_stand_calls, 1);
+    T_EQ(level.events.write, 1);
+}
+
+TEST(wc3_building, plain_build_error_text_is_not_resolved_as_trigger_string_zero) {
+    mapTrigStr_t zero = { .id = 0 };
+
+    snprintf(zero.text, sizeof(zero.text), "Human02");
+    level.mapinfo->strings = &zero;
+
+    T_STREQ(G_LevelString("Unable to build there."), "Unable to build there.");
+    T_STREQ(G_LevelString("TRIGSTR_0"), "Human02");
+    T_STREQ(G_LevelString("TRIGSTR_bad"), "TRIGSTR_bad");
+}
+
+TEST(wc3_building, human_repair_capability_comes_from_unit_ability_list) {
+    LPEDICT worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    UnitAbilities_t human_repair = { .abilList = "Arep" };
+    UnitAbilities_t generic_repair = { .abilList = "Aren" };
+
+    worker->UnitAbilities = &human_repair;
+    T_ASSERT(G_UnitHasHumanRepair(worker));
+
+    worker->UnitAbilities = &generic_repair;
+    T_ASSERT(!G_UnitHasHumanRepair(worker));
+
+    worker->UnitAbilities = NULL;
+    T_ASSERT(!G_UnitHasHumanRepair(worker));
+}
+
+TEST(wc3_building, human_builder_exit_is_outside_baked_building_footprint) {
+    enum { FOOTPRINT_W = 10, FOOTPRINT_H = 10 };
+    LPEDICT builder;
+    LPEDICT building;
+    pathTex_t *pathtex;
+    size_t const pathtex_size = sizeof(*pathtex) +
+                                FOOTPRINT_W * FOOTPRINT_H * sizeof(COLOR32);
+
+    setup_test_world();
+    builder = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    building = alloc_test_unit(MAKEFOURCC('h','b','a','r'), 0, 0);
+    builder->collision = 16.0f;
+    builder->s.model = 1;
+    building->s.model = 1;
+    building->movetype = MOVETYPE_NONE;
+
+    pathtex = gi.MemAlloc(pathtex_size);
+    memset(pathtex, 0, pathtex_size);
+    pathtex->width = FOOTPRINT_W;
+    pathtex->height = FOOTPRINT_H;
+    FOR_LOOP(i, FOOTPRINT_W * FOOTPRINT_H) pathtex->map[i].b = 0x02;
+    building->pathtex = pathtex;
+
+    gi.LinkEntity(builder);
+    gi.LinkEntity(building);
+    CM_BakeStaticObstacles();
+
+    repair_build_primary(builder, building);
+
+    T_ASSERT(builder->build == building);
+    T_ASSERT(CM_PointIsPathableForRadius(&builder->s.origin2, builder->collision));
+    T_ASSERT(fabsf(builder->s.origin2.x - building->s.origin2.x) >= 160.0f ||
+             fabsf(builder->s.origin2.y - building->s.origin2.y) >= 160.0f);
+
+    building->pathtex = NULL;
+    gi.MemFree(pathtex);
 }
 
 #endif

--- a/games/warcraft-3/game/tests/t_building.c
+++ b/games/warcraft-3/game/tests/t_building.c
@@ -1,0 +1,52 @@
+#ifdef BZ_TESTS
+#include "test.h"
+#include "../g_local.h"
+
+LPEDICT alloc_test_unit(DWORD class_id, FLOAT x, FLOAT y);
+
+TEST(wc3_building, player_tech_state_tracks_max_and_researched_levels) {
+    LPGAMECLIENT client = &game.clients[0];
+    DWORD const barracks = MAKEFOURCC('h','b','a','r');
+
+    T_EQ(G_GetPlayerTechMaxAllowed(client, barracks), -1);
+    T_EQ(G_GetPlayerTechResearchedLevel(client, barracks), 0);
+
+    G_SetPlayerTechMaxAllowed(client, barracks, 2);
+    G_SetPlayerTechResearched(client, barracks, 1);
+    G_AddPlayerTechResearched(client, barracks, 2);
+
+    T_EQ(G_GetPlayerTechMaxAllowed(client, barracks), 2);
+    T_EQ(G_GetPlayerTechResearchedLevel(client, barracks), 3);
+}
+
+TEST(wc3_building, tech_count_includes_owned_structures_and_research) {
+    LPGAMECLIENT client = &game.clients[0];
+    DWORD const barracks = MAKEFOURCC('h','b','a','r');
+    LPEDICT building = alloc_test_unit(barracks, 0, 0);
+
+    building->s.player = client->ps.number;
+    building->svflags |= SVF_MONSTER;
+    G_SetPlayerTechResearched(client, barracks, 1);
+
+    T_EQ(G_GetPlayerTechCountValue(client, barracks), 2);
+
+    building->svflags |= SVF_DEADMONSTER;
+    T_EQ(G_GetPlayerTechCountValue(client, barracks), 1);
+}
+
+TEST(wc3_building, building_charge_checks_and_deducts_resources) {
+    LPGAMECLIENT client = &game.clients[0];
+    DWORD const barracks = MAKEFOURCC('h','b','a','r');
+    UnitBalance_t const *balance = G_UnitBalance(barracks);
+
+    client->ps.stats[PLAYERSTATE_RESOURCE_GOLD] = balance->goldCost;
+    client->ps.stats[PLAYERSTATE_RESOURCE_LUMBER] = balance->lumberCost;
+    client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP] = 100;
+    client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_USED] = 0;
+
+    T_ASSERT(G_ChargeBuilding(client, barracks));
+    T_EQ(client->ps.stats[PLAYERSTATE_RESOURCE_GOLD], 0);
+    T_EQ(client->ps.stats[PLAYERSTATE_RESOURCE_LUMBER], 0);
+}
+
+#endif

--- a/games/warcraft-3/game/tests/t_building.c
+++ b/games/warcraft-3/game/tests/t_building.c
@@ -26,6 +26,9 @@ static void building_capture_write(pfWriteType_t type, void const *value) {
     building_command_frame_seen = true;
 }
 
+static void building_noop_write(pfWriteType_t type, void const *value) { (void)type; (void)value; }
+static void building_noop_unicast(LPEDICT ent) { (void)ent; }
+
 TEST(wc3_building, player_tech_state_tracks_max_and_researched_levels) {
     LPGAMECLIENT client = &game.clients[0];
     DWORD const barracks = MAKEFOURCC('h','b','a','r');
@@ -237,7 +240,15 @@ TEST(wc3_building, completing_construction_clears_state_publishes_once_and_grant
     level.events.read = 0;
     building_stand_calls = 0;
 
-    G_CompleteConstruction(building);
+    {
+        void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+        void (*old_unicast)(LPEDICT) = gi.unicast;
+        gi.Write = building_noop_write;
+        gi.unicast = building_noop_unicast;
+        G_CompleteConstruction(building);
+        gi.Write = old_write;
+        gi.unicast = old_unicast;
+    }
 
     T_ASSERT(!building->construction.active);
     T_ASSERT(!building->construction.paused);

--- a/games/warcraft-3/game/tests/t_building.c
+++ b/games/warcraft-3/game/tests/t_building.c
@@ -241,13 +241,13 @@ TEST(wc3_building, completing_construction_clears_state_publishes_once_and_grant
     building_stand_calls = 0;
 
     {
-        void (*old_write)(pfWriteType_t, void const *) = gi.Write;
-        void (*old_unicast)(LPEDICT) = gi.unicast;
-        gi.Write = building_noop_write;
-        gi.unicast = building_noop_unicast;
+        /* Prevent G_CompleteConstruction from invoking HUD refresh (which
+         * requires FDF/UI state unavailable in tests) by hiding the player
+         * entity from G_GetPlayerEntityByNumber while the call runs. */
+        LPGAMECLIENT saved_client = g_edicts[0].client;
+        g_edicts[0].client = NULL;
         G_CompleteConstruction(building);
-        gi.Write = old_write;
-        gi.unicast = old_unicast;
+        g_edicts[0].client = saved_client;
     }
 
     T_ASSERT(!building->construction.active);
@@ -314,7 +314,7 @@ TEST(wc3_building, human_builder_exit_is_outside_baked_building_footprint) {
     memset(pathtex, 0, pathtex_size);
     pathtex->width = FOOTPRINT_W;
     pathtex->height = FOOTPRINT_H;
-    FOR_LOOP(i, FOOTPRINT_W * FOOTPRINT_H) pathtex->map[i].b = 0x02;
+    FOR_LOOP(i, FOOTPRINT_W * FOOTPRINT_H) pathtex->map[i].b = 0xff;
     building->pathtex = pathtex;
 
     gi.LinkEntity(builder);

--- a/games/warcraft-3/game/tests/t_combat.c
+++ b/games/warcraft-3/game/tests/t_combat.c
@@ -20,7 +20,8 @@ void free_slk_rows(slkTestData_t *rows);
  *                          armor reduction (0.06/point), negative armor,
  *                          minimum-1 clamp, zero-armor passthrough
  *   Ability lookup       — FindAbilityByClassname hit/miss,
- *                          GetAbilityByIndex, GetAbilityIndex
+ *                          command-name/rawcode resolution, GetAbilityByIndex,
+ *                          GetAbilityIndex
  *   player_pay           — deducts gold on success,
  *                          refuses when gold insufficient,
  *                          refuses when lumber insufficient,
@@ -671,6 +672,13 @@ TEST(wc3_combat, find_ability_move) {
     T_NOT_NULL(a);
 }
 
+TEST(wc3_combat, command_lookup_preserves_engine_command_name) {
+    ability_t const *a = FindAbilityForCommand(STR_CmdBuild);
+    T_NOT_NULL(a);
+    T_ASSERT(a == FindAbilityByClassname(STR_CmdBuild));
+    T_EQ(GetAbilityIndex(a), FindAbilityIndex(STR_CmdBuild));
+}
+
 TEST(wc3_combat, find_ability_unknown_returns_null) {
     ability_t const *a = FindAbilityByClassname("NotAnAbility");
     T_NULL(a);
@@ -713,7 +721,7 @@ TEST(wc3_combat, registered_reference_ability_codes) {
 }
 
 static const char slk_ability_helpers[] =
-    "ID;PWXL;N;EBB;Y3;X13\n"
+    "ID;PWXL;N;EBB;Y4;X13\n"
     "C;Y1;X1;K\"alias\"\n"
     "C;Y1;X2;K\"code\"\n"
     "C;Y1;X3;K\"targs\"\n"
@@ -745,7 +753,21 @@ static const char slk_ability_helpers[] =
     "C;Y3;X7;K\"75\"\n"
     "C;Y3;X9;K\"2\"\n"
     "C;Y3;X10;K\"hwat\"\n"
+    "C;Y4;X1;K\"Ahrp\"\n"
+    "C;Y4;X2;K\"Arep\"\n"
     "E\n";
+
+TEST(wc3_combat, command_lookup_resolves_fourcc_ability_alias) {
+    slkTestData_t *rows = parse_slk_string(slk_ability_helpers);
+    slkTestData_t *old_abilities = G_SetSLKRows("AbilityData", rows);
+    ability_t const *resolved = FindAbilityForCommand("Ahrp");
+
+    T_NOT_NULL(resolved);
+    T_ASSERT(resolved == FindAbilityByClassname("Arep"));
+
+    G_SetSLKRows("AbilityData", old_abilities);
+    free_slk_rows(rows);
+}
 
 static const char slk_ability_helpers_roc[] =
     "ID;PWXL;N;EBB;Y3;X4\n"

--- a/games/warcraft-3/game/tests/t_jass_map.c
+++ b/games/warcraft-3/game/tests/t_jass_map.c
@@ -128,6 +128,21 @@ TEST(wc3_jass_map, map_metadata_and_start_priority_persist) {
     T_STREQ(level.setup.description, "Native setup state");
 }
 
+TEST(wc3_jass_map, player_technology_roundtrip_uses_declared_types) {
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  call SetPlayerTechMaxAllowed(Player(0), 123456, 3)\n"
+        "  call SetPlayerTechResearched(Player(0), 123456, 1)\n"
+        "  call AddPlayerTechResearched(Player(0), 123456, 1)\n"
+        "  call BJassAssert(GetPlayerTechMaxAllowed(Player(0), 123456) == 3, \"tech maximum\")\n"
+        "  call BJassAssert(GetPlayerTechResearched(Player(0), 123456, true), \"tech researched boolean\")\n"
+        "  call BJassAssert(GetPlayerTechCount(Player(0), 123456, true) == 2, \"tech level count\")\n"
+        "  call SetPlayerTechResearched(Player(0), 123456, 0)\n"
+        "  call BJassAssert(not GetPlayerTechResearched(Player(0), 123456, false), \"tech researched cleared\")\n"
+        "endfunction\n"
+    ));
+}
+
 TEST(wc3_jass_map, player_configuration_roundtrip) {
     T_ASSERT(run_test_jass(
         "function main takes nothing returns nothing\n"

--- a/games/warcraft-3/tests/resources-src/Scripts/common.j
+++ b/games/warcraft-3/tests/resources-src/Scripts/common.j
@@ -98,7 +98,7 @@ native SetPlayerTechMaxAllowed takes player whichPlayer, integer techid, integer
 native GetPlayerTechMaxAllowed takes player whichPlayer, integer techid returns integer
 native AddPlayerTechResearched takes player whichPlayer, integer techid, integer levels returns nothing
 native SetPlayerTechResearched takes player whichPlayer, integer techid, integer setToLevel returns nothing
-native GetPlayerTechResearched takes player whichPlayer, integer techid, boolean specificonly returns integer
+native GetPlayerTechResearched takes player whichPlayer, integer techid, boolean specificonly returns boolean
 native GetPlayerTechCount      takes player whichPlayer, integer techid, boolean specificonly returns integer
 native SetPlayerOnScoreScreen takes player whichPlayer, boolean flag returns nothing
 native Rect                   takes real minx, real miny, real maxx, real maxy returns rect

--- a/games/warcraft-3/tests/resources-src/Scripts/common.j
+++ b/games/warcraft-3/tests/resources-src/Scripts/common.j
@@ -94,6 +94,12 @@ native SetPlayerHandicap     takes player whichPlayer, real handicap returns not
 native GetPlayerHandicap     takes player whichPlayer returns real
 native SetPlayerHandicapXP   takes player whichPlayer, real handicap returns nothing
 native GetPlayerHandicapXP   takes player whichPlayer returns real
+native SetPlayerTechMaxAllowed takes player whichPlayer, integer techid, integer maximum returns nothing
+native GetPlayerTechMaxAllowed takes player whichPlayer, integer techid returns integer
+native AddPlayerTechResearched takes player whichPlayer, integer techid, integer levels returns nothing
+native SetPlayerTechResearched takes player whichPlayer, integer techid, integer setToLevel returns nothing
+native GetPlayerTechResearched takes player whichPlayer, integer techid, boolean specificonly returns integer
+native GetPlayerTechCount      takes player whichPlayer, integer techid, boolean specificonly returns integer
 native SetPlayerOnScoreScreen takes player whichPlayer, boolean flag returns nothing
 native Rect                   takes real minx, real miny, real maxx, real maxy returns rect
 native CreateRegion           takes nothing returns region

--- a/server/game.h
+++ b/server/game.h
@@ -84,6 +84,7 @@ typedef struct {
     BYTE y;
     BYTE research;
     BYTE active;
+    BYTE disabled;
     FLOAT cooldown; /* fraction of the ability's cooldown still remaining (0=ready, 1=just used) */
     FLOAT manacost; /* mana cost to cast this ability at its current level (0 if not a spell) */
 } gameCommandButton_t;

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -868,6 +868,29 @@ TEST(net, entity_delta_preserves_large_wc3_radii) {
     }
 }
 
+/* Building placement cursor metadata must survive svc_cursor entity deltas without
+ * overloading world-position fields. */
+TEST(net, entity_delta_preserves_pathing_dimensions) {
+    BYTE buf[256];
+    sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
+    entityState_t from = { 0 };
+    entityState_t to = { .number = 9, .model = 1, .pathing_width = 6, .pathing_height = 4 };
+    entityState_t out = { 0 };
+    DWORD bits = 0;
+    int number;
+
+    MSG_WriteDeltaEntity(&sb, &from, &to, true);
+    sb.readcount = 0;
+    number = MSG_ReadEntityBits(&sb, &bits);
+    MSG_ReadDeltaEntity(&sb, &out, number, bits);
+
+    T_EQ(number, 9);
+    T_EQ(out.pathing_width, 6);
+    T_EQ(out.pathing_height, 4);
+    T_FEQ(out.origin.x, 0.0f, 0.001f);
+    T_FEQ(out.origin.y, 0.0f, 0.001f);
+}
+
 /* Dead destructable remains rely on EF_NOT_SELECTABLE surviving snapshots, so
  * guard its round trip explicitly. */
 TEST(net, entity_delta_preserves_not_selectable_flag) {


### PR DESCRIPTION
fix for clicking the build button in peasant didn't do anything

in commit 2 - this implements enough that you can complete the main quest and see the second cut scene :)

also added hiding buildings that you can't build - wc3_build_all cmd line to enable all buildings  

a whole bunch of building related fixes e.g.  not building where other things exist and checking before peasant gets there

checking if humans can repair while building - but repair is still broken