### PR TITLE
wc3: skip redundant fog blocker work

### DIFF
--- a/docs/games/warcraft-3/performance.md
+++ b/docs/games/warcraft-3/performance.md
@@ -165,6 +165,21 @@ draw counts throughout the cinematic and showed run-order/thermal noise larger t
 was not treated as an end-to-end result. Repeat the fixed-scene weighted profile on the reported ARM/gl4es device to
 measure the actual frame-rate effect; renderer submission still dominates the available weighted profile.
 
+### Contributor FOW follow-up audit
+
+The non-PortMaster FOW commits from `sookyboo/portmaster_rebase_28_08_2026_2` were audited individually against current
+main. `ffcb57ca` (replace the visible-cell loop with `memchr`/`memset`) is obsolete: the `visible_rows` implementation
+above avoids scanning empty rows altogether. The dirty-blocker idea from `722469c8` and rim-cell list from `e279778d`
+remain useful, but were reapplied rather than cherry-picked because current destructable lifecycle ownership has changed.
+
+A temporary bounded ROC Human02 diagnostic over 50 FOW updates recorded 121,500 blocker-hash edict visits and 540,700
+second-pass rim-cell visits for 41,909 committed rim cells. Steady updates now skip the blocker hash until a blocker is
+spawned, freed, moved, scaled, hidden, killed, restored, or revived. Dirty updates retain the hash comparison as a
+correctness check, so redundant invalidations do not rebuild the grid. The rim pass records its temporary blocker cells
+while discovering them and commits only that list; initialization treats allocation failure as fatal instead of silently
+falling back to the square scan. `wc3_game.fow_blocker_cache_skips_clean_and_unchanged_dirty_updates` covers the clean
+cache hit, dirty/hash hit, and dirty/hash miss paths.
+
 ### Local release A/B and remaining cost
 
 A same-machine release-build comparison used ROC Human02, 150 console `wait` commands, `cmd cancel`, then 1,200 waits

--- a/games/warcraft-3/game/api/api_destructable.h
+++ b/games/warcraft-3/game/api/api_destructable.h
@@ -166,11 +166,13 @@ DWORD ShowDestructable(LPJASS j) {
     LPEDICT d = jass_checkhandle(j, 1, "destructable");
     BOOL show = jass_checkboolean(j, 2);
     if (d) {
+        BOOL const was_hidden = !!(d->s.renderfx & RF_HIDDEN);
         if (show) {
             d->s.renderfx &= ~RF_HIDDEN;
         } else {
             d->s.renderfx |= RF_HIDDEN;
         }
+        if ((d->s.flags & EF_FOW_BLOCKER) && was_hidden != !!(d->s.renderfx & RF_HIDDEN)) G_FowMarkBlockersDirty();
     }
     return 0;
 }

--- a/games/warcraft-3/game/api/api_misc.h
+++ b/games/warcraft-3/game/api/api_misc.h
@@ -673,7 +673,9 @@ DWORD SetWidgetLife(LPJASS j) {
     LPEDICT whichWidget = jass_checkhandle(j, 1, "widget");
     FLOAT newLife = jass_checknumber(j, 2);
     if (whichWidget) {
+        BOOL const was_dead = M_IsDead(whichWidget);
         whichWidget->health.value = newLife;
+        if ((whichWidget->s.flags & EF_FOW_BLOCKER) && was_dead != M_IsDead(whichWidget)) G_FowMarkBlockersDirty();
     }
     return 0;
 }

--- a/games/warcraft-3/game/api/api_unit.h
+++ b/games/warcraft-3/game/api/api_unit.h
@@ -3,6 +3,7 @@ DWORD SetUnit##NAME(LPJASS j) {  \
     LPEDICT whichUnit = jass_checkhandle(j, 1, "unit");  \
     if (whichUnit) { \
         memcpy(&whichUnit->FIELD, jass_checkhandle(j, 2, #TYPE), sizeof(whichUnit->FIELD)); \
+        if (whichUnit->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty(); \
         gi.LinkEntity(whichUnit); \
     } \
     return 0; \
@@ -15,7 +16,10 @@ DWORD GetUnit##NAME(LPJASS j) {  \
 #define UNIT_ACCESS(NAME, FIELD) \
 DWORD SetUnit##NAME(LPJASS j) {  \
     LPEDICT whichUnit = jass_checkhandle(j, 1, "unit");  \
-    if(whichUnit)whichUnit->FIELD = jass_checknumber(j, 2); \
+    if (whichUnit) { \
+        whichUnit->FIELD = jass_checknumber(j, 2); \
+        if (whichUnit->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty(); \
+    } \
     return 0; \
 }  \
 DWORD GetUnit##NAME(LPJASS j) {  \
@@ -61,7 +65,10 @@ DWORD SetUnitFacingTimed(LPJASS j) {
 
 DWORD KillUnit(LPJASS j) {
     LPEDICT whichUnit = jass_checkhandle(j, 1, "unit");
-    if (whichUnit) whichUnit->health.value = 0;
+    if (whichUnit) {
+        whichUnit->health.value = 0;
+        if (whichUnit->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty();
+    }
     return 0;
 }
 DWORD RemoveUnit(LPJASS j) {
@@ -74,14 +81,18 @@ DWORD RemoveUnit(LPJASS j) {
 DWORD ShowUnit(LPJASS j) {
     LPEDICT whichUnit = jass_checkhandle(j, 1, "unit");
     BOOL show = jass_checkboolean(j, 2);
+    BOOL was_hidden;
     if (!whichUnit) {
         return 0;
     }
+    was_hidden = !!(whichUnit->s.renderfx & RF_HIDDEN);
     if (show) {
         whichUnit->s.renderfx &= ~RF_HIDDEN;
     } else {
         whichUnit->s.renderfx |= RF_HIDDEN;
     }
+    if ((whichUnit->s.flags & EF_FOW_BLOCKER) && was_hidden != !!(whichUnit->s.renderfx & RF_HIDDEN))
+        G_FowMarkBlockersDirty();
     return 0;
 }
 
@@ -90,10 +101,13 @@ JASS_API(SetUnitState,
 (UNITSTATE, whichUnitState, "unitstate"),
 (number, newVal))
 {
+    BOOL was_dead;
     if (!whichUnit || !whichUnitState) {
         return;
     }
+    was_dead = M_IsDead(whichUnit);
     (&whichUnit->health.value)[*whichUnitState] = newVal;
+    if ((whichUnit->s.flags & EF_FOW_BLOCKER) && was_dead != M_IsDead(whichUnit)) G_FowMarkBlockersDirty();
 }
 //DWORD SetUnitState(LPJASS j) {
 //    LPEDICT whichUnit = jass_checkhandle(j, 1, "unit");
@@ -115,6 +129,7 @@ DWORD SetUnitPosition(LPJASS j) {
     if (whichUnit) {
         whichUnit->s.origin.x = x;
         whichUnit->s.origin.y = y;
+        if (whichUnit->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty();
         gi.LinkEntity(whichUnit);
     }
     return 0;
@@ -155,7 +170,10 @@ DWORD SetUnitScale(LPJASS j) {
 //    FLOAT scaleX = jass_checknumber(j, 2);
 //    FLOAT scaleY = jass_checknumber(j, 3);
     FLOAT scaleZ = jass_checknumber(j, 4);
-    if (whichUnit) whichUnit->s.scale = scaleZ;
+    if (whichUnit) {
+        whichUnit->s.scale = scaleZ;
+        if (whichUnit->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty();
+    }
     return 0;
 }
 DWORD SetUnitTimeScale(LPJASS j) {

--- a/games/warcraft-3/game/g_ai.c
+++ b/games/warcraft-3/game/g_ai.c
@@ -147,6 +147,7 @@ BOOL M_MoveIsValid(LPEDICT self, LPCVECTOR2 pos) {
 }
 
 static void unit_commit_step(LPEDICT self, LPCVECTOR2 cand) {
+    if (self->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty();
     self->s.origin2 = *cand;
     gi.LinkEntity(self);
 }

--- a/games/warcraft-3/game/g_destructable.c
+++ b/games/warcraft-3/game/g_destructable.c
@@ -66,6 +66,7 @@ void G_ActivateScriptedDestructable(LPEDICT ent,
 
     G_ApplyDestructableAlivePathing(ent);
     G_DestructableStartAliveAnimation(ent, false);
+    if (ent->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty();
 
     gi.LinkEntity(ent);
 }
@@ -251,6 +252,7 @@ static BOOL G_EnterDestructableDeathState(LPEDICT ent,
 
     unit_leavecombat(ent);
     G_ApplyDestructableDeathPathing(ent);
+    if (ent->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty();
     G_DestructableStartDeathAnimation(ent);
     if (rebuild_pathing) {
         CM_BakeStaticObstacles();
@@ -357,6 +359,7 @@ BOOL G_RestoreDestructable(LPEDICT ent, FLOAT life, BOOL birth) {
         ent->s.flags &= ~EF_NOT_SELECTABLE;
     }
     G_ApplyDestructableAlivePathing(ent);
+    if (ent->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty();
     G_DestructableStartAliveAnimation(ent, birth);
     CM_BakeStaticObstacles();
     return true;

--- a/games/warcraft-3/game/g_fow.c
+++ b/games/warcraft-3/game/g_fow.c
@@ -25,6 +25,7 @@
 static DWORD g_fow_blocker_hash;
 static DWORD g_fow_blocker_count;
 static BOOL g_fow_blockers_valid;
+static BOOL g_fow_blockers_dirty = true;
 
 static DWORD G_FowCellCount(void) {
     return level.fow.width * level.fow.height;
@@ -302,30 +303,15 @@ static BOOL G_FowHasVisibleNeighbor(fowPlayerGrid_t *grid, int x, int y, int mar
     return false;
 }
 
-static void G_FowCommitRimCells(fowPlayerGrid_t *grid,
-                                DWORD cx,
-                                DWORD cy,
-                                int max_radius)
-{
-    for (int dy = -max_radius; dy <= max_radius; dy++) {
-        int y = (int)cy + dy;
-        if (y < 0 || y >= (int)level.fow.height) {
-            continue;
-        }
-        for (int dx = -max_radius; dx <= max_radius; dx++) {
-            int x = (int)cx + dx;
-            DWORD index;
+/* Commit only marked blockers; the old second square walk revisited over 10K cells per Human02 update. */
+static void G_FowCommitRimCells(fowPlayerGrid_t *grid, DWORD count) {
+    FOR_LOOP(i, count) {
+        DWORD const index = level.fow.rim_cells[i];
+        DWORD const y = index / level.fow.width;
+        DWORD const x = index - y * level.fow.width;
 
-            if (x < 0 || x >= (int)level.fow.width) {
-                continue;
-            }
-            index = G_FOW_CELL_INDEX((DWORD)x, (DWORD)y);
-            if (grid->visible[index] != 2) {
-                continue;
-            }
-            grid->visible[index] = 0;
-            G_FOW_SET_VISIBLE_CELL(grid, x, y);
-        }
+        grid->visible[index] = 0;
+        G_FOW_SET_VISIBLE_CELL(grid, x, y);
     }
 }
 
@@ -333,6 +319,7 @@ static void G_FowRevealBlockerRim(fowPlayerGrid_t *grid, DWORD cx, DWORD cy, int
     int margin = FOW_BLOCKER_LIGHT_MARGIN_CELLS;
     int max_radius = radius_cells + margin;
     int max_radius_sq = max_radius * max_radius;
+    DWORD rim_count = 0;
 
     for (int dy = -max_radius; dy <= max_radius; dy++) {
         int y = (int)cy + dy;
@@ -358,10 +345,11 @@ static void G_FowRevealBlockerRim(fowPlayerGrid_t *grid, DWORD cx, DWORD cy, int
                 G_FowHasVisibleNeighbor(grid, x, y, margin))
             {
                 grid->visible[index] = 2;
+                level.fow.rim_cells[rim_count++] = index;
             }
         }
     }
-    G_FowCommitRimCells(grid, cx, cy, max_radius);
+    G_FowCommitRimCells(grid, rim_count);
 }
 
 static void G_FowRevealCircle(DWORD player, LPCEDICT ent, FLOAT radius) {
@@ -465,10 +453,15 @@ static DWORD G_FowHashPointer(DWORD hash, void const *ptr) {
     return G_FowHashMix(hash, (DWORD)(value >> 16 >> 16));
 }
 
+/* Blocker owners call this after a lifecycle change so steady updates avoid hashing every edict. */
+void G_FowMarkBlockersDirty(void) { g_fow_blockers_dirty = true; }
+
 static BOOL G_FowBlockersChanged(void) {
     DWORD hash = 2166136261u;
     DWORD count = 0;
 
+    if (!g_fow_blockers_dirty) return false;
+    g_fow_blockers_dirty = false;
     FOR_LOOP(i, globals.num_edicts) {
         LPCEDICT ent = &g_edicts[i];
 
@@ -720,12 +713,14 @@ void G_FowShutdown(void) {
         SAFE_DELETE(grid->dirty_explored_rows, gi.MemFree);
     }
     SAFE_DELETE(level.fow.blocked, gi.MemFree);
+    SAFE_DELETE(level.fow.rim_cells, gi.MemFree);
     memset(&level.fow, 0, sizeof(level.fow));
     memset(g_fog_modifiers, 0, sizeof(g_fog_modifiers));
     g_num_fog_modifiers = 0;
     g_fow_blocker_hash = 0;
     g_fow_blocker_count = 0;
     g_fow_blockers_valid = false;
+    g_fow_blockers_dirty = true;
 }
 
 void G_FowInit(void) {
@@ -733,6 +728,7 @@ void G_FowInit(void) {
 
     G_FowShutdown();
     g_fow_blockers_valid = false;
+    g_fow_blockers_dirty = true;
     level.fow.bounds = CM_GetWorldBounds();
     level.fow.width = (DWORD)ceilf((level.fow.bounds.max.x - level.fow.bounds.min.x) / (FLOAT)FOW_CELL_SIZE);
     level.fow.height = (DWORD)ceilf((level.fow.bounds.max.y - level.fow.bounds.min.y) / (FLOAT)FOW_CELL_SIZE);
@@ -740,7 +736,10 @@ void G_FowInit(void) {
     level.fow.height = MAX(level.fow.height, 1);
     cells = G_FowCellCount();
     level.fow.blocked = gi.MemAlloc(cells);
-    if (!level.fow.blocked) {
+    level.fow.rim_cells = gi.MemAlloc(cells * sizeof(*level.fow.rim_cells));
+    ARRAY_COUNT(level.fow.rim_cells) = cells;
+    if (!level.fow.blocked || !level.fow.rim_cells) {
+        fprintf(stderr, "G_FowInit: failed to allocate %u-cell blocker grid and rim list\n", cells);
         G_FowShutdown();
         return;
     }

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -784,6 +784,7 @@ typedef struct {
     BOX2 bounds;
     BYTE *blocked;
     DWORD num_blocked;
+    ARRAY(DWORD, rim_cells);
     fowPlayerGrid_t players[MAX_PLAYERS];
 } fowGrid_t;
 
@@ -864,6 +865,7 @@ void G_FowInit(void);
 void G_FowShutdown(void);
 void G_FowConnectPlayer(DWORD player);
 void G_FowUpdate(void);
+void G_FowMarkBlockersDirty(void);
 void G_FowSendDeltas(void);
 void G_FowSendFull(LPEDICT ent);
 BOOL G_FowPlayerCanSeeEntity(DWORD player, LPCEDICT ent);

--- a/games/warcraft-3/game/g_monster.c
+++ b/games/warcraft-3/game/g_monster.c
@@ -549,6 +549,7 @@ void SP_SpawnUnit(LPEDICT self) {
     self->targtype = G_GetTargetType(d->targetType);
     if (ui->occluderHeight > 0) {
         self->s.flags |= EF_FOW_BLOCKER;
+        G_FowMarkBlockersDirty();
     }
     if (b->sightRadius > 0 || b->nightSightRadius > 0) {
         self->s.flags |= EF_FOW_REVEALER;

--- a/games/warcraft-3/game/g_phys.c
+++ b/games/warcraft-3/game/g_phys.c
@@ -35,6 +35,7 @@ void G_PushEntity(LPEDICT ent, FLOAT distance, LPCVECTOR2 direction) {
 
 void G_PushEntity3(LPEDICT ent, FLOAT distance, LPCVECTOR3 direction) {
     ent->s.origin = Vector3_mad(&ent->s.origin, distance, direction);
+    if (ent->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty();
     gi.LinkEntity(ent);
 }
 
@@ -62,8 +63,10 @@ void SV_Physics_Toss(LPEDICT ent) {
 }
 
 void SV_Physics_Link(LPEDICT ent) {
+    VECTOR3 const old = ent->s.origin;
     ent->s.origin = ent->goalentity->s.origin;
     ent->s.angle = ent->goalentity->s.angle;
+    if ((ent->s.flags & EF_FOW_BLOCKER) && memcmp(&old, &ent->s.origin, sizeof(old))) G_FowMarkBlockersDirty();
 }
 
 /* Whether a unit's hit points regenerate right now, per its WC3 regenType

--- a/games/warcraft-3/game/g_phys.c
+++ b/games/warcraft-3/game/g_phys.c
@@ -30,6 +30,7 @@ extern void spell_run_frame(LPEDICT ent);
 
 void G_PushEntity(LPEDICT ent, FLOAT distance, LPCVECTOR2 direction) {
     ent->s.origin2 = Vector2_mad(&ent->s.origin2, distance, direction);
+    if (ent->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty();
     gi.LinkEntity(ent);
 }
 

--- a/games/warcraft-3/game/g_spawn.c
+++ b/games/warcraft-3/game/g_spawn.c
@@ -162,6 +162,7 @@ static void SP_SpawnDestructable(LPEDICT edict) {
     edict->targtype = G_GetTargetType(row->targetType);
     if (row->occluderHeight > 0 || edict->targtype == TARG_TREE) {
         edict->s.flags |= EF_FOW_BLOCKER;
+        G_FowMarkBlockersDirty();
     }
     edict->movetype = MOVETYPE_NONE;
     edict->svflags |= SVF_STATIC_SCENERY;

--- a/games/warcraft-3/game/g_utils.c
+++ b/games/warcraft-3/game/g_utils.c
@@ -15,6 +15,7 @@ void G_SetPlayerText(LPGAMECLIENT client, PLAYERTEXT index, LPCSTR text) {
 }
 
 void G_FreeEdict(LPEDICT ent) {
+    if (ent->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty();
     S_GoldMineReleaseWorker(ent);
     gi.UnlinkEntity(ent);
     memset(ent, 0, sizeof(*ent));

--- a/games/warcraft-3/game/m_unit.c
+++ b/games/warcraft-3/game/m_unit.c
@@ -106,6 +106,7 @@ void unit_die(LPEDICT self, LPEDICT attacker) {
     G_PublishEventWithSource(self, EVENT_UNIT_DEATH, attacker);
     G_PublishEventWithSource(self, EVENT_PLAYER_UNIT_DEATH, attacker);
     self->svflags |= SVF_DEADMONSTER;
+    if (self->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty();
     /* Award experience to the killer's nearby heroes (enemy kills only). */
     if (attacker && attacker != self && attacker->s.player != self->s.player) {
         G_GrantKillXP(self, attacker);
@@ -571,6 +572,7 @@ void G_ReviveHero(LPEDICT ent, FLOAT x, FLOAT y) {
     ent->mana.value   = MAX(0.0f, ent->mana.max_value * manaFactor);
     ent->s.origin2.x = x;
     ent->s.origin2.y = y;
+    if (ent->s.flags & EF_FOW_BLOCKER) G_FowMarkBlockersDirty();
     unit_stand(ent); /* back to a living idle state */
 }
 

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -648,6 +648,7 @@ TEST(wc3_game, fow_blocker_stops_visibility_behind_it) {
 TEST(wc3_game, fow_blocker_cache_skips_clean_and_unchanged_dirty_updates) {
     DWORD old_index, new_index, sentinel;
     LPEDICT blocker;
+    VECTOR2 direction = { 1.0f, 0.0f };
 
     reset_entities();
     G_FowInit();
@@ -668,8 +669,7 @@ TEST(wc3_game, fow_blocker_cache_skips_clean_and_unchanged_dirty_updates) {
     G_FowUpdate();
     T_EQ(level.fow.blocked[sentinel], 7);
 
-    blocker->s.origin.x = 320.0f;
-    G_FowMarkBlockersDirty();
+    G_PushEntity(blocker, 256.0f, &direction);
     G_FowUpdate();
     T_EQ(level.fow.blocked[sentinel], 0);
     T_ASSERT(!level.fow.blocked[old_index]);

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -645,6 +645,38 @@ TEST(wc3_game, fow_blocker_stops_visibility_behind_it) {
     G_FowShutdown();
 }
 
+TEST(wc3_game, fow_blocker_cache_skips_clean_and_unchanged_dirty_updates) {
+    DWORD old_index, new_index, sentinel;
+    LPEDICT blocker;
+
+    reset_entities();
+    G_FowInit();
+    G_FowConnectPlayer(0);
+    blocker = alloc_test_unit(MAKEFOURCC('L','T','l','t'), 64.0f, 64.0f);
+    blocker->s.flags |= EF_FOW_BLOCKER;
+    blocker->health.value = blocker->health.max_value = 1.0f;
+    old_index = G_FowWorldToCellY(64.0f) * level.fow.width + G_FowWorldToCellX(64.0f);
+    new_index = G_FowWorldToCellY(64.0f) * level.fow.width + G_FowWorldToCellX(320.0f);
+    sentinel = level.fow.width * level.fow.height - 1;
+
+    G_FowUpdate();
+    T_ASSERT(level.fow.blocked[old_index]);
+    level.fow.blocked[sentinel] = 7;
+    G_FowUpdate();
+    T_EQ(level.fow.blocked[sentinel], 7);
+    G_FowMarkBlockersDirty();
+    G_FowUpdate();
+    T_EQ(level.fow.blocked[sentinel], 7);
+
+    blocker->s.origin.x = 320.0f;
+    G_FowMarkBlockersDirty();
+    G_FowUpdate();
+    T_EQ(level.fow.blocked[sentinel], 0);
+    T_ASSERT(!level.fow.blocked[old_index]);
+    T_ASSERT(level.fow.blocked[new_index]);
+    G_FowShutdown();
+}
+
 static pathTex_t *make_fow_pathtex(DWORD width, DWORD height, BYTE blocked) {
     pathTex_t *tex = gi.MemAlloc(sizeof(*tex) + width * height * sizeof(COLOR32));
 


### PR DESCRIPTION
## Summary
- skip the full blocker hash walk on clean FOW updates while retaining the hash check after lifecycle invalidation
- commit only blocker-rim cells discovered by the reveal pass instead of rescanning the whole reveal square
- cover clean cache hits, dirty hash hits, and dirty hash misses; document the contributor-branch audit

## Evidence
A temporary bounded ROC Human02 diagnostic over 50 FOW updates recorded 121,500 blocker-hash edict visits and 540,700 second-pass rim visits for 41,909 committed rim cells. The obsolete memchr change was excluded because current main already tracks occupied visible rows. PortMaster root files were not included.

## Verification
- focused FOW suite, ROC: 43/43 assertions
- focused FOW suite, TFT: 43/43 assertions
- bounded ROC Human02 launch: 100 frames
- bounded TFT Human02 launch: 100 frames
- make test