### PR TITLE
wc3: accelerate incremental pathfinding startup

### DIFF
--- a/common/cmodel.h
+++ b/common/cmodel.h
@@ -7,6 +7,11 @@
  * forward declaration, so declare the tag here before using it in prototypes. */
 struct edict_s;
 
+typedef struct {
+    LPCVECTOR2 from, target;
+    FLOAT radius;
+} pathAccelParams_t;
+
 struct War3MapVertex {
     USHORT accurate_height;
     USHORT waterlevel;
@@ -53,6 +58,7 @@ BOOL CM_PointIsPathableForRadius(LPCVECTOR2 location, FLOAT radius);
 BOOL CM_LineIsWalkable(LPCVECTOR2 a, LPCVECTOR2 b);
 BOOL CM_GetPathingFlagsAt(LPCVECTOR2 location, LPBYTE flags);
 BOOL CM_LineIsWalkableForRadius(LPCVECTOR2 a, LPCVECTOR2 b, FLOAT radius);
+BOOL CM_FindPathWaypoint(pathAccelParams_t const *params, LPVECTOR2 out);
 BOOL CM_FindDirectApproachPointForRadius(LPCVECTOR2 from, LPCVECTOR2 target, FLOAT range, FLOAT radius, LPVECTOR2 out);
 FLOAT CM_PathCellWorldSize(void);
 DWORD CM_RequestHeatmapForRadius(struct edict_s *goalentity, FLOAT radius);

--- a/common/common.h
+++ b/common/common.h
@@ -247,6 +247,7 @@ DWORD CM_BuildHeatmap(struct edict_s *goalentity);
 DWORD CM_BuildHeatmapForRadius(struct edict_s *goalentity, FLOAT radius);
 DWORD CM_RequestHeatmapForRadius(struct edict_s *goalentity, FLOAT radius);
 void  CM_ProcessPathJobs(DWORD work_budget);
+BOOL  CM_FindPathWaypoint(pathAccelParams_t const *params, LPVECTOR2 out);
 BOOL  CM_ActivateCachedFlow(DWORD generation);
 BOOL  CM_FlowReachedGoal(DWORD generation, FLOAT x, FLOAT y);
 BOOL  CM_FlowCanReach(DWORD generation, FLOAT x, FLOAT y);

--- a/common/routing.c
+++ b/common/routing.c
@@ -27,8 +27,9 @@
 #define HEATMAP_MAX_ITERATIONS(cells) ((int)(cells))
 
 typedef struct {
-    point2_t parent;
-    int f, g, h, s;
+    int parent, f, g, heap_pos;
+    DWORD stamp;
+    BOOL closed;
 } pathNode_t;
 
 /* Per-build heatmap node.  x/y are NOT stored here — they are derivable
@@ -59,6 +60,8 @@ struct {
     pathMapCell_t *data;
     routeNode_t *heatmap;
     DWORD *queue;          /* SPFA relaxation queue (ring buffer, width*height+1) */
+    pathNode_t *pathnodes; /* generation-stamped scratch nodes for bounded point routes */
+    DWORD *pathheap;       /* binary min-heap of pathmap indexes */
     DWORD *obstacle_prefix; /* summed-area table for static nowalk cells */
     BYTE *approach_mask;    /* reusable footprint-approach candidate mask */
 } pathmap = { 0 };
@@ -93,6 +96,10 @@ typedef struct {
  * steering and stop at trees/buildings.  Keep one resumable build here so the
  * expensive relaxation work is bounded per simulation frame. */
 static heatmapJob_t heatmap_job = { 0 };
+static DWORD path_search_stamp = 0;
+
+#define PATH_ACCEL_MAX_EXPANSIONS 2048 // nodes/request; bounds immediate point-route work before shared-field fallback
+#define PATH_ACCEL_MAX_DISTANCE 48 // pathing cells/axis; limits the accelerator to nearby obstacle detours
 
 static void heatmap_job_cancel(void) {
     memset(&heatmap_job, 0, sizeof(heatmap_job));
@@ -222,6 +229,8 @@ void CM_SetupPathMap(DWORD width, DWORD height, BYTE const *cells) {
     SAFE_DELETE(pathmap.original, MemFree);
     SAFE_DELETE(pathmap.heatmap, MemFree);
     SAFE_DELETE(pathmap.queue, MemFree);
+    SAFE_DELETE(pathmap.pathnodes, MemFree);
+    SAFE_DELETE(pathmap.pathheap, MemFree);
     SAFE_DELETE(pathmap.obstacle_prefix, MemFree);
     SAFE_DELETE(pathmap.approach_mask, MemFree);
     FOR_LOOP(i, HEATMAP_CACHE_SLOTS) {
@@ -240,6 +249,8 @@ void CM_SetupPathMap(DWORD width, DWORD height, BYTE const *cells) {
     pathmap.original = MemAlloc(n);
     pathmap.heatmap = MemAlloc(n * sizeof(routeNode_t));
     pathmap.queue = MemAlloc((n + 1) * sizeof(DWORD));
+    pathmap.pathnodes = MemAlloc(n * sizeof(pathNode_t));
+    pathmap.pathheap = MemAlloc(n * sizeof(DWORD));
     pathmap.obstacle_prefix = MemAlloc((width + 1) * (height + 1) * sizeof(DWORD));
     pathmap.approach_mask = MemAlloc(n);
 
@@ -251,6 +262,7 @@ void CM_SetupPathMap(DWORD width, DWORD height, BYTE const *cells) {
     memcpy(pathmap.original, pathmap.terrain, n);
     memcpy(pathmap.data, pathmap.original, n);
     memset(pathmap.heatmap, 0, n * sizeof(routeNode_t));
+    memset(pathmap.pathnodes, 0, n * sizeof(pathNode_t));
     memset(pathmap.approach_mask, 0, n);
     rebuild_static_obstacle_prefix();
 
@@ -743,6 +755,115 @@ BOOL CM_LineIsWalkableForRadius(LPCVECTOR2 a, LPCVECTOR2 b, FLOAT radius) {
 
 BOOL CM_LineIsWalkable(LPCVECTOR2 a, LPCVECTOR2 b) {
     return CM_LineIsWalkableForRadius(a, b, 0);
+}
+
+static int path_octile(int ax, int ay, int bx, int by) {
+    int const x = abs(ax - bx), y = abs(ay - by);
+    return 10 * MAX(x, y) + 4 * MIN(x, y);
+}
+
+static BOOL path_heap_less(DWORD a, DWORD b) {
+    pathNode_t const *an = &pathmap.pathnodes[a], *bn = &pathmap.pathnodes[b];
+    return an->f < bn->f || (an->f == bn->f && an->g > bn->g);
+}
+
+static void path_heap_swap(DWORD a, DWORD b) {
+    DWORD const tmp = pathmap.pathheap[a];
+    pathmap.pathheap[a] = pathmap.pathheap[b]; pathmap.pathheap[b] = tmp;
+    pathmap.pathnodes[pathmap.pathheap[a]].heap_pos = (int)a;
+    pathmap.pathnodes[pathmap.pathheap[b]].heap_pos = (int)b;
+}
+
+static void path_heap_up(DWORD pos) {
+    while (pos) {
+        DWORD const parent = (pos - 1) / 2;
+        if (!path_heap_less(pathmap.pathheap[pos], pathmap.pathheap[parent])) break;
+        path_heap_swap(pos, parent); pos = parent;
+    }
+}
+
+static DWORD path_heap_pop(DWORD *count) {
+    DWORD const result = pathmap.pathheap[0];
+    pathmap.pathnodes[result].heap_pos = -1;
+    if (!--*count) return result;
+    pathmap.pathheap[0] = pathmap.pathheap[*count]; pathmap.pathnodes[pathmap.pathheap[0]].heap_pos = 0;
+    for (DWORD pos = 0;;) {
+        DWORD child = pos * 2 + 1;
+        if (child >= *count) break;
+        if (child + 1 < *count && path_heap_less(pathmap.pathheap[child + 1], pathmap.pathheap[child])) child++;
+        if (!path_heap_less(pathmap.pathheap[child], pathmap.pathheap[pos])) break;
+        path_heap_swap(pos, child); pos = child;
+    }
+    return result;
+}
+
+/* Retail keeps a compact path object per mover and consults a separate pathing
+ * accelerator before its longer-lived route state. This bounded A* supplies
+ * the same useful behavior for nearby detours: return one persistent waypoint
+ * immediately, while long searches remain on the shared incremental field. */
+BOOL CM_FindPathWaypoint(pathAccelParams_t const *params, LPVECTOR2 out) {
+    point2_t start, target;
+    DWORD heap_count = 0, expanded = 0, cells = pathmap.width * pathmap.height;
+    int radius_cells;
+
+    if (!params || !params->from || !params->target || !out || !pathmap.pathnodes || !pathmap.pathheap || !cells)
+        return false;
+    radius_cells = (int)ceilf(MAX(0.f, params->radius) / pathmap_cell_world_size());
+    if (!closest_pathable_node_original(params->from, params->radius, &start) ||
+        !closest_pathable_node_original(params->target, params->radius, &target) ||
+        abs(start.x - target.x) > PATH_ACCEL_MAX_DISTANCE || abs(start.y - target.y) > PATH_ACCEL_MAX_DISTANCE)
+        return false;
+
+    if (++path_search_stamp == 0) {
+        FOR_LOOP(i, cells) pathmap.pathnodes[i].stamp = 0;
+        path_search_stamp = 1;
+    }
+    DWORD const start_index = (DWORD)start.x + (DWORD)start.y * pathmap.width;
+    DWORD const target_index = (DWORD)target.x + (DWORD)target.y * pathmap.width;
+    pathNode_t *node = &pathmap.pathnodes[start_index];
+    *node = (pathNode_t){ .parent = -1, .f = path_octile(start.x, start.y, target.x, target.y),
+                         .g = 0, .heap_pos = 0, .stamp = path_search_stamp };
+    pathmap.pathheap[heap_count++] = start_index;
+
+    while (heap_count && expanded++ < PATH_ACCEL_MAX_EXPANSIONS) {
+        DWORD const current = path_heap_pop(&heap_count);
+        int const cx = (int)(current % pathmap.width), cy = (int)(current / pathmap.width);
+        node = &pathmap.pathnodes[current]; node->closed = true;
+        if (current == target_index) {
+            DWORD count = 0;
+            for (int at = (int)current; at >= 0 && count < cells; at = pathmap.pathnodes[at].parent)
+                pathmap.pathheap[count++] = (DWORD)at;
+            for (DWORD i = 0; i + 1 < count; i++) {
+                DWORD const at = pathmap.pathheap[i];
+                VECTOR2 candidate = CM_GetDenormalizedMapPosition(((FLOAT)(at % pathmap.width) + 0.5f) / pathmap.width,
+                    ((FLOAT)(at / pathmap.width) + 0.5f) / pathmap.height);
+                if (CM_LineIsWalkableForRadius(params->from, &candidate, params->radius)) {
+                    *out = candidate;
+                    return true;
+                }
+            }
+            return false;
+        }
+        FOR_LOOP(dir, 8) {
+            int const nx = cx + dx[dir], ny = cy + dy[dir];
+            if (!is_pathable_node_original_for_radius_cells(nx, ny, radius_cells) ||
+                (dir >= 4 && !(is_pathable_node_original_for_radius_cells(nx, cy, radius_cells) &&
+                              is_pathable_node_original_for_radius_cells(cx, ny, radius_cells)))) continue;
+            DWORD const next = (DWORD)nx + (DWORD)ny * pathmap.width;
+            pathNode_t *next_node = &pathmap.pathnodes[next];
+            int const next_g = node->g + gv[dir];
+            if (next_node->stamp == path_search_stamp && (next_node->closed || next_g >= next_node->g)) continue;
+            if (next_node->stamp != path_search_stamp)
+                *next_node = (pathNode_t){ .heap_pos = -1, .stamp = path_search_stamp };
+            next_node->parent = (int)current; next_node->g = next_g;
+            next_node->f = next_g + path_octile(nx, ny, target.x, target.y);
+            if (next_node->heap_pos < 0) {
+                next_node->heap_pos = (int)heap_count;
+                pathmap.pathheap[heap_count++] = next; path_heap_up(heap_count - 1);
+            } else path_heap_up((DWORD)next_node->heap_pos);
+        }
+    }
+    return false;
 }
 
 BOOL CM_FindDirectApproachPointForRadius(LPCVECTOR2 from, LPCVECTOR2 target,

--- a/docs/games/warcraft-3/memory.md
+++ b/docs/games/warcraft-3/memory.md
@@ -55,6 +55,10 @@ asset sharing. That points initially toward approximately **300–350 MiB**, not
 Getting near **230 MiB / 2×** likely requires additional texture/terrain work and/or a smaller drawable.
 **~155 MiB / 3× at unchanged quality is not established by these measurements.**
 
+The bounded pathfinding accelerator adds one generation-stamped node array plus one index heap per pathing cell. With
+the current 24-byte node and 4-byte heap index this is 1.75 MiB on a 256x256 pathmap and 5.25 MiB on a 384x512 pathmap.
+The storage is global scratch, not per unit; mover persistence adds two points, one radius, and one validity flag.
+
 ## MDX: tiny streams incur large backing allocations
 
 `games/warcraft-3/renderer/mdx/r_mdx_load.c:R_SetupGeosetVertexBuffer` creates separate buffers for

--- a/docs/games/warcraft-3/pathfinding.md
+++ b/docs/games/warcraft-3/pathfinding.md
@@ -22,13 +22,15 @@ Plain right-click movement is different from an interaction order: `move_selectl
 
 Game routing no longer uses the old lifetime quota of two synchronous whole-map flow-field bakes. That quota avoided repeated handheld stalls, but after it was spent a later uncached move order received generation 0 forever and generic steering fell back toward the raw target. A reachable order behind trees/buildings could therefore stop even though the static router could have found a route.
 
-`CM_RequestHeatmapForRadius()` is now the game-facing cache-miss path. A cache hit returns its generation immediately; a miss starts one resumable reverse shortest-path job and returns 0 until the job completes. `G_RunFrame()` advances that job after entity simulation through `CM_ProcessPathJobs()`. The default relaxation budget is 4096 queue pops per frame and is runtime-tunable with:
+`CM_RequestHeatmapForRadius()` is the game-facing shared-cache miss path. A cache hit returns its generation immediately; a miss starts one resumable reverse shortest-path job and returns 0 until the job completes. `G_RunFrame()` advances that job after entity simulation through `CM_ProcessPathJobs()`. The default relaxation budget is 32,768 queue pops per frame and is runtime-tunable with:
 
 ```sh
-+set wc3_path_work_budget 4096
++set wc3_path_work_budget 32768
 ```
 
-The value is clamped to 256-65536. This keeps the expensive SPFA relaxation work bounded without permanently denying later destinations. Only one miss is built at a time; requests for other destinations naturally retry after the active job completes. Static-pathing invalidation cancels the in-progress job along with cached generations. A cache miss can therefore produce a short, intentional start pause when a real detour is required. Raising `wc3_path_work_budget` (for example to 8192) reduces that latency at the cost of more routing work per simulation frame; the default remains 4096 for handheld safety.
+The value is clamped to 256-65,536. This keeps SPFA relaxation bounded without permanently denying later destinations. Only one miss is built at a time; requests for other destinations retry after the active job completes. Static-pathing invalidation cancels the in-progress job along with cached generations.
+
+Nearby detours do not wait for that whole field. `CM_FindPathWaypoint()` runs a bounded point-to-point A* accelerator for endpoints within 48 pathing cells, expands at most 2,048 nodes, and returns the farthest recovered path point with a collision-sized clear line from the mover. The mover retains that waypoint until it reaches it, the target changes, or static pathing invalidates the segment. A failed or out-of-envelope acceleration request falls back to the shared incremental field, so long routes remain frame-budgeted.
 
 While a resumable request is pending, `unit_changeangle*()` leaves both `movement.flow_generation == 0` and `movement.flow_direct == false`. `unit_moveindirection()` treats that pair as "no heading resolved this tick" and does not commit a step. This shared guard is important: a caller must never turn a pending route into movement along the unit's stale facing.
 
@@ -36,10 +38,7 @@ Plain Move also keeps the stand presentation while that pair is clear. The order
 
 `CM_BuildHeatmapForRadius()` remains the synchronous API for tests/tools that explicitly require a completed field. Production movement goes through `M_RefreshHeatmap()` -> `CM_RequestHeatmapForRadius()`.
 
-Production services the shared incremental build with 32,768 queue pops per 10 Hz server frame. A 256x256 open field
-therefore completes in at most two frames instead of the previous sixteen-frame (1.6 second) delay. Override
-`wc3_path_work_budget` for slower targets; values are clamped to 256-65,536. This changes only scheduling: cache misses
-still build a complete destination-rooted field before publishing its generation, so long routes remain frame-budgeted.
+Production services the shared incremental build with 32,768 queue pops per 10 Hz server frame. A 256x256 open field therefore completes in at most two frames instead of the previous sixteen-frame (1.6 second) delay. Override `wc3_path_work_budget` for slower targets. Complete destination-rooted publication remains the long-route fallback; the bounded accelerator is what removes that publication delay from nearby obstacle detours.
 
 `CM_BuildHeatmapForRadius()` and the resumable request path both key cached fields by adjusted target cell and mover collision radius. The flood and flow query use the same radius-expanded static pathability predicate as move-time terrain checks. The zero-radius `CM_BuildHeatmap()` wrapper remains for callers that intentionally route a point.
 
@@ -62,25 +61,39 @@ When a clicked destination is in another static connected component, the destina
 
 Ordinary destination fields remain incremental and frame-budgeted. The mover-component flood is synchronous only after a completed destination field proves the click unreachable, so this exceptional recovery does not add input-time work to reachable orders.
 
-The current router does not need wholesale replacement. Its cached integration fields, collision expansion, direct-line shortcut, and local dynamic avoidance are suitable for WC3 movement once they share one traversability contract. Remaining large-scale work is performance-oriented: incremental field construction and richer dynamic crowd routing, not a different static shortest-path algorithm.
+The current router is now deliberately hybrid. Direct collision-sized lines handle open ground, bounded per-mover A* handles nearby static detours, destination-cached integration fields amortize long routes shared by groups, and local avoidance handles live units. This is closer to retail's split between mover-owned route state and a global pathing system without claiming its unrecovered accelerator implementation.
 
 ### Retail Game.dll path audit
 
-The ROC demo `data/Warcraft3demo/Game.dll` (build 4486, SHA-256
-`286823c37a1083e91f07d040e46a9df7af4c4952e01fcbba460589bd4e297654`) retains RTTI for `CAbilityMove`,
-`NIpse::CLrPathingSys`, `NIpse::CLrPathingAcc`, and `NIpse::CLrPath`. `CAbilityMove` installs its vtable at
-`Game.dll+0x102898`. The low-level path constructor at `+0x458040` creates persistent route state, while `+0x466aa0`
-allocates and stores one of those path objects on a mover. Route setup at `+0x4661d0` compares destination and mode
-state, submits an adjusted coordinate through `+0x458670`, and branches on several path-result states returned by
-`+0x458930`. Group movement at `+0x46a130` and `+0x46a330` derives per-mover coordinates and path flags before updating
-each path object. Retail routing is therefore not a point-only line test followed by movement that independently
-rejects the unit footprint.
+The ROC demo `data/Warcraft3demo/Game.dll` (build 4486, SHA-256 `286823c37a1083e91f07d040e46a9df7af4c4952e01fcbba460589bd4e297654`) retains RTTI for `CAbilityMove`, `NIpse::CLrPathingSys`, and `NIpse::CLrPathingAcc`. `CAbilityMove` installs its vtable at `Game.dll+0x102898`. The path constructor at `+0x458040` initializes a roughly 0xb0-byte persistent object, including two 32-byte containers at `+0x2c` and `+0x4c`, coordinate/state fields, and a pathing-system pointer. Mover setup at `+0x466aa0` allocates and stores one such object. Submission at `+0x458670` resets route state and copies the requested coordinate into both current and destination fields.
+
+The update at `+0x458930` checks flags at `+0x80`, can return a pending state from a countdown at `+0x8c`, invokes progression routines at `+0x457da0` and `+0x457f20`, and exposes multiple result states to the movement caller at `+0x4661d0`. `+0x457da0` appends 8-byte coordinate pairs to the object's route container. `+0x457f20` consults one of two global indexed arrays through a signed selector and a `-2` sentinel before advancing the route. Together with the separate `CLrPathingAcc` and `CLrPathingSys` types, this establishes persistent per-mover progress backed by global accelerated pathing data. It does not establish whether the accelerator is A*, hierarchical sectors, a portal graph, or another Blizzard-specific structure.
+
+Group movement at `+0x46a130` and `+0x46a330` derives per-mover coordinates and path flags before updating each path object. Retail routing is therefore not a point-only line test followed by movement that independently rejects the unit footprint, nor is there evidence that every order waits for a complete destination-rooted map flood.
 
 This supports the direction of commit `4bad783d`: using the mover's collision size consistently and resolving an
 unreachable click to a legal endpoint are closer to retail's per-mover, adjusted-endpoint architecture than routing a
-point toward an impossible destination. The binary does not establish that OpenRealm's nearest-cell flood, SPFA
-integration field, cache policy, or exact `ox/xo` diagonal test matches Blizzard's algorithm. Treat the corner rule as
-a necessary consistency fix and the closest-reachable policy as behaviorally retail-like, not instruction-equivalent.
+point toward an impossible destination. The binary does not establish that OpenRealm's bounded A*, nearest-cell flood,
+SPFA integration field, four-slot cache policy, or exact `ox/xo` diagonal test matches Blizzard's algorithm. Treat the
+accelerator as a behaviorally supported approximation: it reproduces immediate nearby route output and mover-owned
+progress while retaining OpenRealm's group-friendly cache for long routes.
+
+### Retail and OpenRealm algorithm outline
+
+| Stage | Retail evidence | OpenRealm |
+|---|---|---|
+| Open ground | Route setup can retain or reset mover path state by destination and mode | Collision-sized Bresenham line; no search |
+| Nearby detour | Persistent mover path object emits coordinate pairs; global accelerator is consulted | Bounded octile A* emits one smoothed, persistent waypoint |
+| Long/shared route | Global `CLrPathingSys` and `CLrPathingAcc`; exact sharing policy unrecovered | Four LRU destination/radius integration fields, built backward with SPFA |
+| Dynamic units | Per-mover path flags and updates | Swept-circle movement plus deterministic local avoidance; not baked into static routes |
+| Scheduling | Countdown/pending and multiple result states prove resumable progress | A* is capped at 2,048 expansions; complete fields get a configurable per-frame queue budget |
+
+The speed difference was primarily work selection. Before the accelerator, one nearby cache miss cleared every route
+node, relaxed the complete reachable component, then copied one integer per map cell before movement could start. A
+256x256 diagnostic trace printed `cells=65536` at both build start and publication. The accelerator touches only nodes
+reached by the bounded A* and uses generation stamps instead of clearing its scratch array. Its contiguous node/heap
+arrays usually leave a nearby search with a small L1/L2 working set, but no retail evidence identifies an explicit
+"L2 cache" technique.
 
 The same corner rule is applied to direct routing and movement steps: a diagonal
 segment is rejected when either cardinal side of the crossed cell corner is

--- a/docs/games/warcraft-3/pathfinding.md
+++ b/docs/games/warcraft-3/pathfinding.md
@@ -36,6 +36,11 @@ Plain Move also keeps the stand presentation while that pair is clear. The order
 
 `CM_BuildHeatmapForRadius()` remains the synchronous API for tests/tools that explicitly require a completed field. Production movement goes through `M_RefreshHeatmap()` -> `CM_RequestHeatmapForRadius()`.
 
+Production services the shared incremental build with 32,768 queue pops per 10 Hz server frame. A 256x256 open field
+therefore completes in at most two frames instead of the previous sixteen-frame (1.6 second) delay. Override
+`wc3_path_work_budget` for slower targets; values are clamped to 256-65,536. This changes only scheduling: cache misses
+still build a complete destination-rooted field before publishing its generation, so long routes remain frame-budgeted.
+
 `CM_BuildHeatmapForRadius()` and the resumable request path both key cached fields by adjusted target cell and mover collision radius. The flood and flow query use the same radius-expanded static pathability predicate as move-time terrain checks. The zero-radius `CM_BuildHeatmap()` wrapper remains for callers that intentionally route a point.
 
 Flow vectors only descend to a strictly lower heatmap price for both collision-sized and radius-zero point fields. The adjusted goal cell therefore has a zero vector instead of pointing back out to a higher-cost neighbour. This matters for shared interaction routes such as Gold Mines and resource drop-offs: an outward point-flow at the adjusted cell makes every worker sharing that field orbit the same wrong location. Cached prices retain `INT_MAX` for cells that the completed field cannot reach. `CM_FlowReachedGoal(generation, x, y)` identifies the adjusted goal cell, while `CM_FlowCanReach(generation, x, y)` distinguishes a disconnected cell from a zero produced by interpolation near the goal.

--- a/games/warcraft-3/game/g_ai.c
+++ b/games/warcraft-3/game/g_ai.c
@@ -201,7 +201,7 @@ void unit_moveindirection(LPEDICT self) {
      * step using the unit's previous facing/heading while the requested route
      * is still being built.  This is the common safety net for Move, Harvest,
      * Patrol, Attack, Build, Repair, and resource-return walkers. */
-    if (!self->movement.flow_direct && self->movement.flow_generation == 0)
+    if (!self->movement.flow_direct && !self->movement.path_valid && self->movement.flow_generation == 0)
         return;
 
     FLOAT const dist = unit_movedistance(self);
@@ -381,6 +381,27 @@ static void unit_changeangle_towards_point_policy(LPEDICT self, LPCVECTOR2 point
     unit_apply_heading(self, &dir, policy);
 }
 
+/* Keep the bounded point-route turn until it is reached; retail likewise owns
+ * route progress on each mover instead of rebuilding from its current point. */
+static BOOL unit_accel_direction(LPEDICT self, FLOAT radius, LPVECTOR2 dir) {
+    VECTOR2 const target = self->goalentity->s.origin2;
+    FLOAT const reached = CM_PathCellWorldSize();
+
+    if (self->movement.path_valid &&
+        (Vector2_distance(&self->movement.path_target, &target) >= 1.0f ||
+         fabsf(self->movement.path_radius - radius) >= 0.01f ||
+         Vector2_distance(&self->s.origin2, &self->movement.path_waypoint) <= reached ||
+         !CM_LineIsWalkableForRadius(&self->s.origin2, &self->movement.path_waypoint, radius)))
+        self->movement.path_valid = false;
+    if (!self->movement.path_valid) {
+        pathAccelParams_t params = { &self->s.origin2, &target, radius };
+        if (!CM_FindPathWaypoint(&params, &self->movement.path_waypoint)) return false;
+        self->movement.path_target = target; self->movement.path_radius = radius; self->movement.path_valid = true;
+    }
+    *dir = Vector2_sub(&self->movement.path_waypoint, &self->s.origin2);
+    return true;
+}
+
 void unit_changeangle_towards_point(LPEDICT self, LPCVECTOR2 point) {
     unit_changeangle_towards_point_policy(self, point, MOVE_AVOID_GENERIC);
 }
@@ -410,13 +431,21 @@ static void unit_changeangle_policy(LPEDICT self, moveAvoidPolicy_t policy) {
      * use the same footprint as move-time collision; point routing previously
      * sent units into narrow gaps and touching obstacle corners. */
     if (CM_LineIsWalkableForRadius(&self->s.origin2, &self->goalentity->s.origin2, radius)) {
+        self->movement.path_valid = false;
         self->movement.flow_direct = true;
         dir = to_goal;
     } else {
         DWORD heatmap = M_RefreshHeatmap(self->goalentity, radius);
         self->movement.flow_generation = heatmap;
-        if (!heatmap)
-            return; /* incremental route is still building; keep the order */
+        if (!heatmap) {
+            if (!unit_accel_direction(self, radius, &dir))
+                return; /* long incremental route is still building; keep the order */
+            /* path_valid resolves the heading while the shared field builds;
+             * this is not a direct line to the requested destination. */
+            unit_apply_heading(self, &dir, policy);
+            return;
+        }
+        self->movement.path_valid = false;
         if (CM_FlowReachedGoal(heatmap, self->s.origin.x, self->s.origin.y)) {
             /* Location orders stop at their collision-safe route endpoint in
              * the owning behavior.  Interaction orders use a point field whose
@@ -435,7 +464,8 @@ static void unit_changeangle_policy(LPEDICT self, moveAvoidPolicy_t policy) {
                  * raw click made local avoidance walk forever along walls. */
                 if (radius > 0.0f && self->movement.flow_unreachable) {
                     VECTOR2 closest;
-                    if (CM_ClosestReachablePointForRadius(&self->s.origin2, &self->goalentity->s.origin2, radius, &closest)) {
+                        if (CM_ClosestReachablePointForRadius(
+                            &self->s.origin2, &self->goalentity->s.origin2, radius, &closest)) {
                         self->goalentity->s.origin2 = closest;
                         self->goalentity->secondarygoal = NULL;
                         self->goalentity->heatmap2 = 0;
@@ -481,13 +511,19 @@ static void unit_changeangle_for_radius_policy(LPEDICT self, FLOAT radius,
     if (CM_LineIsWalkableForRadius(&self->s.origin2,
                                    &self->goalentity->s.origin2,
                                    radius)) {
+        self->movement.path_valid = false;
         self->movement.flow_direct = true;
         dir = to_goal;
     } else {
         DWORD heatmap = M_RefreshHeatmap(self->goalentity, radius);
         self->movement.flow_generation = heatmap;
-        if (!heatmap)
-            return; /* resumable route field is still building */
+        if (!heatmap) {
+            if (!unit_accel_direction(self, radius, &dir))
+                return; /* long incremental route is still building */
+            unit_apply_heading(self, &dir, policy);
+            return;
+        }
+        self->movement.path_valid = false;
 
         if (CM_FlowReachedGoal(heatmap, self->s.origin.x, self->s.origin.y)) {
             self->movement.flow_goal_reached = true;

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -22,6 +22,9 @@
 #define MAX_EVENT_QUEUE 256
 #define MAX_MESSAGE_SUBSCRIBERS 8 // callbacks; bounded because messages are synchronous and game-local
 #define MAX_UNIT_SELECT_SOUNDS 6 // sounds; largest UnitAckSounds *What variant list in ROC/TFT data
+#define WC3_PATH_WORK_BUDGET 32768 // queue pops/server frame; completes a 256x256 open field in two 10 Hz ticks
+#define BZ_STRINGIFY_INNER(value) #value
+#define BZ_STRINGIFY(value) BZ_STRINGIFY_INNER(value)
 #define MAX_ENTITIES MAX_GAME_ENTITIES
 #define MAX_REGION_SIZE 16
 #define MAX_INVENTORY 6

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -748,6 +748,9 @@ struct edict_s {
         BOOL flow_goal_reached; /* mover occupies the route's adjusted goal cell */
         BOOL flow_unreachable;  /* field exists but current cell has no route */
         BOOL flow_direct;       /* static path from mover to requested goal is clear */
+        VECTOR2 path_waypoint, path_target; /* persistent accelerated turn and the destination that produced it */
+        FLOAT path_radius;
+        BOOL path_valid;
         FLOAT group_speed;  // slowest member's speed for a group move (0 = no cap), keeps the group together
         FLOAT heading;      // avoidance-resolved heading chosen this tick by unit_changeangle; movement follows it
         VECTOR2 worker_avoid_origin; /* start of the active resource-worker avoidance corridor */

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -400,7 +400,7 @@ static void G_StartScripts(void) {
  * a map loads, the JASS "main" function is invoked to run map initialization
  * triggers. */
 static void G_RunFrame(void) {
-    int path_work_budget = 4096;
+    int path_work_budget = WC3_PATH_WORK_BUDGET;
     LPCSTR path_work_value;
 
     if (!level.started)
@@ -420,7 +420,7 @@ static void G_RunFrame(void) {
      * never depend on a lifetime quota of synchronous whole-map floods.  Keep
      * the per-frame relaxation budget runtime-tunable for slower handhelds. */
     path_work_value = gi.CvarString
-        ? gi.CvarString("wc3_path_work_budget", "4096") : NULL;
+        ? gi.CvarString("wc3_path_work_budget", BZ_STRINGIFY(WC3_PATH_WORK_BUDGET)) : NULL;
     if (path_work_value)
         path_work_budget = atoi(path_work_value);
     path_work_budget = MAX(256, MIN(path_work_budget, 65536));

--- a/games/warcraft-3/game/skills/s_goldmine.c
+++ b/games/warcraft-3/game/skills/s_goldmine.c
@@ -16,12 +16,12 @@ static int goldmine_path_debug_level(void) {
     return value ? atoi(value) : 0;
 }
 
-/* A resumable route miss deliberately leaves both fields clear until the
- * shared flow job completes.  Gold movement must hold in that state: moving
- * with the previous facing would send workers in an unrelated direction while
- * the requested mine/drop-off route is still being built. */
+/* A resumable route miss leaves direct, accelerator, and flow states clear.
+ * Gold movement must hold then: using the previous facing would send workers
+ * in an unrelated direction while the shared route is still being built. */
 static BOOL gold_route_pending(LPCEDICT worker) {
     return worker && !worker->movement.flow_direct &&
+           !worker->movement.path_valid &&
            worker->movement.flow_generation == 0;
 }
 

--- a/games/warcraft-3/game/skills/s_move.c
+++ b/games/warcraft-3/game/skills/s_move.c
@@ -306,7 +306,7 @@ static void ai_move_walk(LPEDICT ent) {
             move_hold(ent); /* static topology says this goal cannot be reached */
             return;
         }
-        if (!ent->movement.flow_direct && !ent->movement.flow_generation) {
+        if (!ent->movement.flow_direct && !ent->movement.path_valid && !ent->movement.flow_generation) {
             return; /* resumable route field is still being built */
         }
         if (ent->movement.flow_goal_reached) {

--- a/games/warcraft-3/game/tests/t_movement.c
+++ b/games/warcraft-3/game/tests/t_movement.c
@@ -490,10 +490,9 @@ TEST(wc3_movement, lumber_same_tree_workers_preserve_direct_order) {
     T_ASSERT(fabsf(second->s.origin2.y - second_origin.y) < 2.0f);
 }
 
-/* A plain Move has no valid route heading while an incremental detour is being
- * built. Keep its position and facing until the field is ready, then advance
- * on the first resolved steering tick without changing the logical order. */
-TEST(wc3_movement, pending_move_waits_for_resolved_heading) {
+/* A nearby static detour uses the bounded per-mover accelerator immediately;
+ * it must not wait for the destination field to cover the whole pathmap. */
+TEST(wc3_movement, nearby_move_starts_on_accelerated_waypoint) {
     enum { CELLS = 64 };
     BYTE pathmap[CELLS * CELLS] = {0};
     LPEDICT unit = make_moving_unit(320.0f, 0.0f);
@@ -517,15 +516,10 @@ TEST(wc3_movement, pending_move_waits_for_resolved_heading) {
 
     T_EQ(unit->movement.flow_generation, 0);
     T_ASSERT(!unit->movement.flow_direct);
-    T_FEQ(unit->s.origin2.x, origin.x, 0.001f);
-    T_FEQ(unit->s.origin2.y, origin.y, 0.001f);
-    T_FEQ(unit->s.angle, 0.0f, 0.001f);
-    T_STREQ(unit->currentmove->animation, "walk");
-
-    CM_ProcessPathJobs(65536);
-    unit->currentmove->think(unit);
-    T_ASSERT(unit->movement.flow_generation != 0);
+    T_ASSERT(unit->movement.path_valid);
+    T_ASSERT(CM_LineIsWalkableForRadius(&origin, &unit->movement.path_waypoint, unit->collision));
     T_ASSERT(Vector2_distance(&unit->s.origin2, &origin) > 0.001f);
+    T_STREQ(unit->currentmove->animation, "walk");
 }
 
 /* Retail WC3 does not leave a worker orbiting an unreachable tree buried in a
@@ -831,7 +825,7 @@ TEST(wc3_movement, gold_smart_click_gold_mine_visits_mine_then_returns_and_resum
  * Three workers ordered together must all hold their starting positions during
  * that interval instead of walking along their previous facing (the Human02
  * regression made all three initially head away from the clicked mine). */
-TEST(wc3_movement, gold_three_workers_hold_while_shared_route_is_pending) {
+TEST(wc3_movement, gold_three_workers_accelerate_while_shared_route_is_pending) {
     enum { CELLS = 64, WORKERS = 3 };
     BYTE pathmap[CELLS * CELLS] = {0};
     LPEDICT mine;
@@ -882,16 +876,19 @@ TEST(wc3_movement, gold_three_workers_hold_while_shared_route_is_pending) {
 
     FOR_LOOP(i, WORKERS) {
         workers[i]->currentmove->think(workers[i]);
-        T_FEQ(workers[i]->s.origin2.x, origin[i].x, 0.001f);
-        T_FEQ(workers[i]->s.origin2.y, origin[i].y, 0.001f);
+        T_ASSERT(Vector2_distance(&workers[i]->s.origin2, &origin[i]) > 0.001f);
         T_EQ(workers[i]->movement.flow_generation, 0);
         T_ASSERT(!workers[i]->movement.flow_direct);
+        T_ASSERT(workers[i]->movement.path_valid);
+        T_ASSERT(CM_LineIsWalkableForRadius(
+            &workers[i]->s.origin2, &workers[i]->movement.path_waypoint, workers[i]->movement.path_radius));
     }
 
     CM_ProcessPathJobs(65536);
     FOR_LOOP(i, WORKERS) {
         workers[i]->currentmove->think(workers[i]);
         T_ASSERT(workers[i]->movement.flow_generation != 0);
+        T_ASSERT(!workers[i]->movement.path_valid);
     }
 
     G_SetSLKRows("AbilityData", old_abilities);
@@ -1008,10 +1005,9 @@ TEST(wc3_movement, gold_return_reselects_footprint_edge_after_displacement) {
     gi.MemFree(hall_pathtex);
 }
 
-/* Gold return can miss the cache independently of mine approach.  A worker
- * carrying gold must likewise wait for the drop-off field instead of moving
- * along a stale facing while that route is still being built. */
-TEST(wc3_movement, gold_return_holds_while_route_is_pending) {
+/* Gold return can miss the shared cache independently of mine approach. The
+ * bounded mover route must provide a real heading instead of stale facing. */
+TEST(wc3_movement, gold_return_accelerates_while_shared_route_is_pending) {
     enum { CELLS = 64 };
     BYTE pathmap[CELLS * CELLS] = {0};
     LPEDICT worker = make_moving_unit(320.0f, 0.0f);
@@ -1043,14 +1039,17 @@ TEST(wc3_movement, gold_return_holds_while_route_is_pending) {
     origin = worker->s.origin2;
     worker->currentmove->think(worker);
 
-    T_FEQ(worker->s.origin2.x, origin.x, 0.001f);
-    T_FEQ(worker->s.origin2.y, origin.y, 0.001f);
+    T_ASSERT(Vector2_distance(&worker->s.origin2, &origin) > 0.001f);
     T_EQ(worker->movement.flow_generation, 0);
     T_ASSERT(!worker->movement.flow_direct);
+    T_ASSERT(worker->movement.path_valid);
+    T_ASSERT(CM_LineIsWalkableForRadius(
+        &worker->s.origin2, &worker->movement.path_waypoint, worker->movement.path_radius));
 
     CM_ProcessPathJobs(65536);
     worker->currentmove->think(worker);
     T_ASSERT(worker->movement.flow_generation != 0);
+    T_ASSERT(!worker->movement.path_valid);
 }
 
 /* Right-click is also the cancel gesture for an active targeted command.

--- a/games/warcraft-3/game/tests/t_pathfinding.c
+++ b/games/warcraft-3/game/tests/t_pathfinding.c
@@ -264,6 +264,23 @@ TEST(wc3_pathfinding, incremental_heatmap_serializes_cache_misses_without_losing
     T_ASSERT(second_gen != first_gen);
 }
 
+TEST(wc3_pathfinding, production_budget_completes_large_open_field_in_two_frames) {
+    enum { WIDTH = 256, HEIGHT = 256 };
+    static BYTE open[WIDTH * HEIGHT];
+    LPEDICT goal;
+
+    memset(open, 0, sizeof(open));
+    setup_test_pathmap(WIDTH, HEIGHT, open);
+    reset_entities();
+    goal = make_waypoint(128.0f, 128.0f);
+
+    T_EQ(CM_RequestHeatmapForRadius(goal, 0.0f), 0);
+    CM_ProcessPathJobs(WC3_PATH_WORK_BUDGET);
+    if (!CM_RequestHeatmapForRadius(goal, 0.0f))
+        CM_ProcessPathJobs(WC3_PATH_WORK_BUDGET);
+    T_ASSERT(CM_RequestHeatmapForRadius(goal, 0.0f) != 0);
+}
+
 TEST(wc3_pathfinding, heatmap_cache_separates_collision_radius) {
     build_open_map();
     setup_test_pathmap(MAP_W, MAP_H, open_map);

--- a/games/warcraft-3/game/tests/t_pathfinding.c
+++ b/games/warcraft-3/game/tests/t_pathfinding.c
@@ -281,6 +281,43 @@ TEST(wc3_pathfinding, production_budget_completes_large_open_field_in_two_frames
     T_ASSERT(CM_RequestHeatmapForRadius(goal, 0.0f) != 0);
 }
 
+TEST(wc3_pathfinding, nearby_detour_accelerator_returns_clear_waypoint) {
+    VECTOR2 from = {2.0f, 5.0f}, target = {7.0f, 5.0f}, waypoint;
+    pathAccelParams_t params = { &from, &target, 0.0f };
+
+    build_wall_map();
+    setup_test_pathmap(MAP_W, MAP_H, wall_map);
+    T_ASSERT(!CM_LineIsWalkableForRadius(&from, &target, 0.0f));
+    T_ASSERT(CM_FindPathWaypoint(&params, &waypoint));
+    T_ASSERT(CM_LineIsWalkableForRadius(&from, &waypoint, 0.0f));
+    T_ASSERT(waypoint.y > 7.0f);
+}
+
+TEST(wc3_pathfinding, distant_detour_skips_bounded_accelerator) {
+    enum { WIDTH = 128, HEIGHT = 16 };
+    static BYTE open[WIDTH * HEIGHT];
+    VECTOR2 from = {2.0f, 8.0f}, target = {100.0f, 8.0f}, waypoint;
+    pathAccelParams_t params = { &from, &target, 0.0f };
+
+    memset(open, 0, sizeof(open));
+    setup_test_pathmap(WIDTH, HEIGHT, open);
+    T_ASSERT(!CM_FindPathWaypoint(&params, &waypoint));
+}
+
+TEST(wc3_pathfinding, nearby_detour_accelerator_respects_collision_radius) {
+    BYTE narrow[MAP_W * MAP_H];
+    VECTOR2 from = {2.0f, 5.0f}, target = {7.0f, 5.0f}, waypoint;
+    pathAccelParams_t point = { &from, &target, 0.0f };
+    pathAccelParams_t wide = { &from, &target, 1.0f };
+
+    memset(narrow, 0, sizeof(narrow));
+    FOR_LOOP(y, MAP_H) narrow[5 + y * MAP_W] = 0x02;
+    narrow[5 + 5 * MAP_W] = 0;
+    setup_test_pathmap(MAP_W, MAP_H, narrow);
+    T_ASSERT(CM_FindPathWaypoint(&point, &waypoint));
+    T_ASSERT(!CM_FindPathWaypoint(&wide, &waypoint));
+}
+
 TEST(wc3_pathfinding, heatmap_cache_separates_collision_radius) {
     build_open_map();
     setup_test_pathmap(MAP_W, MAP_H, open_map);


### PR DESCRIPTION
## Summary

- add a bounded octile A* accelerator for nearby static detours, capped at 2,048 expansions and 48 pathing cells per axis
- persist the accelerated waypoint per mover while a shared destination field builds in the background
- retain four-slot destination/radius flow-field caching for long routes and formations
- increase the incremental field budget from 4,096 to 32,768 queue pops per 10 Hz frame
- document the retail `Game.dll` path-object lifecycle, verified boundaries, cache differences, and memory cost

## Retail comparison

The ROC demo binary shows a roughly 0xb0-byte persistent path object per mover, global `CLrPathingSys` / `CLrPathingAcc` ownership, route coordinate containers, pending/countdown state, and multiple progression results. It does not prove Blizzard uses A*, hierarchical sectors, or OpenRealm-style integration fields.

OpenRealm now follows the verified architecture more closely: direct line for open ground, bounded mover-owned route progress for nearby detours, shared incremental fields for long/group routes, and local collision avoidance for live units.

## Result

- nearby obstacle detours move on the first steering tick instead of waiting for whole-map publication
- a 256x256 full-field fallback completes in at most two ticks (about 200 ms), down from sixteen ticks (1.6 seconds)
- unreachable or out-of-envelope local searches retain the frame-budgeted fallback
- global accelerator scratch costs 1.75 MiB at 256x256 and 5.25 MiB at 384x512; mover state remains compact

## Validation

- WC3 pathfinding, ROC/TFT: 114/114 assertions in 42 tests
- WC3 movement, ROC/TFT: 861/861 assertions in 77 tests
- `make build`
- bounded Human02 ROC and TFT runs with `+com_frame_limit 100`
- `make test`
- `git diff --check`