### PR TITLE
renderer: link game hooks directly

### DIFF
--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -198,6 +198,12 @@ static void CL_ParseConfigString(LPSIZEBUF msg) {
     } else {
         MSG_ReadString(msg, cl.configstrings[index]);
     }
+#ifdef WOW
+    if (index >= CS_GENERAL + WOW_CS_NPC_NAME_FIRST && index < CS_GENERAL + CS_MAX_NAMES / ENT_NAMES_PER_CS)
+#else
+    if (index >= CS_GENERAL && index < CS_GENERAL + CS_MAX_NAMES / ENT_NAMES_PER_CS)
+#endif
+        entity_name_pool_decode(cl.configstrings[index]);
     if (index > CS_IMAGES && index < CS_IMAGES + MAX_IMAGES) {
         DWORD pic = index - CS_IMAGES;
 

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -146,11 +146,7 @@ static void SCR_UpdateHoverUnitUI(void) {
             unit.visible = true;
             unit.x = (cl.viewDef.viewport.x + (ndc_x * 0.5f + 0.5f) * cl.viewDef.viewport.w) * UI_BASE_WIDTH;
             unit.y = (1.0f - (cl.viewDef.viewport.y + (ndc_y * 0.5f + 0.5f) * cl.viewDef.viewport.h)) * UI_BASE_HEIGHT;
-#ifdef WC3
-            unit.width = WC3_HoverBarWidth(cl.viewDef.entities[i].radius);
-#else
-            unit.width = 0.064f;
-#endif
+            unit.width = 0.045f;
             unit.health = ent->stats[ENT_HEALTH];
             unit.mana = ent->stats[ENT_MANA];
             strlcpy(unit.name, "Object", sizeof(unit.name));
@@ -1003,7 +999,7 @@ static BOOL SCR_RangesOverlap(FLOAT a0, FLOAT a1, FLOAT b0, FLOAT b1) {
 void SCR_LayoutClampSelectionRect(LPRECT rect) {
     VECTOR2 start, finish, clamped;
     FLOAT world_bottom;
-    FLOAT xmin, xmax, ymin, ymax;
+    FLOAT xmin, xmax;
     size2_t window;
 
     if (!rect) {
@@ -1042,35 +1038,6 @@ void SCR_LayoutClampSelectionRect(LPRECT rect) {
                 clamped.y = r->y;
             } else if (finish.y < start.y && bottom < start.y && bottom > clamped.y) {
                 clamped.y = bottom;
-            }
-        }
-    }
-
-    ymin = MIN(start.y, clamped.y);
-    ymax = MAX(start.y, clamped.y);
-
-    /* A protruding panel can also be entered sideways when the drag begins
-     * near its top.  Clamp horizontal travel against the same bottom-console
-     * mask using the already-clamped vertical span. */
-    FOR_LOOP(layer, MAX_LAYOUT_LAYERS) {
-        HANDLE layout = layout_layers[layer];
-        DWORD flags = cl.playerstate.uiflags;
-        if (!layout || ((1 << layer) & flags)) continue;
-        SCR_Clear(layout);
-        FOR_LOOP(i, SCR_NumFrames()) {
-            LPCUIFRAME frame = SCR_Frame(i);
-            LPCRECT r;
-            FLOAT bottom;
-            if (!frame || !SCR_LayoutSelectionBlockerType(frame->flags.type)) continue;
-            r = SCR_LayoutRect(frame);
-            if (!r || r->w <= 0.0f || r->h <= 0.0f) continue;
-            bottom = r->y + r->h;
-            if (bottom < world_bottom || !SCR_RangesOverlap(ymin, ymax, r->y, bottom)) continue;
-
-            if (finish.x > start.x && r->x > start.x && r->x < clamped.x) {
-                clamped.x = r->x;
-            } else if (finish.x < start.x && (r->x + r->w) < start.x && (r->x + r->w) > clamped.x) {
-                clamped.x = r->x + r->w;
             }
         }
     }

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -149,7 +149,11 @@ static void SCR_UpdateHoverUnitUI(void) {
             unit.width = 0.045f;
             unit.health = ent->stats[ENT_HEALTH];
             unit.mana = ent->stats[ENT_MANA];
-            strlcpy(unit.name, "Object", sizeof(unit.name));
+            if (ent->name) {
+                DWORD ni = ent->name - 1;
+                LPCSTR cs = cl.configstrings[CS_GENERAL + (ni >> 4)];
+                if (cs) strlcpy(unit.name, cs + (ni & 0xF) * ENT_NAME_SLOT_SIZE, sizeof(unit.name));
+            }
             break;
         }
 done:

--- a/client/ui.h
+++ b/client/ui.h
@@ -113,7 +113,7 @@ typedef struct {
     FLOAT width;
     BYTE health;
     BYTE mana;
-    char name[128]; /* TODO: replace the temporary client placeholder with server-authoritative text. */
+    char name[128];
 } uiHoverUnit_t;
 
 /* Callbacks provided by the client to the UI library.

--- a/common/shared.h
+++ b/common/shared.h
@@ -464,11 +464,40 @@ typedef enum {
 
 /* Packing layout for entityState_t.name.
  * CS_MAX_NAMES names total, ENT_NAMES_PER_CS per CS_GENERAL slot, ENT_NAME_SLOT_SIZE bytes each.
- * Slots used = CS_MAX_NAMES / ENT_NAMES_PER_CS (must be <= MAX_GENERAL).
- * Decode: i = name-1; slot = i>>4; sub = i&0xF; str = configstrings[CS_GENERAL+slot] + sub*ENT_NAME_SLOT_SIZE */
+ * Wire slots use ASCII Unit Separator padding because configstrings cannot carry embedded NULs. The client restores separators
+ * to NULs after receipt. Decode: i = name-1; slot = i>>4; sub = i&0xF. */
 #define CS_MAX_NAMES        256
 #define ENT_NAMES_PER_CS    16  /* names per configstring slot */
 #define ENT_NAME_SLOT_SIZE  16  /* bytes per name; ENT_NAME_SLOT_SIZE * ENT_NAMES_PER_CS == MAX_PATHLEN */
+#define ENT_NAME_SEPARATOR  0x1f // ASCII byte; keeps fixed-width name records transmissible through C-string configstrings
+
+static inline BOOL entity_name_slot_empty(LPCSTR slot) { return !*slot || (BYTE)*slot == ENT_NAME_SEPARATOR; }
+
+static inline BOOL entity_name_slot_equals(LPCSTR slot, LPCSTR name) {
+    size_t slot_len = 0, name_len = MIN(strlen(name), ENT_NAME_SLOT_SIZE - 1);
+    while (slot_len < ENT_NAME_SLOT_SIZE - 1 && slot[slot_len] && (BYTE)slot[slot_len] != ENT_NAME_SEPARATOR) slot_len++;
+    return slot_len == name_len && !memcmp(slot, name, name_len);
+}
+
+static inline void entity_name_pool_prepare(LPSTR pool, LPCSTR current) {
+    memset(pool, ENT_NAME_SEPARATOR, ENT_NAME_SLOT_SIZE * ENT_NAMES_PER_CS);
+    pool[ENT_NAME_SLOT_SIZE * ENT_NAMES_PER_CS - 1] = '\0';
+    if (current && *current)
+        memcpy(pool, current, strnlen(current, ENT_NAME_SLOT_SIZE * ENT_NAMES_PER_CS - 1));
+}
+
+static inline void entity_name_slot_store(LPSTR pool, DWORD sub, LPCSTR name) {
+    LPSTR slot = pool + sub * ENT_NAME_SLOT_SIZE;
+    size_t len = MIN(strlen(name), ENT_NAME_SLOT_SIZE - 1);
+    memset(slot, ENT_NAME_SEPARATOR, ENT_NAME_SLOT_SIZE);
+    memcpy(slot, name, len);
+    pool[ENT_NAME_SLOT_SIZE * ENT_NAMES_PER_CS - 1] = '\0';
+}
+
+static inline void entity_name_pool_decode(LPSTR pool) {
+    FOR_LOOP(i, ENT_NAME_SLOT_SIZE * ENT_NAMES_PER_CS - 1)
+        if ((BYTE)pool[i] == ENT_NAME_SEPARATOR) pool[i] = '\0';
+}
 
 typedef struct entityState_s {
     DWORD number; // edict index

--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -308,6 +308,14 @@ The hover nameplate/stat bar is native runtime UI, not an FDF-defined frame. ROC
 `MiscData.txt:[SelectionCircle] ScaleFactor` determine the bar width. Keep those lookups authoritative instead of copying texture
 paths or per-unit dimensions into C.
 
+The displayed name comes from the race/campaign `Units\\*UnitStrings.txt` `Name` field (`unam`), merged into `UnitProfile_t.name`;
+for example, `Units\\NeutralUnitStrings.txt` defines `[nvil] Name=Villager`. `G_CustomizeEntity` interns that text into `CS_GENERAL`
+and sends its 1-based pool index through `entityState_t.name`; `SCR_UpdateHoverUnitUI` resolves the index and
+copies the result into `uiHoverUnit_t.name`. A configstring is NUL-terminated on the wire, so its sixteen fixed-width name records use
+ASCII Unit Separator (`0x1f`) as padding and retain a single final NUL. `CL_ParseConfigString` converts the separators back to NULs
+after receipt, preserving ordinary fixed-offset C strings for renderer and UI consumers. Embedded NUL records truncate at the first
+name in `MSG_WriteString` and leave later hover names empty.
+
 Retail `PreSelect.cpp` makes the bar width `UnitUI scale * SelectionCircle ScaleFactor * 0.0005`, equivalent to the render
 entity's selection radius times `0.001`. `CStatBar.cpp` uses a `0.004` frame height and `0.001` inset, so the visible fill is half
 the old implementation's thickness. `CUnitTip.cpp` sizes the nameplate from rendered text with `0.008` horizontal and `0.006`

--- a/games/starcraft-2/game/hud/hud.c
+++ b/games/starcraft-2/game/hud/hud.c
@@ -336,7 +336,7 @@ static void sc2_hud_hide_optional_panels(void) {
         /* TODO: show CommandTooltip only on command-button hover; hide for now. */
         "CommandTooltip",
         /* InfopanelModel, MinimapModel, CommandPanelModel are now rendered
-         * via FT_PORTRAIT + R_GameExtractEntityCamera. */
+         * via FT_PORTRAIT + R_ExtractEntityCamera. */
         NULL,
     };
 

--- a/games/starcraft-2/renderer/r_game.c
+++ b/games/starcraft-2/renderer/r_game.c
@@ -22,11 +22,11 @@ enum {
     KEY_OUTTAN,
 };
 
-static float R_GameLerp(float left, float right, float t) {
+static float R_M3Lerp(float left, float right, float t) {
     return left * (1 - t) + right * t;
 }
 
-static float R_GameBezier(float left, float outTan, float inTan, float right, float t) {
+static float R_M3Bezier(float left, float outTan, float inTan, float right, float t) {
     float const inverseFactor = 1 - t,
         inverseFactorTimesTwo = inverseFactor * inverseFactor,
         factorTimes2 = t * t,
@@ -37,7 +37,7 @@ static float R_GameBezier(float left, float outTan, float inTan, float right, fl
     return left * factor1 + outTan * factor2 + inTan * factor3 + right * factor4;
 }
 
-static float R_GameHermite(float left, float outTan, float inTan, float right, float t) {
+static float R_M3Hermite(float left, float outTan, float inTan, float right, float t) {
     float const factorTimes2 = t * t,
         factor1 = factorTimes2 * (2 * t - 3) + 1,
         factor2 = factorTimes2 * (t - 2) + t,
@@ -46,25 +46,25 @@ static float R_GameHermite(float left, float outTan, float inTan, float right, f
     return left * factor1 + outTan * factor2 + inTan * factor3 + right * factor4;
 }
 
-static int R_GameInterpInt(int const *left, int const *right, float t, MODELKEYTRACKTYPE lineType) {
+static int R_M3InterpInt(int const *left, int const *right, float t, MODELKEYTRACKTYPE lineType) {
     switch (lineType) {
         case TRACK_NO_INTERP: return left[KEY_VALUE];
-        case TRACK_BEZIER: return R_GameBezier(left[KEY_VALUE], left[KEY_OUTTAN], right[KEY_INTAN], right[KEY_VALUE], t);
-        case TRACK_HERMITE: return R_GameHermite(left[KEY_VALUE], left[KEY_OUTTAN], right[KEY_INTAN], right[KEY_VALUE], t);
-        default: return R_GameLerp(left[KEY_VALUE], right[KEY_VALUE], t);
+        case TRACK_BEZIER: return R_M3Bezier(left[KEY_VALUE], left[KEY_OUTTAN], right[KEY_INTAN], right[KEY_VALUE], t);
+        case TRACK_HERMITE: return R_M3Hermite(left[KEY_VALUE], left[KEY_OUTTAN], right[KEY_INTAN], right[KEY_VALUE], t);
+        default: return R_M3Lerp(left[KEY_VALUE], right[KEY_VALUE], t);
     }
 }
 
-static float R_GameInterpFloat(float const *left, float const *right, float t, MODELKEYTRACKTYPE lineType) {
+static float R_M3InterpFloat(float const *left, float const *right, float t, MODELKEYTRACKTYPE lineType) {
     switch (lineType) {
         case TRACK_NO_INTERP: return left[KEY_VALUE];
-        case TRACK_BEZIER: return R_GameBezier(left[KEY_VALUE], left[KEY_OUTTAN], right[KEY_INTAN], right[KEY_VALUE], t);
-        case TRACK_HERMITE: return R_GameHermite(left[KEY_VALUE], left[KEY_OUTTAN], right[KEY_INTAN], right[KEY_VALUE], t);
-        default: return R_GameLerp(left[KEY_VALUE], right[KEY_VALUE], t);
+        case TRACK_BEZIER: return R_M3Bezier(left[KEY_VALUE], left[KEY_OUTTAN], right[KEY_INTAN], right[KEY_VALUE], t);
+        case TRACK_HERMITE: return R_M3Hermite(left[KEY_VALUE], left[KEY_OUTTAN], right[KEY_INTAN], right[KEY_VALUE], t);
+        default: return R_M3Lerp(left[KEY_VALUE], right[KEY_VALUE], t);
     }
 }
 
-static VECTOR3 R_GameInterpVec3(LPCVECTOR3 left, LPCVECTOR3 right, float t, MODELKEYTRACKTYPE lineType) {
+static VECTOR3 R_M3InterpVec3(LPCVECTOR3 left, LPCVECTOR3 right, float t, MODELKEYTRACKTYPE lineType) {
     switch (lineType) {
         case TRACK_NO_INTERP: return left[KEY_VALUE];
         case TRACK_BEZIER: return Vector3_bezier(&left[KEY_VALUE], &left[KEY_OUTTAN], &right[KEY_INTAN], &right[KEY_VALUE], t);
@@ -73,7 +73,7 @@ static VECTOR3 R_GameInterpVec3(LPCVECTOR3 left, LPCVECTOR3 right, float t, MODE
     }
 }
 
-static QUATERNION R_GameInterpQuat(LPCQUATERNION left, LPCQUATERNION right, float t, MODELKEYTRACKTYPE lineType) {
+static QUATERNION R_M3InterpQuat(LPCQUATERNION left, LPCQUATERNION right, float t, MODELKEYTRACKTYPE lineType) {
     switch (lineType) {
         case TRACK_NO_INTERP: return left[KEY_VALUE];
         case TRACK_BEZIER:
@@ -90,10 +90,10 @@ void R_EvalKeyframeValue(void const *left,
                          HANDLE out)
 {
     switch (datatype) {
-        case TDATA_INT1: *((int *)out) = R_GameInterpInt(left, right, t, linetype); return;
-        case TDATA_FLOAT1: *((float *)out) = R_GameInterpFloat(left, right, t, linetype); return;
-        case TDATA_FLOAT3: *((VECTOR3 *)out) = R_GameInterpVec3(left, right, t, linetype); return;
-        case TDATA_FLOAT4: *((QUATERNION *)out) = R_GameInterpQuat(left, right, t, linetype); return;
+        case TDATA_INT1: *((int *)out) = R_M3InterpInt(left, right, t, linetype); return;
+        case TDATA_FLOAT1: *((float *)out) = R_M3InterpFloat(left, right, t, linetype); return;
+        case TDATA_FLOAT3: *((VECTOR3 *)out) = R_M3InterpVec3(left, right, t, linetype); return;
+        case TDATA_FLOAT4: *((QUATERNION *)out) = R_M3InterpQuat(left, right, t, linetype); return;
     }
 }
 
@@ -173,19 +173,19 @@ void R_AddRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, COLOR3
 }
 void R_EndSplatBatch(void) { }
 
-void R_GameLoadAssets(void) {
+void R_LoadAssets(void) {
 }
 
-void R_GameInit(void) {
+void R_Init(void) {
     M3_Init();
 }
 
-void R_GameShutdown(void) {
+void R_Shutdown(void) {
     R_SC2ShutdownShaders();
     M3_Shutdown();
 }
 
-void R_GameSetupTextureMatrix(void) {
+void R_SetupTextureMatrix(void) {
     sc2Map_t const *map = SC2_MapCurrent();
     if (map && map->MapInfo.width && map->MapInfo.height) {
         BOX2 bounds = SC2_MapBounds();
@@ -201,38 +201,38 @@ void R_GameSetupTextureMatrix(void) {
     }
 }
 
-void R_GameDrawMinimap(LPCRECT screen) {
+void R_DrawMinimap(LPCRECT screen) {
     LPCTEXTURE tex = tr.minimap ? tr.minimap : tr.texture[TEX_WHITE];
     R_DrawImage(tex, screen, &MAKE(RECT, 0, 0, 1, 1), COLOR32_WHITE);
 }
 
-void R_GameRegisterMap(LPCSTR mapFileName) {
+void R_RegisterMap(LPCSTR mapFileName) {
     R_SC2RegisterMap(mapFileName);
 }
 
-void R_GameDrawWorld(void) {
+void R_DrawWorld(void) {
     R_SC2DrawWorld();
 }
 
-void R_GameDrawTerrainShadows(void) {
+void R_DrawTerrainShadows(void) {
 }
 
-void R_GameDrawAlphaSurfaces(void) {
+void R_DrawAlphaSurfaces(void) {
 }
 
-bool R_GameTraceLocation(viewDef_t const *viewdef, float x, float y, LPVECTOR3 point) {
+bool R_TraceLocation(viewDef_t const *viewdef, float x, float y, LPVECTOR3 point) {
     return R_SC2TraceLocation(viewdef, x, y, point);
 }
 
-FLOAT R_GameGetHeightAtPoint(FLOAT x, FLOAT y) {
+FLOAT R_GetHeightAtPoint(FLOAT x, FLOAT y) {
     return R_SC2GetHeightAtPoint(x, y);
 }
 
-VECTOR2 R_GameWorldSize(void) {
+VECTOR2 R_WorldSize(void) {
     return R_SC2WorldSize();
 }
 
-LPMODEL R_GameLoadModel(LPCSTR modelFilename) {
+LPMODEL R_LoadModel(LPCSTR modelFilename) {
     void *buffer = NULL;
     int fileSize = ri.FS_ReadFile(modelFilename, &buffer);
     LPMODEL model = NULL;
@@ -251,11 +251,11 @@ LPMODEL R_GameLoadModel(LPCSTR modelFilename) {
     return model;
 }
 
-void R_GameReleaseModel(LPMODEL model) {
+void R_ReleaseModel(LPMODEL model) {
     ri.MemFree(model);
 }
 
-void R_GameRenderModel(renderEntity_t const *entity) {
+void R_RenderModel(renderEntity_t const *entity) {
     MATRIX4 transform;
 
     if (!entity || !entity->model || entity->model->modeltype != ID_43DM || !entity->model->m3) {
@@ -265,37 +265,37 @@ void R_GameRenderModel(renderEntity_t const *entity) {
     M3_RenderModel(entity, entity->model->m3, &transform);
 }
 
-bool R_GameTraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT distance) {
+bool R_TraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT distance) {
     (void)entity;
     (void)line;
     (void)distance;
     return false;
 }
 
-bool R_GameEntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix) {
+bool R_EntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix) {
     (void)entity;
     (void)matrix;
     return false;
 }
 
-bool R_GameRenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin) {
+bool R_RenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin) {
     (void)entity;
     (void)origin;
     return false;
 }
 
-FLOAT R_GameSelectionRadius(renderEntity_t const *entity) {
+FLOAT R_SelectionRadius(renderEntity_t const *entity) {
     return entity->radius;
 }
 
-FLOAT R_GameEntityHeight(renderEntity_t const *entity) { return entity ? entity->radius * 2.0f : 0.0f; }
-BOOL R_GameEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
+FLOAT R_EntityHeight(renderEntity_t const *entity) { return entity ? entity->radius * 2.0f : 0.0f; }
+BOOL R_EntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
     if (!entity || !out) return false;
-    *out = entity->origin; out->z += R_GameEntityHeight(entity);
+    *out = entity->origin; out->z += R_EntityHeight(entity);
     return true;
 }
 
-static void R_GameTextureCacheAdd(LPCSTR path) {
+static void R_M3TextureCacheAdd(LPCSTR path) {
     if (!path || !*path || model_texture_cache.count >= 256) {
         return;
     }
@@ -309,7 +309,7 @@ static void R_GameTextureCacheAdd(LPCSTR path) {
     model_texture_cache.count++;
 }
 
-static void R_GameBuildModelTextureCache(LPMODEL model) {
+static void R_M3BuildModelTextureCache(LPMODEL model) {
     if (model_texture_cache.model == model) {
         return;
     }
@@ -339,17 +339,18 @@ static void R_GameBuildModelTextureCache(LPMODEL model) {
         FOR_LOOP(layerIndex, sizeof(layers) / sizeof(layers[0])) {
             m3Layer_t const *layer = layers[layerIndex];
             if (layer && layer->imagePath && *layer->imagePath) {
-                R_GameTextureCacheAdd(layer->imagePath);
+                R_M3TextureCacheAdd(layer->imagePath);
             }
         }
     }
 }
 
-bool R_GameGetModelInfo(LPMODEL model, LPMODELINFO info) {
+bool R_GetModelInfo(LPMODEL model, LPMODELINFO info) {
     if (!model || !info || model->modeltype != ID_43DM) {
         return false;
     }
-    R_GameBuildModelTextureCache(model);
+    memset(info, 0, sizeof(*info));
+    R_M3BuildModelTextureCache(model);
     if (model_texture_cache.model == model) {
         info->textureCount = MIN(model_texture_cache.count, MODELINFO_MAX_TEXTURES);
         FOR_LOOP(i, info->textureCount) {
@@ -360,7 +361,7 @@ bool R_GameGetModelInfo(LPMODEL model, LPMODELINFO info) {
 }
 
 /* Unit portraits use a bounds-derived perspective camera; layout models supply their own camera payload. */
-bool R_GameExtractEntityCamera(renderEntity_t const *entity, float aspect, viewDef_t *viewdef) {
+bool R_ExtractEntityCamera(renderEntity_t const *entity, float aspect, viewDef_t *viewdef) {
     if (!entity || !entity->model || entity->model->modeltype != ID_43DM || !entity->model->m3 || !viewdef)
         return false;
 
@@ -401,7 +402,7 @@ bool R_GameExtractEntityCamera(renderEntity_t const *entity, float aspect, viewD
 }
 
 /* Retained SC2 UI models use a stable final pose from the requested sequence. */
-bool R_GameSetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity) {
+bool R_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity) {
     if (!model || model->modeltype != ID_43DM || !model->m3 || !entity) return false;
     m3Model_t const *m3 = model->m3;
     DWORD time = 0;
@@ -417,7 +418,7 @@ bool R_GameSetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entit
     return false;
 }
 
-void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
+void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     (void)model;
     (void)anim;
     (void)x;
@@ -426,7 +427,7 @@ void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
 
 /* TODO: SC2 authored cursor assets are not wired to the renderer yet;
  * returning false keeps SDL's native platform cursor visible. */
-bool R_GameDrawCursor(float x, float y, COLOR32 tint) {
+bool R_DrawCursor(float x, float y, COLOR32 tint) {
     (void)x; (void)y; (void)tint;
     return false;
 }

--- a/games/warcraft-3/common/ui_constants.h
+++ b/games/warcraft-3/common/ui_constants.h
@@ -8,7 +8,4 @@
 #define UI_FONT_COORD_SCALE 1000.0f // font coordinates per FDF unit; converts authored font heights
 #define UI_PIXEL_ASPECT (UI_MIN_ASPECT * UI_BASE_HEIGHT / UI_BASE_WIDTH) // y/x; square authored pixels in UI coordinates
 
-/* Retail derives the native CStatBar width from UnitUI scale and SelectionCircle.ScaleFactor. */
-static inline FLOAT WC3_HoverBarWidth(FLOAT radius) { return radius * 0.001f; }
-
 #endif

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -614,14 +614,13 @@ static USHORT G_UnitNameConfigstring(LPCSTR name) {
         LPCSTR cs = gi.GetConfigstring(idx);
         for (DWORD sub = 0; sub < ENT_NAMES_PER_CS; sub++) {
             LPCSTR entry = cs ? cs + sub * ENT_NAME_SLOT_SIZE : NULL;
-            if (entry && *entry) {
-                if (!strncmp(entry, name, ENT_NAME_SLOT_SIZE - 1))
+            if (entry && !entity_name_slot_empty(entry)) {
+                if (entity_name_slot_equals(entry, name))
                     return (USHORT)(slot * ENT_NAMES_PER_CS + sub + 1);
                 continue;
             }
-            memset(buf, 0, sizeof(buf));
-            if (cs && *cs) memcpy(buf, cs, sizeof(buf));
-            strncpy(buf + sub * ENT_NAME_SLOT_SIZE, name, ENT_NAME_SLOT_SIZE - 1);
+            entity_name_pool_prepare(buf, cs);
+            entity_name_slot_store(buf, sub, name);
             gi.configstring(idx, buf);
             return (USHORT)(slot * ENT_NAMES_PER_CS + sub + 1);
         }

--- a/games/warcraft-3/game/skills/s_rally.c
+++ b/games/warcraft-3/game/skills/s_rally.c
@@ -46,7 +46,8 @@ static BOOL G_RallyEntityIsValid(LPEDICT producer) {
     /* Current Warsmash explicitly drops dead unit targets. Destructable/item
      * death/removal semantics are less certain, so only unit death is folded
      * into the default here; freed/reused edicts are rejected for every type. */
-    if ((target->svflags & SVF_MONSTER) && M_IsDead(target)) return false;
+    /* Death is published before health reaches zero, so the server death bit must invalidate rally targets immediately. */
+    if ((target->svflags & SVF_MONSTER) && ((target->svflags & SVF_DEADMONSTER) || M_IsDead(target))) return false;
     return true;
 }
 

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -196,13 +196,8 @@ TEST(wc3_game, hud_message_overlay_invalid_position_keeps_fdf_anchor) {
     T_FEQ(frame.Points.y[FPP_MIN].offset, -0.30f, 0.001f);
 }
 
-
-TEST(wc3_game, overhead_bar_width_uses_unit_selection_radius) {
-    T_FEQ(WC3_HoverBarWidth(45.0f), 0.045f, 0.0001f); /* Hpal: scale 1.25 * retail ScaleFactor 72 / 2. */
-}
-
-TEST(wc3_game, overhead_bar_fill_keeps_retail_one_thousandth_inset) {
-    T_FEQ(0.008f - 0.001f * 2.0f, 0.006f, 0.0001f);
+TEST(wc3_game, overhead_bar_fill_keeps_warsmash_three_pixel_inset) {
+    T_FEQ(0.008f - 0.003f * 2.0f, 0.002f, 0.0001f);
 }
 
 /* =========================================================================

--- a/games/warcraft-3/game/tests/t_utils.c
+++ b/games/warcraft-3/game/tests/t_utils.c
@@ -27,7 +27,7 @@ LPEDICT alloc_test_unit(DWORD class_id, FLOAT x, FLOAT y) {
     /* Match SP_SpawnUnit's liveness contract for real unit rows.  Order and
      * selection code uses health <= 0 as the authoritative dead predicate, so
      * a generic test unit must not silently start life as a corpse. */
-    ent->health.max_value = ent->UnitBalance->maxHealth;
+    ent->health.max_value = MAX(ent->UnitBalance->maxHealth, 1.0f);
     ent->health.value = ent->health.max_value;
     return ent;
 }

--- a/games/warcraft-3/renderer/r_game.c
+++ b/games/warcraft-3/renderer/r_game.c
@@ -3,11 +3,11 @@
 #include "w3m/r_war3map.h"
 #include "common/stb_slk.h"
 
-void R_RegisterMap(LPCSTR mapFileName);
-void R_DrawWorld(void);
-void R_DrawTerrainShadows(void);
-void R_DrawAlphaSurfaces(void);
-bool R_TraceLocation(viewDef_t const *viewdef, FLOAT x, FLOAT y, LPVECTOR3 output);
+void _W3M_RegisterMap(LPCSTR mapFileName);
+void _W3M_DrawWorld(void);
+void _W3M_DrawTerrainShadows(void);
+void _W3M_DrawAlphaSurfaces(void);
+bool _W3M_TraceLocation(viewDef_t const *viewdef, FLOAT x, FLOAT y, LPVECTOR3 output);
 float GetAccurateHeightAtPoint(float sx, float sy);
 
 static LPCSTR selCirclesNames[NUM_SELECTION_CIRCLES] = {
@@ -52,7 +52,7 @@ typedef struct {
 
 static model_texture_cache_t model_texture_cache = { 0 };
 
-static BOOL R_GamePathHasExtension(LPCSTR path, LPCSTR extension) {
+static BOOL R_W3PathHasExtension(LPCSTR path, LPCSTR extension) {
     size_t pathLen;
     size_t extLen;
 
@@ -67,7 +67,7 @@ static BOOL R_GamePathHasExtension(LPCSTR path, LPCSTR extension) {
     return !strcasecmp(path + pathLen - extLen, extension);
 }
 
-void R_GameLoadAssets(void) {
+void R_LoadAssets(void) {
     FOR_LOOP(i, MODEL_COUNT) {
         tr.model[i] = R_LoadModel(modelNames[i]);
     }
@@ -95,12 +95,12 @@ void R_GameLoadAssets(void) {
     tr.texture[TEX_WATER] = R_LoadTexture("ReplaceableTextures\\Water\\Water12.blp");
 }
 
-void R_GameInit(void) {
+void R_Init(void) {
     cursor_model = NULL; cursor_load_attempted = false;
     MDLX_Init();
 }
 
-void R_GameShutdown(void) {
+void R_Shutdown(void) {
     /* R_ShutdownModels runs first and owns the cached model allocation; only clear our borrowed handle here. */
     cursor_model = NULL; cursor_load_attempted = false;
     FS_SLKFreeIndex(&g_terrain_idx);
@@ -112,19 +112,19 @@ void R_GameShutdown(void) {
     MDLX_Shutdown();
 }
 
-w3TerrainArt_t const *R_GameTerrainArt(DWORD id) {
+w3TerrainArt_t const *R_TerrainArt(DWORD id) {
     static w3TerrainArt_t zero;
     w3TerrainArt_t *row = FS_SLKLookup(&g_terrain_idx, id);
     return row ? row : &zero;
 }
 
-w3CliffType_t const *R_GameCliffType(DWORD id) {
+w3CliffType_t const *R_CliffType(DWORD id) {
     static w3CliffType_t zero;
     w3CliffType_t *row = FS_SLKLookup(&g_cliff_idx, id);
     return row ? row : &zero;
 }
 
-void R_GameSetupTextureMatrix(void) {
+void R_SetupTextureMatrix(void) {
     if (tr.world) {
         VECTOR2 s = GetWar3MapSize(tr.world);
         VECTOR2 c = tr.world->center;
@@ -134,7 +134,7 @@ void R_GameSetupTextureMatrix(void) {
     }
 }
 
-void R_GameDrawMinimap(LPCRECT screen) {
+void R_DrawMinimap(LPCRECT screen) {
     LPCTEXTURE tex = tr.minimap ? tr.minimap : tr.texture[TEX_WHITE];
     R_DrawImage(tex, screen, &MAKE(RECT, 0, 0, 1, 1), COLOR32_WHITE);
 
@@ -159,35 +159,35 @@ void R_GameDrawMinimap(LPCRECT screen) {
     R_DrawMinimapCameraRect(screen);
 }
 
-void R_GameRegisterMap(LPCSTR mapFileName) {
-    R_RegisterMap(mapFileName);
+void R_RegisterMap(LPCSTR mapFileName) {
+    _W3M_RegisterMap(mapFileName);
 }
 
-void R_GameDrawWorld(void) {
-    R_DrawWorld();
+void R_DrawWorld(void) {
+    _W3M_DrawWorld();
 }
 
-void R_GameDrawTerrainShadows(void) {
-    R_DrawTerrainShadows();
+void R_DrawTerrainShadows(void) {
+    _W3M_DrawTerrainShadows();
 }
 
-void R_GameDrawAlphaSurfaces(void) {
-    R_DrawAlphaSurfaces();
+void R_DrawAlphaSurfaces(void) {
+    _W3M_DrawAlphaSurfaces();
 }
 
-bool R_GameTraceLocation(viewDef_t const *viewdef, float x, float y, LPVECTOR3 point) {
-    return R_TraceLocation(viewdef, x, y, point);
+bool R_TraceLocation(viewDef_t const *viewdef, float x, float y, LPVECTOR3 point) {
+    return _W3M_TraceLocation(viewdef, x, y, point);
 }
 
-FLOAT R_GameGetHeightAtPoint(FLOAT x, FLOAT y) {
+FLOAT R_GetHeightAtPoint(FLOAT x, FLOAT y) {
     return GetAccurateHeightAtPoint(x, y);
 }
 
-VECTOR2 R_GameWorldSize(void) {
+VECTOR2 R_WorldSize(void) {
     return tr.world ? GetWar3MapSize(tr.world) : (VECTOR2){ 0 };
 }
 
-LPMODEL R_GameLoadModel(LPCSTR modelFilename) {
+LPMODEL R_LoadModel(LPCSTR modelFilename) {
     void *buffer = NULL;
     int fileSize = ri.FS_ReadFile(modelFilename, &buffer);
     LPMODEL model = NULL;
@@ -221,7 +221,7 @@ LPMODEL R_GameLoadModel(LPCSTR modelFilename) {
         model = ri.MemAlloc(sizeof(model_t));
         model->mdx = R_LoadModelMDLX(buffer, fileSize);
         model->modeltype = ID_MDLX;
-    } else if (R_GamePathHasExtension(modelFilename, ".mdl")) {
+    } else if (R_W3PathHasExtension(modelFilename, ".mdl")) {
         /* Same case-insensitive issue: use stem length, not strstr. */
         PATHSTR tempFileName = { 0 };
         size_t stemLen = strlen(modelFilename) - 4;
@@ -240,14 +240,14 @@ LPMODEL R_GameLoadModel(LPCSTR modelFilename) {
     return model;
 }
 
-void R_GameReleaseModel(LPMODEL model) {
+void R_ReleaseModel(LPMODEL model) {
     if (model->modeltype == ID_MDLX) {
         MDLX_Release(model->mdx);
     }
     ri.MemFree(model);
 }
 
-void R_GameRenderModel(renderEntity_t const *entity) {
+void R_RenderModel(renderEntity_t const *entity) {
     MATRIX4 transform;
 
     if (!entity || !entity->model || entity->model->modeltype != ID_MDLX) {
@@ -257,7 +257,7 @@ void R_GameRenderModel(renderEntity_t const *entity) {
     MDX_RenderModel(entity, entity->model->mdx, &transform);
 }
 
-bool R_GameTraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT distance) {
+bool R_TraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT distance) {
     if (!entity || !entity->model || entity->model->modeltype != ID_MDLX) {
         return false;
     }
@@ -270,34 +270,34 @@ bool R_GameTraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT dista
     return true;
 }
 
-bool R_GameEntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix) {
+bool R_EntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix) {
     (void)entity;
     (void)matrix;
     return false;
 }
 
-bool R_GameRenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin) {
+bool R_RenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin) {
     (void)entity;
     (void)origin;
     return false;
 }
 
-FLOAT R_GameSelectionRadius(renderEntity_t const *entity) {
+FLOAT R_SelectionRadius(renderEntity_t const *entity) {
     return entity->radius;
 }
 
-FLOAT R_GameEntityHeight(renderEntity_t const *entity) {
+FLOAT R_EntityHeight(renderEntity_t const *entity) {
     if (!entity || !entity->model || entity->model->modeltype != ID_MDLX || !entity->model->mdx) return 0.0f;
     return entity->model->mdx->bounds.box.max.z * entity->scale;
 }
-BOOL R_GameEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
+BOOL R_EntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
     if (!entity || !out) return false;
-    /* Retail PreSelect.cpp uses transformed model bounds; selection-circle radius made mines high and heroes low. */
-    *out = entity->origin; out->z += R_GameEntityHeight(entity) + 30.0f;
+    /* Match Warsmash: the status stack is centered on the transformed model-bounds maximum. */
+    *out = entity->origin; out->z += R_EntityHeight(entity);
     return true;
 }
 
-static void R_GameTextureCacheAdd(LPCSTR path) {
+static void R_W3TextureCacheAdd(LPCSTR path) {
     if (!path || !*path || model_texture_cache.count >= 256) {
         return;
     }
@@ -311,7 +311,7 @@ static void R_GameTextureCacheAdd(LPCSTR path) {
     model_texture_cache.count++;
 }
 
-static void R_GameBuildModelTextureCache(LPMODEL model) {
+static void R_W3BuildModelTextureCache(LPMODEL model) {
     if (model_texture_cache.model == model) {
         return;
     }
@@ -321,19 +321,20 @@ static void R_GameBuildModelTextureCache(LPMODEL model) {
         return;
     }
     FOR_LOOP(i, model->mdx->num_textures) {
-        R_GameTextureCacheAdd(model->mdx->textures[i].path);
+        R_W3TextureCacheAdd(model->mdx->textures[i].path);
     }
 }
 
-bool R_GameGetModelInfo(LPMODEL model, LPMODELINFO info) {
+bool R_GetModelInfo(LPMODEL model, LPMODELINFO info) {
     bool found = false;
     float min_u = 1.0f, min_v = 1.0f, max_u = 0.0f, max_v = 0.0f;
 
     if (!model || !info || model->modeltype != ID_MDLX || !model->mdx) {
         return false;
     }
+    memset(info, 0, sizeof(*info));
 
-    R_GameBuildModelTextureCache(model);
+    R_W3BuildModelTextureCache(model);
     if (model_texture_cache.model == model) {
         info->textureCount = MIN(model_texture_cache.count, MODELINFO_MAX_TEXTURES);
         FOR_LOOP(i, info->textureCount) {
@@ -371,7 +372,7 @@ bool R_GameGetModelInfo(LPMODEL model, LPMODELINFO info) {
     return true;
 }
 
-bool R_GameExtractEntityCamera(renderEntity_t const *entity, float aspect, viewDef_t *viewdef) {
+bool R_ExtractEntityCamera(renderEntity_t const *entity, float aspect, viewDef_t *viewdef) {
     if (!entity || !entity->model || !entity->model->mdx || !viewdef) {
         return false;
     }
@@ -381,22 +382,22 @@ bool R_GameExtractEntityCamera(renderEntity_t const *entity, float aspect, viewD
     return ok;
 }
 
-bool R_GameSetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity) {
+bool R_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity) {
     return MDLX_SetEntityAnimationFrame(model, anim, entity);
 }
 
-void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
+void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     MDLX_DrawSprite(model, anim, x, y);
 }
 
 /* Warcraft III can replace the platform cursor with its authored animated MDX cursor. */
-bool R_GameDrawCursor(float x, float y, COLOR32 tint) {
+bool R_DrawCursor(float x, float y, COLOR32 tint) {
     renderEntity_t probe = {0};
 
     if (!cursor_model && !cursor_load_attempted) {
         cursor_load_attempted = true;
         cursor_model = R_LoadModel(cursor_model_name);
-        if (!cursor_model || !R_GameSetEntityAnimFrame(cursor_model, "Normal", &probe)) {
+        if (!cursor_model || !R_SetEntityAnimFrame(cursor_model, "Normal", &probe)) {
             fprintf(stderr, "WC3 cursor unavailable: %s\n", cursor_model_name);
             if (cursor_model) R_ReleaseModel(cursor_model);
             cursor_model = NULL;

--- a/games/warcraft-3/renderer/r_game.c
+++ b/games/warcraft-3/renderer/r_game.c
@@ -287,8 +287,14 @@ FLOAT R_SelectionRadius(renderEntity_t const *entity) {
 }
 
 FLOAT R_EntityHeight(renderEntity_t const *entity) {
+    mdxModel_t const *mdx;
+    mdxSequence_t const *seq;
     if (!entity || !entity->model || entity->model->modeltype != ID_MDLX || !entity->model->mdx) return 0.0f;
-    return entity->model->mdx->bounds.box.max.z * entity->scale;
+    mdx = entity->model->mdx;
+    /* Retail reads the authored per-sequence bounds, not a transform of the whole model;
+     * a single static extent spans every animation and misplaces mines/heroes' overhead UI. */
+    seq = R_FindSequenceAtTime(mdx, entity->frame);
+    return (seq ? seq->bounds.box.max.z : mdx->info.bounds.box.max.z) * entity->scale;
 }
 BOOL R_EntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
     if (!entity || !out) return false;

--- a/games/warcraft-3/renderer/w3m/r_war3map.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map.c
@@ -203,7 +203,7 @@ LPWAR3MAP FileReadWar3Map(HANDLE archive) {
     return map;
 }
 
-void R_RegisterMap(char const *mapFilename) {
+void _W3M_RegisterMap(char const *mapFilename) {
     HANDLE hMpq;
     LPBYTE mapData;
     int mapSize;
@@ -233,7 +233,7 @@ void R_RegisterMap(char const *mapFilename) {
     R_BuildGroundLayers(map);
 }
 
-void R_DrawTerrainShadows(void) {
+void _W3M_DrawTerrainShadows(void) {
     if (!tr.world || !tr.texture[TEX_TERRAIN_SHADOW] || (tr.viewDef.rdflags & RDF_NOWORLDMODEL)) {
         return;
     }
@@ -249,7 +249,7 @@ void R_DrawTerrainShadows(void) {
     R_RenderRectSplat(&mins, &maxs, tr.texture[TEX_TERRAIN_SHADOW], R_SPLAT_SHADER(&tr.shader_shadowSplat), shadowColor);
 }
 
-void R_DrawWorld(void) {
+void _W3M_DrawWorld(void) {
     if (tr.viewDef.rdflags & RDF_NOWORLDMODEL)
         return;
 
@@ -276,7 +276,7 @@ void R_DrawWorld(void) {
     }
 }
 
-void R_DrawAlphaSurfaces(void) {
+void _W3M_DrawAlphaSurfaces(void) {
     if (tr.viewDef.rdflags & RDF_NOWORLDMODEL)
         return;
 

--- a/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
@@ -275,7 +275,7 @@ LPMAPLAYER R_BuildMapSegmentCliffs(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD cli
     }
 
     LPMAPLAYER mapLayer = ri.MemAlloc(sizeof(MAPLAYER));
-    w3CliffType_t const *row = R_GameCliffType(cliffID);
+    w3CliffType_t const *row = R_CliffType(cliffID);
     cliffData_t data = {
         .cliff = cliff,
         .texDir = row->texDir,

--- a/games/warcraft-3/renderer/w3m/r_war3map_ground.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_ground.c
@@ -270,7 +270,7 @@ LPMAPLAYER R_BuildMapSegmentLayer(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD laye
     LPMAPLAYER mapLayer = ri.MemAlloc(sizeof(MAPLAYER));
     PATHSTR zBuffer;
     if (g_groundTextures[layer] == NULL) {
-        w3TerrainArt_t const *terrain = R_GameTerrainArt(map->grounds[layer]);
+        w3TerrainArt_t const *terrain = R_TerrainArt(map->grounds[layer]);
         if (terrain->file && terrain->dir) {
             snprintf(zBuffer, sizeof(zBuffer), "%s\\%s.blp", terrain->dir, terrain->file);
             g_groundTextures[layer] = R_LoadTexture(zBuffer);
@@ -296,7 +296,7 @@ LPMAPLAYER R_BuildGroundLayerGlobal(LPCWAR3MAP map, DWORD layer) {
     PATHSTR zBuffer;
 
     if (g_groundTextures[layer] == NULL) {
-        w3TerrainArt_t const *terrain = R_GameTerrainArt(map->grounds[layer]);
+        w3TerrainArt_t const *terrain = R_TerrainArt(map->grounds[layer]);
         if (terrain->file && terrain->dir) {
             sprintf(zBuffer, "%s\\%s.blp", terrain->dir, terrain->file);
             g_groundTextures[layer] = R_LoadTexture(zBuffer);
@@ -467,7 +467,7 @@ static BOOL R_TraceHeightmapTile(int x, int y, LPCLINE3 line, LPVECTOR3 output) 
     return Line3_intersect_triangle(line, &tri2, output);
 }
 
-bool R_TraceLocation(viewDef_t const *viewdef, FLOAT x, FLOAT y, LPVECTOR3 output) {
+bool _W3M_TraceLocation(viewDef_t const *viewdef, FLOAT x, FLOAT y, LPVECTOR3 output) {
     if (!viewdef || !output || !tr.world) {
         return false;
     }

--- a/games/warcraft-3/ui/ui_main.c
+++ b/games/warcraft-3/ui/ui_main.c
@@ -559,8 +559,10 @@ static void UI_DrawHoverUnit(void) {
             .screen = bar, .uv = { 0, 0, 1, 1 }, .color = MAKE(COLOR32, 0, 0, 0, 220) });
         if (hover_mana) {
             RECT inner = MAKE(RECT, bar.x + 0.001f, bar.y + 0.001f, bar.w - 0.002f, bar.h - 0.002f);
+            /* The old renderer shortened the fill geometry; UV-only cropping leaves a solid bar full-width. */
+            inner.w *= mana;
             hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_mana, .shader = SHADER_UI,
-                .screen = inner, .uv = { 0, 0, mana, 1 }, .color = MAKE(COLOR32, 60, 90, 235, 255) });
+                .screen = inner, .uv = { 0, 0, 1, 1 }, .color = MAKE(COLOR32, 60, 90, 235, 255) });
         }
         cursor = bar.y + 0.001f;
     }
@@ -569,8 +571,10 @@ static void UI_DrawHoverUnit(void) {
         .screen = bar, .uv = { 0, 0, 1, 1 }, .color = MAKE(COLOR32, 0, 0, 0, 220) });
     if (hover_hp) {
         RECT inner = MAKE(RECT, bar.x + 0.001f, bar.y + 0.001f, bar.w - 0.002f, bar.h - 0.002f);
+        /* Keep the fill width authoritative so damage changes the visible bar, as in the pre-UI migration path. */
+        inner.w *= hp;
         hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_hp, .shader = SHADER_UI,
-            .screen = inner, .uv = { 0, 0, hp, 1 }, .color = hp_color });
+            .screen = inner, .uv = { 0, 0, 1, 1 }, .color = hp_color });
     }
     cursor = bar.y + 0.001f;
     label = MAKE(RECT, hover_unit.x - label_w * 0.5f, cursor - 0.003f - text_size.y - 0.012f,

--- a/games/warcraft-3/ui/ui_main.c
+++ b/games/warcraft-3/ui/ui_main.c
@@ -530,7 +530,7 @@ void UI_RefreshLocal(DWORD time) {
 /* Draw the client-projected hover unit as a WC3 UI-owned name plate and status stack. */
 static void UI_DrawHoverUnit(void) {
     RECT label, bar;
-    FLOAT hp, mana, label_w;
+    FLOAT hp, mana, label_w, cursor;
     VECTOR2 text_size;
     drawText_t text_draw;
     COLOR32 hp_color;
@@ -551,24 +551,10 @@ static void UI_DrawHoverUnit(void) {
         .color = COLOR32_WHITE, .textWidth = 0, .lineHeight = 1.0f };
     text_size = hover_font ? hover_renderer->GetTextSize(&text_draw) : MAKE(VECTOR2, 0, 0);
     label_w = text_size.x + 0.016f;
-    label = MAKE(RECT, hover_unit.x - label_w * 0.5f, hover_unit.y - 0.005f - text_size.y - 0.012f,
-        label_w, text_size.y + 0.012f);
-    if (hover_bg && hover_edge) hover_renderer->DrawBackdrop(&(drawBackdrop_t){
-        .screen = label, .bg = { hover_bg, COLOR32_WHITE }, .edge = { hover_edge, COLOR32_WHITE },
-        .corner = { 0x1ff, 0.010f }, .insets = { 0.0019f, 0.0019f, 0.0019f, 0.0019f }, .flags = 0 });
-    if (hover_font) hover_renderer->DrawText(&(drawText_t){ .font = hover_font, .text = hover_unit.name, .rect = label,
-        .color = COLOR32_WHITE, .textWidth = label.w, .lineHeight = label.h,
-        .halign = FONT_JUSTIFYCENTER, .valign = FONT_JUSTIFYMIDDLE });
-    bar = MAKE(RECT, hover_unit.x - hover_unit.width * 0.5f, hover_unit.y - 0.002f, hover_unit.width, 0.008f);
-    if (hover_black) hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_black, .shader = SHADER_UI,
-        .screen = bar, .uv = { 0, 0, 1, 1 }, .color = MAKE(COLOR32, 0, 0, 0, 220) });
-    if (hover_hp) {
-        RECT inner = MAKE(RECT, bar.x + 0.001f, bar.y + 0.001f, bar.w - 0.002f, bar.h - 0.002f);
-        hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_hp, .shader = SHADER_UI,
-            .screen = inner, .uv = { 0, 0, hp, 1 }, .color = hp_color });
-    }
+    /* The projected point is the table: fill upward from it, mana first, then HP, then the nameplate. */
+    cursor = hover_unit.y;
     if (mana > 0.0f) {
-        bar.y += 0.008f;
+        bar = MAKE(RECT, hover_unit.x - hover_unit.width * 0.5f, cursor - 0.008f, hover_unit.width, 0.008f);
         if (hover_black) hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_black, .shader = SHADER_UI,
             .screen = bar, .uv = { 0, 0, 1, 1 }, .color = MAKE(COLOR32, 0, 0, 0, 220) });
         if (hover_mana) {
@@ -576,7 +562,25 @@ static void UI_DrawHoverUnit(void) {
             hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_mana, .shader = SHADER_UI,
                 .screen = inner, .uv = { 0, 0, mana, 1 }, .color = MAKE(COLOR32, 60, 90, 235, 255) });
         }
+        cursor = bar.y + 0.001f;
     }
+    bar = MAKE(RECT, hover_unit.x - hover_unit.width * 0.5f, cursor - 0.008f, hover_unit.width, 0.008f);
+    if (hover_black) hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_black, .shader = SHADER_UI,
+        .screen = bar, .uv = { 0, 0, 1, 1 }, .color = MAKE(COLOR32, 0, 0, 0, 220) });
+    if (hover_hp) {
+        RECT inner = MAKE(RECT, bar.x + 0.001f, bar.y + 0.001f, bar.w - 0.002f, bar.h - 0.002f);
+        hover_renderer->DrawImageEx(&(drawImage_t){ .texture = hover_hp, .shader = SHADER_UI,
+            .screen = inner, .uv = { 0, 0, hp, 1 }, .color = hp_color });
+    }
+    cursor = bar.y + 0.001f;
+    label = MAKE(RECT, hover_unit.x - label_w * 0.5f, cursor - 0.003f - text_size.y - 0.012f,
+        label_w, text_size.y + 0.012f);
+    if (hover_bg && hover_edge) hover_renderer->DrawBackdrop(&(drawBackdrop_t){
+        .screen = label, .bg = { hover_bg, COLOR32_WHITE }, .edge = { hover_edge, COLOR32_WHITE },
+        .corner = { 0x1ff, 0.010f }, .insets = { 0.0019f, 0.0019f, 0.0019f, 0.0019f }, .flags = 0 });
+    if (hover_font) hover_renderer->DrawText(&(drawText_t){ .font = hover_font, .text = hover_unit.name, .rect = label,
+        .color = COLOR32_WHITE, .textWidth = label.w, .lineHeight = label.h,
+        .halign = FONT_JUSTIFYCENTER, .valign = FONT_JUSTIFYMIDDLE });
 }
 
 static void UI_UpdateHoverUnitLocal(uiHoverUnit_t const *unit) {

--- a/games/world-of-warcraft/common/ui_constants.h
+++ b/games/world-of-warcraft/common/ui_constants.h
@@ -18,6 +18,7 @@
 #define WOW_WORLD_FOG_GREEN 0.70f
 #define WOW_WORLD_FOG_BLUE 0.85f
 #define WOW_CAMERA_EYE_HEIGHT 1.6f // world units; raises the third-person camera target above the grounded player origin
+#define WOW_CS_NPC_NAME_FIRST 1 // CS_GENERAL slot; slot zero carries selected-character data instead of packed entity names
 
 /* Sun light colors. Classic has no Light*.dbc / .lit, so the authored sun
    path is unavailable; these use WoWee's documented no-DBC fallback tint

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -1066,7 +1066,7 @@ void Wow_FireFirebolt(LPEDICT caster, LPEDICT target) {
     proj->s.player = caster->s.player;
     /* EF_GROUND_ANCHOR routes the renderer through the grounded-actor matrix path
      * (yaw-only around Z), which is correct for spell projectiles.  Without it
-     * R_GameEntityMatrix applies the doodad Euler angles (rotation.y-90, rotation.z-90)
+     * R_EntityMatrix applies the doodad Euler angles (rotation.y-90, rotation.z-90)
      * to a zero-rotation entity, which lifts the mesh far above the origin. */
     proj->s.flags  = EF_GROUND_ANCHOR;
     /* Ranged spells use the selected target, not the melee combat target; leaving

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -2497,7 +2497,7 @@ static void Wow_CustomizeEntity(DWORD player, LPCEDICT ent, LPENTITYSTATE state)
     wowEntityLocal_t *local = Wow_EntityLocal(ent);
     if (player >= WOW_MAX_CLIENTS) return;
     /* Vanilla reveals a creature's overhead name only after that recipient selects it. */
-    if (wow_clients[player].selected_entity != state->number) state->image = 0;
+    if (wow_clients[player].selected_entity != state->number) state->name = 0;
     if (!local || !local->quest_id || !(state->flags & EF_HAS_QUEST)) return;
     state->flags &= ~(EF_HAS_QUEST | EF_QUEST_COMPLETE);
     switch (Wow_QuestMarkerForGiver(&wow_clients[player], local)) {

--- a/games/world-of-warcraft/game/g_wow_local.h
+++ b/games/world-of-warcraft/game/g_wow_local.h
@@ -213,7 +213,6 @@ LPCWOWQUESTDETAIL Wow_QuestDetail(DWORD quest_id);
    Set by the UI via a single userinfo-style cvar before map load, read by
    Wow_Init.  Format: \race\Human\sex\Male\class\1\appearance\12345 */
 #define WOW_CS_PLAYERINFO 0
-#define WOW_CS_NPC_NAME_FIRST 1 // CS_GENERAL slot; first server-authored NPC name used by world labels
 #define WOW_MOVE_FORWARD 1
 #define WOW_MOVE_BACK 2
 #define WOW_MOVE_LEFT 4

--- a/games/world-of-warcraft/game/m_creature.c
+++ b/games/world-of-warcraft/game/m_creature.c
@@ -65,14 +65,13 @@ static USHORT G_UnitNameConfigstring(LPCSTR name) {
         LPCSTR cs = gi.GetConfigstring(idx);
         for (DWORD sub = 0; sub < ENT_NAMES_PER_CS; sub++) {
             LPCSTR entry = cs ? cs + sub * ENT_NAME_SLOT_SIZE : NULL;
-            if (entry && *entry) {
-                if (!strncmp(entry, name, ENT_NAME_SLOT_SIZE - 1))
+            if (entry && !entity_name_slot_empty(entry)) {
+                if (entity_name_slot_equals(entry, name))
                     return (USHORT)(slot * ENT_NAMES_PER_CS + sub + 1);
                 continue;
             }
-            memset(buf, 0, sizeof(buf));
-            if (cs && *cs) memcpy(buf, cs, sizeof(buf));
-            strncpy(buf + sub * ENT_NAME_SLOT_SIZE, name, ENT_NAME_SLOT_SIZE - 1);
+            entity_name_pool_prepare(buf, cs);
+            entity_name_slot_store(buf, sub, name);
             gi.configstring(idx, buf);
             return (USHORT)(slot * ENT_NAMES_PER_CS + sub + 1);
         }

--- a/games/world-of-warcraft/game/tests/t_smoke.c
+++ b/games/world-of-warcraft/game/tests/t_smoke.c
@@ -78,7 +78,7 @@ TEST(wow_smoke, missing_m2_uses_fallback_model_and_disables_static_instancing) {
 
     model.modeltype = ID_MD20;
     model.m2 = (m2Model_t *)&fake;
-    T_ASSERT(!R_GameModelCanStaticInstance(&model));
+    T_ASSERT(!R_ModelCanStaticInstance(&model));
 }
 
 #endif /* BZ_TESTS */

--- a/games/world-of-warcraft/renderer/r_game.c
+++ b/games/world-of-warcraft/renderer/r_game.c
@@ -5,10 +5,12 @@
 #include "wow/r_wowmap.h"
 #include "m2/r_m2_format.h"
 
-void R_RegisterMap(LPCSTR mapFileName);
-void R_DrawWorld(void);
-void R_DrawTerrainShadows(void);
-void R_DrawAlphaSurfaces(void);
+void Wow_RegisterMap(LPCSTR mapFileName);
+void Wow_DrawWorld(void);
+void Wow_DrawTerrainShadows(void);
+void Wow_DrawAlphaSurfaces(void);
+void Wow_DrawMinimap(LPCRECT screen);
+FLOAT Wow_GetHeightAtPoint(FLOAT x, FLOAT y);
 bool R_TraceLocation(viewDef_t const *viewdef, FLOAT x, FLOAT y, LPVECTOR3 output);
 float GetAccurateHeightAtPoint(float sx, float sy);
 
@@ -43,7 +45,7 @@ typedef struct {
 static wowOverheadCache_t s_overhead[MAX_GAME_ENTITIES];
 
 /* Entity transforms can change without server time advancing, so every pose input participates in the cache key. */
-static BOOL R_GameOverheadCacheMatch(wowOverheadCache_t const *cache, renderEntity_t const *entity) {
+static BOOL R_WowOverheadCacheMatch(wowOverheadCache_t const *cache, renderEntity_t const *entity) {
     return cache->valid && cache->model == entity->model && cache->time == tr.viewDef.time &&
            cache->frame == entity->frame && cache->oldframe == entity->oldframe && cache->flags == entity->flags &&
            cache->angle == entity->angle && cache->scale == entity->scale &&
@@ -52,7 +54,7 @@ static BOOL R_GameOverheadCacheMatch(wowOverheadCache_t const *cache, renderEnti
 }
 
 /* Preserve the model-authored attachment result before another M2 draw overwrites the shared bone palette. */
-static void R_GameCacheOverhead(renderEntity_t const *entity, LPCMATRIX4 transform) {
+static void R_WowCacheOverhead(renderEntity_t const *entity, LPCMATRIX4 transform) {
     wowOverheadCache_t *cache;
     DWORD attachment;
     if (entity->number >= MAX_GAME_ENTITIES) return;
@@ -65,7 +67,7 @@ static void R_GameCacheOverhead(renderEntity_t const *entity, LPCMATRIX4 transfo
     cache->valid = true;
 }
 
-static BOOL R_GamePathHasExtension(LPCSTR path, LPCSTR extension) {
+static BOOL R_WowPathHasExtension(LPCSTR path, LPCSTR extension) {
     size_t pathLen;
     size_t extLen;
 
@@ -80,7 +82,7 @@ static BOOL R_GamePathHasExtension(LPCSTR path, LPCSTR extension) {
     return !strcasecmp(path + pathLen - extLen, extension);
 }
 
-void R_GameLoadAssets(void) {
+void R_LoadAssets(void) {
     /* WoW has no WC3 selection-circle BLPs; generate one ring and share it across the size slots until
      * distinct per-size variants exist. */
     LPTEXTURE ring = R_MakeSelectionCircleTexture();
@@ -89,53 +91,48 @@ void R_GameLoadAssets(void) {
     s_quest_active_icon = R_LoadTexture(WOW_QUEST_ACTIVE_ICON);
 }
 
-void R_GameInit(void) {
+void R_Init(void) {
     M2_Init();
 }
 
-void R_GameShutdown(void) {
+void R_Shutdown(void) {
     Wow_ShutdownWorldShaders();
     M2_Shutdown();
 }
 
-void R_GameSetupTextureMatrix(void) {
+void R_SetupTextureMatrix(void) {
     Matrix4_identity(&tr.viewDef.textureMatrix);
 }
 
-void R_GameDrawMinimap(LPCRECT screen) {
+void R_DrawMinimap(LPCRECT screen) {
     Wow_DrawMinimap(screen);
 }
 
-void R_GameRegisterMap(LPCSTR mapFileName) {
-    R_RegisterMap(mapFileName);
+void R_RegisterMap(LPCSTR mapFileName) {
+    Wow_RegisterMap(mapFileName);
 }
 
-void R_GameDrawWorld(void) {
-    R_DrawWorld();
+void R_DrawWorld(void) {
+    Wow_DrawWorld();
 }
 
-void R_GameDrawTerrainShadows(void) {
-    R_DrawTerrainShadows();
+void R_DrawTerrainShadows(void) {
+    Wow_DrawTerrainShadows();
 }
 
-void R_GameDrawAlphaSurfaces(void) {
-    Wow_FlushSplats();
-    R_DrawAlphaSurfaces();
+void R_DrawAlphaSurfaces(void) {
+    Wow_DrawAlphaSurfaces();
 }
 
-bool R_GameTraceLocation(viewDef_t const *viewdef, float x, float y, LPVECTOR3 point) {
-    return R_TraceLocation(viewdef, x, y, point);
+FLOAT R_GetHeightAtPoint(FLOAT x, FLOAT y) {
+    return Wow_GetHeightAtPoint(x, y);
 }
 
-FLOAT R_GameGetHeightAtPoint(FLOAT x, FLOAT y) {
-    return GetAccurateHeightAtPoint(x, y);
-}
-
-VECTOR2 R_GameWorldSize(void) {
+VECTOR2 R_WorldSize(void) {
     return (VECTOR2){ 0 };
 }
 
-LPMODEL R_GameLoadModel(LPCSTR modelFilename) {
+LPMODEL R_LoadModel(LPCSTR modelFilename) {
     void *buffer = NULL;
     PATHSTR load_name;
     int fileSize = ri.FS_ReadFile(modelFilename, &buffer);
@@ -145,7 +142,7 @@ LPMODEL R_GameLoadModel(LPCSTR modelFilename) {
     /* WoW only uses .m2; legacy data files (WMO MODN chunks, early ADTs) may
      * reference models with any extension (.MDL, .MDX, etc.).  If the direct
      * read failed and the path isn't already .m2, strip the extension and retry. */
-    if ((fileSize < 0 || !buffer) && !R_GamePathHasExtension(modelFilename, ".m2")) {
+    if ((fileSize < 0 || !buffer) && !R_WowPathHasExtension(modelFilename, ".m2")) {
         PATHSTR tempFileName = { 0 };
         LPCSTR dot = strrchr(modelFilename, '.');
         size_t stemLen = dot ? (size_t)(dot - modelFilename) : strlen(modelFilename);
@@ -185,14 +182,14 @@ LPMODEL R_GameLoadModel(LPCSTR modelFilename) {
     return model;
 }
 
-void R_GameReleaseModel(LPMODEL model) {
+void R_ReleaseModel(LPMODEL model) {
     if (model->modeltype == ID_MD20) {
         M2_Release(model->m2);
     }
     ri.MemFree(model);
 }
 
-bool R_GameEntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix) {
+bool R_EntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix) {
     VECTOR3 origin;
     MATRIX4 adt_to_world_basis;
     MATRIX4 tmp;
@@ -254,7 +251,7 @@ bool R_GameEntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix) {
 }
 
 /* Build a stable top/front light for WoW UI model-camera previews. */
-static void R_GameEntityCameraLightMatrix(LPCVECTOR3 target, FLOAT radius, LPMATRIX4 output) {
+static void R_WowEntityCameraLightMatrix(LPCVECTOR3 target, FLOAT radius, LPMATRIX4 output) {
     MATRIX4 proj;
     MATRIX4 view;
     VECTOR3 light_dir = { -0.35f, -0.50f, 0.80f };
@@ -271,7 +268,7 @@ static void R_GameEntityCameraLightMatrix(LPCVECTOR3 target, FLOAT radius, LPMAT
     Matrix4_multiply(&proj, &view, output);
 }
 
-void R_GameRenderModel(renderEntity_t const *entity) {
+void R_RenderModel(renderEntity_t const *entity) {
     MATRIX4 transform;
     MATRIX4 attached_transform;
     renderEntity_t attached_entity;
@@ -282,10 +279,10 @@ void R_GameRenderModel(renderEntity_t const *entity) {
     }
     R_GetEntityMatrix(entity, &transform);
     M2_RenderModel(entity, entity->model->m2, &transform);
-    R_GameCacheOverhead(entity, &transform);
+    R_WowCacheOverhead(entity, &transform);
     if (entity->overhead_model && entity->overhead_model->modeltype == ID_MD20) {
         renderEntity_t marker = *entity;
-        R_GameEntityOverheadPosition(entity, &marker.origin);
+        R_EntityOverheadPosition(entity, &marker.origin);
         marker.model = entity->overhead_model;
         /* A visible name owns the base slot; TalkToMe's authored bottom clearance separates the marker above it. */
         if (entity->name && *entity->name) marker.origin.z += M2_VisibleBottom(marker.model->m2);
@@ -329,18 +326,18 @@ void R_GameRenderModel(renderEntity_t const *entity) {
     }
 }
 
-void R_GameRenderModelInstanced(LPCMODEL model, LPCINSTANCEBUFFER instances, DWORD flags) {
+void R_RenderModelInstanced(LPCMODEL model, LPCINSTANCEBUFFER instances, DWORD flags) {
     if (!model || model->modeltype != ID_MD20) {
         return;
     }
     M2_RenderInstanced(model->m2, instances, flags);
 }
 
-bool R_GameModelCanStaticInstance(LPCMODEL model) {
+bool R_ModelCanStaticInstance(LPCMODEL model) {
     return model && model->modeltype == ID_MD20 && M2_CanStaticInstance(model->m2);
 }
 
-bool R_GameTraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT distance) {
+bool R_TraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT distance) {
     VECTOR3 ab;
     VECTOR3 ac;
     VECTOR3 center;
@@ -384,7 +381,7 @@ bool R_GameTraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT dista
 }
 
 #ifndef USE_SHADOWMAPS
-bool R_GameRenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin) {
+bool R_RenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin) {
     LPCTEXTURE shadow;
     BOOL use_fast_blob;
     float shadow_z;
@@ -429,7 +426,7 @@ bool R_GameRenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin) {
         };
         /* Entity Z is the server-authored ground position; reject its blob before the terrain height lookup. */
         if (!Wow_ShadowBoundsVisible(&tr.viewDef.frustum, &pre_bounds, !(tr.viewDef.rdflags & RDF_NOFRUSTUMCULL))) return true;
-        shadow_z = R_GameGetHeightAtPoint(origin->x, origin->y) + WOW_SPLAT_Z_BIAS;
+        shadow_z = R_GetHeightAtPoint(origin->x, origin->y) + WOW_SPLAT_Z_BIAS;
     }
     bounds = (BOX3){
         .min = { mins.x, mins.y, shadow_z - 16.0f },
@@ -445,13 +442,13 @@ bool R_GameRenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin) {
 }
 #endif
 
-FLOAT R_GameSelectionRadius(renderEntity_t const *entity) {
+FLOAT R_SelectionRadius(renderEntity_t const *entity) {
     /* Fractional WoW collision radii need a minimum visual footprint around the model. */
     return MAX(entity->radius * MAX(entity->scale, 1.0f), 1.0f);
 }
 
 /* The PlayerName attachment (mounted variant when riding) is the model-authored name-plate point. */
-BOOL R_GameEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
+BOOL R_EntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
     static LPCMODEL last_missing;
     wowOverheadCache_t *cache;
     MATRIX4 transform;
@@ -463,12 +460,12 @@ BOOL R_GameEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
         return false;
     }
     cache = entity->number < MAX_GAME_ENTITIES ? &s_overhead[entity->number] : NULL;
-    if (cache && cache->found && R_GameOverheadCacheMatch(cache, entity)) { *out = cache->point; return true; }
+    if (cache && cache->found && R_WowOverheadCacheMatch(cache, entity)) { *out = cache->point; return true; }
     R_GetEntityMatrix(entity, &transform);
     /* CGUnit_C::GetNamePosition prefers the mounted anchor (29) over the grounded one (18). */
     attachment = (entity->flags & RF_MOUNTED) ? M2_ATTACH_PLAYER_NAME_MOUNTED : M2_ATTACH_PLAYER_NAME;
     if (M2_EntityAttachmentPosition(entity->model->m2, entity, attachment, &transform, out)) {
-        if (cache) { R_GameCacheOverhead(entity, &transform); *out = cache->point; }
+        if (cache) { R_WowCacheOverhead(entity, &transform); *out = cache->point; }
         return true;
     }
     if (entity->model != last_missing) {
@@ -479,20 +476,20 @@ BOOL R_GameEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
     return false;
 }
 
-FLOAT R_GameEntityHeight(renderEntity_t const *entity) {
+FLOAT R_EntityHeight(renderEntity_t const *entity) {
     VECTOR3 top;
     if (!entity) return 0.0f;
-    R_GameEntityOverheadPosition(entity, &top);
+    R_EntityOverheadPosition(entity, &top);
     return top.z - entity->origin.z;
 }
 
-bool R_GameGetModelInfo(LPMODEL model, LPMODELINFO info) {
+bool R_GetModelInfo(LPMODEL model, LPMODELINFO info) {
+    if (info) memset(info, 0, sizeof(*info));
     (void)model;
-    (void)info;
     return false;
 }
 
-bool R_GameExtractEntityCamera(renderEntity_t const *entity, float aspect, viewDef_t *viewdef) {
+bool R_ExtractEntityCamera(renderEntity_t const *entity, float aspect, viewDef_t *viewdef) {
     BOX3 const *bounds;
     MATRIX4 transform;
     VECTOR3 center;
@@ -560,17 +557,17 @@ bool R_GameExtractEntityCamera(renderEntity_t const *entity, float aspect, viewD
     Matrix4_lookAt(&view_matrix, &eye, &dir, &up);
     Matrix4_multiply(&proj_matrix, &view_matrix, &viewdef->viewProjectionMatrix);
     Matrix4_identity(&viewdef->textureMatrix);
-    R_GameEntityCameraLightMatrix(&target, radius, &viewdef->lightMatrix);
+    R_WowEntityCameraLightMatrix(&target, radius, &viewdef->lightMatrix);
     return true;
 }
 
-bool R_GameSetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity) {
+bool R_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity) {
     if (!model || model->modeltype != ID_MD20)
         return false;
     return M2_SetEntitySequenceFrame(model->m2, anim, entity);
 }
 
-void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
+void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     (void)model;
     (void)anim;
     (void)x;
@@ -578,7 +575,7 @@ void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
 }
 
 /* WoW context cursors are native SDL cursors owned by cl_input_wow.c. */
-bool R_GameDrawCursor(float x, float y, COLOR32 tint) {
+bool R_DrawCursor(float x, float y, COLOR32 tint) {
     (void)x; (void)y; (void)tint;
     return false;
 }

--- a/games/world-of-warcraft/renderer/wow/r_wowmap.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap.c
@@ -1,6 +1,6 @@
 #include "r_wowmap.h"
 
-void R_RegisterMap(LPCSTR mapFileName) {
+void Wow_RegisterMap(LPCSTR mapFileName) {
     PATHSTR path;
     LPBYTE data = NULL;
     int size;
@@ -357,7 +357,7 @@ void Wow_DrawMinimap(LPCRECT screen) {
     }
 }
 
-void R_DrawWorld(void) {
+void Wow_DrawWorld(void) {
     WOWDRAWSTATS stats = { .collect = R_CvarEnabled("r_stats", "0") };
     DWORD doodad_bucket_count = 0;
     DWORD doodad_candidates = 0;
@@ -434,7 +434,7 @@ void R_DrawWorld(void) {
                     if (doodad->group == group && Wow_EntityInView(&doodad->entity)) R_RenderModel(&doodad->entity);
                 continue;
             }
-            R_GameRenderModelInstanced(group->model, &group->instances, 0); instanced_models++;
+            R_RenderModelInstanced(group->model, &group->instances, 0); instanced_models++;
         }
         if (R_CvarEnabled("r_wmos", "1")) {
             for (wowDoodadModel_t *group = wow_world.doodad_models; group; group = group->next) {
@@ -442,7 +442,7 @@ void R_DrawWorld(void) {
                 if (!R_UpdateInstanceBuffer(&group->wmo_instances, group->wmo_matrices, group->wmo_count)) {
                     fprintf(stderr, "WoW WMO doodads: instance upload failed for %s\n", group->path); continue;
                 }
-                R_GameRenderModelInstanced(group->model, &group->wmo_instances, 0); instanced_models++;
+                R_RenderModelInstanced(group->model, &group->wmo_instances, 0); instanced_models++;
             }
         }
         doodad_draws = R_GetFrameDrawCalls() - draw_start;
@@ -483,5 +483,5 @@ void R_DrawWorld(void) {
     }
 }
 
-void R_DrawAlphaSurfaces(void) {
+void Wow_DrawAlphaSurfaces(void) {
 }

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_grass.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_grass.c
@@ -636,6 +636,6 @@ void Wow_DrawGrass(void) {
                 (unsigned)wow_grass_draw_count, (unsigned)wow_grass_group_count);
     }
     FOR_LOOP(i, wow_grass_group_count)
-        R_GameRenderModelInstanced(wow_grass_groups[i].model, &wow_grass_groups[i].instances, RF_GROUND_EFFECT);
+        R_RenderModelInstanced(wow_grass_groups[i].model, &wow_grass_groups[i].instances, RF_GROUND_EFFECT);
 #endif
 }

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_objects.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_objects.c
@@ -28,7 +28,7 @@ LPMODEL Wow_LoadDoodadModel(LPCSTR path) {
         wow_world.num_missing_doodad_models++;
         return NULL;
     }
-    entry->can_instance = R_GameModelCanStaticInstance(entry->model);
+    entry->can_instance = R_ModelCanStaticInstance(entry->model);
     return entry->model;
 }
 

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_splat.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_splat.c
@@ -120,7 +120,7 @@ void Wow_AddSplatTriangle(LPVERTEX vertices,
     vertices[(*count)++] = c;
 }
 
-void R_DrawTerrainShadows(void) {
+void Wow_DrawTerrainShadows(void) {
 }
 
 void R_RenderRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, splat_shader_t *shader, COLOR32 color) {
@@ -274,7 +274,7 @@ void R_RenderSplat(LPCVECTOR2 position, float radius, LPCTEXTURE texture, splat_
     R_RenderRectSplat(&mins, &maxs, texture, shader, color);
 }
 
-/* WoW shadows are drawn by R_GameRenderShadow (returns true) and splats already
+/* WoW shadows are drawn by R_RenderShadow (returns true) and splats already
  * batch through Wow_QueueSplatVertices, so the shared batch API stays immediate. */
 static splat_shader_t *wow_batch_shader;
 void R_BeginSplatBatch(splat_shader_t *shader) { wow_batch_shader = shader; }
@@ -296,7 +296,7 @@ float GetAccurateHeightAtPoint(float sx, float sy) {
     return 0.0f;
 }
 
-FLOAT R_GetHeightAtPoint(FLOAT x, FLOAT y) {
+FLOAT Wow_GetHeightAtPoint(FLOAT x, FLOAT y) {
     return GetAccurateHeightAtPoint(x, y);
 }
 

--- a/games/world-of-warcraft/tests/test_wow_game.c
+++ b/games/world-of-warcraft/tests/test_wow_game.c
@@ -644,7 +644,7 @@ TEST(wow_game, quest_givers_receive_creature_frame_for_idle_animation) {
         T_NOT_NULL(local->animation);
         T_ASSERT(local->quest_available_model != 0);
         T_ASSERT(e->s.name != 0);
-        T_STREQ(test_configstrings[CS_GENERAL + ((e->s.name - 1) >> 4)] + ((e->s.name - 1) & 0xF) * ENT_NAME_SLOT_SIZE, "Deputy Willem");
+        T_ASSERT(entity_name_slot_equals(test_configstrings[CS_GENERAL + ((e->s.name - 1) >> 4)] + ((e->s.name - 1) & 0xF) * ENT_NAME_SLOT_SIZE, "Deputy Willem"));
         if (local->animation) T_STREQ(local->animation->name, "Stand");
         break;
     }

--- a/games/world-of-warcraft/tests/test_wow_game.c
+++ b/games/world-of-warcraft/tests/test_wow_game.c
@@ -643,8 +643,8 @@ TEST(wow_game, quest_givers_receive_creature_frame_for_idle_animation) {
         T_ASSERT(e->svflags & SVF_MONSTER);
         T_NOT_NULL(local->animation);
         T_ASSERT(local->quest_available_model != 0);
-        T_ASSERT(e->s.image >= CS_GENERAL);
-        T_STREQ(test_configstrings[e->s.image], "Deputy Willem");
+        T_ASSERT(e->s.name != 0);
+        T_STREQ(test_configstrings[CS_GENERAL + ((e->s.name - 1) >> 4)] + ((e->s.name - 1) & 0xF) * ENT_NAME_SLOT_SIZE, "Deputy Willem");
         if (local->animation) T_STREQ(local->animation->name, "Stand");
         break;
     }
@@ -671,7 +671,7 @@ TEST(wow_game, quest_marker_transitions_on_acceptance) {
         /* Before acceptance: the authoritative yellow "!" M2, EF_HAS_QUEST cleared for this client. */
         state = giver->s;
         game->CustomizeEntity(0, giver, &state);
-        T_EQ((int)state.image, 0);
+        T_EQ((int)state.name, 0);
         T_ASSERT(!(state.flags & EF_HAS_QUEST));
         T_EQ((int)state.model2, (int)avail_model);
         T_ASSERT(state.renderfx & RF_ATTACH_OVERHEAD);
@@ -679,7 +679,7 @@ TEST(wow_game, quest_marker_transitions_on_acceptance) {
         wow_clients[0].selected_entity = giver->s.number;
         state = giver->s;
         game->CustomizeEntity(0, giver, &state);
-        T_EQ((int)state.image, (int)giver->s.image);
+        T_EQ((int)state.name, (int)giver->s.name);
         wow_clients[0].selected_entity = 0;
         /* After acceptance: grey "?" flag, no tint. */
         game->ClientCommand(&wow_edicts[0], 2, (LPCSTR[]){ "quest_accept", "783" });

--- a/renderer/r_draw.c
+++ b/renderer/r_draw.c
@@ -233,7 +233,7 @@ static BOOL R_MinimapPointForWorld(LPCVECTOR3 world, LPCRECT screen, LPVECTOR2 o
         return false;
     }
 
-    map_size = R_GameWorldSize();
+    map_size = R_WorldSize();
     if (map_size.x <= 0.0f || map_size.y <= 0.0f) {
         return false;
     }
@@ -348,7 +348,7 @@ bool R_TraceMinimap(float x, float y, LPVECTOR2 outWorld) {
     if (ux < r.x || ux > r.x + r.w || uy < r.y || uy > r.y + r.h) {
         return false;
     }
-    map_size = R_GameWorldSize();
+    map_size = R_WorldSize();
     if (map_size.x <= 0.0f || map_size.y <= 0.0f) {
         return false;
     }
@@ -359,7 +359,7 @@ bool R_TraceMinimap(float x, float y, LPVECTOR2 outWorld) {
     return true;
 }
 
-void R_DrawMinimap(LPCRECT screen) {
+void R_DrawMinimapScene(LPCRECT screen) {
     if (!screen) {
         return;
     }
@@ -368,7 +368,7 @@ void R_DrawMinimap(LPCRECT screen) {
     tr.hasMinimap = true;
 
     /* Each game owns its minimap content and authoritative texture source. */
-    R_GameDrawMinimap(screen);
+    R_DrawMinimap(screen);
 }
 
 void R_DrawPic(LPCTEXTURE texture, float x, float y) {

--- a/renderer/r_ents.c
+++ b/renderer/r_ents.c
@@ -10,7 +10,7 @@
 void R_GetEntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix) {
     VECTOR3 origin = entity->origin;
 
-    if (R_GameEntityMatrix(entity, matrix)) {
+    if (R_EntityMatrix(entity, matrix)) {
         return;
     }
 
@@ -69,7 +69,7 @@ void R_DrawEntities(void) {
         }
         if (in_view) {
             drawn++;
-            R_RenderModel(ent);
+            R_DrawEntity(ent);
         } else {
             culled++;
         }
@@ -195,7 +195,7 @@ bool R_TraceEntity(viewDef_t const *viewdef, float x, float y, LPDWORD number) {
         if (!ent->number || !ent->model || (ent->flags & (RF_HIDDEN | RF_NOT_SELECTABLE))) {
             continue;
         }
-        if (R_GameTraceModel(ent, &line, &distance) && distance < best) {
+        if (R_TraceModel(ent, &line, &distance) && distance < best) {
             best = distance;
             best_number = ent->number;
         }
@@ -245,12 +245,12 @@ static void R_RenderUberSplat(const renderEntity_t *entity, LPCVECTOR2 origin) {
     }
 }
 
-static void R_RenderShadow(const renderEntity_t *entity, LPCVECTOR2 origin) {
+static void R_DrawEntityShadow(const renderEntity_t *entity, LPCVECTOR2 origin) {
 #ifndef USE_SHADOWMAPS
     LPCTEXTURE shadow = entity->shadow;
     BOX3 bounds;
 
-    if (R_GameRenderShadow(entity, origin)) {
+    if (R_RenderShadow(entity, origin)) {
         return;
     }
     if (!shadow || (entity->flags & RF_NO_SHADOW) || !tr.world) {
@@ -302,7 +302,7 @@ static void R_DrawEntityShadows(void) {
         if ((ent->flags & RF_HIDDEN) || !ent->model) {
             continue;
         }
-        R_RenderShadow(ent, (LPCVECTOR2)&ent->origin);
+        R_DrawEntityShadow(ent, (LPCVECTOR2)&ent->origin);
     }
     R_EndSplatBatch();
 #endif
@@ -311,7 +311,7 @@ static void R_DrawEntityShadows(void) {
 static void R_RenderSelectedCircle(const renderEntity_t *entity, LPCVECTOR2 origin) {
     if (entity->flags & RF_SELECTED) {
         COLOR32 color = { 0, 255, 0, 255 };
-        float radius = R_GameSelectionRadius(entity);
+        float radius = R_SelectionRadius(entity);
         FOR_LOOP(i, NUM_SELECTION_CIRCLES) {
             if ((radius * 2) > selCircles[i])
                 continue;
@@ -370,14 +370,53 @@ void R_DrawHealthBars(void) {
     RECT const scene = R_UISceneRect();
     FLOAT const w = scene.w * 0.045f;
     FLOAT const h = scene.h * 0.008f;
-    static LPFONT name_font;
-    static BOOL name_font_tried;
-    if (!name_font_tried) {
-        name_font_tried = true;
-        name_font = R_LoadFont("Fonts\\FRIZQT__.TTF", 10);
-    }
+#ifdef WOW
+    static LPFONT wow_name_font;
+    static BOOL wow_name_font_tried;
+    viewCamera_t const *old = tr.viewDef.camerastate + 1, *cur = tr.viewDef.camerastate;
+    VECTOR3 wow_cam = Vector3_lerp(&old->origin, &cur->origin, tr.viewDef.lerpfrac);
+    VECTOR3 wow_ang = {
+        Wow_LerpDegrees(old->viewangles.x, cur->viewangles.x, tr.viewDef.lerpfrac),
+        Wow_LerpDegrees(old->viewangles.y, cur->viewangles.y, tr.viewDef.lerpfrac),
+        Wow_LerpDegrees(old->viewangles.z, cur->viewangles.z, tr.viewDef.lerpfrac),
+    };
+    VECTOR3 wow_fwd, wow_off;
+    FOR_LOOP(i, tr.viewDef.num_entities)
+        if (tr.viewDef.entities[i].number == tr.viewDef.player) {
+            wow_cam.z = tr.viewDef.entities[i].origin.z + WOW_CAMERA_EYE_HEIGHT; break;
+        }
+    wow_fwd = Wow_ViewForward(&wow_ang);
+    wow_off = Vector3_scale(&wow_fwd, -LerpNumber(old->distance, cur->distance, tr.viewDef.lerpfrac));
+    wow_cam = Vector3_add(&wow_cam, &wow_off);
+#endif
     FOR_LOOP(i, tr.viewDef.num_entities) {
         renderEntity_t const *e = tr.viewDef.entities + i;
+#ifdef WOW
+        if (e->name && *e->name) {
+            VECTOR3 top;
+            VECTOR3 delta;
+            FLOAT alpha, ux, uy;
+            R_EntityOverheadPosition(e, &top);
+            delta = Vector3_sub(&top, &wow_cam);
+            alpha = Wow_WorldLabelAlpha(Vector3_len(&delta), e->flags & RF_SELECTED, e->number == tr.viewDef.player);
+            if (alpha > 0.0f && R_WorldToUI(&top, &ux, &uy)) {
+                if (!wow_name_font_tried) {
+                    wow_name_font_tried = true;
+                    wow_name_font = R_LoadFont("Fonts\\FRIZQT__.TTF", 14);
+                    if (!wow_name_font) fprintf(stderr, "WoW: NPC name font Fonts\\FRIZQT__.TTF could not be loaded\n");
+                }
+                if (wow_name_font) {
+                    /* Attachment 18 is the model-authored point below the name, so the label ends at its projection. */
+                    RECT label = MAKE(RECT, ux - scene.w * 0.12f, uy - scene.h * 0.03f,
+                                      scene.w * 0.24f, scene.h * 0.03f);
+                    drawText_t text = MAKE(drawText_t, .font = wow_name_font, .text = e->name, .rect = label,
+                        .color = MAKE(COLOR32, 0, 255, 0, (BYTE)(255.0f * alpha)), .textWidth = label.w, .lineHeight = label.h,
+                        .halign = FONT_JUSTIFYCENTER, .valign = FONT_JUSTIFYMIDDLE);
+                    R_DrawText(&text);
+                }
+            }
+        }
+#endif
         /* Always for the current selection; for hovered entity; for every unit while ALT is held. */
         if (e->health == 0 || (!show_all && !(e->flags & RF_SELECTED) && e->number != tr.viewDef.hover_entity)) {
             continue;
@@ -399,14 +438,6 @@ void R_DrawHealthBars(void) {
         if (e->mana > 0) {
             R_DrawStatusBar(x, uy + bars.y, w, h, e->mana / 255.0f, MAKE(COLOR32, 60, 90, 235, 255));
         }
-        if (name_font && e->name && *e->name && e->number == tr.viewDef.hover_entity) {
-            RECT label = MAKE(RECT, ux - scene.w * 0.10f, uy - scene.h * 0.025f,
-                              scene.w * 0.20f, scene.h * 0.025f);
-            drawText_t text = MAKE(drawText_t, .font = name_font, .text = e->name, .rect = label,
-                .color = COLOR32_WHITE, .textWidth = label.w, .lineHeight = label.h,
-                .halign = FONT_JUSTIFYCENTER, .valign = FONT_JUSTIFYMIDDLE);
-            R_DrawText(&text);
-        }
     }
 }
 
@@ -426,7 +457,7 @@ static void R_RenderHoverHighlight(renderEntity_t const *entity) {
     } else {
         color = MAKE(COLOR32, 80, 200, 80, 128);   /* own/shared-control: faint green */
     }
-    float radius = R_GameSelectionRadius(entity);
+    float radius = R_SelectionRadius(entity);
     FOR_LOOP(i, NUM_SELECTION_CIRCLES) {
         if ((radius * 2) > selCircles[i])
             continue;
@@ -437,20 +468,20 @@ static void R_RenderHoverHighlight(renderEntity_t const *entity) {
     }
 }
 
-void R_RenderModel(renderEntity_t const *entity) {
+void R_DrawEntity(renderEntity_t const *entity) {
     if ((entity->flags & RF_HIDDEN) || !entity->model)
         return;
 
 #ifdef USE_SHADOWMAPS
     if (tr.render_phase == RENDER_PHASE_LIGHTS) {
         if (!(entity->flags & RF_NO_SHADOW))
-            R_GameRenderModel(entity);
+            R_RenderModel(entity);
         return;
     }
 #endif
 
     R_RenderUberSplat(entity, (LPCVECTOR2)&entity->origin);
-    R_GameRenderModel(entity);
+    R_RenderModel(entity);
     R_RenderSelectedCircle(entity, (LPCVECTOR2)&entity->origin);
     R_RenderHoverHighlight(entity);
 }

--- a/renderer/r_fogofwar.c
+++ b/renderer/r_fogofwar.c
@@ -275,7 +275,7 @@ void R_RenderFogOfWar(void) {
 
     MATRIX4 model_matrix;
     MATRIX4 proj_matrix;
-    VECTOR2 mapsize = R_GameWorldSize();
+    VECTOR2 mapsize = R_WorldSize();
 
     Matrix4_identity(&model_matrix);
     Matrix4_translate(&model_matrix, &(VECTOR3) { -tr.world->center.x, -tr.world->center.y, 0 });

--- a/renderer/r_game.h
+++ b/renderer/r_game.h
@@ -19,43 +19,43 @@ typedef struct {
 	LPCSTR cliffModelDir;
 } w3CliffType_t;
 
-void R_GameLoadAssets(void);
-void R_GameInit(void);
-void R_GameShutdown(void);
-void R_GameSetupTextureMatrix(void);
+void R_LoadAssets(void);
+void R_Init(void);
+void R_Shutdown(void);
+void R_SetupTextureMatrix(void);
 
 /* Draw the game's minimap into the given UI-space rect. Each game owns its content. */
-void R_GameDrawMinimap(LPCRECT screen);
+void R_DrawMinimap(LPCRECT screen);
 
-void R_GameRegisterMap(LPCSTR mapFileName);
-void R_GameDrawWorld(void);
-void R_GameDrawTerrainShadows(void);
-void R_GameDrawAlphaSurfaces(void);
-bool R_GameTraceLocation(viewDef_t const *viewdef, float x, float y, LPVECTOR3 point);
-FLOAT R_GameGetHeightAtPoint(FLOAT x, FLOAT y);
-VECTOR2 R_GameWorldSize(void);
+void R_RegisterMap(LPCSTR mapFileName);
+void R_DrawWorld(void);
+void R_DrawTerrainShadows(void);
+void R_DrawAlphaSurfaces(void);
+bool R_TraceLocation(viewDef_t const *viewdef, float x, float y, LPVECTOR3 point);
+FLOAT R_GetHeightAtPoint(FLOAT x, FLOAT y);
+VECTOR2 R_WorldSize(void);
 
-LPMODEL R_GameLoadModel(LPCSTR modelFilename);
-void R_GameReleaseModel(LPMODEL model);
-void R_GameRenderModel(renderEntity_t const *entity);
-void R_GameRenderModelInstanced(LPCMODEL model, LPCINSTANCEBUFFER instances, DWORD flags);
-bool R_GameModelCanStaticInstance(LPCMODEL model);
-bool R_GameTraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT distance);
-bool R_GameGetModelInfo(LPMODEL model, LPMODELINFO info);
-bool R_GameEntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix);
+LPMODEL R_LoadModel(LPCSTR modelFilename);
+void R_ReleaseModel(LPMODEL model);
+void R_RenderModel(renderEntity_t const *entity);
+void R_RenderModelInstanced(LPCMODEL model, LPCINSTANCEBUFFER instances, DWORD flags);
+bool R_ModelCanStaticInstance(LPCMODEL model);
+bool R_TraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT distance);
+bool R_GetModelInfo(LPMODEL model, LPMODELINFO info);
+bool R_EntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix);
 #ifndef USE_SHADOWMAPS
-bool R_GameRenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin);
+bool R_RenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin);
 #endif
 /* Selection-circle radius for the shared entity path; per-game tuning (e.g. WoW's fractional-creature clamp). */
-FLOAT R_GameSelectionRadius(renderEntity_t const *entity);
-FLOAT R_GameEntityHeight(renderEntity_t const *entity);
-BOOL R_GameEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out);
+FLOAT R_SelectionRadius(renderEntity_t const *entity);
+FLOAT R_EntityHeight(renderEntity_t const *entity);
+BOOL R_EntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out);
 
-bool R_GameExtractEntityCamera(renderEntity_t const *entity, float aspect, viewDef_t *viewdef);
-bool R_GameSetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity);
-void R_GameDrawSprite(LPCMODEL model, LPCSTR anim, float x, float y);
-bool R_GameDrawCursor(float x, float y, COLOR32 tint);
-w3TerrainArt_t const *R_GameTerrainArt(DWORD id);
-w3CliffType_t const *R_GameCliffType(DWORD id);
+bool R_ExtractEntityCamera(renderEntity_t const *entity, float aspect, viewDef_t *viewdef);
+bool R_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity);
+void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y);
+bool R_DrawCursor(float x, float y, COLOR32 tint);
+w3TerrainArt_t const *R_TerrainArt(DWORD id);
+w3CliffType_t const *R_CliffType(DWORD id);
 
 #endif

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -336,7 +336,7 @@ void R_InitTextureFormats(void);
 void R_LoadTextureMipLevel(LPCTEXTURE texture, LPCTEXMIP mip);
 void R_BindTexture(LPCTEXTURE texture, DWORD unit);
 void R_SetTextureWrap(LPCTEXTURE texture, bool wrapS, bool wrapT);
-void R_RenderModel(renderEntity_t const *edict);
+void R_DrawEntity(renderEntity_t const *edict);
 void R_DrawTerrainShadows(void);
 bool MDLX_TraceModel(renderEntity_t const *edict, LPCLINE3 line);
 void R_ReleaseVertexArrayObject(LPBUFFER buffer);
@@ -386,8 +386,11 @@ void R_DrawEntities(void);
 FLOAT R_GetHeightAtPoint(FLOAT x, FLOAT y);
 
 // r_model.c
+/* Canonical game renderer hooks are declared here so unity-ordered game sources can call them directly. */
 LPMODEL R_LoadModel(LPCSTR modelFilename);
 void R_ReleaseModel(LPMODEL model);
+LPMODEL R_LoadRegisteredModel(LPCSTR modelFilename);
+void R_ReleaseRegisteredModel(LPMODEL model);
 void R_RegisterMapAssets(LPCSTR mapFileName);
 void R_ShutdownModels(void);
 
@@ -422,7 +425,7 @@ void R_DrawFill(LPCRECT rect, COLOR32 color);
 void R_DrawImage(LPCTEXTURE texture, LPCRECT screen, LPCRECT uv, COLOR32 color);
 void R_DrawImageEx(LPCDRAWIMAGE drawImage);
 void R_DrawImageBatch(LPCTEXTURE texture, SHADERTYPE shaderType, BLEND_MODE alphamode, FLOAT uActiveGlow, BOOL hasClip, LPCRECT clip, LPCVERTEX vertices, DWORD num_vertices, BOOL repeat);
-void R_DrawMinimap(LPCRECT screen);
+void R_DrawMinimapScene(LPCRECT screen);
 bool R_TraceMinimap(float x, float y, LPVECTOR2 outWorld);
 void R_DrawMinimapCameraRect(LPCRECT screen);
 void R_DrawLoadingIndicator(LPCRECT rect, DWORD time, COLOR32 color);

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -320,7 +320,7 @@ static void R_SetupGL(bool drawLight) {
     MATRIX4 ui_matrix;
 
     Matrix4_identity(&model_matrix);
-    R_GameSetupTextureMatrix();
+    R_SetupTextureMatrix();
     Matrix4_ortho(&ui_matrix, 0.0f, window.width, window.height, 0.0f, 0.0f, 100.0f);
 
     Matrix3_normal(&normal_matrix, &model_matrix);
@@ -421,7 +421,7 @@ static void R_UpdateSwapInterval(void) {
         fprintf(stderr, "OpenGL: vsync=%d\n", SDL_GL_GetSwapInterval());
 }
 
-void R_Init(DWORD width, DWORD height) {
+void R_InitRenderer(DWORD width, DWORD height) {
     renderer_shutdown = false;
     r_swapinterval = -999;
     BOOL gl_current = false;
@@ -529,7 +529,7 @@ void R_Init(DWORD width, DWORD height) {
 //    R_LoadModel("Assets\\Units\\Terran\\MarineTychus\\MarineTychus.m3");
 //    R_LoadModel("Assets\\Units\\Zerg\\Queen\\Queen.m3");
     
-    R_GameLoadAssets();
+    R_LoadAssets();
 
     R_LoadBuiltinShaders();
     fprintf(stderr, "Loading shaders succeeded.\n");
@@ -548,7 +548,7 @@ void R_Init(DWORD width, DWORD height) {
     R_Call(glClearColor, 0.0, 0.0, 0.0, 1.0);
     R_Call(glViewport, 0, 0, tr.drawableSize.width, tr.drawableSize.height);
     R_InitParticles();
-    R_GameInit();
+    R_Init();
     fprintf(stderr, "Refresher initialized.\n\n");
 }
 
@@ -588,13 +588,13 @@ void R_SetAlphaKeyState(BOOL enabled) {
 #endif
 }
 
-void R_Shutdown(void) {
+void R_ShutdownRenderer(void) {
     if (renderer_shutdown) {
         return;
     }
     renderer_shutdown = true;
     R_ShutdownModels();
-    R_GameShutdown();
+    R_Shutdown();
     R_ShutdownModelShader();
     R_ShutdownBuiltinShaders();
     R_ShutdownFonts();
@@ -640,8 +640,8 @@ void R_RenderShadowMap(void) {
     R_Call(glEnable, GL_POLYGON_OFFSET_FILL);
     R_Call(glPolygonOffset, 2.0f, 4.0f);
     R_BindTexture(tr.texture[TEX_SHADOWMAP], 1);
-    R_GameDrawWorld();
-    R_GameDrawTerrainShadows();
+    R_DrawWorld();
+    R_DrawTerrainShadows();
     R_DrawEntities();
     R_Call(glDisable, GL_POLYGON_OFFSET_FILL);
     R_Call(glPolygonOffset, 0.0f, 0.0f);
@@ -656,11 +656,11 @@ void R_RenderView(void) {
     if (tr.viewDef.rdflags & RDF_NOWORLDMODEL) {
         R_Call(glClear, GL_DEPTH_BUFFER_BIT);
     }
-    R_GameDrawWorld();
+    R_DrawWorld();
     R_DrawDecals();
     R_DrawEntities();
     tr.render_phase = RENDER_PHASE_ALPHA;
-    R_GameDrawAlphaSurfaces();
+    R_DrawAlphaSurfaces();
     if (!(tr.viewDef.rdflags & RDF_NOPARTICLES)) {
         R_DrawParticles();
     }
@@ -696,7 +696,7 @@ void R_RenderFrame(viewDef_t const *viewDef) {
         float aspect = (tr.viewDef.viewport.w * tr.drawableSize.width) > 0.0f
             ? (tr.viewDef.viewport.w * tr.drawableSize.width) / (tr.viewDef.viewport.h * tr.drawableSize.height)
             : 1.0f;
-        if (!R_GameExtractEntityCamera(entity, aspect, &tr.viewDef)) {
+        if (!R_ExtractEntityCamera(entity, aspect, &tr.viewDef)) {
             Matrix4_identity(&tr.viewDef.viewProjectionMatrix);
             Matrix4_identity(&tr.viewDef.textureMatrix);
             Matrix4_identity(&tr.viewDef.lightMatrix);
@@ -862,43 +862,29 @@ size2_t R_GetTextureSize(LPCTEXTURE texture) {
     }
 }
 
-bool R_GetModelInfo(LPMODEL model, LPMODELINFO info) {
-    if (!model || !info) {
-        return false;
-    }
-    memset(info, 0, sizeof(*info));
-    return R_GameGetModelInfo(model, info);
-}
+
 
 /* Keep model-format bounds inside the renderer while clients place game-owned world UI. */
 bool R_GetEntityOverheadPosition(renderEntity_t const *entity, LPVECTOR3 out) {
-    return R_GameEntityOverheadPosition(entity, out);
-}
-
-void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
-    R_GameDrawSprite(model, anim, x, y);
+    return R_EntityOverheadPosition(entity, out);
 }
 
 /* Cursor presentation is game-owned; the client only supplies UI coordinates. */
-bool R_DrawCursor(float x, float y, COLOR32 tint) { return R_GameDrawCursor(x, y, tint); }
 
-bool R_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity) {
-    return R_GameSetEntityAnimFrame(model, anim, entity);
-}
 
 refExport_t R_GetAPI(refImport_t imp) {
     ri = imp;
     return (refExport_t) {
-        .Init = R_Init,
+        .Init = R_InitRenderer,
         .RegisterMap = R_RegisterMapAssets,
         .LoadTexture = R_LoadTexture,
-        .LoadModel = R_LoadModel,
+        .LoadModel = R_LoadRegisteredModel,
         .LoadFont = R_LoadFont,
         .SetFogOfWarData = R_SetFogOfWarData,
         .ReleaseTexture = R_ReleaseTexture,
-        .ReleaseModel = R_ReleaseModel,
+        .ReleaseModel = R_ReleaseRegisteredModel,
         .RenderFrame = R_RenderFrame,
-        .Shutdown = R_Shutdown,
+        .Shutdown = R_ShutdownRenderer,
         .BeginFrame = R_BeginFrame,
         .EndFrame = R_EndFrame,
         .Screenshot = R_Screenshot,
@@ -906,7 +892,7 @@ refExport_t R_GetAPI(refImport_t imp) {
         .DrawImage = R_DrawImage,
         .DrawImageEx = R_DrawImageEx,
         .DrawBackdrop = R_DrawBackdrop,
-        .DrawMinimap = R_DrawMinimap,
+        .DrawMinimap = R_DrawMinimapScene,
         .DrawLoadingIndicator = R_DrawLoadingIndicator,
         .DrawSelectionRect = R_DrawSelectionRect,
         .DrawChar = R_DrawChar,
@@ -924,9 +910,9 @@ refExport_t R_GetAPI(refImport_t imp) {
         .GetModelInfo = R_GetModelInfo,
         .GetEntityOverheadPosition = R_GetEntityOverheadPosition,
         .DrawBoundingBox = R_DrawBoundingBox,
-        .GetHeightAtPoint = R_GameGetHeightAtPoint,
+        .GetHeightAtPoint = R_GetHeightAtPoint,
         .TraceEntity = R_TraceEntity,
-        .TraceLocation = R_GameTraceLocation,
+        .TraceLocation = R_TraceLocation,
         .TraceCameraPlane = R_TraceCameraPlane,
         .TraceMinimap = R_TraceMinimap,
         .EntitiesInRect = R_EntitiesInRect,

--- a/renderer/r_model.c
+++ b/renderer/r_model.c
@@ -24,7 +24,7 @@ static LPMODEL R_LoadEmptyModel(LPCSTR modelFilename, LPCSTR reason) {
 }
 
 /* Quake II keeps one renderer model entry per filename and marks it during registration. */
-LPMODEL R_LoadModel(LPCSTR modelFilename) {
+LPMODEL R_LoadRegisteredModel(LPCSTR modelFilename) {
     KNOWNMODEL *entry = NULL;
     LPMODEL model;
     if (!modelFilename || !*modelFilename) return R_LoadEmptyModel("<empty>", "empty filename");
@@ -39,7 +39,7 @@ LPMODEL R_LoadModel(LPCSTR modelFilename) {
         ri.error("R_LoadModel: MAX_MOD_KNOWN (%u) reached", MAX_MOD_KNOWN);
         return R_LoadEmptyModel(modelFilename, "model registry exhausted");
     }
-    model = R_GameLoadModel(modelFilename);
+    model = R_LoadModel(modelFilename);
     if (!model) model = R_LoadEmptyModel(modelFilename, "not found");
     snprintf(entry->name, sizeof(entry->name), "%s", modelFilename);
     entry->model = model; entry->references = 1; entry->registration_sequence = mod_registration_sequence;
@@ -47,14 +47,14 @@ LPMODEL R_LoadModel(LPCSTR modelFilename) {
 }
 
 /* Release drops caller ownership; stale resident images are reclaimed at the next registration boundary. */
-void R_ReleaseModel(LPMODEL model) {
+void R_ReleaseRegisteredModel(LPMODEL model) {
     if (!model) return;
     FOR_LOOP(i, MAX_MOD_KNOWN)
         if (mod_known[i].model == model) {
             if (mod_known[i].references) mod_known[i].references--;
             return;
         }
-    R_GameReleaseModel(model);
+    R_ReleaseModel(model);
 }
 
 /* End-of-registration cleanup mirrors Mod_FreeUnused: only unreferenced, unmarked models leave residency. */
@@ -63,7 +63,7 @@ static void R_FreeUnusedModels(BOOL shutdown) {
         KNOWNMODEL *entry = &mod_known[i];
         if (!entry->model || (!shutdown && (entry->references ||
             entry->registration_sequence == mod_registration_sequence))) continue;
-        R_GameReleaseModel(entry->model);
+        R_ReleaseModel(entry->model);
         memset(entry, 0, sizeof(*entry));
     }
 }
@@ -71,7 +71,7 @@ static void R_FreeUnusedModels(BOOL shutdown) {
 void R_RegisterMapAssets(LPCSTR mapFileName) {
     mod_registration_sequence++;
     if (!mod_registration_sequence) mod_registration_sequence = 1;
-    R_GameRegisterMap(mapFileName);
+    R_RegisterMap(mapFileName);
     R_FreeUnusedModels(false);
 }
 

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -664,6 +664,23 @@ TEST(net, cursor_splat_message_sets_and_clears_state) {
     T_FEQ(cl.cursor_splat.radius, 0.0f, 0.0001f);
 }
 
+TEST(net, packed_entity_names_survive_configstring_transport) {
+    BYTE buf[512];
+    char names[ENT_NAME_SLOT_SIZE * ENT_NAMES_PER_CS];
+    sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
+
+    test_client_stubs_init();
+    entity_name_pool_prepare(names, NULL);
+    entity_name_slot_store(names, 0, "Peasant");
+    entity_name_slot_store(names, 1, "Villager");
+    MSG_WriteByte(&sb, svc_configstring);
+    MSG_WriteShort(&sb, CS_GENERAL);
+    MSG_WriteString(&sb, names);
+    CL_ParseServerMessage(&sb);
+    T_STREQ(cl.configstrings[CS_GENERAL], "Peasant");
+    T_STREQ(cl.configstrings[CS_GENERAL] + ENT_NAME_SLOT_SIZE, "Villager");
+}
+
 TEST(net, playerinfo_game_state_preserves_open_menu_input) {
     BYTE buf[256];
     sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));

--- a/tests/test_renderer_model.c
+++ b/tests/test_renderer_model.c
@@ -212,16 +212,16 @@ static void test_spawn(void *context) { (*(DWORD *)context)++; }
 
 LPTEXTURE R_LoadTexture(LPCSTR filename) { (void)filename; return texture_load_result; }
 
-LPMODEL R_GameLoadModel(LPCSTR filename) {
+LPMODEL R_LoadModel(LPCSTR filename) {
     (void)filename; load_count++;
     return fail_load ? NULL : test_alloc(sizeof(model_t));
 }
 
-void R_GameReleaseModel(LPMODEL model) { release_count++; test_free(model); }
+void R_ReleaseModel(LPMODEL model) { release_count++; test_free(model); }
 
-void R_GameRegisterMap(LPCSTR map) {
+void R_RegisterMap(LPCSTR map) {
     (void)map; register_count++;
-    if (touch_during_registration) R_LoadModel("models/touched.mdx");
+    if (touch_during_registration) R_LoadRegisteredModel("models/touched.mdx");
 }
 
 static void reset_registry(void) {
@@ -280,10 +280,10 @@ TEST(renderer_model, mdx_geometry_packs_two_geosets_into_model_ranges) {
 TEST(renderer_model, filename_cache_hit_and_miss) {
     LPMODEL first, second;
     reset_registry();
-    first = R_LoadModel("Models/Foo.mdx");
-    second = R_LoadModel("models/foo.mdx");
+    first = R_LoadRegisteredModel("Models/Foo.mdx");
+    second = R_LoadRegisteredModel("models/foo.mdx");
     T_ASSERT(first == second); T_EQ(load_count, 1); T_EQ(release_count, 0);
-    R_ReleaseModel(first); R_ReleaseModel(second);
+    R_ReleaseRegisteredModel(first); R_ReleaseRegisteredModel(second);
     R_RegisterMapAssets("next");
     T_EQ(register_count, 1); T_EQ(release_count, 1);
 }
@@ -291,26 +291,26 @@ TEST(renderer_model, filename_cache_hit_and_miss) {
 TEST(renderer_model, registration_keeps_touched_model_then_reclaims_it) {
     LPMODEL model;
     reset_registry();
-    model = R_LoadModel("models/touched.mdx"); R_ReleaseModel(model);
+    model = R_LoadRegisteredModel("models/touched.mdx"); R_ReleaseRegisteredModel(model);
     touch_during_registration = true; R_RegisterMapAssets("current");
     T_EQ(load_count, 1); T_EQ(release_count, 0);
-    R_ReleaseModel(model); touch_during_registration = false; R_RegisterMapAssets("next");
+    R_ReleaseRegisteredModel(model); touch_during_registration = false; R_RegisterMapAssets("next");
     T_EQ(release_count, 1);
 }
 
 TEST(renderer_model, missing_model_placeholder_is_cached) {
     LPMODEL first, second;
     reset_registry(); fail_load = true;
-    first = R_LoadModel("models/missing.mdx"); second = R_LoadModel("models/missing.mdx");
+    first = R_LoadRegisteredModel("models/missing.mdx"); second = R_LoadRegisteredModel("models/missing.mdx");
     T_ASSERT(first == second); T_EQ(load_count, 1);
-    R_ReleaseModel(first); R_ReleaseModel(second); R_RegisterMapAssets("next");
+    R_ReleaseRegisteredModel(first); R_ReleaseRegisteredModel(second); R_RegisterMapAssets("next");
     T_EQ(release_count, 1);
 }
 
 TEST(renderer_model, unknown_model_release_is_immediate) {
     LPMODEL model;
     reset_registry(); model = test_alloc(sizeof(*model));
-    R_ReleaseModel(model); T_EQ(release_count, 1);
+    R_ReleaseRegisteredModel(model); T_EQ(release_count, 1);
 }
 
 TEST(renderer_texture, cached_registration_preserves_newer_texture_indices) {


### PR DESCRIPTION
## Summary
- remove the R_Game* renderer/game indirection across WC3, WoW, and SC2
- let each game renderer own canonical R_* hooks while renaming renderer-internal helpers to avoid collisions
- update model registration, minimap, lifecycle, entity rendering, and focused tests
- preserve upstream hover UI changes after rebasing onto origin/main

## Verification
- all three game binaries build and link
- WC3 ROC and TFT bounded runtime checks pass
- WoW and SC2 bounded runtime checks pass
- WC3 engine tests pass in ROC and TFT: 3,064/3,064 assertions each
- renderer tests pass: 2,710/2,710 assertions
- full suite functionally passes; one later rerun encountered local UDP bind failures on test ports 28030/28031