### PR TITLE
wc3: implement triggered in-game dialogue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 data model (SLK, unit stats, combat) | [docs/wc3-data-model.md](docs/wc3-data-model.md) |
 | WC3 JASS native coverage, callback contracts, state ownership | [docs/games/warcraft-3/jass-native-coverage.md](docs/games/warcraft-3/jass-native-coverage.md) |
 | WC3 fog states, scripted reveals, fog modifiers, shared vision, cinematic separation | [docs/games/warcraft-3/fog-and-cinematics.md](docs/games/warcraft-3/fog-and-cinematics.md) |
+| WC3 triggered dialogue, gameplay/cinematic presentation split, message and transmission lifetimes | [docs/games/warcraft-3/triggered-dialogue.md](docs/games/warcraft-3/triggered-dialogue.md) |
 | WC3 gathering, immobile units, construction HUD, overhead bars | [docs/games/warcraft-3/economy-and-unit-presentation.md](docs/games/warcraft-3/economy-and-unit-presentation.md) |
 | WC3 building menu, placement validation, Human construction and power building | [docs/games/warcraft-3/building-construction.md](docs/games/warcraft-3/building-construction.md) |
 | WC3 pathfinding, flow fields, collision-sized routing, unreachable lumber targets | [docs/games/warcraft-3/pathfinding.md](docs/games/warcraft-3/pathfinding.md) |

--- a/docs/games/warcraft-3/jass-native-coverage.md
+++ b/docs/games/warcraft-3/jass-native-coverage.md
@@ -221,6 +221,13 @@ the WC3 sound-data tables; they must not treat the label itself as a filename.
 The server emits sound commands/state through the existing sound architecture;
 JASS callbacks must not call a client mixer directly.
 
+Triggered transmissions reuse this sound path but remain presentation state,
+not cinematic-mode policy. `StartSound` preserves `GetLocalPlayer()` context so
+force-gated Blizzard.j transmissions send speech only to the represented local
+player; global calls still broadcast. See
+[triggered-dialogue.md](triggered-dialogue.md) for the gameplay portrait/message
+layer split, independent voice/scene lifetimes, and remaining ping/indicator gaps.
+
 `StartSound`, `StopSound`, attachment, 3D position, and playing/loading queries
 must describe one coherent handle state machine. `killWhenDone` releases only
 after playback completion, while an immediate destroyed/stopped handle cannot

--- a/docs/games/warcraft-3/triggered-dialogue.md
+++ b/docs/games/warcraft-3/triggered-dialogue.md
@@ -1,0 +1,129 @@
+# Warcraft III Triggered Dialogue
+
+## Contract
+
+Normal Warcraft III transmissions are presentation state, not cinematic mode.
+`SetCinematicScene` may run while `PLAYER.client_ui_state == CLIENT_UI_GAME` and
+must not itself move the camera, alter fog, pause simulation, hide the HUD, or
+disable user control. Full cinematic policy remains owned by `ShowInterface`,
+`EnableUserControl`, camera natives, and the map script.
+
+The server owns transmission/message state in `games/warcraft-3/game/client_s`:
+
+- `ps.cinematic_portrait` — model index used by the talking-head portrait.
+- `PLAYERTEXT_SPEAKER` / `PLAYERTEXT_DIALOGUE` — resolved map strings.
+- `cinematic_voice_end_time` — end of `Portrait Talk`; the scene may remain.
+- `cinematic_end_time` — end of the complete transmission scene.
+- `message` — one ordinary `DisplayText*` message, including position and
+  expiry time.
+
+`G_SetPlayerText` preserves an actual empty string. Do not normalize cinematic
+clear state to a single space: `UI_WriteCinematicLayer` and the gameplay
+transmission path use empty strings to decide whether a scene exists.
+
+## Presentation Flow
+
+`SetCinematicScene`
+
+```text
+resolve TRIGSTR speaker/text
+  -> resolve portrait unit type to model
+  -> store scene and voice expiry independently
+  -> UI_WriteDialoguePresentation(player entity)
+```
+
+`UI_WriteDialoguePresentation` selects presentation from the existing UI mode:
+
+```text
+CLIENT_UI_GAME
+  -> LAYER_PORTRAIT: temporary transmission portrait
+  -> LAYER_MESSAGE: yellow speaker name + dialogue
+
+CLIENT_UI_CINEMATIC
+  -> LAYER_CINEMATIC: CinematicPanel portrait/speaker/dialogue
+```
+
+A gameplay transmission does not set `CLIENT_UI_CINEMATIC`. When it expires,
+`G_RunClients` clears transmission state, restores the selected-unit portrait,
+and restores an ordinary timed message if that message is still alive.
+
+The portrait animation has two lifetimes. While
+`cinematic_voice_end_time > GetTime()` the frame requests `Portrait Talk`.
+After voice expiry it requests `Portrait` until `cinematic_end_time` clears the
+scene. This allows Blizzard.j's transmission portrait hang time to remain
+visible without forcing the talking animation for the entire hang period.
+
+## Ordinary Text Messages
+
+`DisplayTimedTextToPlayer` stores its JASS X/Y coordinates and explicit
+lifetime. `DisplayTextToPlayer` passes the untimed sentinel to `UI_ShowText`,
+which derives the current compatibility duration as:
+
+```text
+strlen(resolved text) / 6 + 5 seconds
+```
+
+The current HUD intentionally retains one ordinary message per player because
+`LAYER_MESSAGE` is a single server-authored layer. A new ordinary message
+replaces the previous ordinary message state. `ClearTextMessages` clears that
+state for the current local-player JASS context; when no local-player context
+exists it clears all player clients, matching a global invocation in the
+server-side multi-client VM.
+
+During a gameplay transmission, `LAYER_MESSAGE` belongs to the transmission.
+An ordinary message started underneath it retains its own expiry time and is
+shown after the transmission only if it has not expired.
+
+## Local Audio
+
+The JASS VM evaluates `GetLocalPlayer()` branches once per represented player
+by setting `currentplayer`. `StartSound` must preserve that context:
+
+```text
+currentplayer != NULL -> send "snd" only to that player's entity
+currentplayer == NULL -> broadcast, preserving global StartSound calls
+```
+
+Do not make transmission audio a synchronized world entity merely to target a
+force; Blizzard.j already gates transmission presentation/audio with local
+player membership.
+
+## Known Gaps
+
+The following transmission features remain separate work because the current
+engine has no established representation for them:
+
+- `PingMinimap` / `PingMinimapEx` are still stubs. A correct implementation
+  should reuse the renderer's existing world-to-minimap conversion rather than
+  duplicate map-coordinate math in JASS/UI code.
+- `UnitAddIndicator` / `AddIndicator` are still stubs. A speaking-unit marker
+  needs per-client lifetime/color state and must not reveal a fogged unit.
+- `SetCinematicScene` player color is not yet applied to the portrait. The MDX
+  renderer currently has a fixed `MAX_TEAMS` texture table, while common.j
+  exposes more player colors; do not silently wrap unsupported colors.
+- Ordinary text uses one active-message slot rather than Warcraft's full
+  multi-message stack.
+- `StopSound` / dialogue-specific sound replacement remain unimplemented.
+
+These gaps do not justify coupling dialogue to camera, fog, simulation pause,
+or UI mode.
+
+## Verification
+
+Relevant in-engine tests are under `games/warcraft-3/game/tests/t_api.c`:
+
+- `wc3_api.display_text_tracks_lifetime_and_clear`
+- `wc3_api.display_text_uses_automatic_duration`
+- `wc3_api.transmission_keeps_gameplay_ui_and_separates_voice_lifetime`
+- `wc3_api.gameplay_transmission_preserves_underlying_timed_message_state`
+
+Run when validating changes:
+
+```sh
+make test-wc3-engine WC3_PATTERN='wc3_api.*'
+```
+
+For campaign behavior, verify a bounded Human02 run with a transmission that
+occurs outside cinematic mode. Confirm the normal command UI remains usable,
+the selected portrait is restored after speech, the camera does not move from
+the transmission itself, and fog state is unchanged.

--- a/games/warcraft-3/game/api/api_misc.h
+++ b/games/warcraft-3/game/api/api_misc.h
@@ -1293,10 +1293,11 @@ DWORD SetCinematicScene(LPJASS j) {
     LPCSTR speakerTitle = jass_checkstring(j, 3);
     LPCSTR text = jass_checkstring(j, 4);
     FLOAT sceneDuration = jass_checknumber(j, 5);
-    //FLOAT voiceoverDuration = jass_checknumber(j, 6);
+    FLOAT voiceoverDuration = jass_checknumber(j, 6);
     if (G_SkipCutscene()) return 0;
     if (currentplayer) {
         LPGAMECLIENT gc = PLAYER_CLIENT(currentplayer);
+        DWORD now = gi.GetTime();
         G_SetPlayerText(gc, PLAYERTEXT_SPEAKER, G_LevelString(speakerTitle));
         G_SetPlayerText(gc, PLAYERTEXT_DIALOGUE, G_LevelString(text));
         currentplayer->cinematic_portrait = 0;
@@ -1308,8 +1309,11 @@ DWORD SetCinematicScene(LPJASS j) {
                 currentplayer->cinematic_portrait = G_RegisterModel(mf);
             }
         }
-        if (gc) gc->cinematic_end_time = sceneDuration > 0 ? gi.GetTime() + (DWORD)(sceneDuration * 1000.0f) : 0;
-        UI_WriteCinematicLayer(PLAYER_ENT(currentplayer));
+        if (gc) {
+            gc->cinematic_end_time = sceneDuration > 0 ? now + (DWORD)(sceneDuration * 1000.0f) : 0;
+            gc->cinematic_voice_end_time = voiceoverDuration > 0 ? now + (DWORD)(voiceoverDuration * 1000.0f) : 0;
+        }
+        UI_WriteDialoguePresentation(PLAYER_ENT(currentplayer));
     }
     return 0;
 }
@@ -1319,8 +1323,11 @@ DWORD EndCinematicScene(LPJASS j) {
         G_SetPlayerText(gc, PLAYERTEXT_SPEAKER, "");
         G_SetPlayerText(gc, PLAYERTEXT_DIALOGUE, "");
         currentplayer->cinematic_portrait = 0;
-        if (gc) gc->cinematic_end_time = 0;
-        UI_WriteCinematicLayer(PLAYER_ENT(currentplayer));
+        if (gc) {
+            gc->cinematic_end_time = 0;
+            gc->cinematic_voice_end_time = 0;
+        }
+        UI_WriteDialoguePresentation(PLAYER_ENT(currentplayer));
     }
     return 0;
 }

--- a/games/warcraft-3/game/api/api_player.h
+++ b/games/warcraft-3/game/api/api_player.h
@@ -550,7 +550,7 @@ DWORD DisplayTextToPlayer(LPJASS j) {
     FLOAT x = jass_checknumber(j, 2);
     FLOAT y = jass_checknumber(j, 3);
     LPCSTR message = jass_checkstring(j, 4);
-    UI_ShowText(PLAYER_ENT(toPlayer), &MAKE(VECTOR2, x, y), message, 0);
+    UI_ShowText(PLAYER_ENT(toPlayer), &MAKE(VECTOR2, x, y), message, -1.0f);
     return 0;
 }
 DWORD DisplayTimedTextToPlayer(LPJASS j) {
@@ -572,6 +572,14 @@ DWORD DisplayTimedTextFromPlayer(LPJASS j) {
     return 0;
 }
 DWORD ClearTextMessages(LPJASS j) {
+    if (currentplayer) {
+        UI_ClearTextMessages(PLAYER_ENT(currentplayer));
+    } else {
+        FOR_LOOP(i, game.max_clients) {
+            LPEDICT ent = G_GetPlayerEntityByNumber(i);
+            if (ent && ent->client) UI_ClearTextMessages(ent);
+        }
+    }
     return 0;
 }
 DWORD StartMeleeAI(LPJASS j) {

--- a/games/warcraft-3/game/api/api_sound.h
+++ b/games/warcraft-3/game/api/api_sound.h
@@ -1,3 +1,5 @@
+extern LPPLAYER currentplayer;
+
 DWORD CreateSound(LPJASS j) {
     LPCSTR fileName = jass_checkstring(j, 1);
     BOOL looping = jass_checkboolean(j, 2);
@@ -115,6 +117,11 @@ DWORD AttachSoundToUnit(LPJASS j) {
 DWORD StartSound(LPJASS j) {
     gsound_t *sound = jass_checkhandle(j, 1, "sound");
     if (!sound || !sound->soundIndex) return 0;
+    if (currentplayer) {
+        LPEDICT clent = PLAYER_ENT(currentplayer);
+        if (clent) gi.GameCommand(clent, "snd", &sound->soundIndex, sizeof(int));
+        return 0;
+    }
     FOR_LOOP(i, game.max_clients) {
         LPEDICT clent = G_GetPlayerEntityByNumber(i);
         if (clent) gi.GameCommand(clent, "snd", &sound->soundIndex, sizeof(int));

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -377,7 +377,13 @@ struct client_s {
         LONG food_used;
         LONG food_cap;
     } resourcebar;
-    DWORD cinematic_end_time;  /* game time (ms) when current SetCinematicScene expires, 0 = none */
+    struct {
+        VECTOR2 position;
+        DWORD end_time;        /* game time (ms), 0 = inactive */
+        char text[1024];
+    } message;
+    DWORD cinematic_end_time;       /* game time (ms) when current SetCinematicScene expires, 0 = none */
+    DWORD cinematic_voice_end_time; /* game time (ms) when Portrait Talk becomes Portrait, 0 = not talking */
 };
 
 typedef struct {
@@ -1011,6 +1017,7 @@ void Get_Portrait_f(LPEDICT);
 void G_RefreshInventoryLayer(LPEDICT);
 void G_RefreshInfoPanel(LPEDICT);
 void G_UpdateClientInfoPanels(void);
+void UI_WriteSelectedPortraitLayer(LPEDICT);
 void G_RefreshResourceBar(LPEDICT);
 void G_UpdateClientResourceBars(void);
 void UI_AddCancelButton(LPEDICT);
@@ -1021,6 +1028,8 @@ void UI_WriteTooltipFrame(void);
 void UI_SetCurrentClient(LPGAMECLIENT client);
 void UI_ShowInterface(LPEDICT, BOOL, FLOAT);
 void UI_ShowText(LPEDICT, LPCVECTOR2, LPCSTR, FLOAT);
+void UI_ClearTextMessages(LPEDICT);
+void UI_WriteDialoguePresentation(LPEDICT);
 LPCSTR GetBuildCommand(unitRace_t);
 void UI_RenderRoute(LPEDICT, LPCSTR);
 void UI_ShowMainMenu(LPEDICT);

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -272,7 +272,9 @@ static void G_RunClients(void) {
     FLOAT cinefade = G_Cinefade();
     FOR_LOOP(i, game.max_clients) {
         LPGAMECLIENT client = game.clients+i;
+        LPEDICT client_ent = G_GetPlayerEntityByNumber(client->ps.number);
         DWORD duration;
+        BOOL presentation_dirty = false;
         G_UpdateCameraTarget(client);
         duration = client->camera.end_time - client->camera.start_time;
         if (gi.GetTime() < client->camera.end_time && duration > 0) {
@@ -291,17 +293,25 @@ static void G_RunClients(void) {
             client->ps.fov = client->camera.state.fov;
             client->ps.distance = client->camera.state.target_distance;
         }
-        /* Auto-clear cinematic scene when its duration expires.
-         * Blizzard.j TransmissionFromUnitWithNameBJ never calls
-         * EndCinematicScene; the original WC3 engine times out via the
-         * sceneDuration parameter of SetCinematicScene. */
+        /* Transmission scene and voice lifetimes are independent. Blizzard.j
+         * keeps the portrait scene alive past the voice, so Portrait Talk must
+         * fall back to Portrait before the entire transmission disappears. */
         if (client->cinematic_end_time && gi.GetTime() >= client->cinematic_end_time) {
             G_SetPlayerText(client, PLAYERTEXT_SPEAKER, "");
             G_SetPlayerText(client, PLAYERTEXT_DIALOGUE, "");
             client->ps.cinematic_portrait = 0;
             client->cinematic_end_time = 0;
-            UI_WriteCinematicLayer(G_GetPlayerEntityByNumber(client->ps.number));
+            client->cinematic_voice_end_time = 0;
+            presentation_dirty = true;
+        } else if (client->cinematic_voice_end_time && gi.GetTime() >= client->cinematic_voice_end_time) {
+            client->cinematic_voice_end_time = 0;
+            presentation_dirty = true;
         }
+        if (client->message.end_time && gi.GetTime() >= client->message.end_time) {
+            memset(&client->message, 0, sizeof(client->message));
+            presentation_dirty = true;
+        }
+        if (presentation_dirty && client_ent) UI_WriteDialoguePresentation(client_ent);
         client->ps.cinefade = cinefade;
     }
 }

--- a/games/warcraft-3/game/g_utils.c
+++ b/games/warcraft-3/game/g_utils.c
@@ -10,7 +10,7 @@ void G_SetPlayerText(LPGAMECLIENT client, PLAYERTEXT index, LPCSTR text) {
     snprintf(client->playerTextStorage[index][cursor],
              sizeof(client->playerTextStorage[index][cursor]),
              "%s",
-             text && *text ? text : " ");
+             text ? text : "");
     client->ps.texts[index] = client->playerTextStorage[index][cursor];
 }
 

--- a/games/warcraft-3/game/hud/hud_cinematic.c
+++ b/games/warcraft-3/game/hud/hud_cinematic.c
@@ -1,14 +1,19 @@
 /*
- * hud_cinematic.c — Cinematic layer, interface toggle, message overlay.
+ * hud_cinematic.c — Cinematic layer, gameplay transmissions, interface toggle,
+ * and timed message overlay.
  *
- * Manages the cinematic letterbox bars, portrait model, speaker/dialogue
- * text, the client_ui_state toggle, the text message overlay, and the
- * layer clear helper.
+ * SetCinematicScene is presentation state, not the UI-mode switch.  When the
+ * normal interface is active a transmission temporarily owns the ordinary
+ * portrait/message layers; when cinematic mode is active the same state is
+ * rendered through CinematicPanel.
  */
 
 #include "hud_local.h"
 #include "hud_utils.h"
 #include "../generated/cinematic_panel.h"
+
+#define WC3_MESSAGE_CHARS_PER_SECOND 6.0f
+#define WC3_MESSAGE_BASE_DURATION 5.0f
 
 static CinematicPanel_t cin;
 static FRAMEDEF msg_overlay_root, msg_overlay_text;
@@ -52,10 +57,109 @@ static FRAMEDEF MessageFrame(LPCVECTOR2 pos, LPCSTR message) {
     return frame;
 }
 
+static BOOL HasTransmission(LPGAMECLIENT client) {
+    LPPLAYER ps;
+
+    if (!client) return false;
+    ps = &client->ps;
+    return ps->cinematic_portrait ||
+           (ps->texts[PLAYERTEXT_SPEAKER] && ps->texts[PLAYERTEXT_SPEAKER][0]) ||
+           (ps->texts[PLAYERTEXT_DIALOGUE] && ps->texts[PLAYERTEXT_DIALOGUE][0]);
+}
+
+static BOOL TransmissionTalking(LPGAMECLIENT client) {
+    return client && client->cinematic_voice_end_time &&
+           gi.GetTime() < client->cinematic_voice_end_time;
+}
+
+static void WriteMessageLayer(LPEDICT ent, LPCVECTOR2 pos, LPCSTR message) {
+    FRAMEDEF frame;
+
+    if (!ent || !MessageEnsureLoaded()) return;
+    UI_WriteStart(LAYER_MESSAGE);
+    if (message && *message) {
+        frame = MessageFrame(pos, message);
+        UI_WriteFrame(&msg_overlay_root);
+        UI_WriteFrameWithChildren(&frame, &msg_overlay_root);
+    }
+    UI_WriteEnd(ent);
+}
+
+static void WriteStoredMessageLayer(LPEDICT ent) {
+    LPGAMECLIENT client;
+
+    if (!ent || !ent->client) return;
+    client = ent->client;
+    WriteMessageLayer(ent,
+                      client->message.end_time ? &client->message.position : NULL,
+                      client->message.end_time ? client->message.text : NULL);
+}
+
+static void WriteGameplayTransmissionPortrait(LPEDICT ent) {
+    LPGAMECLIENT client;
+    uiFrame_t frame;
+
+    if (!ent || !ent->client) return;
+    client = ent->client;
+
+    UI_WriteStart(LAYER_PORTRAIT);
+    if (client->ps.cinematic_portrait) {
+        memset(&frame, 0, sizeof(frame));
+        frame.flags.type = FT_PORTRAIT;
+        frame.color = COLOR32_WHITE;
+        frame.tex.index = client->ps.cinematic_portrait;
+        frame.text = TransmissionTalking(client) ? "Portrait Talk" : "Portrait";
+        UI_SetFrameRect(&frame, 0.215f, 0.486f, 0.080f, 0.080f);
+        UI_WriteProxyFrame(&frame, NULL, 0);
+    }
+    UI_WriteEnd(ent);
+}
+
+static void WriteGameplayTransmissionMessage(LPEDICT ent) {
+    LPGAMECLIENT client;
+    LPCSTR speaker, dialogue;
+    char message[1200];
+
+    if (!ent || !ent->client) return;
+    client = ent->client;
+    speaker = client->ps.texts[PLAYERTEXT_SPEAKER];
+    dialogue = client->ps.texts[PLAYERTEXT_DIALOGUE];
+
+    if (speaker && *speaker && dialogue && *dialogue) {
+        snprintf(message, sizeof(message), "|cffffcc00%s:|r %s", speaker, dialogue);
+    } else if (speaker && *speaker) {
+        snprintf(message, sizeof(message), "|cffffcc00%s|r", speaker);
+    } else {
+        snprintf(message, sizeof(message), "%s", dialogue && *dialogue ? dialogue : "");
+    }
+    WriteMessageLayer(ent, NULL, UI_FormatMessageText(message));
+}
+
 void UI_ClearLayer(LPEDICT ent, DWORD layer) {
     if (!ent) return;
     UI_WriteStart(layer);
     UI_WriteEnd(ent);
+}
+
+void UI_WriteDialoguePresentation(LPEDICT ent) {
+    LPGAMECLIENT client;
+
+    if (!ent || !ent->client) return;
+    client = ent->client;
+
+    if (client->ps.client_ui_state == CLIENT_UI_CINEMATIC) {
+        UI_WriteCinematicLayer(ent);
+        return;
+    }
+    if (client->ps.client_ui_state != CLIENT_UI_GAME) return;
+
+    if (HasTransmission(client)) {
+        WriteGameplayTransmissionPortrait(ent);
+        WriteGameplayTransmissionMessage(ent);
+    } else {
+        UI_WriteSelectedPortraitLayer(ent);
+        WriteStoredMessageLayer(ent);
+    }
 }
 
 void UI_ShowInterface(LPEDICT ent, BOOL flag, FLOAT duration) {
@@ -66,34 +170,59 @@ void UI_ShowInterface(LPEDICT ent, BOOL flag, FLOAT duration) {
         ent->client->ps.uiflags = 1 << LAYER_CINEMATIC;
     else
         ent->client->ps.uiflags = ~(1u << LAYER_CINEMATIC);
+    UI_WriteDialoguePresentation(ent);
 }
 
 __attribute__((visibility("hidden"))) void UI_ShowMainMenu(LPEDICT ent) { (void)ent; }
 
 void UI_ShowGameInterface(LPEDICT ent) {
-    UI_WriteCinematicLayer(ent);
+    UI_WriteDialoguePresentation(ent);
 }
 
 void UI_ShowText(LPEDICT ent, LPCVECTOR2 pos, LPCSTR text, FLOAT duration) {
-    FRAMEDEF frame;
-    LPCSTR message;
+    LPGAMECLIENT client;
+    LPCSTR resolved, message;
 
-    (void)duration;
-    if (!ent || !MessageEnsureLoaded()) return;
-    message = UI_FormatMessageText(UI_LevelStringSafe(text));
-    frame = MessageFrame(pos, message);
+    if (!ent || !ent->client || !MessageEnsureLoaded()) return;
+    client = ent->client;
+    resolved = UI_LevelStringSafe(text);
+    message = UI_FormatMessageText(resolved);
 
-    UI_WriteStart(LAYER_MESSAGE);
-    UI_WriteFrame(&msg_overlay_root);
-    UI_WriteFrameWithChildren(&frame, &msg_overlay_root);
-    UI_WriteEnd(ent);
+    if (duration < 0.0f)
+        duration = (FLOAT)strlen(resolved) / WC3_MESSAGE_CHARS_PER_SECOND + WC3_MESSAGE_BASE_DURATION;
+    if (duration <= 0.0f) {
+        UI_ClearTextMessages(ent);
+        return;
+    }
+
+    client->message.position = pos ? *pos : MAKE(VECTOR2, 0.05f, 0.0f);
+    client->message.end_time = gi.GetTime() + MAX(1u, (DWORD)(duration * 1000.0f));
+    snprintf(client->message.text, sizeof(client->message.text), "%s", message);
+
+    /* A gameplay transmission owns LAYER_MESSAGE while active.  Preserve an
+     * ordinary message started underneath it and reveal that message when the
+     * transmission ends if its own lifetime has not expired. */
+    if (client->ps.client_ui_state == CLIENT_UI_GAME && HasTransmission(client)) return;
+    WriteStoredMessageLayer(ent);
+}
+
+void UI_ClearTextMessages(LPEDICT ent) {
+    LPGAMECLIENT client;
+
+    if (!ent || !ent->client) return;
+    client = ent->client;
+    memset(&client->message, 0, sizeof(client->message));
+    if (client->ps.client_ui_state == CLIENT_UI_GAME && HasTransmission(client)) return;
+    UI_ClearLayer(ent, LAYER_MESSAGE);
 }
 
 void UI_WriteCinematicLayer(LPEDICT ent) {
+    LPGAMECLIENT client;
     LPPLAYER ps;
 
     if (!ent || !ent->client) return;
-    ps = &ent->client->ps;
+    client = ent->client;
+    ps = &client->ps;
 
     CinematicEnsureLoaded();
 
@@ -108,11 +237,13 @@ void UI_WriteCinematicLayer(LPEDICT ent) {
     UI_SetHidden(cin.CinematicPortraitBackground, !has_portrait);
     UI_SetHidden(cin.CinematicPortrait, !has_portrait);
     UI_SetHidden(cin.CinematicPortraitCover, !has_portrait);
+    UI_SetHidden(cin.CinematicSpeakerText, !has_speaker);
+    UI_SetHidden(cin.CinematicDialogueText, !has_dialogue);
 
     if (has_portrait) {
         /* FT_PORTRAIT serialization reads Portrait.model; Texture.Image left the transmitted model at zero. */
         UI_SetPortraitFrameModel(cin.CinematicPortrait, ps->cinematic_portrait);
-        cin.CinematicPortrait->Text = has_dialogue ? "Portrait Talk" : "Portrait";
+        cin.CinematicPortrait->Text = TransmissionTalking(client) ? "Portrait Talk" : "Portrait";
     }
 
     if (has_speaker) {

--- a/games/warcraft-3/game/hud/hud_infopanel.c
+++ b/games/warcraft-3/game/hud/hud_infopanel.c
@@ -207,6 +207,18 @@ static void WritePortraitFrame(LPEDICT ent) {
     UI_WriteProxyFrame(&frame, NULL, 0);
 }
 
+void UI_WriteSelectedPortraitLayer(LPEDICT ent) {
+    LPEDICT selected[MAX_SELECTED_ENTITIES];
+    DWORD count;
+
+    if (!ent || !ent->client) return;
+    count = SelectedUnits(ent->client, selected, MAX_SELECTED_ENTITIES);
+
+    UI_WriteStart(LAYER_PORTRAIT);
+    if (count == 1) WritePortraitFrame(selected[0]);
+    UI_WriteEnd(ent);
+}
+
 static void WriteInventoryCharge(FLOAT x, FLOAT y, FLOAT w, FLOAT h, DWORD charges) {
     uiFrame_t frame;
     uiLabel_t label;
@@ -308,9 +320,10 @@ void Get_Portrait_f(LPEDICT ent) {
     if (!ent || !ent->client) return;
     count = SelectedUnits(ent->client, selected, MAX_SELECTED_ENTITIES);
 
-    UI_WriteStart(LAYER_PORTRAIT);
-    if (count == 1) WritePortraitFrame(selected[0]);
-    UI_WriteEnd(ent);
+    /* A normal-game transmission temporarily owns LAYER_PORTRAIT. Selection
+     * still updates the info/inventory panels, but the talking head remains
+     * authoritative until the transmission ends. */
+    UI_WriteDialoguePresentation(ent);
 
     UI_SendInfoPanel(ent, selected, count);
     UI_SendInventoryLayer(ent, selected, count);

--- a/games/warcraft-3/game/hud/hud_local.h
+++ b/games/warcraft-3/game/hud/hud_local.h
@@ -57,6 +57,7 @@ void UI_WriteSingleInfo(LPEDICT ent);
 void UI_WriteMultiselect(LPEDICT *ents, DWORD count);
 void UI_SeedInfoPanelCache(LPEDICT ent, LPEDICT *selected, DWORD count);
 void UI_SendInfoPanel(LPEDICT ent, LPEDICT *selected, DWORD count);
+void UI_WriteSelectedPortraitLayer(LPEDICT ent);
 
 /* Quests (hud_quests.c) */
 DWORD UI_QuestIndex(LPCQUEST quest);
@@ -72,6 +73,8 @@ void UI_HideGameResult(LPEDICT ent);
 void UI_ShowInterface(LPEDICT ent, BOOL flag, FLOAT duration);
 void UI_ShowGameInterface(LPEDICT ent);
 void UI_ShowText(LPEDICT ent, LPCVECTOR2 pos, LPCSTR text, FLOAT duration);
+void UI_ClearTextMessages(LPEDICT ent);
+void UI_WriteDialoguePresentation(LPEDICT ent);
 void UI_WriteCinematicLayer(LPEDICT ent);
 void UI_ClearLayer(LPEDICT ent, DWORD layer);
 

--- a/games/warcraft-3/game/tests/t_api.c
+++ b/games/warcraft-3/game/tests/t_api.c
@@ -350,6 +350,94 @@ TEST(wc3_api, fog_modifier_states_and_visible_stop_transition) {
     G_FogModifierStop(&mod);
 }
 
+TEST(wc3_api, display_text_tracks_lifetime_and_clear) {
+    LPGAMECLIENT gc = &game.clients[0];
+
+    level.time = 100;
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  call DisplayTimedTextToPlayer(Player(0), 0.10, 0.20, 2.0, \"Timed message\")\n"
+        "endfunction\n"));
+    T_EQ(gc->message.end_time, 2100);
+    T_FEQ(gc->message.position.x, 0.10f, 0.001f);
+    T_FEQ(gc->message.position.y, 0.20f, 0.001f);
+    T_STREQ(gc->message.text, "Timed message");
+
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  call ClearTextMessages()\n"
+        "endfunction\n"));
+    T_EQ(gc->message.end_time, 0);
+    T_STREQ(gc->message.text, "");
+}
+
+TEST(wc3_api, display_text_uses_automatic_duration) {
+    LPGAMECLIENT gc = &game.clients[0];
+
+    level.time = 100;
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  call DisplayTextToPlayer(Player(0), 0.0, 0.0, \"123456\")\n"
+        "endfunction\n"));
+    T_EQ(gc->message.end_time, 6100);
+
+    level.time = gc->message.end_time;
+    G_RunClients();
+    T_EQ(gc->message.end_time, 0);
+}
+
+TEST(wc3_api, transmission_keeps_gameplay_ui_and_separates_voice_lifetime) {
+    LPGAMECLIENT gc = &game.clients[0];
+
+    level.time = 100;
+    gc->ps.client_ui_state = CLIENT_UI_GAME;
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  if GetLocalPlayer() == Player(0) then\n"
+        "    call SetCinematicScene(0, PLAYER_COLOR_RED, \"Captain\", \"Hold the line!\", 6.0, 4.0)\n"
+        "  endif\n"
+        "endfunction\n"));
+    T_EQ(gc->ps.client_ui_state, CLIENT_UI_GAME);
+    T_STREQ(gc->ps.texts[PLAYERTEXT_SPEAKER], "Captain");
+    T_STREQ(gc->ps.texts[PLAYERTEXT_DIALOGUE], "Hold the line!");
+    T_EQ(gc->cinematic_voice_end_time, 4100);
+    T_EQ(gc->cinematic_end_time, 6100);
+
+    level.time = 4100;
+    G_RunClients();
+    T_EQ(gc->cinematic_voice_end_time, 0);
+    T_EQ(gc->cinematic_end_time, 6100);
+    T_STREQ(gc->ps.texts[PLAYERTEXT_DIALOGUE], "Hold the line!");
+
+    level.time = 6100;
+    G_RunClients();
+    T_EQ(gc->cinematic_end_time, 0);
+    T_STREQ(gc->ps.texts[PLAYERTEXT_SPEAKER], "");
+    T_STREQ(gc->ps.texts[PLAYERTEXT_DIALOGUE], "");
+}
+
+TEST(wc3_api, gameplay_transmission_preserves_underlying_timed_message_state) {
+    LPGAMECLIENT gc = &game.clients[0];
+
+    level.time = 100;
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  call DisplayTimedTextToPlayer(Player(0), 0.0, 0.0, 10.0, \"Objective updated\")\n"
+        "  if GetLocalPlayer() == Player(0) then\n"
+        "    call SetCinematicScene(0, PLAYER_COLOR_RED, \"Footman\", \"Ready.\", 3.0, 2.0)\n"
+        "  endif\n"
+        "endfunction\n"));
+    T_EQ(gc->message.end_time, 10100);
+    T_STREQ(gc->message.text, "Objective updated");
+    T_EQ(gc->cinematic_end_time, 3100);
+
+    level.time = 3100;
+    G_RunClients();
+    T_EQ(gc->cinematic_end_time, 0);
+    T_EQ(gc->message.end_time, 10100);
+    T_STREQ(gc->message.text, "Objective updated");
+}
+
 /* Create a minimal unit in slot 0 and return it. */
 static LPEDICT make_unit_hero(void) {
     reset_entities();


### PR DESCRIPTION
Recovered and rebased implementation of PR #211 after its contributor branch became unavailable. Adds gameplay transmission presentation, independent voice/scene lifetimes, timed text state, local transmission audio, tests, and documentation.