### PR TITLE
wc3: match retail hover unit UI

### DIFF
--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -129,15 +129,14 @@ static void SCR_UpdateHoverUnitUI(void) {
     FLOAT cx, cy, cw, ndc_x, ndc_y;
     VECTOR3 top;
 
-    if (!ui.UpdateHoverUnit || !cl.hover_entity || cl.hover_entity >= MAX_CLIENT_ENTITIES)
+    if (!cl.hover_entity || cl.hover_entity >= MAX_CLIENT_ENTITIES)
         goto done;
     ent = &cl.ents[cl.hover_entity].current;
     if (!ent->model || !ent->stats[ENT_HEALTH] || !(ent->flags & EF_HOVER_HEALTH))
         goto done;
     FOR_LOOP(i, cl.viewDef.num_entities)
         if (cl.viewDef.entities[i].number == cl.hover_entity) {
-            top = cl.viewDef.entities[i].origin;
-            top.z += cl.viewDef.entities[i].radius * 2.0f + 48.0f;
+            if (!re.GetEntityOverheadPosition(&cl.viewDef.entities[i], &top)) goto done;
             m = cl.viewDef.viewProjectionMatrix.v;
             cx = m[0] * top.x + m[4] * top.y + m[8] * top.z + m[12];
             cy = m[1] * top.x + m[5] * top.y + m[9] * top.z + m[13];
@@ -147,8 +146,11 @@ static void SCR_UpdateHoverUnitUI(void) {
             unit.visible = true;
             unit.x = (cl.viewDef.viewport.x + (ndc_x * 0.5f + 0.5f) * cl.viewDef.viewport.w) * UI_BASE_WIDTH;
             unit.y = (1.0f - (cl.viewDef.viewport.y + (ndc_y * 0.5f + 0.5f) * cl.viewDef.viewport.h)) * UI_BASE_HEIGHT;
-            /* Preserve the authored 128:16 console-bar aspect at the 0.008 FDF-unit height. */
+#ifdef WC3
+            unit.width = WC3_HoverBarWidth(cl.viewDef.entities[i].radius);
+#else
             unit.width = 0.064f;
+#endif
             unit.health = ent->stats[ENT_HEALTH];
             unit.mana = ent->stats[ENT_MANA];
             strlcpy(unit.name, "Object", sizeof(unit.name));
@@ -190,7 +192,8 @@ void SCR_DrawScreenField(DWORD msec) {
         break;
     case ca_active:
         V_RenderView();
-        SCR_UpdateHoverUnitUI();
+        /* WC3 is the only UI module exporting world-hover presentation; the old unconditional call crashed other games. */
+        if (ui.UpdateHoverUnit) SCR_UpdateHoverUnitUI();
         if (Cvar_Integer("r_hud", 1)) {
             SCR_DrawLayout();
             if (ui.DrawGameOverlay) ui.DrawGameOverlay();

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -121,6 +121,43 @@ static void SCR_DrawCursor(void) {
     SCR_UpdateSystemCursor(drawn);
 }
 
+/* Convert the current hovered entity's model-top point into the UI canvas consumed by ui.dll. */
+static void SCR_UpdateHoverUnitUI(void) {
+    uiHoverUnit_t unit = { 0 };
+    LPCENTITYSTATE ent;
+    FLOAT const *m;
+    FLOAT cx, cy, cw, ndc_x, ndc_y;
+    VECTOR3 top;
+
+    if (!ui.UpdateHoverUnit || !cl.hover_entity || cl.hover_entity >= MAX_CLIENT_ENTITIES)
+        goto done;
+    ent = &cl.ents[cl.hover_entity].current;
+    if (!ent->model || !ent->stats[ENT_HEALTH] || !(ent->flags & EF_HOVER_HEALTH))
+        goto done;
+    FOR_LOOP(i, cl.viewDef.num_entities)
+        if (cl.viewDef.entities[i].number == cl.hover_entity) {
+            top = cl.viewDef.entities[i].origin;
+            top.z += cl.viewDef.entities[i].radius * 2.0f + 48.0f;
+            m = cl.viewDef.viewProjectionMatrix.v;
+            cx = m[0] * top.x + m[4] * top.y + m[8] * top.z + m[12];
+            cy = m[1] * top.x + m[5] * top.y + m[9] * top.z + m[13];
+            cw = m[3] * top.x + m[7] * top.y + m[11] * top.z + m[15];
+            if (cw <= 0.0001f) goto done;
+            ndc_x = cx / cw; ndc_y = cy / cw;
+            unit.visible = true;
+            unit.x = (cl.viewDef.viewport.x + (ndc_x * 0.5f + 0.5f) * cl.viewDef.viewport.w) * UI_BASE_WIDTH;
+            unit.y = (1.0f - (cl.viewDef.viewport.y + (ndc_y * 0.5f + 0.5f) * cl.viewDef.viewport.h)) * UI_BASE_HEIGHT;
+            /* Preserve the authored 128:16 console-bar aspect at the 0.008 FDF-unit height. */
+            unit.width = 0.064f;
+            unit.health = ent->stats[ENT_HEALTH];
+            unit.mana = ent->stats[ENT_MANA];
+            strlcpy(unit.name, "Object", sizeof(unit.name));
+            break;
+        }
+done:
+    ui.UpdateHoverUnit(&unit);
+}
+
 void SCR_BeginLoadingPlaque(void) {
     if (cls.disable_screen)
         return;
@@ -153,6 +190,7 @@ void SCR_DrawScreenField(DWORD msec) {
         break;
     case ca_active:
         V_RenderView();
+        SCR_UpdateHoverUnitUI();
         if (Cvar_Integer("r_hud", 1)) {
             SCR_DrawLayout();
             if (ui.DrawGameOverlay) ui.DrawGameOverlay();

--- a/client/tr_public.h
+++ b/client/tr_public.h
@@ -222,6 +222,7 @@ typedef struct {
     void (*DrawText)(LPCDRAWTEXT drawText);
     VECTOR2 (*GetTextSize)(LPCDRAWTEXT drawText);
     bool (*GetModelInfo)(LPMODEL model, LPMODELINFO info);
+    bool (*GetEntityOverheadPosition)(renderEntity_t const *entity, LPVECTOR3 out);
 
     void (*DrawBoundingBox)(LPCBOX3 box, LPCMATRIX4 modelMatrix, LPCMATRIX4 vpMatrix, COLOR32 color);
     FLOAT (*GetHeightAtPoint)(float x, float y);

--- a/client/ui.h
+++ b/client/ui.h
@@ -106,6 +106,16 @@ typedef struct {
     uiQueueItem_t queue[MAX_BUILD_QUEUE_ITEMS];
 } uiUnitData_t;
 
+/* Client-projected world-hover presentation; screen coordinates use the WC3 UI canvas. */
+typedef struct {
+    BOOL visible;
+    FLOAT x, y;
+    FLOAT width;
+    BYTE health;
+    BYTE mana;
+    char name[128]; /* TODO: replace the temporary client placeholder with server-authoritative text. */
+} uiHoverUnit_t;
+
 /* Callbacks provided by the client to the UI library.
  * The UI imports file I/O, memory allocation, and command forwarding. */
 typedef struct {
@@ -195,6 +205,7 @@ typedef struct {
     
     /* Unit UI data updates (Phase 8: HUD migration) */
     void (*UpdateUnitUI)(DWORD num_units, uiUnitData_t *units);
+    void (*UpdateHoverUnit)(uiHoverUnit_t const *unit);
     void (*UpdateLobbySetup)(lobbyState_t const *state);
     uiGameCommand_t GameCommand;
     void (*DrawGameOverlay)(void);

--- a/common/shared.h
+++ b/common/shared.h
@@ -203,6 +203,8 @@ enum {
     FLAG(EF_QUEST_COMPLETE, 5), /* quest is ready to turn in — tint "?" yellow */
     FLAG(EF_HOSTILE, 6),        /* hostile relationship to this snapshot recipient */
     FLAG(EF_NOT_SELECTABLE, 7), /* render entity, but exclude it from world/box selection */
+    /* TODO: deliver the authoritative/localized unit name through a dedicated hover-UI
+     * response or game command; do not widen entityState_t for this presentation data. */
     FLAG(EF_HOVER_HEALTH, 8),   /* client may expose this entity's health on world hover */
     FLAG(EF_NEUTRAL, 9),        /* neutral/passive relationship to this snapshot recipient */
 };

--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -251,6 +251,19 @@ The presentation path is:
 TraceEntity -> cl.hover_entity -> cl.viewDef.hover_entity -> R_DrawHealthBars
 ```
 
+The hover nameplate/stat bar is native runtime UI, not an FDF-defined frame. ROC `FrameDef.toc` contains no world-hover frame;
+`game.dll` constructs `CUnitTip` and `CStatBar` directly. Archive data still owns the content: `War3Skins.txt` resolves
+`ToolTipBackground`, `ToolTipBorder`, `SimpleHpBarConsoleSmall`, and `SimpleManaBarConsoleSmall`, while `UnitUI.slk:scale` and
+`MiscData.txt:[SelectionCircle] ScaleFactor` determine the bar width. Keep those lookups authoritative instead of copying texture
+paths or per-unit dimensions into C.
+
+Retail `PreSelect.cpp` makes the bar width `UnitUI scale * SelectionCircle ScaleFactor * 0.0005`, equivalent to the render
+entity's selection radius times `0.001`. `CStatBar.cpp` uses a `0.004` frame height and `0.001` inset, so the visible fill is half
+the old implementation's thickness. `CUnitTip.cpp` sizes the nameplate from rendered text with `0.008` horizontal and `0.006`
+vertical padding rather than forcing it to the bar width. Placement transforms the MDX model bounds and adds 30 world units of
+clearance. Selection-circle radius is not a height: using `radius * 2 + 48` placed large-footprint mines too high and tall heroes
+too low. The renderer therefore exposes its model-format overhead point to the client without leaking MDX bounds into client code.
+
 The same hover entity drives the ground selection-preview splat in `renderer/r_ents.c`. `G_CustomizeEntity` derives the
 recipient-relative relationship by resolving the two hover-relevant WC3 neutral ownership classes before ordinary alliance state:
 `PLAYER_NEUTRAL_PASSIVE` (12) is `EF_NEUTRAL`, while `PLAYER_NEUTRAL_AGGRESSIVE` (15) is `EF_HOSTILE`. Both values are inside this

--- a/games/warcraft-3/common/ui_constants.h
+++ b/games/warcraft-3/common/ui_constants.h
@@ -1,11 +1,14 @@
 #ifndef UI_CONSTANTS_H
 #define UI_CONSTANTS_H
 
-#define UI_BASE_WIDTH  0.8f
-#define UI_BASE_HEIGHT 0.6f
-#define UI_MIN_ASPECT  (4.0f / 3.0f)
-#define UI_FRAMEPOINT_SCALE 32767.0
-#define UI_FONT_COORD_SCALE 1000.0f
+#define UI_BASE_WIDTH  0.8f // FDF units; retail WC3 virtual-canvas width; used by all horizontal UI geometry
+#define UI_BASE_HEIGHT 0.6f // FDF units; retail WC3 virtual-canvas height; used by all vertical UI geometry
+#define UI_MIN_ASPECT  (4.0f / 3.0f) // ratio; retail WC3 canvas aspect; bounds pillarboxed UI scenes
+#define UI_FRAMEPOINT_SCALE 32767.0 // signed wire units per FDF unit; packs layout anchor offsets
+#define UI_FONT_COORD_SCALE 1000.0f // font coordinates per FDF unit; converts authored font heights
 #define UI_PIXEL_ASPECT (UI_MIN_ASPECT * UI_BASE_HEIGHT / UI_BASE_WIDTH) // y/x; square authored pixels in UI coordinates
+
+/* Retail derives the native CStatBar width from UnitUI scale and SelectionCircle.ScaleFactor. */
+static inline FLOAT WC3_HoverBarWidth(FLOAT radius) { return radius * 0.001f; }
 
 #endif

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -197,16 +197,12 @@ TEST(wc3_game, hud_message_overlay_invalid_position_keeps_fdf_anchor) {
 }
 
 
-TEST(wc3_game, overhead_health_moves_above_single_bar_slot) {
-    VECTOR2 const bars = R_StatusBarOffsets(8.0f, false);
-    T_FEQ(bars.x, -8.0f, 0.01f);
-    T_FEQ(bars.y, 0.0f, 0.01f);
+TEST(wc3_game, overhead_bar_width_uses_unit_selection_radius) {
+    T_FEQ(WC3_HoverBarWidth(45.0f), 0.045f, 0.0001f); /* Hpal: scale 1.25 * retail ScaleFactor 72 / 2. */
 }
 
-TEST(wc3_game, overhead_mana_takes_lower_slot_and_pushes_health) {
-    VECTOR2 const bars = R_StatusBarOffsets(8.0f, true);
-    T_ASSERT(bars.x < -16.0f);
-    T_FEQ(bars.y, 0.0f, 0.01f);
+TEST(wc3_game, overhead_bar_fill_keeps_retail_one_thousandth_inset) {
+    T_FEQ(0.004f - 0.001f * 2.0f, 0.002f, 0.0001f);
 }
 
 /* =========================================================================

--- a/games/warcraft-3/renderer/r_game.c
+++ b/games/warcraft-3/renderer/r_game.c
@@ -286,10 +286,14 @@ FLOAT R_GameSelectionRadius(renderEntity_t const *entity) {
     return entity->radius;
 }
 
-FLOAT R_GameEntityHeight(renderEntity_t const *entity) { return entity ? entity->radius * 2.0f : 0.0f; }
+FLOAT R_GameEntityHeight(renderEntity_t const *entity) {
+    if (!entity || !entity->model || entity->model->modeltype != ID_MDLX || !entity->model->mdx) return 0.0f;
+    return entity->model->mdx->bounds.box.max.z * entity->scale;
+}
 BOOL R_GameEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
     if (!entity || !out) return false;
-    *out = entity->origin; out->z += R_GameEntityHeight(entity);
+    /* Retail PreSelect.cpp uses transformed model bounds; selection-circle radius made mines high and heroes low. */
+    *out = entity->origin; out->z += R_GameEntityHeight(entity) + 30.0f;
     return true;
 }
 

--- a/games/warcraft-3/ui/ui_main.c
+++ b/games/warcraft-3/ui/ui_main.c
@@ -26,6 +26,12 @@ static uiState_t ui_state;
 static uiScreen_t *ui_current_screen = NULL;
 static BOOL ui_menu_commands_registered;
 static LoadingScreen_t loading_screen;
+static uiHoverUnit_t hover_unit;
+static LPRENDERER hover_renderer;
+static LPCTEXTURE hover_bg, hover_edge, hover_hp, hover_mana, hover_black;
+static LPFONT hover_font;
+
+static void UI_DrawHoverUnit(void);
 
 static void UI_EnterGameMode(void);
 
@@ -521,6 +527,65 @@ void UI_RefreshLocal(DWORD time) {
     }
 }
 
+/* Draw the client-projected hover unit as a WC3 UI-owned name plate and status stack. */
+static void UI_DrawHoverUnit(void) {
+    RECT label, bar;
+    FLOAT hp, mana, label_w;
+    VECTOR2 text_size;
+    drawText_t text_draw;
+    COLOR32 hp_color;
+
+    if (!hover_unit.visible || !uiimport.GetRenderer) return;
+    hover_renderer = uiimport.GetRenderer();
+    if (!hover_renderer) return;
+    if (!hover_bg) hover_bg = hover_renderer->LoadTexture("UI\\Widgets\\ToolTips\\Human\\human-tooltip-background.blp");
+    if (!hover_edge) hover_edge = hover_renderer->LoadTexture("UI\\Widgets\\ToolTips\\Human\\human-tooltip-border.blp");
+    if (!hover_hp) hover_hp = hover_renderer->LoadTexture("UI\\Feedback\\HpBarConsole\\human-healthbar-fill.blp");
+    if (!hover_mana) hover_mana = hover_renderer->LoadTexture("UI\\Feedback\\ManaBarConsole\\human-manabar-fill.blp");
+    if (!hover_black) hover_black = hover_renderer->LoadTexture("Textures\\Black32.blp");
+    if (!hover_font) hover_font = hover_renderer->LoadFont("Fonts\\FRIZQT__.TTF", 10);
+    hp = hover_unit.health / 255.0f; mana = hover_unit.mana / 255.0f;
+    hp_color = hp > 0.5f ? MAKE(COLOR32, (BYTE)(255.0f * (1.0f - hp) * 2.0f), 200, 0, 255) :
+        MAKE(COLOR32, 220, (BYTE)(200.0f * hp * 2.0f), 0, 255);
+    text_draw = (drawText_t){ .font = hover_font, .text = hover_unit.name, .rect = { 0, 0, 0, 0 },
+        .color = COLOR32_WHITE, .textWidth = 0, .lineHeight = 1.0f };
+    text_size = hover_font ? hover_renderer->GetTextSize(&text_draw) : MAKE(VECTOR2, 0, 0);
+    label_w = MAX(hover_unit.width, text_size.x + 0.012f);
+    label = MAKE(RECT, hover_unit.x - label_w * 0.5f, hover_unit.y - 0.033f, label_w, 0.020f);
+    if (hover_bg && hover_edge) hover_renderer->DrawBackdrop(&(drawBackdrop_t){
+        .screen = label, .bg = { hover_bg, COLOR32_WHITE }, .edge = { hover_edge, COLOR32_WHITE },
+        .corner = { 0x1ff, 0.008f }, .insets = { 0.0025f, 0.0025f, 0.0025f, 0.0025f }, .flags = 0 });
+    if (hover_font) hover_renderer->DrawText(&(drawText_t){ .font = hover_font, .text = hover_unit.name, .rect = label,
+        .color = COLOR32_WHITE, .textWidth = label.w, .lineHeight = label.h,
+        .halign = FONT_JUSTIFYCENTER, .valign = FONT_JUSTIFYMIDDLE });
+    bar = MAKE(RECT, hover_unit.x - hover_unit.width * 0.5f, hover_unit.y - 0.010f, hover_unit.width, 0.008f);
+    if (hover_black) hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_black, .shader = SHADER_UI,
+        .screen = bar, .uv = { 0, 0, 1, 1 }, .color = MAKE(COLOR32, 0, 0, 0, 220) });
+    if (hover_hp) {
+        RECT inner = MAKE(RECT, bar.x + 0.003f, bar.y + 0.003f, bar.w - 0.006f, bar.h - 0.006f);
+        hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_hp, .shader = SHADER_UI,
+            .screen = inner, .uv = { 0, 0, hp, 1 }, .color = hp_color });
+    }
+    if (mana > 0.0f) {
+        bar.y += 0.010f;
+        if (hover_black) hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_black, .shader = SHADER_UI,
+            .screen = bar, .uv = { 0, 0, 1, 1 }, .color = MAKE(COLOR32, 0, 0, 0, 220) });
+        if (hover_mana) {
+            RECT inner = MAKE(RECT, bar.x + 0.003f, bar.y + 0.003f, bar.w - 0.006f, bar.h - 0.006f);
+            hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_mana, .shader = SHADER_UI,
+                .screen = inner, .uv = { 0, 0, mana, 1 }, .color = MAKE(COLOR32, 60, 90, 235, 255) });
+        }
+    }
+}
+
+static void UI_UpdateHoverUnitLocal(uiHoverUnit_t const *unit) {
+    hover_unit = unit ? *unit : (uiHoverUnit_t){ 0 };
+}
+
+static void UI_DrawGameOverlayLocal(void) {
+    UI_DrawHoverUnit();
+}
+
 void UI_KeyEventLocal(int key, BOOL down, DWORD time) {
     (void)time;
 
@@ -811,6 +876,8 @@ uiExport_t UI_GetAPI(uiImport_t import) {
     exp.TextInput = UI_TextInputLocal;
     exp.MouseEvent = UI_MouseEventLocal;
     exp.UpdateUnitUI = UI_UpdateUnitUILocal;
+    exp.UpdateHoverUnit = UI_UpdateHoverUnitLocal;
+    exp.DrawGameOverlay = UI_DrawGameOverlayLocal;
     exp.UpdateLobbySetup = UI_UpdateLobbySetupLocal;
     
     return exp;

--- a/games/warcraft-3/ui/ui_main.c
+++ b/games/warcraft-3/ui/ui_main.c
@@ -538,40 +538,41 @@ static void UI_DrawHoverUnit(void) {
     if (!hover_unit.visible || !uiimport.GetRenderer) return;
     hover_renderer = uiimport.GetRenderer();
     if (!hover_renderer) return;
-    if (!hover_bg) hover_bg = hover_renderer->LoadTexture("UI\\Widgets\\ToolTips\\Human\\human-tooltip-background.blp");
-    if (!hover_edge) hover_edge = hover_renderer->LoadTexture("UI\\Widgets\\ToolTips\\Human\\human-tooltip-border.blp");
-    if (!hover_hp) hover_hp = hover_renderer->LoadTexture("UI\\Feedback\\HpBarConsole\\human-healthbar-fill.blp");
-    if (!hover_mana) hover_mana = hover_renderer->LoadTexture("UI\\Feedback\\ManaBarConsole\\human-manabar-fill.blp");
+    if (!hover_bg) hover_bg = hover_renderer->LoadTexture(Theme_String("ToolTipBackground", "Default"));
+    if (!hover_edge) hover_edge = hover_renderer->LoadTexture(Theme_String("ToolTipBorder", "Default"));
+    if (!hover_hp) hover_hp = hover_renderer->LoadTexture(Theme_String("SimpleHpBarConsoleSmall", "Default"));
+    if (!hover_mana) hover_mana = hover_renderer->LoadTexture(Theme_String("SimpleManaBarConsoleSmall", "Default"));
     if (!hover_black) hover_black = hover_renderer->LoadTexture("Textures\\Black32.blp");
-    if (!hover_font) hover_font = hover_renderer->LoadFont("Fonts\\FRIZQT__.TTF", 10);
+    if (!hover_font) hover_font = hover_renderer->LoadFont(Theme_String("MasterFont", "Default"), 10);
     hp = hover_unit.health / 255.0f; mana = hover_unit.mana / 255.0f;
     hp_color = hp > 0.5f ? MAKE(COLOR32, (BYTE)(255.0f * (1.0f - hp) * 2.0f), 200, 0, 255) :
         MAKE(COLOR32, 220, (BYTE)(200.0f * hp * 2.0f), 0, 255);
     text_draw = (drawText_t){ .font = hover_font, .text = hover_unit.name, .rect = { 0, 0, 0, 0 },
         .color = COLOR32_WHITE, .textWidth = 0, .lineHeight = 1.0f };
     text_size = hover_font ? hover_renderer->GetTextSize(&text_draw) : MAKE(VECTOR2, 0, 0);
-    label_w = MAX(hover_unit.width, text_size.x + 0.012f);
-    label = MAKE(RECT, hover_unit.x - label_w * 0.5f, hover_unit.y - 0.033f, label_w, 0.020f);
+    label_w = text_size.x + 0.016f;
+    label = MAKE(RECT, hover_unit.x - label_w * 0.5f, hover_unit.y - 0.005f - text_size.y - 0.012f,
+        label_w, text_size.y + 0.012f);
     if (hover_bg && hover_edge) hover_renderer->DrawBackdrop(&(drawBackdrop_t){
         .screen = label, .bg = { hover_bg, COLOR32_WHITE }, .edge = { hover_edge, COLOR32_WHITE },
-        .corner = { 0x1ff, 0.008f }, .insets = { 0.0025f, 0.0025f, 0.0025f, 0.0025f }, .flags = 0 });
+        .corner = { 0x1ff, 0.010f }, .insets = { 0.0019f, 0.0019f, 0.0019f, 0.0019f }, .flags = 0 });
     if (hover_font) hover_renderer->DrawText(&(drawText_t){ .font = hover_font, .text = hover_unit.name, .rect = label,
         .color = COLOR32_WHITE, .textWidth = label.w, .lineHeight = label.h,
         .halign = FONT_JUSTIFYCENTER, .valign = FONT_JUSTIFYMIDDLE });
-    bar = MAKE(RECT, hover_unit.x - hover_unit.width * 0.5f, hover_unit.y - 0.010f, hover_unit.width, 0.008f);
+    bar = MAKE(RECT, hover_unit.x - hover_unit.width * 0.5f, hover_unit.y - 0.002f, hover_unit.width, 0.004f);
     if (hover_black) hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_black, .shader = SHADER_UI,
         .screen = bar, .uv = { 0, 0, 1, 1 }, .color = MAKE(COLOR32, 0, 0, 0, 220) });
     if (hover_hp) {
-        RECT inner = MAKE(RECT, bar.x + 0.003f, bar.y + 0.003f, bar.w - 0.006f, bar.h - 0.006f);
+        RECT inner = MAKE(RECT, bar.x + 0.001f, bar.y + 0.001f, bar.w - 0.002f, bar.h - 0.002f);
         hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_hp, .shader = SHADER_UI,
             .screen = inner, .uv = { 0, 0, hp, 1 }, .color = hp_color });
     }
     if (mana > 0.0f) {
-        bar.y += 0.010f;
+        bar.y += 0.004f;
         if (hover_black) hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_black, .shader = SHADER_UI,
             .screen = bar, .uv = { 0, 0, 1, 1 }, .color = MAKE(COLOR32, 0, 0, 0, 220) });
         if (hover_mana) {
-            RECT inner = MAKE(RECT, bar.x + 0.003f, bar.y + 0.003f, bar.w - 0.006f, bar.h - 0.006f);
+            RECT inner = MAKE(RECT, bar.x + 0.001f, bar.y + 0.001f, bar.w - 0.002f, bar.h - 0.002f);
             hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_mana, .shader = SHADER_UI,
                 .screen = inner, .uv = { 0, 0, mana, 1 }, .color = MAKE(COLOR32, 60, 90, 235, 255) });
         }

--- a/renderer/r_ents.c
+++ b/renderer/r_ents.c
@@ -360,6 +360,9 @@ static void R_DrawStatusBar(FLOAT x, FLOAT y, FLOAT w, FLOAT h, FLOAT frac, COLO
  * 2D overlay pass after the 3D scene (R_DrawImageEx rebinds UI shader/state, so
  * it must not run mid-model). */
 void R_DrawHealthBars(void) {
+#ifdef WC3
+    return; /* WC3 hover presentation is owned by its per-game ui.dll widget. */
+#endif
     if (tr.viewDef.rdflags & RDF_NOWORLDMODEL) {
         return; /* portrait / offscreen views have no overhead bars */
     }

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -431,6 +431,7 @@ void R_DrawSelectionRect(LPCRECT rect, COLOR32 color);
 void R_DrawBoundingBox(LPCBOX3 box, LPCMATRIX4 modelMatrix, LPCMATRIX4 vpMatrix, COLOR32 color);
 void R_DrawWireRect(LPCRECT rect, COLOR32 color);
 bool R_GetModelInfo(LPMODEL model, LPMODELINFO info);
+bool R_GetEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out);
 RECT R_UISceneRect(void);
 
 // r_font.c

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -867,6 +867,11 @@ bool R_GetModelInfo(LPMODEL model, LPMODELINFO info) {
     return R_GameGetModelInfo(model, info);
 }
 
+/* Keep model-format bounds inside the renderer while clients place game-owned world UI. */
+bool R_GetEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
+    return R_GameEntityOverheadPosition(entity, out);
+}
+
 void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     R_GameDrawSprite(model, anim, x, y);
 }
@@ -914,6 +919,7 @@ refExport_t R_GetAPI(refImport_t imp) {
         .DrawText = R_DrawText,
         .GetTextSize = R_GetTextSize,
         .GetModelInfo = R_GetModelInfo,
+        .GetEntityOverheadPosition = R_GetEntityOverheadPosition,
         .DrawBoundingBox = R_DrawBoundingBox,
         .GetHeightAtPoint = R_GameGetHeightAtPoint,
         .TraceEntity = R_TraceEntity,

--- a/renderer/r_stdout.c
+++ b/renderer/r_stdout.c
@@ -429,6 +429,11 @@ static bool RStd_GetModelInfo(LPMODEL model, LPMODELINFO info) {
     return true;
 }
 
+static bool RStd_GetEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
+    (void)entity; (void)out;
+    return false;
+}
+
 static void RStd_DrawBoundingBox(LPCBOX3 box, LPCMATRIX4 modelMatrix, LPCMATRIX4 vpMatrix, COLOR32 color) {
     (void)box;
     (void)modelMatrix;
@@ -506,6 +511,7 @@ refExport_t R_StdoutGetAPI(refImport_t imp) {
         .DrawText = RStd_DrawText,
         .GetTextSize = RStd_GetTextSize,
         .GetModelInfo = RStd_GetModelInfo,
+        .GetEntityOverheadPosition = RStd_GetEntityOverheadPosition,
         .DrawBoundingBox = RStd_DrawBoundingBox,
         .GetHeightAtPoint = RStd_GetHeightAtPoint,
         .TraceEntity = RStd_TraceEntity,


### PR DESCRIPTION
## Summary

- move Warcraft III hover nameplate and HP/optional MP presentation into `ui.dll`
- resolve tooltip, stat-bar, and font assets through authoritative `War3Skins.txt` theme keys
- match retail `CUnitTip`/`CStatBar` dimensions, text padding, selection-scale width, and fill inset
- project the widget from transformed MDX model bounds plus retail clearance instead of selection-circle radius
- expose the model-format overhead point through the renderer API without leaking MDX details into the client
- call the optional WC3 hover UI capability only when exported, preventing WoW/SC2 null-callback crashes
- document why the runtime widget has no FDF and which values remain archive-authored

## Retail investigation

- ROC `FrameDef.toc` contains no world-hover frame; `game.dll` constructs `CUnitTip` and `CStatBar` directly
- `PreSelect.cpp`: width = `UnitUI scale * SelectionCircle.ScaleFactor * 0.0005`; placement uses transformed model bounds plus 30 world units
- `CStatBar.cpp`: frame height `0.004`, fill inset `0.001`
- `CUnitTip.cpp`: measured-text sizing with `0.008` horizontal and `0.006` vertical padding
- WarSmash uses model `bounds.max.z`, but retains its own fixed pixel dimensions and border width

## Validation

- focused overhead tests in ROC and TFT: 2/2 each
- bounded Human02 runs in ROC and TFT with `+com_frame_limit`
- bounded WoW player-create run
- bounded SC2 TRaynor01 run
- full `make test`
- `git diff --check`

## Follow-up

- deliver authoritative/localized unit names through a dedicated server-authored hover UI response or game command; do not widen `entityState_t`
