### PR TITLE
Lumber logic fixes

### DIFF
--- a/docs/games/warcraft-3/architecture/ability-coverage.md
+++ b/docs/games/warcraft-3/architecture/ability-coverage.md
@@ -91,8 +91,8 @@ generic `Button` command path rather than by a registered ability code.
 | `Abgm` | Blighted Gold Mine | TODO | Needs undead mine variant. |
 | `Abli` | Blight | TODO | Needs blight placement/spread and terrain interaction. |
 | `Aaha` | Acolyte Harvest | TODO | Needs undead gold harvesting behavior. |
-| `Artn` | Return Resources | Partial | Drop-off eligibility is ability-driven (`Argd`/`Arlm`/`Argl` plus `Artn`-derived data), with nearest compatible selection and retargeting; the carried-resource command/state still lives in harvest state machines. |
-| `Ahar` | Harvest | Partial | Local worker harvest exists, but not as the same split data model as the ability data. |
+| `Artn` | Return Resources | Partial | Drop-off eligibility is ability-driven (`Argd`/`Arlm`/`Argl` plus `Artn`-derived data), with nearest compatible selection, destroyed-target retargeting, explicit Smart-click return, and no-target return through the worker Harvest command; carried-resource state still lives in the harvest state machines. |
+| `Ahar` | Harvest | Partial | Human worker harvest/return gameplay exists, including capacity clamping and same-forest resume after a dead remembered tree, but not as the same split data model as the ability data; command-card art/text does not yet model the carried-state presentation separately. |
 | `Awha` | Wisp Harvest | TODO | Needs wisp-specific gather behavior. |
 | `Ahrl` | Harvest Lumber | Partial | Local lumber harvest is under `Ahar`; `Ahrl` is not registered. |
 | `ANcl` | Channel test | Stub | Opens cancel mode as a generic channel scaffold. |

--- a/docs/games/warcraft-3/architecture/roc-ability-checklist.md
+++ b/docs/games/warcraft-3/architecture/roc-ability-checklist.md
@@ -224,7 +224,7 @@ ROC totals: 397 ability aliases, 244 unique base codes.
 | `TODO` | `Aroa` | Item | Roar | Aroa, ACro, AIrr |  |
 | `Partial` | `Aroo` | Unit/Common | Root (Ancients) | Aro1, Aro2 | Basic rooted movement toggle exists. |
 | `Stub` | `Arst` | Unit/Common | Restoration | Arst | Registered repair variant stub. |
-| `Partial` | `Artn` | Unit/Common | Return (Gold) | Argd, Argl, Arlm | Drop-off capability, nearest compatible selection, and retargeting are implemented; command/carry state remains in harvest state machines. |
+| `Partial` | `Artn` | Unit/Common | Return (Gold) | Argd, Argl, Arlm | Drop-off capability, nearest compatible selection, destroyed-target retargeting, explicit Smart-click return, and no-target return through `Ahar` are implemented; carried-resource state remains in harvest state machines. |
 | `TODO` | `Asac` | Unit/Common | Sacrifice (Sacrificial Pit) | Asac |  |
 | `TODO` | `Asal` | Unit/Common | Pillage | Asal |  |
 | `TODO` | `Asds` | Unit/Common | Self Destruct | Asds |  |

--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -6,7 +6,7 @@
 The Gather command reaches the same state machines through `harvest_menu_selecttarget`.
 
 - Gold: `harvest_gold_start` -> walk to mine -> capacity-gated hidden mining wait -> carry finite mine gold -> nearest live same-owner drop-off accepting gold -> deposit -> resume the mine while it remains harvestable.
-- Lumber: `harvest_start` -> walk into `HARVEST_RANGE` -> swing/damage -> carry lumber -> nearest live same-owner drop-off accepting lumber -> deposit -> resume or find another tree.
+- Lumber: `harvest_start` -> walk into `HARVEST_RANGE` -> swing/damage -> carry lumber -> nearest live same-owner drop-off accepting lumber -> deposit -> resume or find another tree. Successful chops clamp carried lumber to `HARVEST_LUMBER_CAPACITY`; a tree that cannot take damage (for example an invulnerable destructible) does not award lumber.
 - If an explicitly clicked live tree is buried behind other trees, routing remains responsible only for reaching the best legal approach.  Once that route is exhausted outside `HARVEST_RANGE`, Harvest selects a reachable replacement tree and continues lumber work, matching retail behavior.  See [WC3 Pathfinding And Harvest Reachability](pathfinding.md).
 - `s_goldmine.c` uses the mine's authored no-walk pathing footprint plus the worker radius and one movement step as the primary entry boundary. A collision-circle contact check remains the fallback for mines without a path texture. Mine footprints are authoritative; do not restore the old fixed 180-unit radius.
 - A chop is lethal when tree life is less than or equal to `HARVEST_TREE_DAMAGE`. The lethal path must call `tree->die` because
@@ -63,6 +63,8 @@ route lengths. A Human Lumber Mill therefore competes with a Town Hall for lumbe
 while a Lumber Mill remains ineligible for gold.
 
 Return completion is footprint-aware for buildings that expose an authored pathing texture. The worker deposits when its collision radius plus one simulation step reaches the building's no-walk footprint; the older worker+building collision+step test remains the fallback when no path texture is available. This prevents a Peasant carrying gold from stopping at a Town Hall corner while still outside the scalar centre-circle threshold. The return move revalidates its target before each movement/deposit tick. If the selected drop-off dies, is removed, changes owner, or no longer exposes a compatible Return Resources ability, the worker retargets the nearest remaining compatible drop-off. If none exists, the worker stands while preserving the carried resource and carry visual.
+
+A worker carrying lumber or gold may explicitly Smart/right-click a compatible return building; that exact clicked building becomes the initial return target rather than being replaced immediately by the nearest candidate. Activating the stock worker `Ahar` command while the main selected worker is carrying resources performs the same no-target Return Resources action instead of entering Harvest target-selection mode. The current command-card presentation still comes from `Ahar`; this is the gameplay/order toggle, not a separate UI-art implementation.
 
 ### Mine Entry — Collision Formula
 
@@ -159,16 +161,11 @@ placement succeeds. Scripted `CreateUnit` coordinates and the separate resource-
 
 ### Lumber gather cycle
 
-Each swing does `HARVEST_TREE_DAMAGE` (slot 1 = 1) HP of damage to the tree and adds the same amount
-as lumber. Capacity (`HARVEST_LUMBER_CAPACITY`, slot 2 = 10) fills after 10 swings, triggering
-`harvest_walkback`. When a tree's HP reaches zero on the lethal chop, `tree->die()` is called
+Each successful swing does `HARVEST_TREE_DAMAGE` (slot 1 = 1) HP of damage to the tree and adds the same amount as lumber, clamped to `HARVEST_LUMBER_CAPACITY`. A rejected destructible hit (including invulnerability) leaves carried lumber unchanged. Capacity (`HARVEST_LUMBER_CAPACITY`, slot 2 = 10) fills after 10 stock swings, triggering `harvest_walkback`; reissuing Harvest while already full remembers the requested tree and returns before another chop. When a tree's HP reaches zero on the lethal chop, `tree->die()` is called
 (m_tree.c owns the fall animation and pathing removal). `tree_die` sets the death sequence and its
 first frame in the same transition, so the lethal snapshot cannot retain the upright hit frame.
 
-The return transition first selects the nearest compatible return building and revalidates it while travelling. The deposit
-transition then validates `secondarygoal` before publishing resume. A dead tree is replaced
-with the nearest live tree; if none exists, the worker stands. Therefore `RESUME_LUMBER` always names
-a live target and a worker never spends a movement tick targeting the tree it just felled.
+The automatic return transition first selects the nearest compatible return building and revalidates it while travelling; an explicit Smart/right-click return instead starts with the compatible building the player selected. The deposit transition then validates `secondarygoal` before publishing resume. A still-live remembered tree is resumed directly. If that tree died while the worker was away, replacement selection is centered on the dead tree's position so the worker stays in the same forest; only a return with no remembered tree searches around the worker. If no live tree exists, the worker stands. Therefore `RESUME_LUMBER` always names a live target and a worker never spends a movement tick targeting the tree it just felled.
 
 ### Gameplay message stream
 
@@ -277,7 +274,7 @@ make test-wc3-engine WC3_PATTERN='wc3_game.overhead_*'
 The movement suite covers large-footprint mine entry, mine entry through an authored blocking pathing footprint, the complete gold
 deposit/resume cycle, stock capacity 1 under six assigned workers, independent custom mine capacities/durations, non-orderable inside
 miners, finite-gold depletion and partial final trips,
-trained-unit exit placement against static footprints, nearest compatible lumber drop-off selection, lumber return through an authored
-blocking Town Hall footprint, rejection of lumber-only drop-offs for gold, drop-off destruction retargeting, exact lethal tree trips with next-tree selection, the no-live-tree stop path,
+trained-unit exit placement against static footprints, nearest compatible lumber drop-off selection, explicit Smart-click drop-off return, lumber return through an authored
+blocking Town Hall footprint, rejection of lumber-only drop-offs for gold, drop-off destruction retargeting, exact lethal tree trips with next-tree selection, dead-previous-tree same-forest retargeting, the no-live-tree stop path, capacity clamping, invulnerable-tree rejection,
 non-lethal chops, and both sides of the immobility contract. The in-engine fixture
 `games/warcraft-3/tests/resources-src/Units/UnitUI.slk` supplies `isbldg` for the same metadata lookup used by the game.

--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -7,6 +7,7 @@ The Gather command reaches the same state machines through `harvest_menu_selectt
 
 - Gold: `harvest_gold_start` -> walk to mine -> capacity-gated hidden mining wait -> carry finite mine gold -> nearest live same-owner drop-off accepting gold -> deposit -> resume the mine while it remains harvestable.
 - Lumber: `harvest_start` -> walk into `HARVEST_RANGE` -> swing/damage -> carry lumber -> nearest live same-owner drop-off accepting lumber -> deposit -> resume or find another tree. Successful chops clamp carried lumber to `HARVEST_LUMBER_CAPACITY`; a tree that cannot take damage (for example an invulnerable destructible) does not award lumber.
+- Carried resources are mutually exclusive presentation/gameplay state: collecting gold clears stale carried lumber and its `RF_HAS_LUMBER` tag; collecting lumber clears stale carried gold and `RF_HAS_GOLD`. Depositing clears both carry counters/tags, so a worker carrying nothing uses its ordinary animation set rather than retaining a lumber/gold carry model.
 - If an explicitly clicked live tree is buried behind other trees, routing remains responsible only for reaching the best legal approach.  Once that route is exhausted outside `HARVEST_RANGE`, Harvest selects a reachable replacement tree and continues lumber work, matching retail behavior.  See [WC3 Pathfinding And Harvest Reachability](pathfinding.md).
 - `s_goldmine.c` uses the mine's authored no-walk pathing footprint plus the worker radius and one movement step as the primary entry boundary. A collision-circle contact check remains the fallback for mines without a path texture. Mine footprints are authoritative; do not restore the old fixed 180-unit radius.
 - A chop is lethal when tree life is less than or equal to `HARVEST_TREE_DAMAGE`. The lethal path must call `tree->die` because
@@ -275,6 +276,6 @@ The movement suite covers large-footprint mine entry, mine entry through an auth
 deposit/resume cycle, stock capacity 1 under six assigned workers, independent custom mine capacities/durations, non-orderable inside
 miners, finite-gold depletion and partial final trips,
 trained-unit exit placement against static footprints, nearest compatible lumber drop-off selection, explicit Smart-click drop-off return, lumber return through an authored
-blocking Town Hall footprint, rejection of lumber-only drop-offs for gold, drop-off destruction retargeting, exact lethal tree trips with next-tree selection, dead-previous-tree same-forest retargeting, the no-live-tree stop path, capacity clamping, invulnerable-tree rejection,
+blocking Town Hall footprint, rejection of lumber-only drop-offs for gold, drop-off destruction retargeting, exact lethal tree trips with next-tree selection, dead-previous-tree same-forest retargeting, the no-live-tree stop path, capacity clamping, invulnerable-tree rejection, carried-resource gold/lumber visual switching and zero-carry visual clearing,
 non-lethal chops, and both sides of the immobility contract. The in-engine fixture
 `games/warcraft-3/tests/resources-src/Units/UnitUI.slk` supplies `isbldg` for the same metadata lookup used by the game.

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -1146,6 +1146,8 @@ void S_GoldMineInitUnit(LPEDICT);
 void S_GoldMineReleaseWorker(LPEDICT);
 void harvest_start(LPEDICT, LPEDICT);
 void harvest_gold_start(LPEDICT, LPEDICT);
+BOOL harvest_lumber_return_to(LPEDICT, LPEDICT);
+BOOL harvest_gold_return_to(LPEDICT, LPEDICT);
 void cargo_drop_all(LPEDICT);
 void blight_mine_think(LPEDICT);
 BOOL move_selectlocation(LPEDICT, LPCVECTOR2);

--- a/games/warcraft-3/game/m_unit.c
+++ b/games/warcraft-3/game/m_unit.c
@@ -151,6 +151,8 @@ BOOL unit_issuetargetorder(LPEDICT self, LPCSTR order, LPEDICT target) {
                 return true;
             }
             if (target->targtype == TARG_TREE) {
+                if (self->harvested_lumber > 0 || self->harvested_gold > 0)
+                    return false;
                 harvest_start(self, target);
                 return true;
             }

--- a/games/warcraft-3/game/m_unit.c
+++ b/games/warcraft-3/game/m_unit.c
@@ -142,6 +142,10 @@ BOOL unit_issuetargetorder(LPEDICT self, LPCSTR order, LPEDICT target) {
             return G_OrderPickupItem(self, target);
         }
         if (G_ActorHasSkill(self, "Ahar")) {
+            if (self->harvested_lumber > 0 && harvest_lumber_return_to(self, target))
+                return true;
+            if (self->harvested_gold > 0 && harvest_gold_return_to(self, target))
+                return true;
             if (S_GoldMineIsMine(target)) {
                 harvest_gold_start(self, target);
                 return true;

--- a/games/warcraft-3/game/skills/s_goldmine.c
+++ b/games/warcraft-3/game/skills/s_goldmine.c
@@ -247,8 +247,7 @@ static void ai_goldmine_walkback(LPEDICT ent) {
                     ent->s.number, dropoff->s.number,
                     ent->goalentity ? ent->goalentity->s.number : -1,
                     ent->harvested_gold);
-        ent->s.renderfx &= ~RF_HAS_GOLD;
-        ent->harvested_gold = 0;
+        S_SetCarriedResource(ent, RETURN_RESOURCE_GOLD, 0);
         if (S_GoldMineCanHarvest(ent->goalentity)) {
             G_PublishMessage(ent, GAME_MSG_HARVEST_RESUME_GOLD, ent->goalentity);
             harvestgold_walk(ent);
@@ -362,8 +361,7 @@ void harvestgold_walkback(LPEDICT ent) {
         return;
     }
 
-    ent->s.renderfx |= RF_HAS_GOLD;
-    ent->harvested_gold += amount;
+    S_SetCarriedResource(ent, RETURN_RESOURCE_GOLD, ent->harvested_gold + amount);
     LPEDICT dropoff = S_FindNearestResourceDropoff(ent, RETURN_RESOURCE_GOLD);
     if (dropoff) {
         if (goldmine_path_debug_level() >= 1)

--- a/games/warcraft-3/game/skills/s_goldmine.c
+++ b/games/warcraft-3/game/skills/s_goldmine.c
@@ -282,6 +282,18 @@ static umove_t harvestgold_move_walkback = { "walk", ai_goldmine_walkback, NULL,
 static umove_t harvestgold_move_minegold = { "attack", ai_minegold, NULL, &a_goldmine };
 static umove_t harvestgold_move_wait = { "stand", ai_waittoenter, NULL, &a_goldmine };
 
+BOOL harvest_gold_return_to(LPEDICT ent, LPEDICT dropoff) {
+    if (!ent || !dropoff || !ent->harvested_gold ||
+        !S_CanReturnResourceAt(ent, dropoff, RETURN_RESOURCE_GOLD)) {
+        return false;
+    }
+
+    G_PublishMessage(ent, GAME_MSG_HARVEST_RETURN_GOLD, dropoff);
+    ent->goalentity = dropoff;
+    unit_setmove(ent, &harvestgold_move_walkback);
+    return true;
+}
+
 void harvestgold_walk(LPEDICT ent) {
     unit_setmove(ent, &harvestgold_move_walk);
 }

--- a/games/warcraft-3/game/skills/s_harvest_lumber.c
+++ b/games/warcraft-3/game/skills/s_harvest_lumber.c
@@ -90,20 +90,30 @@ LPEDICT S_FindNearestResourceDropoff(LPEDICT unit, returnResource_t resource) {
     return best;
 }
 
-static LPEDICT find_another_tree(LPEDICT ent) {
+static LPEDICT find_another_tree_near(LPCVECTOR2 origin) {
     FLOAT min_dist = HARVEST_SEARCH_RANGE;
     LPEDICT other = NULL;
+
+    if (!origin)
+        return NULL;
+
     FOR_LOOP(i, globals.num_edicts) {
-        LPEDICT tree = globals.edicts+i;
+        LPEDICT tree = globals.edicts + i;
+        FLOAT dist;
+
         if (tree->targtype != TARG_TREE || M_IsDead(tree))
             continue;
-        FLOAT dist = Vector2_distance(&ent->s.origin2, &tree->s.origin2);
+        dist = Vector2_distance(origin, &tree->s.origin2);
         if (dist < min_dist) {
             other = tree;
             min_dist = dist;
         }
     }
     return other;
+}
+
+static LPEDICT find_another_tree(LPEDICT ent) {
+    return ent ? find_another_tree_near(&ent->s.origin2) : NULL;
 }
 
 /* Retail WC3 continues lumber work when the explicitly clicked tree is alive
@@ -271,7 +281,9 @@ static void ai_harvest_walkback(LPEDICT ent) {
         /* Resolve the next live tree at the deposit boundary.  Resuming with
          * the felled tree left it as the worker's active goal for another tick. */
         LPEDICT tree = ent->secondarygoal;
-        if (!tree || M_IsDead(tree))
+        if (tree && M_IsDead(tree))
+            tree = find_another_tree_near(&tree->s.origin2);
+        else if (!tree)
             tree = find_another_tree(ent);
         ent->goalentity = ent->secondarygoal = tree;
         if (tree) {
@@ -288,13 +300,21 @@ static void ai_harvest_walkback(LPEDICT ent) {
 
 static void ai_chop(LPEDICT ent) {
     LPEDICT tree = ent->secondarygoal;
+    BOOL const valid_hit = tree && G_IsDestructable(tree) && !M_IsDead(tree) &&
+                           !tree->invulnerable && HARVEST_TREE_DAMAGE > 0.0f;
+    BOOL felled = false;
 
     G_PublishMessage(ent, GAME_MSG_HARVEST_CHOP, tree);
-    if (tree && !M_IsDead(tree)) {
-        ent->harvested_lumber += HARVEST_TREE_DAMAGE;
-        ent->s.renderfx |= RF_HAS_LUMBER;
+    if (valid_hit) {
+        FLOAT const carried = MIN((FLOAT)ent->harvested_lumber + HARVEST_TREE_DAMAGE,
+                                  HARVEST_LUMBER_CAPACITY);
+
+        felled = G_DestructableApplyDamage(tree, ent, HARVEST_TREE_DAMAGE);
+        if (carried > ent->harvested_lumber) {
+            ent->harvested_lumber = (DWORD)carried;
+            ent->s.renderfx |= RF_HAS_LUMBER;
+        }
     }
-    BOOL felled = G_DestructableApplyDamage(tree, ent, HARVEST_TREE_DAMAGE);
     /* Tree-fall supersedes chop: play one-shot EV_ATTACK sound for all clients. */
     if (felled && g_numTreeFallSounds) {
         G_PublishMessage(ent, GAME_MSG_HARVEST_TREE_FELLED, tree);
@@ -339,22 +359,33 @@ void harvest_swing(LPEDICT ent) {
     ent->wait = ent->UnitWeapons->attack1.damagePoint;
 }
 
+BOOL harvest_lumber_return_to(LPEDICT ent, LPEDICT dropoff) {
+    if (!ent || !dropoff || !ent->harvested_lumber ||
+        !S_CanReturnResourceAt(ent, dropoff, RETURN_RESOURCE_LUMBER)) {
+        return false;
+    }
+
+    G_PublishMessage(ent, GAME_MSG_HARVEST_RETURN_LUMBER, dropoff);
+    ent->goalentity = dropoff;
+    unit_setmove(ent, &harvest_move_walkback);
+    return true;
+}
+
 void harvest_walkback(LPEDICT ent) {
     LPEDICT dropoff = S_FindNearestResourceDropoff(ent, RETURN_RESOURCE_LUMBER);
-    if (dropoff) {
-        G_PublishMessage(ent, GAME_MSG_HARVEST_RETURN_LUMBER, dropoff);
-        ent->goalentity = dropoff;
-        unit_setmove(ent, &harvest_move_walkback);
-    } else {
+    if (!harvest_lumber_return_to(ent, dropoff))
         ent->stand(ent);
-    }
 }
 
 void CMD_Harvest(LPEDICT ent);
 
 void harvest_start(LPEDICT self, LPEDICT target) {
-    self->goalentity = target;
     self->secondarygoal = target;
+    if (self->harvested_lumber >= HARVEST_LUMBER_CAPACITY && self->harvested_lumber > 0) {
+        harvest_walkback(self);
+        return;
+    }
+    self->goalentity = target;
     move_reset_progress(self);
     HARVEST_PATH_LOG(1,
         "start worker=%d target=%d worker_pos=(%.1f,%.1f) target_pos=(%.1f,%.1f)\n",
@@ -450,8 +481,12 @@ ability_t a_acolyte_harvest = {
 /* ---- Return Resources: standalone command to deposit carried resources --- */
 static void return_resources_command(LPEDICT clent) {
     FOR_SELECTED_UNITS(clent->client, ent) {
-        if (ent->harvested_lumber > 0 || ent->harvested_gold > 0) {
+        if (ent->harvested_lumber > 0) {
             harvest_walkback(ent);
+        } else if (ent->harvested_gold > 0) {
+            LPEDICT dropoff = S_FindNearestResourceDropoff(ent, RETURN_RESOURCE_GOLD);
+            if (!harvest_gold_return_to(ent, dropoff))
+                ent->stand(ent);
         }
     }
 }
@@ -479,6 +514,16 @@ BOOL harvest_menu_selecttarget(LPEDICT clent, LPEDICT target) {
 }
 
 void harvest_command(LPEDICT ent) {
+    LPEDICT selected = G_GetMainSelectedUnit(ent->client);
+
+    /* Ahar is the worker's visible command in stock unit data. While the main
+     * selected worker carries resources, activating it performs the same
+     * no-target Return Resources behavior instead of entering target mode. */
+    if (selected && (selected->harvested_lumber > 0 || selected->harvested_gold > 0)) {
+        return_resources_command(ent);
+        return;
+    }
+
     UI_AddCancelButton(ent);
     ent->client->menu.on_entity_selected = harvest_menu_selecttarget;
 }

--- a/games/warcraft-3/game/skills/s_harvest_lumber.c
+++ b/games/warcraft-3/game/skills/s_harvest_lumber.c
@@ -71,6 +71,29 @@ BOOL S_CanReturnResourceAt(LPEDICT unit, LPEDICT building, returnResource_t reso
     return false;
 }
 
+void S_SetCarriedResource(LPEDICT unit, returnResource_t resource, DWORD amount) {
+    if (!unit)
+        return;
+
+    /* A worker carries exactly one visible resource type.  Keep the gameplay
+     * counters and renderer flags in one transition so stale lumber/gold tags
+     * cannot survive a resource switch or completed deposit. */
+    unit->harvested_gold = 0;
+    unit->harvested_lumber = 0;
+    unit->s.renderfx &= ~(RF_HAS_GOLD | RF_HAS_LUMBER);
+
+    if (!amount)
+        return;
+
+    if (resource == RETURN_RESOURCE_GOLD) {
+        unit->harvested_gold = amount;
+        unit->s.renderfx |= RF_HAS_GOLD;
+    } else if (resource == RETURN_RESOURCE_LUMBER) {
+        unit->harvested_lumber = amount;
+        unit->s.renderfx |= RF_HAS_LUMBER;
+    }
+}
+
 LPEDICT S_FindNearestResourceDropoff(LPEDICT unit, returnResource_t resource) {
     LPEDICT best = NULL;
     FLOAT best_dist = 0;
@@ -276,8 +299,7 @@ static void ai_harvest_walkback(LPEDICT ent) {
         if (player) {
             player->stats[PLAYERSTATE_RESOURCE_LUMBER] += ent->harvested_lumber;
         }
-        ent->s.renderfx &= ~RF_HAS_LUMBER;
-        ent->harvested_lumber = 0;
+        S_SetCarriedResource(ent, RETURN_RESOURCE_LUMBER, 0);
         /* Resolve the next live tree at the deposit boundary.  Resuming with
          * the felled tree left it as the worker's active goal for another tick. */
         LPEDICT tree = ent->secondarygoal;
@@ -310,10 +332,8 @@ static void ai_chop(LPEDICT ent) {
                                   HARVEST_LUMBER_CAPACITY);
 
         felled = G_DestructableApplyDamage(tree, ent, HARVEST_TREE_DAMAGE);
-        if (carried > ent->harvested_lumber) {
-            ent->harvested_lumber = (DWORD)carried;
-            ent->s.renderfx |= RF_HAS_LUMBER;
-        }
+        if (carried > ent->harvested_lumber)
+            S_SetCarriedResource(ent, RETURN_RESOURCE_LUMBER, (DWORD)carried);
     }
     /* Tree-fall supersedes chop: play one-shot EV_ATTACK sound for all clients. */
     if (felled && g_numTreeFallSounds) {

--- a/games/warcraft-3/game/skills/s_skills.h
+++ b/games/warcraft-3/game/skills/s_skills.h
@@ -82,6 +82,7 @@ typedef enum {
 
 BOOL S_CanReturnResourceAt(LPEDICT unit, LPEDICT building, returnResource_t resource);
 LPEDICT S_FindNearestResourceDropoff(LPEDICT unit, returnResource_t resource);
+void S_SetCarriedResource(LPEDICT unit, returnResource_t resource, DWORD amount);
 
 typedef enum {
 	ABILITY_NUMBER_CAST,

--- a/games/warcraft-3/game/tests/t_movement.c
+++ b/games/warcraft-3/game/tests/t_movement.c
@@ -527,6 +527,21 @@ TEST(wc3_movement, lumber_chop_replaces_gold_carry_state) {
     T_ASSERT(worker->s.renderfx & RF_HAS_LUMBER);
 }
 
+/* A worker carrying gold must not discard it when Smart-clicking a tree. */
+TEST(wc3_movement, lumber_smart_click_preserves_gold_carry) {
+    LPEDICT worker = make_moving_unit(0.0f, 0.0f);
+    LPEDICT tree = make_harvest_tree(20.0f, 0.0f, 100.0f);
+
+    worker->UnitAbilities = &harvest_abilities;
+    worker->harvested_gold = 7;
+    worker->s.renderfx |= RF_HAS_GOLD;
+
+    T_ASSERT(!unit_issuetargetorder(worker, "smart", tree));
+    T_EQ(worker->harvested_gold, 7);
+    T_ASSERT(worker->s.renderfx & RF_HAS_GOLD);
+    T_NULL(worker->goalentity);
+}
+
 /* Reissuing Harvest while already full remembers the requested tree but begins
  * return immediately, so no extra over-capacity chop can occur. */
 TEST(wc3_movement, lumber_full_worker_returns_before_new_chop) {

--- a/games/warcraft-3/game/tests/t_movement.c
+++ b/games/warcraft-3/game/tests/t_movement.c
@@ -501,6 +501,30 @@ TEST(wc3_movement, lumber_invulnerable_tree_does_not_award_lumber) {
     T_ASSERT(!(worker->s.renderfx & RF_HAS_LUMBER));
 }
 
+/* A worker has one carried-resource presentation.  Starting to collect lumber
+ * after gold must replace the gold bag rather than leaving both carry flags set. */
+TEST(wc3_movement, lumber_chop_replaces_gold_carry_state) {
+    LPEDICT worker = make_moving_unit(0.0f, 0.0f);
+    LPEDICT tree = make_harvest_tree(20.0f, 0.0f, 100.0f);
+
+    worker->attack1.damagePoint = 0.01f;
+    worker->harvested_gold = 7;
+    worker->s.renderfx |= RF_HAS_GOLD;
+    HARVEST_RANGE = 64.0f;
+    HARVEST_TREE_DAMAGE = 1.0f;
+    HARVEST_LUMBER_CAPACITY = 10.0f;
+
+    harvest_start(worker, tree);
+    worker->currentmove->think(worker);
+    worker->wait = 0.01f;
+    worker->currentmove->think(worker);
+
+    T_EQ(worker->harvested_gold, 0);
+    T_EQ(worker->harvested_lumber, 1);
+    T_ASSERT(!(worker->s.renderfx & RF_HAS_GOLD));
+    T_ASSERT(worker->s.renderfx & RF_HAS_LUMBER);
+}
+
 /* Reissuing Harvest while already full remembers the requested tree but begins
  * return immediately, so no extra over-capacity chop can occur. */
 TEST(wc3_movement, lumber_full_worker_returns_before_new_chop) {
@@ -687,11 +711,14 @@ TEST(wc3_movement, lumber_return_deposits_at_next_step_contact) {
     harvest_walkback(worker);
     T_ASSERT(M_DistanceToGoal(worker) > worker->collision + hall->collision + 5.0f);
     T_ASSERT(M_DistanceToGoal(worker) <= worker->collision + hall->collision + unit_movedistance(worker));
+    worker->s.renderfx |= RF_HAS_GOLD; /* stale opposite carry tag must not survive deposit */
     worker->currentmove->think(worker);
 
     T_EQ(game.clients[0].ps.stats[PLAYERSTATE_RESOURCE_LUMBER], old_lumber + 10);
     T_EQ(worker->harvested_lumber, 0);
+    T_EQ(worker->harvested_gold, 0);
     T_ASSERT(!(worker->s.renderfx & RF_HAS_LUMBER));
+    T_ASSERT(!(worker->s.renderfx & RF_HAS_GOLD));
     T_ASSERT(worker->goalentity == tree);
 }
 
@@ -916,6 +943,32 @@ TEST(wc3_movement, gold_worker_deposits_and_resumes_mining) {
     free_slk_rows(rows);
 }
 
+/* Gold pickup replaces a prior lumber carry state.  RF_HAS_LUMBER used to
+ * survive here, and the renderer checks lumber before gold, so the Peasant
+ * continued to display the lumber-carry model while actually carrying gold. */
+TEST(wc3_movement, gold_pickup_replaces_lumber_carry_state) {
+    LPEDICT worker = make_moving_unit(0.0f, 0.0f);
+    LPEDICT mine = alloc_test_unit(MAKEFOURCC('n','g','o','l'), 0.0f, 0.0f);
+    slkTestData_t *rows, *old_abilities = install_goldmine_test_data(&rows);
+
+    setup_test_goldmine(mine, &test_goldmine_cap1, 100);
+    gi.LinkEntity(mine);
+    HARVEST_GOLD_CAPACITY = 10.0f;
+    worker->harvested_lumber = 5;
+    worker->s.renderfx |= RF_HAS_LUMBER;
+    worker->goalentity = worker->secondarygoal = mine;
+
+    harvestgold_minegold(worker);
+    harvestgold_walkback(worker);
+
+    T_EQ(worker->harvested_lumber, 0);
+    T_EQ(worker->harvested_gold, 10);
+    T_ASSERT(!(worker->s.renderfx & RF_HAS_LUMBER));
+    T_ASSERT(worker->s.renderfx & RF_HAS_GOLD);
+    G_SetSLKRows("AbilityData", old_abilities);
+    free_slk_rows(rows);
+}
+
 /* A large Town Hall footprint can block the next step before the old +5u
  * deposit tolerance is reached. The interaction must complete at contact plus
  * one simulation step, just like entering a gold mine. */
@@ -938,10 +991,13 @@ TEST(wc3_movement, gold_return_deposits_at_next_step_contact) {
     harvestgold_walkback(worker);
     T_ASSERT(M_DistanceToGoal(worker) > worker->collision + hall->collision + 5.0f);
     T_ASSERT(M_DistanceToGoal(worker) <= worker->collision + hall->collision + unit_movedistance(worker));
+    worker->s.renderfx |= RF_HAS_LUMBER; /* stale opposite carry tag must not survive deposit */
     worker->currentmove->think(worker);
 
     T_EQ(game.clients[0].ps.stats[PLAYERSTATE_RESOURCE_GOLD], old_gold + 10);
+    T_EQ(worker->harvested_lumber, 0);
     T_EQ(worker->harvested_gold, 0);
+    T_ASSERT(!(worker->s.renderfx & RF_HAS_LUMBER));
     T_ASSERT(!(worker->s.renderfx & RF_HAS_GOLD));
     T_ASSERT(worker->goalentity == mine);
     T_EQ(mine->resources, 90);

--- a/games/warcraft-3/game/tests/t_movement.c
+++ b/games/warcraft-3/game/tests/t_movement.c
@@ -311,6 +311,7 @@ TEST(wc3_movement, lumber_final_chop_fells_tree) {
     T_ASSERT(G_SubscribeMessage(trace_message, &trace));
     HARVEST_RANGE = 64.0f;
     HARVEST_TREE_DAMAGE = 10.0f;
+    HARVEST_LUMBER_CAPACITY = 10.0f;
     harvest_start(worker, tree);
 
     worker->currentmove->think(worker);
@@ -343,6 +344,7 @@ TEST(wc3_movement, lumber_nonlethal_chop_keeps_tree_standing) {
     tree_pained = 0;
     HARVEST_RANGE = 64.0f;
     HARVEST_TREE_DAMAGE = 10.0f;
+    HARVEST_LUMBER_CAPACITY = 10.0f;
     harvest_start(worker, tree);
 
     worker->currentmove->think(worker);

--- a/games/warcraft-3/game/tests/t_movement.c
+++ b/games/warcraft-3/game/tests/t_movement.c
@@ -74,6 +74,7 @@ static LPEDICT make_harvest_tree(FLOAT x, FLOAT y, FLOAT life) {
     return tree;
 }
 
+static UnitAbilities_t const harvest_abilities = { .abilList = "Ahar" };
 static UnitAbilities_t const return_gold_lumber_abilities = { .abilList = "Argl" };
 static UnitAbilities_t const return_lumber_abilities = { .abilList = "Arlm" };
 
@@ -450,6 +451,77 @@ TEST(wc3_movement, lumber_worker_takes_ten_swings_per_trip) {
     T_ASSERT(!tree_died);
 }
 
+/* A custom/non-even capacity must clamp the final successful chop instead of
+ * allowing the worker to carry more lumber than the Harvest capacity. */
+TEST(wc3_movement, lumber_final_chop_clamps_to_capacity) {
+    LPEDICT worker = make_moving_unit(0.0f, 0.0f);
+    LPEDICT tree = make_harvest_tree(20.0f, 0.0f, 100.0f);
+
+    worker->attack1.damagePoint = 0.01f;
+    HARVEST_RANGE = 64.0f;
+    HARVEST_TREE_DAMAGE = 10.0f;
+    HARVEST_LUMBER_CAPACITY = 25.0f;
+    HARVEST_COOLDOWN = 0.01f;
+    harvest_start(worker, tree);
+    worker->currentmove->think(worker);
+
+    FOR_LOOP(i, 3) {
+        worker->wait = 0.01f;
+        worker->currentmove->think(worker);
+        if (i < 2) {
+            harvest_cooldown(worker);
+            worker->wait = 0.01f;
+            worker->currentmove->think(worker);
+        }
+    }
+
+    T_EQ(worker->harvested_lumber, 25);
+    T_FEQ(tree->health.value, 70.0f, 0.01f);
+    T_ASSERT(worker->s.renderfx & RF_HAS_LUMBER);
+}
+
+/* Harvest only awards carried lumber when the tree can actually take the
+ * chop. Invulnerable destructibles reject G_DestructableApplyDamage. */
+TEST(wc3_movement, lumber_invulnerable_tree_does_not_award_lumber) {
+    LPEDICT worker = make_moving_unit(0.0f, 0.0f);
+    LPEDICT tree = make_harvest_tree(20.0f, 0.0f, 100.0f);
+
+    worker->attack1.damagePoint = 0.01f;
+    tree->invulnerable = true;
+    HARVEST_RANGE = 64.0f;
+    HARVEST_TREE_DAMAGE = 10.0f;
+    HARVEST_LUMBER_CAPACITY = 25.0f;
+    harvest_start(worker, tree);
+    worker->currentmove->think(worker);
+    worker->wait = 0.01f;
+    worker->currentmove->think(worker);
+
+    T_EQ(worker->harvested_lumber, 0);
+    T_FEQ(tree->health.value, 100.0f, 0.01f);
+    T_ASSERT(!(worker->s.renderfx & RF_HAS_LUMBER));
+}
+
+/* Reissuing Harvest while already full remembers the requested tree but begins
+ * return immediately, so no extra over-capacity chop can occur. */
+TEST(wc3_movement, lumber_full_worker_returns_before_new_chop) {
+    LPEDICT worker = make_moving_unit(0.0f, 0.0f);
+    LPEDICT tree = make_harvest_tree(100.0f, 0.0f, 100.0f);
+    LPEDICT hall = alloc_test_unit(MAKEFOURCC('h','t','o','w'), 300.0f, 0.0f);
+
+    hall->s.player = worker->s.player;
+    make_live_dropoff(hall, &return_gold_lumber_abilities);
+    worker->harvested_lumber = 10;
+    worker->s.renderfx |= RF_HAS_LUMBER;
+    HARVEST_LUMBER_CAPACITY = 10.0f;
+
+    harvest_start(worker, tree);
+
+    T_ASSERT(worker->secondarygoal == tree);
+    T_ASSERT(worker->goalentity == hall);
+    T_STREQ(worker->currentmove->animation, "walk");
+    T_EQ(worker->harvested_lumber, 10);
+}
+
 /* The capacity-filling chop must fell the tree before return starts.  After
  * depositing, the worker must reject that dead tree and select the next one. */
 TEST(wc3_movement, lumber_lethal_trip_fells_then_selects_next_tree) {
@@ -548,6 +620,51 @@ TEST(wc3_movement, lumber_manual_return_without_tree_stops) {
     T_ASSERT(worker->secondarygoal == NULL);
     T_EQ(worker->harvested_lumber, 0);
     T_STREQ(worker->currentmove->animation, "stand");
+}
+
+/* If the remembered tree dies while the worker is away, replacement-tree
+ * selection is centered on that forest rather than the return building. */
+TEST(wc3_movement, lumber_dead_previous_tree_searches_near_old_tree) {
+    LPEDICT worker = make_moving_unit(0.0f, 0.0f);
+    LPEDICT old_tree = make_harvest_tree(-400.0f, 0.0f, 100.0f);
+    LPEDICT forest_tree = make_harvest_tree(-450.0f, 0.0f, 100.0f);
+    LPEDICT dropoff_tree = make_harvest_tree(50.0f, 0.0f, 100.0f);
+    LPEDICT hall = alloc_test_unit(MAKEFOURCC('h','t','o','w'), 0.0f, 0.0f);
+
+    hall->s.player = worker->s.player;
+    make_live_dropoff(hall, &return_gold_lumber_abilities);
+    old_tree->health.value = 0.0f;
+    worker->harvested_lumber = 10;
+    worker->s.renderfx |= RF_HAS_LUMBER;
+    worker->secondarygoal = old_tree;
+    HARVEST_SEARCH_RANGE = 1000.0f;
+
+    harvest_walkback(worker);
+    worker->currentmove->think(worker);
+
+    T_ASSERT(worker->goalentity == forest_tree);
+    T_ASSERT(worker->secondarygoal == forest_tree);
+    T_ASSERT(worker->goalentity != dropoff_tree);
+    T_EQ(worker->harvested_lumber, 0);
+}
+
+/* Smart-targeting a compatible drop-off while carrying lumber honors the
+ * building the player clicked instead of silently choosing another nearer one. */
+TEST(wc3_movement, lumber_smart_click_returns_to_clicked_dropoff) {
+    LPEDICT worker = make_moving_unit(0.0f, 0.0f);
+    LPEDICT hall = alloc_test_unit(MAKEFOURCC('h','t','o','w'), 100.0f, 0.0f);
+    LPEDICT mill = alloc_test_unit(MAKEFOURCC('h','l','u','m'), 500.0f, 0.0f);
+
+    worker->UnitAbilities = &harvest_abilities;
+    hall->s.player = mill->s.player = worker->s.player;
+    make_live_dropoff(hall, &return_gold_lumber_abilities);
+    make_live_dropoff(mill, &return_lumber_abilities);
+    worker->harvested_lumber = 10;
+    worker->s.renderfx |= RF_HAS_LUMBER;
+
+    T_ASSERT(unit_issuetargetorder(worker, "smart", mill));
+    T_ASSERT(worker->goalentity == mill);
+    T_EQ(worker->harvested_lumber, 10);
 }
 
 /* A large Town Hall footprint can block the next step before the old +5u


### PR DESCRIPTION
Peasants are seen to be carrying the correct resources at the correct amounts.

Clamps carried lumber to HARVEST_LUMBER_CAPACITY.
Prevents invulnerable/rejected tree hits from granting lumber.
A full Peasant ordered to harvest another tree returns resources before chopping again.
After depositing, if the previous tree died, searches around that old tree/forest, not around the Town Hall/Lumber Mill.
Smart/right-clicking a compatible Town Hall/Lumber Mill while carrying resources returns to the clicked building.
Adds equivalent explicit-return plumbing for carried gold.
Activating Ahar while carrying resources performs Return Resources instead of entering Harvest target-selection mode.
Preserves the existing nearest Lumber Mill/Town Hall automatic-return logic.
Preserves your unreachable-interior-tree fallback.
Adds five lumber regression tests.
Updates economy and ability-coverage documentation.
lumber → gold clears lumber amount and lumber visual before showing gold;
gold → lumber clears gold amount and gold visual before showing lumber;
depositing either resource clears both carry-model flags;
zero carried resources therefore always uses the normal Peasant model;
adds regression tests for both resource-switch directions and stale flags after deposit;
updates the WC3 economy documentation.