### PR TITLE
WC3: route units to closest reachable destinations

### DIFF
--- a/common/cmodel.h
+++ b/common/cmodel.h
@@ -48,6 +48,7 @@ VECTOR2 CM_GetNormalizedMapPosition(float x, float y);
 VECTOR2 CM_GetDenormalizedMapPosition(float x, float y);
 BOOL CM_ClosestPathablePoint(LPCVECTOR2 location, LPVECTOR2 out);
 BOOL CM_ClosestPathablePointForRadius(LPCVECTOR2 location, FLOAT radius, LPVECTOR2 out);
+BOOL CM_ClosestReachablePointForRadius(LPCVECTOR2 from, LPCVECTOR2 target, FLOAT radius, LPVECTOR2 out);
 BOOL CM_PointIsPathableForRadius(LPCVECTOR2 location, FLOAT radius);
 BOOL CM_LineIsWalkable(LPCVECTOR2 a, LPCVECTOR2 b);
 BOOL CM_GetPathingFlagsAt(LPCVECTOR2 location, LPBYTE flags);

--- a/common/common.h
+++ b/common/common.h
@@ -256,6 +256,7 @@ void CM_SetupPathMap(DWORD width, DWORD height, BYTE const *cells);
 BOOL CM_IsMapLoaded(LPCSTR mapFilename);
 BOOL CM_ClosestPathablePoint(LPCVECTOR2 location, LPVECTOR2 out);
 BOOL CM_ClosestPathablePointForRadius(LPCVECTOR2 location, FLOAT radius, LPVECTOR2 out);
+BOOL CM_ClosestReachablePointForRadius(LPCVECTOR2 from, LPCVECTOR2 target, FLOAT radius, LPVECTOR2 out);
 BOOL CM_FindDirectApproachPointForRadius(LPCVECTOR2 from, LPCVECTOR2 target, FLOAT range, FLOAT radius, LPVECTOR2 out);
 BOOL CM_FindApproachPointToFootprintForRadius(struct edict_s const *target, LPCVECTOR2 from, FLOAT range, FLOAT radius, LPVECTOR2 out);
 FLOAT CM_GetHeightAtPoint(FLOAT sx, FLOAT sy);

--- a/common/mpq.c
+++ b/common/mpq.c
@@ -5,7 +5,7 @@
  * Supports:
  *  - MPQ v1/v2 format
  *  - File lookup by name
- *  - ZLIB decompression
+ *  - ZLIB, adaptive Huffman, and Blizzard ADPCM decompression
  *  - Uncompressed files
  *
  * Based on StormLib specifications and MPQ format documentation.
@@ -255,6 +255,8 @@ static BOOL Mpq_DecompressSector(mpqDecompress_t *p) {
         if (uncompress(p->dst, &size, p->src + 1, p->src_size - 1) != Z_OK) return FALSE;
         p->out_size = (DWORD)size; return TRUE;
     }
+    if (mask == MPQ_COMP_ADPCM_MONO || mask == MPQ_COMP_ADPCM_STEREO)
+        return Mpq_AdpcmDecode(p->src + 1, p->src_size - 1, p->dst, p->dst_size, mask == MPQ_COMP_ADPCM_STEREO ? 2 : 1, &p->out_size);
     if (mask == (MPQ_COMP_HUFF | MPQ_COMP_ADPCM_MONO) || mask == (MPQ_COMP_HUFF | MPQ_COMP_ADPCM_STEREO)) {
         BYTE *tmp = malloc(p->dst_size);
         DWORD tmp_size = 0, channels = mask & MPQ_COMP_ADPCM_STEREO ? 2 : 1;
@@ -266,6 +268,15 @@ static BOOL Mpq_DecompressSector(mpqDecompress_t *p) {
     fprintf(stderr, "MPQ: unsupported sector compression mask 0x%02x\n", mask);
     return FALSE;
 }
+
+#ifdef MPQ_TEST_API
+BOOL Mpq_TestDecompressSector(BYTE const *src, DWORD src_size, BYTE *dst, DWORD dst_size, DWORD *out_size) {
+    mpqDecompress_t p = { src, src_size, dst, dst_size, 0 };
+    BOOL ok = Mpq_DecompressSector(&p);
+    if (out_size) *out_size = p.out_size;
+    return ok;
+}
+#endif
 
 typedef struct {
     DWORD dwID;                 // "MPQ\x1a"

--- a/common/mpq.h
+++ b/common/mpq.h
@@ -61,6 +61,10 @@ HANDLE SFileFindFirstFile(HANDLE archive, LPCSTR mask, SFILE_FIND_DATA *findData
 BOOL SFileFindNextFile(HANDLE find, SFILE_FIND_DATA *findData);
 BOOL SFileFindClose(HANDLE find);
 
+#ifdef MPQ_TEST_API
+BOOL Mpq_TestDecompressSector(BYTE const *src, DWORD src_size, BYTE *dst, DWORD dst_size, DWORD *out_size);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/common/routing.c
+++ b/common/routing.c
@@ -712,8 +712,17 @@ BOOL CM_LineIsWalkableForRadius(LPCVECTOR2 a, LPCVECTOR2 b, FLOAT radius) {
             return true;
         }
         int e2 = 2 * err;
-        if (e2 > -dy) { err -= dy; x += sx; }
-        if (e2 <  dx) { err += dx; y += sy; }
+        BOOL const step_x = e2 > -dy;
+        BOOL const step_y = e2 < dx;
+        /* A simultaneous Bresenham step crosses a cell corner.  Check both
+         * cardinal neighbours so the direct shortcut cannot bypass the
+         * flow-field rule and steer through touching obstacle corners. */
+        if (step_x && step_y &&
+            !(is_pathable_node_original_for_radius_cells(x + sx, y, radius_cells) &&
+              is_pathable_node_original_for_radius_cells(x, y + sy, radius_cells)))
+            return false;
+        if (step_x) { err -= dy; x += sx; }
+        if (step_y) { err += dx; y += sy; }
     }
     return true;
 }
@@ -1005,6 +1014,60 @@ static BOOL resolve_heatmap_request(edict_t *goalentity, FLOAT radius,
         if (!closest_pathable_node_original(&goalentity->s.origin2, radius, target))
             return false;
     }
+    return true;
+}
+
+/* Resolve a click to the closest legal point in the mover's static connected
+ * component.  This is used only after destination-rooted routing proves the
+ * mover cannot reach that component, so the whole-component flood is paid once
+ * for an exceptional order rather than on every ordinary right click. */
+BOOL CM_ClosestReachablePointForRadius(LPCVECTOR2 from, LPCVECTOR2 target, FLOAT radius, LPVECTOR2 out) {
+    VECTOR2 n;
+    point2_t start;
+    heatmapJob_t job = { 0 };
+    FLOAT tx, ty, best_dist = FLT_MAX;
+    int radius_cells, target_x, target_y, best_x = -1, best_y = -1;
+
+    if (!from || !target || !out || !pathmap.original || !pathmap.heatmap)
+        return false;
+    radius_cells = (int)ceilf(MAX(0.f, radius) / pathmap_cell_world_size());
+    if (!closest_pathable_node_original(from, radius, &start))
+        return false;
+
+    begin_heatmap_build(&job, start, radius_cells);
+    while (!step_heatmap_build(&job, UINT_MAX)) {
+        /* UINT_MAX is already effectively unbounded for WC3 pathmap sizes. */
+    }
+    n = CM_GetNormalizedMapPosition(target->x, target->y);
+    tx = n.x * pathmap.width;
+    ty = n.y * pathmap.height;
+    target_x = (int)floorf(tx);
+    target_y = (int)floorf(ty);
+    if (is_valid_point(target_x, target_y) &&
+        pathmap.heatmap[target_x + target_y * pathmap.width].price != INT_MAX &&
+        is_pathable_node_original_for_radius_cells(target_x, target_y, radius_cells)) {
+        *out = *target;
+        return true;
+    }
+    FOR_LOOP(y, pathmap.height) {
+        FOR_LOOP(x, pathmap.width) {
+            FLOAT dxw, dyw, dist;
+            if (pathmap.heatmap[x + y * pathmap.width].price == INT_MAX)
+                continue;
+            dxw = (FLOAT)x + 0.5f - tx;
+            dyw = (FLOAT)y + 0.5f - ty;
+            dist = dxw * dxw + dyw * dyw;
+            if (dist < best_dist) {
+                best_dist = dist;
+                best_x = x;
+                best_y = y;
+            }
+        }
+    }
+    if (best_x < 0)
+        return false;
+    *out = CM_GetDenormalizedMapPosition(((FLOAT)best_x + 0.5f) / pathmap.width,
+                                         ((FLOAT)best_y + 0.5f) / pathmap.height);
     return true;
 }
 

--- a/docs/games/warcraft-3/file-docs/mpq.md
+++ b/docs/games/warcraft-3/file-docs/mpq.md
@@ -53,7 +53,7 @@ Units\MiscData.txt
 ## Tools
 
 - **Ladik's MPQ Editor** — https://www.zezula.net/en/mpq/download.html (GUI editor)
-- **OW3 MPQ layer** (`common/mpq.c`) — in-tree Warcraft III MPQ reader. Handles archive open/read/find operations without StormLib at build or run time, and normalizes forward-slash paths to the backslash-separated form used in MPQs.
+- **OW3 MPQ layer** (`common/mpq.c`) — in-tree Warcraft III MPQ reader. Handles archive open/read/find operations without StormLib at build or run time, normalizes forward-slash paths to the backslash-separated form used in MPQs, and decodes zlib, adaptive Huffman plus Blizzard ADPCM, and standalone mono/stereo Blizzard ADPCM sectors. TFT voice assets such as `Units\\Creeps\\SpiritWolf\\SpiritWolfYesAttack1.wav` use standalone mono ADPCM (`0x40`).
 - **mpqtool** (`tools/mpqtool.c`) — in-tree CLI built by `make build`. Supports `ls [subdir]` for incremental directory listing and `cat <file>` for dumping file contents to stdout. Usage: `build/bin/mpqtool -mpq <path> ls [subdir]` / `build/bin/mpqtool -mpq <path> cat <archive-file>`.
 - **SFmpqapi** — older API, source available at https://sfsrealm.hopto.org/downloads/SFmpqapi.html
 - **MPQDraft** — creates executable patches embedding a custom MPQ (for overriding files that can't go in the map MPQ)

--- a/docs/games/warcraft-3/pathfinding.md
+++ b/docs/games/warcraft-3/pathfinding.md
@@ -8,9 +8,9 @@ WC3 movement keeps target selection, static routing, and interaction behavior se
 order / behavior -> target + interaction range -> routing -> collision-aware step
 ```
 
-`games/warcraft-3/game/g_ai.c` owns per-tick steering and local block-and-slide. `common/routing.c` owns static pathmap line tests and cached flow fields. Harvest target selection remains in `skills/s_harvest_lumber.c`; the router never changes a tree target by itself.
+`games/warcraft-3/game/g_ai.c` owns per-tick steering and local block-and-slide. `common/routing.c` owns static pathmap line tests, connectivity queries, and cached flow fields. Harvest target selection remains in `skills/s_harvest_lumber.c`; the router never changes a tree target by itself.
 
-Move-time occupancy is collision-size aware, but generic interaction routing deliberately keeps the existing point-route contract. Attack, gold-mine entry, resource return, repair, and similar behaviors own their interaction ranges and may need to continue toward a blocked target after the point flow reaches the footprint edge. Live units remain outside the static flow field and are handled by the precise swept-circle checks in `move_is_valid`.
+Ground Move, Patrol, and Attack-move location orders are collision-size aware from destination selection through line tests, flow generation, and move-time validation. Generic interaction routing deliberately keeps the point-route contract: attack, gold-mine entry, resource return, repair, and similar behaviors own their interaction ranges and may need to continue toward a blocked target after the point flow reaches the footprint edge. Live units remain outside static flow fields and are handled by the precise swept-circle checks in `move_is_valid`.
 
 Attack range against a building is measured from the attacker's collision edge to the building's authored no-walk footprint when `pathtex` is available. `skills/s_attack.c` therefore uses `CM_DistanceToPathingFootprint()` for building targets instead of requiring the attacker to enter weapon range of the blocked building centre. This is especially important for explicit force-fire on owned/friendly large buildings: centre-distance range checks make a melee unit orbit the footprint forever even though it is already beside a valid attack surface. Non-building targets retain the existing centre-distance attack check.
 
@@ -37,6 +37,19 @@ While a resumable request is pending, `unit_changeangle*()` leaves both `movemen
 `CM_BuildHeatmapForRadius()` and the resumable request path both key cached fields by adjusted target cell and mover collision radius. The flood and flow query use the same radius-expanded static pathability predicate as move-time terrain checks. The zero-radius `CM_BuildHeatmap()` wrapper remains for callers that intentionally route a point.
 
 Flow vectors only descend to a strictly lower heatmap price. The adjusted goal cell therefore has a zero vector instead of pointing back out to a higher-cost neighbour. Cached prices retain `INT_MAX` for cells that the completed field cannot reach. `CM_FlowReachedGoal(generation, x, y)` identifies the adjusted goal cell, while `CM_FlowCanReach(generation, x, y)` distinguishes a disconnected cell from a zero produced by interpolation near the goal.
+
+## Retail Move Destination Behavior
+
+Two defects explained the Human01 fence report and units getting stuck behind trees or towers:
+
+1. `CM_LineIsWalkableForRadius()` used ordinary Bresenham stepping. A 45-degree step from one cell to the next checked only those two cells, so the direct shortcut accepted an `ox/xo` arrangement even though both cardinal side cells were blocked. The shortcut now requires both side cells to be legal, matching heatmap expansion and `compute_flow_at()`.
+2. Location steering requested a point-sized route while `move_is_valid()` rejected positions using the unit collision radius. The field could therefore direct a unit through a gap that its body could not occupy. Move, Patrol, and Attack-move now use `self->collision` for the direct line and field; interaction behaviors retain radius zero.
+
+When a clicked destination is in another static connected component, the destination-rooted field reports the mover cell unreachable. `CM_ClosestReachablePointForRadius(from, target, radius)` floods the mover component with the same radius and diagonal rules, then chooses its legal cell nearest the click. The location order retargets its private waypoint once and follows a normal field to that point. This avoids both failure modes of the old behavior: freezing at the order origin and sliding forever along the blocking wall.
+
+Ordinary destination fields remain incremental and frame-budgeted. The mover-component flood is synchronous only after a completed destination field proves the click unreachable, so this exceptional recovery does not add input-time work to reachable orders.
+
+The current router does not need wholesale replacement. Its cached integration fields, collision expansion, direct-line shortcut, and local dynamic avoidance are suitable for WC3 movement once they share one traversability contract. Remaining large-scale work is performance-oriented: incremental field construction and richer dynamic crowd routing, not a different static shortest-path algorithm.
 
 ## Retail Lumber Fallback
 
@@ -90,7 +103,13 @@ Focused tests live in `games/warcraft-3/game/tests/t_pathfinding.c` and `t_movem
 - cache separation by collision radius;
 - resumable cache misses serialize without losing a later destination;
 - collision-radius-aware line walkability;
+- direct-line and flow rejection of diagonal `ox/xo` corner cuts;
 - rejection of a corridor too narrow for the mover;
+- collision-sized Move, Patrol, and Attack-move route selection;
+- collision-sized Move routing around a long wall;
+- exact reachable clicks and closest reachable points across a disconnected wall;
+- collision-radius expansion of the closest reachable boundary;
+- end-to-end settling at the nearest reachable point for a disconnected click;
 - a zero outward vector at the flow goal;
 - end-to-end lumber retarget from a buried clicked tree to a reachable edge tree;
 - gold-mine entry through an authored blocking mine footprint;
@@ -104,6 +123,7 @@ Run when validating locally:
 make test-wc3-engine WC3_PATTERN='wc3_pathfinding.*'
 make test-wc3-engine WC3_PATTERN='wc3_movement.plain_move_*'
 make test-wc3-engine WC3_PATTERN='wc3_movement.blocked_move_*'
+make test-wc3-engine WC3_PATTERN='wc3_movement.*'
 make test-wc3-engine WC3_PATTERN='wc3_movement.lumber_*'
 ```
 

--- a/games/warcraft-3/game.mk
+++ b/games/warcraft-3/game.mk
@@ -81,7 +81,7 @@ $(JASS_BIN): tools/jass.c $(TOOL_DEPS) | $(BIN_DIR) $(SHARED_LIB) $(JASS_LIB) $(
 
 $(MPQ_TEST): $(WC3_TEST_DIR)/test_mpq_compat.c common/mpq.c common/mpq.h | $(BIN_DIR)
 	@echo "[mpq-compat-test]"
-	@$(CC) $(CFLAGS) -o $@ $(WC3_TEST_DIR)/test_mpq_compat.c common/mpq.c -lm -lz
+	@$(CC) $(CFLAGS) -DMPQ_TEST_API -o $@ $(WC3_TEST_DIR)/test_mpq_compat.c common/mpq.c -lm -lz
 
 # jass.h includes g_local.h: stale edict/client offsets break player-local ESC cleanup after contract changes.
 JASS_HEADERS := $(COMMON_HEADERS) $(CLIENT_HEADERS) $(shell find $(WC3_DIR)/game $(WC3_DIR)/common server shared -name '*.h')

--- a/games/warcraft-3/game/g_ai.c
+++ b/games/warcraft-3/game/g_ai.c
@@ -12,11 +12,21 @@ static FLOAT angle_wrap(FLOAT a) {
 /* unit_changeangle is defined lower down — it needs the move-validity test and
  * the give-way helpers, which are declared below. */
 
-extern ability_t a_move;
+extern ability_t a_move, a_attack, a_patrol;
 
 /* A unit is actively executing a ground move order (right-click move). */
 BOOL unit_is_walking(LPCEDICT ent) {
     return ent->currentmove && ent->currentmove->ability == &a_move;
+}
+
+/* Location orders own a legal ground endpoint; interaction orders route to an
+ * entity centre and let their behavior-specific range decide arrival. */
+static BOOL unit_routes_to_location(LPCEDICT ent) {
+    if (!ent->currentmove)
+        return false;
+    if (ent->currentmove->ability == &a_move || ent->currentmove->ability == &a_patrol)
+        return true;
+    return ent->currentmove->ability == &a_attack && ent->goalentity == ent->movement.attackmove_waypoint;
 }
 
 /* Unit's effective current move speed.  Group moves travel at the slowest
@@ -279,6 +289,7 @@ void unit_changeangle(LPEDICT self) {
         return;
     VECTOR2 to_goal = Vector2_sub(&self->goalentity->s.origin2, &self->s.origin2);
     VECTOR2 dir;
+    FLOAT const radius = unit_routes_to_location(self) ? self->collision : 0.0f;
 
     self->movement.heading = self->s.angle;  /* default if no heading is resolved this tick */
     self->movement.flow_generation = 0;
@@ -289,20 +300,42 @@ void unit_changeangle(LPEDICT self) {
     /* Generic interaction movement keeps the original point-route contract.
      * Attack, mine entry, resource return, repair, and other ranged behaviors
      * decide when their interaction boundary has been reached.  Do not stop
-     * those orders at a collision-expanded flow goal outside that boundary. */
-    if (CM_LineIsWalkable(&self->s.origin2, &self->goalentity->s.origin2)) {
+     * those orders at a collision-expanded flow goal outside that boundary.
+     * Move orders own radius-valid reserved destinations, so their route must
+     * use the same footprint as move-time collision; point routing previously
+     * sent units into narrow gaps and touching obstacle corners. */
+    if (CM_LineIsWalkableForRadius(&self->s.origin2, &self->goalentity->s.origin2, radius)) {
         self->movement.flow_direct = true;
         dir = to_goal;
     } else {
-        DWORD heatmap = M_RefreshHeatmap(self->goalentity, 0.0f);
+        DWORD heatmap = M_RefreshHeatmap(self->goalentity, radius);
         self->movement.flow_generation = heatmap;
         if (!heatmap)
             return; /* incremental route is still building; keep the order */
-        dir = get_flow_direction(heatmap, self->s.origin.x, self->s.origin.y);
-        if (Vector2_len(&dir) <= 0.001f) {
-            self->movement.flow_unreachable =
-                !CM_FlowCanReach(heatmap, self->s.origin.x, self->s.origin.y);
-            return;
+        if (radius > 0.0f && CM_FlowReachedGoal(heatmap, self->s.origin.x, self->s.origin.y)) {
+            self->movement.flow_goal_reached = true;
+            dir = to_goal;
+        } else {
+            dir = get_flow_direction(heatmap, self->s.origin.x, self->s.origin.y);
+            if (Vector2_len(&dir) <= 0.001f) {
+                self->movement.flow_unreachable = !CM_FlowCanReach(heatmap, self->s.origin.x, self->s.origin.y);
+                /* Location targets are private waypoints.  When the clicked static
+                 * component is unreachable, replace the waypoint with the
+                 * closest legal point in this mover's component; aiming at the
+                 * raw click made local avoidance walk forever along walls. */
+                if (radius > 0.0f && self->movement.flow_unreachable) {
+                    VECTOR2 closest;
+                    if (CM_ClosestReachablePointForRadius(&self->s.origin2, &self->goalentity->s.origin2, radius, &closest)) {
+                        self->goalentity->s.origin2 = closest;
+                        self->goalentity->secondarygoal = NULL;
+                        self->goalentity->heatmap2 = 0;
+                        self->goalentity->heatmap2_radius = 0;
+                        move_reset_progress(self);
+                    }
+                    return;
+                }
+                return;
+            }
         }
     }
 

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -1024,6 +1024,7 @@ void G_RefreshInfoPanel(LPEDICT);
 void G_UpdateClientInfoPanels(void);
 void UI_WriteSelectedPortraitLayer(LPEDICT);
 void G_RefreshResourceBar(LPEDICT);
+void G_AccumulatePlayerFood(LPGAMECLIENT client);
 void G_UpdateClientResourceBars(void);
 void UI_AddCancelButton(LPEDICT);
 void UI_WriteCommandButtonFrame(gameCommandButton_t const *button);

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -512,6 +512,15 @@ void G_SetClientConnected(LPEDICT player, BOOL connected) {
     player->client->connected = connected;
 }
 
+/* Client slots and free edicts have zero-initialized player ownership but no
+ * unit row.  Only live, metadata-bound units contribute authored food values. */
+void G_AccumulatePlayerFood(LPGAMECLIENT client) {
+    FILTER_EDICTS(ent, ent->inuse && ent->UnitBalance && client->ps.number == ent->s.player) {
+        client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP] += ent->UnitBalance->foodMade;
+        client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_USED] += ent->UnitBalance->foodUsed;
+    }
+}
+
 /* Called when a client finishes the connection handshake and is ready to play.
  * The in-game HUD is server-authored through svc_layout; this binds the game
  * client and initializes gameplay state when a map is loaded. */
@@ -542,11 +551,7 @@ static void G_ClientBegin(LPEDICT edict) {
 
     UI_ShowGameInterface(edict);
 
-    FILTER_EDICTS(ent, client->ps.number == ent->s.player) {
-        UnitBalance_t const *b = ent->UnitBalance;
-        client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP] += b->foodMade;
-        client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_USED] += b->foodUsed;
-    }
+    G_AccumulatePlayerFood(client);
     /* Invalidate cache so the initial resource bar write always fires. */
     client->resourcebar.gold = -1;
     G_RefreshResourceBar(edict);

--- a/games/warcraft-3/game/skills/s_attack.c
+++ b/games/warcraft-3/game/skills/s_attack.c
@@ -420,18 +420,16 @@ void order_attackmove(LPEDICT self, LPEDICT waypoint) {
 }
 
 static BOOL attackmove_selectlocation(LPEDICT clent, LPCVECTOR2 location) {
-    LPEDICT waypoint;
     BOOL any = false;
 
     FOR_SELECTED_UNITS(clent->client, ent) {
+        VECTOR2 target = *location;
         if ((ent->aiflags & AI_IMMOBILE) || ent->UnitBalance->speed <= 0) {
             continue;
         }
-        if (!any) {
-            waypoint = Waypoint_add(location);
-            any = true;
-        }
-        order_attackmove(ent, waypoint);
+        CM_ClosestPathablePointForRadius(location, ent->collision, &target);
+        order_attackmove(ent, Waypoint_add(&target));
+        any = true;
     }
     return any;
 }

--- a/games/warcraft-3/game/skills/s_move.c
+++ b/games/warcraft-3/game/skills/s_move.c
@@ -281,11 +281,10 @@ static void ai_move_walk(LPEDICT ent) {
     } else {
         blocked = move_is_blocked(ent, distance, move_distance);
 
-        /* A plain move waypoint is collision-safe and has no interaction
-         * boundary owned by another behavior, so route it using the mover's
-         * real footprint.  Point-sized generic routing can legitimately choose
-         * a tree/building gap that the unit itself cannot enter. */
-        unit_changeangle_for_radius(ent, ent->collision);
+        /* Plain Move owns a private destination, so location-aware steering
+         * uses the mover footprint and retargets a disconnected click before
+         * this behavior treats an unresolved route as terminal. */
+        unit_changeangle(ent);
 
         if (ent->movement.flow_unreachable) {
             move_hold(ent); /* static topology says this goal cannot be reached */

--- a/games/warcraft-3/game/tests/t_building.c
+++ b/games/warcraft-3/game/tests/t_building.c
@@ -43,9 +43,6 @@ static void building_capture_write(pfWriteType_t type, void const *value) {
     }
 }
 
-static void building_noop_write(pfWriteType_t type, void const *value) { (void)type; (void)value; }
-static void building_noop_unicast(LPEDICT ent) { (void)ent; }
-
 static LPCSTR building_all_cvar(LPCSTR name, LPCSTR fallback) {
     return !strcmp(name, "wc3_build_all") ? "1" : fallback;
 }

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -80,6 +80,23 @@ TEST(wc3_game, hud_valid_texture_path_is_unchanged) {
 }
 TEST(wc3_game, hud_second_attack_present_with_dice) { T_ASSERT(UI_HasSecondAttack(1)); }
 TEST(wc3_game, hud_second_attack_absent_without_dice) { T_ASSERT(!UI_HasSecondAttack(0)); }
+TEST(wc3_game, player_zero_food_ignores_free_edicts) {
+    static UnitBalance_t const owned_balance = { .foodMade = 6, .foodUsed = 1 };
+    static UnitBalance_t const enemy_balance = { .foodMade = 12, .foodUsed = 2 };
+    LPGAMECLIENT client = &game.clients[0];
+    LPEDICT owned, enemy;
+
+    reset_entities();
+    client->ps.number = 0;
+    owned = G_Spawn(); enemy = G_Spawn();
+    owned->s.player = 0; owned->UnitBalance = &owned_balance;
+    enemy->s.player = 1; enemy->UnitBalance = &enemy_balance;
+
+    G_AccumulatePlayerFood(client);
+
+    T_EQ(client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP], 6);
+    T_EQ(client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_USED], 1);
+}
 TEST(wc3_game, hud_portrait_model_uses_serialized_field) {
     FRAMEDEF frame = { 0 };
     UI_SetPortraitFrameModel(&frame, 42);

--- a/games/warcraft-3/game/tests/t_movement.c
+++ b/games/warcraft-3/game/tests/t_movement.c
@@ -1702,6 +1702,65 @@ TEST(wc3_movement, unit_position_changes_after_move_frame) {
     T_ASSERT(unit->s.origin2.x > x0);
 }
 
+/* Route generation must expand obstacles by the mover radius, matching the
+ * move-time collision test.  The point route hugs this wall too closely; a
+ * Peasant-sized route has room to detour above it and reach the destination. */
+TEST(wc3_movement, move_order_detours_with_unit_collision_radius) {
+    enum { CELLS = 16 };
+    BYTE pathmap[CELLS * CELLS] = {0};
+    LPEDICT unit = make_moving_unit(80.0f, 240.0f);
+    VECTOR2 dest = {432.0f, 240.0f};
+
+    for (int y = 3; y <= 12; y++)
+        pathmap[y * CELLS + 7] = 2;
+    CM_SetupTestPathmap(CELLS, CELLS, pathmap);
+    CM_SetupTestWorldBounds(&MAKE(BOX2, .min = {0.0f, 0.0f}, .max = {512.0f, 512.0f}));
+    unit->collision = 16.0f;
+    unit->unitinfo.MoveSpeed = 80.0f;
+    gi.LinkEntity(unit);
+    order_move(unit, Waypoint_add(&dest));
+
+    for (int frame = 0; frame < 200 && unit->currentmove->think; frame++) {
+        unit->currentmove->think(unit);
+        CM_ProcessPathJobs(4096);
+        T_ASSERT(CM_PointIsPathableForRadius(&unit->s.origin2, unit->collision));
+    }
+
+    T_STREQ(unit->currentmove->animation, "stand");
+    T_FEQ(Vector2_distance(&unit->s.origin2, &dest), 0.0f, 0.01f);
+}
+
+/* A click in another static connected component cannot be reached.  Retail
+ * movement still advances as far as collision permits, then settles at the
+ * closest boundary instead of freezing at the order origin or walking forever. */
+TEST(wc3_movement, unreachable_move_settles_at_closest_boundary) {
+    enum { CELLS = 16 };
+    BYTE pathmap[CELLS * CELLS] = {0};
+    LPEDICT unit = make_moving_unit(80.0f, 240.0f);
+    VECTOR2 const start = unit->s.origin2;
+    VECTOR2 dest = {432.0f, 240.0f};
+
+    for (int y = 0; y < CELLS; y++)
+        pathmap[y * CELLS + 7] = 2;
+    CM_SetupTestPathmap(CELLS, CELLS, pathmap);
+    CM_SetupTestWorldBounds(&MAKE(BOX2, .min = {0.0f, 0.0f}, .max = {512.0f, 512.0f}));
+    unit->collision = 16.0f;
+    unit->unitinfo.MoveSpeed = 80.0f;
+    gi.LinkEntity(unit);
+    order_move(unit, Waypoint_add(&dest));
+
+    for (int frame = 0; frame < 200 && unit->currentmove->think; frame++) {
+        unit->currentmove->think(unit);
+        CM_ProcessPathJobs(4096);
+        T_ASSERT(CM_PointIsPathableForRadius(&unit->s.origin2, unit->collision));
+    }
+
+    T_STREQ(unit->currentmove->animation, "stand");
+    T_ASSERT(unit->s.origin2.x > start.x);
+    T_ASSERT(unit->s.origin2.x < 7.0f * 32.0f);
+    T_ASSERT(Vector2_distance(&unit->s.origin2, &dest) < Vector2_distance(&start, &dest));
+}
+
 /* Immobile is a single movement/facing contract, not just a command-menu filter. */
 TEST(wc3_movement, immobile_unit_neither_moves_nor_rotates) {
     LPEDICT unit = make_moving_unit(0.0f, 0.0f);
@@ -1866,10 +1925,12 @@ TEST(wc3_movement, plain_move_uses_collision_sized_static_route) {
     T_ASSERT(unit_issueorder(unit, "move", &dest));
     unit->currentmove->think(unit); /* queues the resumable radius field */
     CM_ProcessPathJobs(65536);
-    unit->currentmove->think(unit); /* completed field reports no route */
+    unit->currentmove->think(unit); /* completed field retargets the private waypoint */
 
-    T_STREQ(unit->currentmove->animation, "stand");
-    T_ASSERT(unit->movement.flow_unreachable);
+    T_STREQ(unit->currentmove->animation, "walk");
+    T_ASSERT(!unit->movement.flow_unreachable);
+    T_ASSERT(unit->goalentity->s.origin2.x > unit->s.origin2.x);
+    T_ASSERT(unit->goalentity->s.origin2.x < 0.0f);
 }
 
 TEST(wc3_movement, blocked_move_keeps_order_alive_away_from_goal) {

--- a/games/warcraft-3/game/tests/t_pathfinding.c
+++ b/games/warcraft-3/game/tests/t_pathfinding.c
@@ -52,6 +52,7 @@ DWORD  CM_BuildHeatmapForRadius(edict_t *goalentity, FLOAT radius);
 DWORD  CM_RequestHeatmapForRadius(edict_t *goalentity, FLOAT radius);
 void   CM_ProcessPathJobs(DWORD work_budget);
 BOOL   CM_ClosestPathablePointForRadius(LPCVECTOR2 location, FLOAT radius, LPVECTOR2 out);
+BOOL   CM_ClosestReachablePointForRadius(LPCVECTOR2 from, LPCVECTOR2 target, FLOAT radius, LPVECTOR2 out);
 BOOL   CM_LineIsWalkableForRadius(LPCVECTOR2 a, LPCVECTOR2 b, FLOAT radius);
 BOOL   CM_FindDirectApproachPointForRadius(LPCVECTOR2 from, LPCVECTOR2 target, FLOAT range, FLOAT radius, LPVECTOR2 out);
 BOOL   CM_FindApproachPointToFootprintForRadius(LPCEDICT target, LPCVECTOR2 from, FLOAT range, FLOAT radius, LPVECTOR2 out);
@@ -69,6 +70,8 @@ DWORD M_RefreshHeatmap(LPEDICT goal, FLOAT radius);
 
 /* From s_move.c — needed to set up a moving unit. */
 void order_move(LPEDICT self, LPEDICT target);
+void order_patrol(LPEDICT self, LPEDICT target);
+void order_attackmove(LPEDICT self, LPEDICT target);
 
 /* From m_unit.c */
 void unit_stand(LPEDICT self);
@@ -508,6 +511,64 @@ TEST(wc3_pathfinding, heatmap_rejects_corridor_too_narrow_for_radius) {
     T_EQ(CM_BuildHeatmapForRadius(wp, 1.0f), 0);
 }
 
+/* Move steering and move-time collision must use the same footprint.  A point
+ * route fits through this one-cell opening, but a radius-one unit does not. */
+TEST(wc3_pathfinding, move_order_requests_collision_sized_route) {
+    BYTE gap_map[MAP_W * MAP_H];
+    memset(gap_map, 0, sizeof(gap_map));
+    for (int y = 2; y <= 6; y++)
+        if (y != 5) gap_map[y * MAP_W + 5] = 2;
+    setup_test_pathmap(MAP_W, MAP_H, gap_map);
+    reset_entities();
+
+    LPEDICT unit = make_unit_at(2.0f, 5.0f);
+    LPEDICT wp = make_waypoint(8.0f, 5.0f);
+    unit->collision = 1.0f;
+    order_move(unit, wp);
+
+    T_ASSERT(CM_LineIsWalkableForRadius(&unit->s.origin2, &wp->s.origin2, 0.0f));
+    T_ASSERT(!CM_LineIsWalkableForRadius(&unit->s.origin2, &wp->s.origin2, unit->collision));
+    T_ASSERT(CM_BuildHeatmapForRadius(wp, unit->collision));
+    unit_changeangle(unit);
+    T_FEQ(wp->heatmap2_radius, unit->collision, 0.001f);
+}
+
+TEST(wc3_pathfinding, patrol_requests_collision_sized_route) {
+    BYTE gap_map[MAP_W * MAP_H];
+    memset(gap_map, 0, sizeof(gap_map));
+    for (int y = 2; y <= 6; y++)
+        if (y != 5) gap_map[y * MAP_W + 5] = 2;
+    setup_test_pathmap(MAP_W, MAP_H, gap_map);
+    reset_entities();
+
+    LPEDICT unit = make_unit_at(2.0f, 5.0f);
+    LPEDICT wp = make_waypoint(8.0f, 5.0f);
+    unit->collision = 1.0f;
+    order_patrol(unit, wp);
+    T_ASSERT(CM_BuildHeatmapForRadius(wp, unit->collision));
+    unit_changeangle(unit);
+
+    T_FEQ(wp->heatmap2_radius, unit->collision, 0.001f);
+}
+
+TEST(wc3_pathfinding, attack_move_requests_collision_sized_route) {
+    BYTE gap_map[MAP_W * MAP_H];
+    memset(gap_map, 0, sizeof(gap_map));
+    for (int y = 2; y <= 6; y++)
+        if (y != 5) gap_map[y * MAP_W + 5] = 2;
+    setup_test_pathmap(MAP_W, MAP_H, gap_map);
+    reset_entities();
+
+    LPEDICT unit = make_unit_at(2.0f, 5.0f);
+    LPEDICT wp = make_waypoint(8.0f, 5.0f);
+    unit->collision = 1.0f;
+    order_attackmove(unit, wp);
+    T_ASSERT(CM_BuildHeatmapForRadius(wp, unit->collision));
+    unit_changeangle(unit);
+
+    T_FEQ(wp->heatmap2_radius, unit->collision, 0.001f);
+}
+
 /* -----------------------------------------------------------------------
  * Unit-obstacle separation (fix #2):
  * A live unit entity at a given location must NOT cause the heatmap for
@@ -560,6 +621,36 @@ TEST(wc3_pathfinding, closest_pathable_keeps_exact_open_point) {
     T_FEQ(out.y, point.y, 0.001f);
 }
 
+TEST(wc3_pathfinding, closest_reachable_keeps_exact_reachable_point) {
+    VECTOR2 from = { 1.25f, 5.25f }, target = { 3.75f, 5.75f }, out = {0};
+    build_open_map();
+    setup_test_pathmap(MAP_W, MAP_H, open_map);
+
+    T_ASSERT(CM_ClosestReachablePointForRadius(&from, &target, 0.0f, &out));
+    T_FEQ(out.x, target.x, 0.001f);
+    T_FEQ(out.y, target.y, 0.001f);
+}
+
+TEST(wc3_pathfinding, closest_reachable_stops_at_disconnected_wall) {
+    VECTOR2 from = { 1.5f, 5.5f }, target = { 8.5f, 5.5f }, out = {0};
+    build_split_map();
+    setup_test_pathmap(MAP_W, MAP_H, split_map);
+
+    T_ASSERT(CM_ClosestReachablePointForRadius(&from, &target, 0.0f, &out));
+    T_FEQ(out.x, 4.5f, 0.001f);
+    T_FEQ(out.y, 5.5f, 0.001f);
+}
+
+TEST(wc3_pathfinding, closest_reachable_respects_collision_radius) {
+    VECTOR2 from = { 1.5f, 5.5f }, target = { 8.5f, 5.5f }, out = {0};
+    build_split_map();
+    setup_test_pathmap(MAP_W, MAP_H, split_map);
+
+    T_ASSERT(CM_ClosestReachablePointForRadius(&from, &target, 1.0f, &out));
+    T_FEQ(out.x, 3.5f, 0.001f);
+    T_FEQ(out.y, 5.5f, 0.001f);
+}
+
 /* The flood and the flow must not cut diagonally through a wall corner: with
  * walls at (1,0) and (0,1), the cell (0,0) is boxed off from a goal at (1,1)
  * (squeezing the corner is not a legal move), so its flow is zero, not a
@@ -578,6 +669,36 @@ TEST(wc3_pathfinding, no_diagonal_corner_cutting) {
     VECTOR2 flow = flow_at_cell(0.0f, 0.0f);
     T_FEQ(flow.x, 0.0f, 0.001f);
     T_FEQ(flow.y, 0.0f, 0.001f);
+}
+
+/* The direct-line shortcut must obey the same corner rule as the flow field.
+ * Otherwise generic movement bypasses routing for the exact ox/xo fence shape
+ * and repeatedly asks collision to enter the blocked diagonal gap. */
+TEST(wc3_pathfinding, direct_line_rejects_diagonal_corner_cutting) {
+    BYTE corner_map[MAP_W * MAP_H];
+    VECTOR2 start = { 0.5f, 0.5f };
+    VECTOR2 goal = { 1.5f, 1.5f };
+    memset(corner_map, 0, sizeof(corner_map));
+    corner_map[0 * MAP_W + 1] = 2;
+    corner_map[1 * MAP_W + 0] = 2;
+    setup_test_pathmap(MAP_W, MAP_H, corner_map);
+
+    T_ASSERT(!CM_LineIsWalkable(&start, &goal));
+}
+
+TEST(wc3_pathfinding, closest_reachable_does_not_cross_diagonal_corner) {
+    BYTE corner_map[MAP_W * MAP_H];
+    VECTOR2 start = { 0.5f, 0.5f };
+    VECTOR2 target = { 1.5f, 1.5f };
+    VECTOR2 out = {0};
+    memset(corner_map, 0, sizeof(corner_map));
+    corner_map[0 * MAP_W + 1] = 2;
+    corner_map[1 * MAP_W + 0] = 2;
+    setup_test_pathmap(MAP_W, MAP_H, corner_map);
+
+    T_ASSERT(CM_ClosestReachablePointForRadius(&start, &target, 0.0f, &out));
+    T_FEQ(out.x, start.x, 0.001f);
+    T_FEQ(out.y, start.y, 0.001f);
 }
 
 /* -----------------------------------------------------------------------
@@ -654,6 +775,7 @@ TEST(wc3_pathfinding, proximity_shortcut_gives_correct_angle) {
     /* Place unit close to goal (within NAVI_THRESHOLD). */
     LPEDICT unit = make_unit_at(0.0f, 0.0f);
     LPEDICT wp   = make_waypoint(5.0f, 5.0f);
+    unit->collision = 0.0f;
     unit->goalentity = wp;
     unit->stand      = unit_stand;
     unit_stand(unit);

--- a/games/warcraft-3/tests/test_mpq_compat.c
+++ b/games/warcraft-3/tests/test_mpq_compat.c
@@ -27,6 +27,8 @@ static const char *resolve_mpq_path(int argc, char **argv)
 
 int main(int argc, char **argv)
 {
+    static BYTE const adpcm_mono[] = { 0x40, 0, 0, 0x34, 0x12 };
+    static BYTE const adpcm_stereo[] = { 0x80, 0, 0, 0x34, 0x12, 0x78, 0x56 };
     const char *mpq_path = resolve_mpq_path(argc, argv);
     HANDLE archive;
     HANDLE file;
@@ -50,7 +52,15 @@ int main(int argc, char **argv)
     DWORD sound_size;
     DWORD riff_size;
     BYTE *sound_data;
+    BYTE decoded[4];
+    DWORD decoded_size;
 
+    if (!Mpq_TestDecompressSector(adpcm_mono, sizeof(adpcm_mono), decoded, 2, &decoded_size) ||
+        decoded_size != 2 || decoded[0] != 0x34 || decoded[1] != 0x12)
+        fail("pure mono ADPCM sector decode failed");
+    if (!Mpq_TestDecompressSector(adpcm_stereo, sizeof(adpcm_stereo), decoded, 4, &decoded_size) ||
+        decoded_size != 4 || memcmp(decoded, "\x34\x12\x78\x56", 4))
+        fail("pure stereo ADPCM sector decode failed");
     if (!SFileOpenArchive(mpq_path, 0, 0, &archive)) {
         fail("SFileOpenArchive failed");
     }


### PR DESCRIPTION
## Summary

- reject diagonal route steps that squeeze between two touching blocked cells
- build Move, Patrol, and Attack-move flow fields with the moving unit collision radius
- retarget disconnected destination clicks to the geometrically closest point in the reachable component
- give each attack-moving unit a private radius-valid waypoint
- fix TFT player-zero startup by excluding free edicts and entities without `UnitBalance` from food aggregation
- decode standalone Blizzard mono/stereo ADPCM MPQ sectors used by TFT voice assets
- document the routing contracts, nearest-point behavior, performance tradeoff, and MPQ codec support

## Root causes

The reported `ox/xo` fence case crossed a diagonal Bresenham step without checking the two cardinal side cells. The direct-line test therefore accepted a corner transition that normal collision correctly rejected.

Location orders also requested point-sized flow fields while movement enforced the unit collision radius. A route could be valid for the center point but physically impossible for the unit. If the clicked destination belonged to a disconnected component, the resulting zero flow left the unit sliding indefinitely along the obstruction.

The TFT HumanX01 crash was independent of the nearby sound warning. LLDB placed the fault in `G_ClientBegin`: player zero matched zero-initialized free edicts, and food aggregation dereferenced their null `UnitBalance` pointers. The MPQ warning was a second issue: mask `0x40` is standalone Blizzard mono ADPCM, but dispatch only handled Huffman-plus-ADPCM masks `0x41` and `0x81`.

## Behavior

Location orders now use one traversal contract from line-of-sight routing through flow generation and move-time collision. When an exact clicked point is disconnected, routing floods from the mover with the same collision radius and selects the reachable cell center nearest to the requested point. Reachable exact destinations remain unchanged. Entity-interaction orders remain point-routed because their ability-specific approach ranges own arrival semantics.

## Tests

Added coverage for:

- diagonal corner rejection
- exact reachable destinations
- disconnected wall-boundary selection
- collision-radius expansion
- diagonal component separation
- collision-sized Move, Patrol, and Attack-move route requests
- long-wall movement detours with per-frame collision validation
- settling at the closest reachable boundary
- player-zero food aggregation with free edicts present
- standalone mono and stereo Blizzard ADPCM sectors

## Validation

- `make test-mpq-compat` against the real `War3.mpq` archive
- `make test-wc3-engine`: 2431/2431 assertions across 548 tests, including ROC and TFT
- `make test`
- bounded Human01 campaign runs with ROC and TFT archives
- bounded TFT `Maps/FrozenThrone/Campaign/HumanX01.w3x` run through client begin and gameplay with `+com_frame_limit 300`
- confirmed the previous `0x40` compression and incomplete `SpiritWolfYesAttack1.wav` warnings no longer occur
- `git diff --check`

## Scope and tradeoffs

This keeps the existing cached flow-field architecture. A wholesale pathfinder replacement is not needed for these failures. Closest-component resolution performs a flood only when the requested location has no usable flow; future scalability work can incrementally build fields or improve dynamic crowd routing without changing this behavior contract.

MP3 dialogue remains unsupported and continues to log format rejection; that is separate from the MPQ ADPCM issue and the HumanX01 crash.

This is rebased on #216 and preserves its frame-budgeted asynchronous heatmap construction. It adds collision-radius location routing, disconnected-target semantics, campaign crash repair, MPQ codec coverage, and ROC/TFT validation.