### PR TITLE
wc3: complete single-player campaign and custom-game menu flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 inventory, world-item lifecycle, item UI presentation | [docs/games/warcraft-3/inventory-and-items.md](docs/games/warcraft-3/inventory-and-items.md) |
 | WC3 player AI, Blizzard AI script contract, Human02 implementation plan | [docs/games/warcraft-3/player-ai.md](docs/games/warcraft-3/player-ai.md) |
 | WC3 player AI architecture and implementation postmortem | [docs/games/warcraft-3/player-ai-postmortem.md](docs/games/warcraft-3/player-ai-postmortem.md) |
+| WC3 client UI lifecycle, single-player campaign/mission/custom-game flow | [docs/games/warcraft-3/architecture/ui-flow.md](docs/games/warcraft-3/architecture/ui-flow.md) |
 | WC3 campaign loading lifecycle, texture references, unused FDF art, cliff transitions | [docs/games/warcraft-3/loading-and-assets.md](docs/games/warcraft-3/loading-and-assets.md) |
 | WC3 perf hot spots: MDX bone/geoset setup, shadow batching, client/server entity scans | [docs/games/warcraft-3/performance.md](docs/games/warcraft-3/performance.md) |
 | WC3 RAM profiling: MDX buffer overhead, FDF pools, texture residency, loopback budgets | [docs/games/warcraft-3/memory.md](docs/games/warcraft-3/memory.md) |

--- a/common/cvar.c
+++ b/common/cvar.c
@@ -461,6 +461,10 @@ void Cvar_Init(void) {
     Cvar_GetD("ui_module",        "ui",                CVAR_ARCHIVE, "UI shared library name");
     Cvar_GetD("g_module",         "game",              CVAR_ARCHIVE, "game logic shared library name");
     Cvar_GetD("ui_game_setup_map","",                  0,            "map pre-selected in game setup UI");
+#ifdef WC3
+    Cvar_GetD("wc3_campaign_mission_visibility", "all", CVAR_ARCHIVE,
+              "campaign mission list visibility: all or played");
+#endif
     Cvar_GetD("game_port",        PORT_SERVER_STRING,  CVAR_ARCHIVE, "UDP port the game server listens on");
     Cvar_GetD("name",             "Player",            CVAR_ARCHIVE, "player display name shown in lobbies");
     Cvar_GetD("sv_hostname",      "OpenWarcraft3",     CVAR_ARCHIVE, "server name shown in lobby browser");

--- a/docs/games/warcraft-3/architecture/ui-flow.md
+++ b/docs/games/warcraft-3/architecture/ui-flow.md
@@ -70,6 +70,78 @@ menu_game
 
 The screen switch is local to the client. No network traffic is required for menu transitions.
 
+## Single Player Flow
+
+The WC3 single-player frontend uses the native Blizzard glue FDFs and keeps campaign/map metadata separate from the
+actual `map` command:
+
+```text
+MainMenu.fdf
+  -> SinglePlayerMenu.fdf
+      -> CampaignMenu.fdf
+          -> campaign selection
+          -> MissionSelectFrame
+          -> selected mission
+          -> map "..."
+
+      -> SkirmishButton
+          -> existing local map browser
+          -> GameSetup
+          -> lobby_config / lobby_slot
+          -> map "..."
+```
+
+`games/warcraft-3/ui/screens/single_player.c` parses the skin-selected `CampaignFile` (with the classic campaign
+string files as fallback). Campaign selection changes the campaign backdrop and builds a mission list dynamically
+from every parsed `MissionN` / `FileN` entry; selecting a campaign alone does not start its first map. This mirrors
+Warsmash's `CampaignMenuUI` approach and does not depend on non-portable `Mission0Frame`...`Mission13Frame` children
+being present in the retail `MissionSelectFrame`. The campaign Back button returns Mission Select to Campaign Select
+first, then returns to the Single Player menu.
+
+Mission visibility is controlled by `wc3_campaign_mission_visibility`. The default `all` mode shows every parsed
+map-backed chapter so campaign testing is not blocked by frontend progression state. `played` mode shows only
+missions whose `wc3_campaign_played_<campaign>_<mission>` cvar is non-zero; launching a mission marks that cvar for
+the current process. This is intentionally a frontend/testing bridge until profile-backed retail campaign mission
+availability (`SetMissionAvailable`/profile persistence) is implemented.
+
+The generated selector reuses Warcraft's `MapListBox` template. That template is a `CONTROL` root in the retail FDF,
+so bound map-list controls must participate in the same hit testing and mouse-event dispatch as programmatic `FRAME`
+map lists. A `CONTROL` map list that is renderable but excluded from interaction produces visible campaign rows that
+cannot be clicked.
+
+`CampaignMenu.fdf` can also expose legacy/static frames such as `HumanButton`, `OrcButton`,
+`UndeadButton`, `NightElfButton`, and `TutorialButton`. Their presence is not a signal that the authored FDF already
+contains the active campaign selector: Warsmash builds the visible campaign entries dynamically from
+`CampaignStrings`. OpenRealm likewise always creates its data-driven campaign list. Suppressing that list merely
+because an optional static button frame bound successfully can leave the campaign screen showing only the
+difficulty control, with no campaign entry to click.
+
+The menu's Easy/Normal/Hard selection writes `wc3_campaign_difficulty` (`0`, `1`, or `2`). For stock ROC/TFT campaign
+map paths, `G_SpawnEntities` uses that value as the initial `GetGameDifficulty()` state before `war3map.j`
+initialization; non-campaign maps retain the existing Normal default. Map script calls to `SetGameDifficulty` may
+still change it later. The Single Player profile caption uses the engine `name` cvar, which is also the local human
+name used by Game Setup. A full Warcraft profile database is not implemented.
+
+Single Player Custom Game deliberately reuses the existing local map-selection and Game Setup controllers instead
+of duplicating their W3I parsing, map info, slot, race, team, color, and game-speed logic. The source mode only
+changes glue presentation and Cancel destinations; the final local-server launch path remains shared.
+
+### Remaining frontend lifecycle gaps
+
+The following Warsmash/retail-style lifecycle work is intentionally not approximated in the current UI code:
+
+- menu changes are still immediate `UI_SetScreen` operations rather than Birth/Stand/Death sequence-completion
+  transitions;
+- campaign ambient sound and campaign-specific cursor switching are not wired;
+- profile creation/deletion/persistence is not implemented;
+- map `config()` is not yet run as a distinct pre-lobby configuration phase; doing so correctly requires separating
+  authored map configuration from later lobby overrides;
+- map/server loading remains synchronous, and the WC3 loading progress sprite does not yet represent incremental
+  loader work.
+
+Do not paper over these with fixed timers, hard-coded campaign assets, a second custom-game implementation, or fake
+loading percentages. They require the corresponding lifecycle/data ownership to exist first.
+
 ## Draw Flow
 
 Each client frame calls:
@@ -173,6 +245,9 @@ The HUD screen renders from this cache on later frames.
 - FDF assets are parsed by the UI library, not by the game DLL.
 - Runtime modules communicate through Quake-style function tables.
 - `r_module=stdout` makes draw-call output scriptable for UI debugging.
+- Campaign selection and mission selection are separate states; only a mission issues `map`.
+- Campaign difficulty is startup game state, not merely a menu label.
+- Single-player Custom Game reuses the local map browser/Game Setup data path instead of maintaining a second copy.
 
 ## See Also
 

--- a/docs/games/warcraft-3/loading-and-assets.md
+++ b/docs/games/warcraft-3/loading-and-assets.md
@@ -68,10 +68,12 @@ make test-renderer-model test-ui
 make test
 ```
 
-For the menu regression, launch without `+map`, then select Single Player → Campaign → Human. The console
+For the menu regression, launch without `+map`, then select Single Player → Campaign → Human → the desired mission. The console
 registers `menu_single_player_campaign`, but `menu_single_player_campaign_human` is a UI-handler command,
-not a console command. A diagnostic replay can temporarily invoke that handler after showing the campaign
-screen; remove the hook afterward. Queue `screenshot 1` before the handler to capture the frozen loading plaque.
+not a console command. Campaign selection now enters `MissionSelectFrame`; the selected mission's
+`menu_single_player_mission_select N` handler is what issues the map command. A diagnostic replay can temporarily
+invoke those handlers after showing the campaign screen; remove the hook afterward. Queue `screenshot 1` before
+the mission handler to capture the frozen loading plaque.
 Use `+com_frame_limit 100` for bounded runs; engine screenshots appear under `screenshots/`.
 
 Regression tests cover texture extension lookup and exact-file precedence, SLK replacement sentinels,

--- a/docs/games/warcraft-3/player-ai.md
+++ b/docs/games/warcraft-3/player-ai.md
@@ -33,7 +33,7 @@ Do not translate `h02_red.ai` into a C wave table or add map-name checks. `Scrip
 
 These helpers are not six simple engine directives. Their transitive path starts Blizzard's perpetual `CampaignBasics` and `BuildLoop` threads and reaches production, harvesting, unit counts and costs, captain management, readiness, attack, command, and sleep natives. Human02 therefore requires the campaign economy/build loop and captain behavior; implementing only wave timers is not script compatibility.
 
-`CampaignAI` chooses difficulty once. Each `Campaign*Ex` uses the easy, normal, or hard quantity; the script's final branch gives an unsupported higher difficulty the hard quantity.
+`CampaignAI` chooses difficulty once. Each `Campaign*Ex` uses the easy, normal, or hard quantity; the script's final branch gives an unsupported higher difficulty the hard quantity. The Single Player campaign difficulty selector stores `wc3_campaign_difficulty`; for stock ROC/TFT campaign map paths `G_SpawnEntities` seeds `GetGameDifficulty()` from it before map startup, so campaign AI sees the selected Easy/Normal/Hard value unless the map later changes game difficulty itself. Non-campaign maps retain the existing Normal default.
 
 ### Defender Requests
 

--- a/games/warcraft-3/game/g_spawn.c
+++ b/games/warcraft-3/game/g_spawn.c
@@ -351,6 +351,8 @@ void G_SpawnEntities(void) {
     LPCMAPINFO mapinfo = CM_GetMapInfo();
     LPCDOODAD entities = CM_GetDoodads();
     DWORD local_player = G_LocalMapPlayerNumber(mapinfo);
+    LONG difficulty = 1;
+    LPCSTR map_path = gi.CvarString ? gi.CvarString("map", "") : "";
 
     /* Map replacement must release script roots before level pointers are cleared. */
     G_BotShutdown();
@@ -363,7 +365,15 @@ void G_SpawnEntities(void) {
     if (mapinfo) FOR_LOOP(i, MAX_PLAYERS) level.setup.players += mapinfo->players[i].used;
     level.setup.game_type = 4;
     level.setup.speed = 2;
-    level.setup.difficulty = 1;
+    if ((!strncasecmp(map_path, "Maps\\Campaign\\", 14) ||
+         !strncasecmp(map_path, "Maps/Campaign/", 14) ||
+         !strncasecmp(map_path, "Maps\\FrozenThrone\\Campaign\\", 26) ||
+         !strncasecmp(map_path, "Maps/FrozenThrone/Campaign/", 26)) && gi.CvarString) {
+        difficulty = atoi(gi.CvarString("wc3_campaign_difficulty", "1"));
+    }
+    if (difficulty < 0) difficulty = 0;
+    if (difficulty > 3) difficulty = 3;
+    level.setup.difficulty = (DWORD)difficulty;
     level.setup.resource_density = level.setup.creature_density = 2;
     if (mapinfo) {
         strlcpy(level.setup.name, mapinfo->mapName ? mapinfo->mapName : "", sizeof(level.setup.name));

--- a/games/warcraft-3/tests/resources-src/TestUI/CampaignStrings.txt
+++ b/games/warcraft-3/tests/resources-src/TestUI/CampaignStrings.txt
@@ -6,9 +6,13 @@ Header="Human Campaign"
 Name="The Scourge of Lordaeron"
 Background="HumanBackdrop"
 Cursor=0
-Entries=1
+Entries=3
 Mission0="The Defense of Strahnbrad"
 File0="Human01"
+Mission1="Blackrock & Roll"
+File1="Human02"
+Mission2="Ravages of the Plague"
+File2="Human03"
 
 [Undead]
 Header="Undead Campaign"

--- a/games/warcraft-3/tests/resources-src/TestUI/CampaignStrings_exp.txt
+++ b/games/warcraft-3/tests/resources-src/TestUI/CampaignStrings_exp.txt
@@ -14,6 +14,8 @@ Name="Curse of the Blood Elves"
 Background="HumanBackdrop"
 Cursor=0
 Mission0="Chapter One","Misconceptions","Maps\FrozenThrone\Campaign\HumanX01.w3x"
+Mission1="Chapter Two","A Dark Covenant","Maps\FrozenThrone\Campaign\HumanX02.w3x"
+Mission2="Chapter Three","The Dungeons of Dalaran","Maps\FrozenThrone\Campaign\HumanX03.w3x"
 
 [Undead]
 Header="Scourge Campaign"

--- a/games/warcraft-3/tests/resources-src/TestUI/FrameDef/Glue/CampaignMenu.fdf
+++ b/games/warcraft-3/tests/resources-src/TestUI/FrameDef/Glue/CampaignMenu.fdf
@@ -21,13 +21,11 @@ Frame "FRAME" "CampaignMenu" {
         // Warsmash does not use them as the campaign list; it builds campaign
         // buttons dynamically from CampaignStrings instead.
         Frame "FRAME" "TutorialFrame" {
-            Hidden,
             Frame "TEXT" "TutorialCampaignLabel" {}
             Frame "TEXT" "TutorialCampaignDesc" {}
             Frame "BUTTON" "TutorialButton" {}
         }
         Frame "FRAME" "HumanFrame" {
-            Hidden,
             Frame "TEXT" "HumanCampaignLabel" {}
             Frame "TEXT" "HumanCampaignDesc" {}
             Frame "BUTTON" "HumanButton" {}

--- a/games/warcraft-3/tests/resources-src/TestUI/FrameDef/Glue/CampaignMenu.fdf
+++ b/games/warcraft-3/tests/resources-src/TestUI/FrameDef/Glue/CampaignMenu.fdf
@@ -7,6 +7,8 @@ Frame "FRAME" "CampaignMenu" {
     Frame "FRAME" "MissionSelectFrame" {
         Frame "TEXT" "MissionName" {}
         Frame "TEXT" "MissionNameHeader" {}
+        // Retail/Warsmash mission rows are created dynamically rather than
+        // relying on Mission0Frame...Mission13Frame children.
     }
     Frame "FRAME" "CampaignSelectFrame" {
         Frame "SPRITE" "WarCraftIIILogo" {}
@@ -14,6 +16,21 @@ Frame "FRAME" "CampaignMenu" {
             Frame "POPUPMENU" "DifficultySelect" {}
             Frame "TEXT" "DifficultySelectLabel" {}
             Frame "TEXT" "DifficultyDescriptionText" {}
+        }
+        // Retail CampaignMenu.fdf exposes legacy/static campaign frames too.
+        // Warsmash does not use them as the campaign list; it builds campaign
+        // buttons dynamically from CampaignStrings instead.
+        Frame "FRAME" "TutorialFrame" {
+            Hidden,
+            Frame "TEXT" "TutorialCampaignLabel" {}
+            Frame "TEXT" "TutorialCampaignDesc" {}
+            Frame "BUTTON" "TutorialButton" {}
+        }
+        Frame "FRAME" "HumanFrame" {
+            Hidden,
+            Frame "TEXT" "HumanCampaignLabel" {}
+            Frame "TEXT" "HumanCampaignDesc" {}
+            Frame "BUTTON" "HumanButton" {}
         }
     }
 }

--- a/games/warcraft-3/tests/test_ui_fdf.c
+++ b/games/warcraft-3/tests/test_ui_fdf.c
@@ -13,6 +13,8 @@
 static const char *captured_image_path;
 static const char *captured_model_path;
 static char captured_command[128];
+static char captured_cvar_name[64];
+static char captured_cvar_value[64];
 static char captured_printf[512];
 static DWORD captured_draw_calls;
 static DWORD captured_dim_draws;
@@ -28,6 +30,8 @@ static VECTOR2 fake_text_size;
 static HANDLE test_mpq_archive;
 static BOOL hide_expansion_campaign_file;
 static BOOL test_fs_expansion;
+static LPCSTR test_campaign_mission_visibility;
+static int test_campaign_played_mission = -1;
 static VECTOR2 test_mouse_pos;
 static LPCPLAYER test_player;
 static LPCSTR test_map = "";
@@ -235,7 +239,19 @@ static LPCSTR test_cvar_string(LPCSTR name, LPCSTR fallback) {
     if (name && !strcmp(name, "game_port")) {
         return "27910";
     }
+    if (name && !strcmp(name, "wc3_campaign_mission_visibility") && test_campaign_mission_visibility) {
+        return test_campaign_mission_visibility;
+    }
+    if (name && !strncmp(name, "wc3_campaign_played_human_", 26)) {
+        int mission = atoi(name + 26);
+        return mission == test_campaign_played_mission ? "1" : "0";
+    }
     return fallback;
+}
+
+static void test_cvar_set(LPCSTR name, LPCSTR value) {
+    snprintf(captured_cvar_name, sizeof(captured_cvar_name), "%s", name ? name : "");
+    snprintf(captured_cvar_value, sizeof(captured_cvar_value), "%s", value ? value : "");
 }
 
 static LPCPLAYER test_get_player_state(void) {
@@ -1277,6 +1293,42 @@ TEST(ui_fdf, glue_checkbox_toggles_and_draws_check_highlight) {
     T_EQ(captured_draw_calls, 1);
 }
 
+TEST(ui_fdf, control_map_list_receives_mouse_clicks) {
+    LPFRAMEDEF root;
+    LPFRAMEDEF list;
+    uiMapListState_t state = {0};
+
+    reset_ui_state();
+    uiimport.Cmd_ExecuteText = test_cmd_execute_text;
+    parse_fdf("control_map_list.fdf",
+              "Frame \"FRAME\" \"Root\" {"
+              " Width 0.8, Height 0.6,"
+              " Frame \"CONTROL\" \"MapListBox\" {"
+              "  Width 0.3, Height 0.1,"
+              "  SetPoint TOPLEFT, \"Root\", TOPLEFT, 0.1, -0.1,"
+              " }"
+              "}");
+
+    root = UI_FindFrame("Root");
+    list = UI_FindFrame("MapListBox");
+    if (!require_not_null(root)) return;
+    if (!require_not_null(list)) return;
+
+    state.count = 2;
+    snprintf(state.items[0].name, sizeof(state.items[0].name), "Campaign One");
+    snprintf(state.items[1].name, sizeof(state.items[1].name), "Campaign Two");
+    UI_BindMapList(list, &state, NULL, 4, "test_map_list_select %u");
+
+    T_EQ(list->Type, FT_CONTROL);
+    T_NOT_NULL(list->event_handler);
+
+    /* Populate the layout cache, then click in the first 0.019-high row. */
+    UI_DrawFrame(root);
+    captured_command[0] = '\0';
+    UI_MouseEventLocal(UI_MOUSE_UP, 188, 144, 1);
+    T_STREQ(captured_command, "test_map_list_select 0");
+}
+
 TEST(ui_fdf, popup_menu_hover_sets_flag_on_middle_row) {
     LPFRAMEDEF root;
     LPFRAMEDEF popup;
@@ -1803,13 +1855,22 @@ static void test_single_player_campaign_profile(BOOL tft) {
     uiImport_t saved = uiimport;
     LPFRAMEDEF root;
     LPFRAMEDEF campaign_button;
+    LPFRAMEDEF skirmish_button;
     LPFRAMEDEF cancel_button;
     LPFRAMEDEF back_button;
     LPFRAMEDEF campaign_select_frame;
+    LPFRAMEDEF mission_select_frame;
+    LPFRAMEDEF mission_name;
+    LPFRAMEDEF mission_name_header;
+    LPFRAMEDEF mission_list_box;
+    LPFRAMEDEF difficulty_title;
     LPFRAMEDEF campaign_list_box;
+    LPFRAMEDEF human_button;
 
     hide_expansion_campaign_file = false;
     test_fs_expansion = tft;
+    test_campaign_mission_visibility = NULL;
+    test_campaign_played_mission = -1;
     load_ui_files(files, sizeof(files) / sizeof(files[0]));
 
     memset(&uiimport, 0, sizeof(uiimport));
@@ -1817,6 +1878,7 @@ static void test_single_player_campaign_profile(BOOL tft) {
     uiimport.GetRenderer = test_get_renderer;
     uiimport.Cmd_ExecuteText = test_cmd_execute_text;
     uiimport.Cvar_String = test_cvar_string;
+    uiimport.Cvar_Set = test_cvar_set;
     uiimport.FS_ReadFile = test_fs_read_file;
     uiimport.FS_FreeFile = test_fs_free_file;
     uiimport.MemAlloc = test_ui_mem_alloc;
@@ -1832,6 +1894,7 @@ static void test_single_player_campaign_profile(BOOL tft) {
 
     root = UI_FindFrame("SinglePlayerMenu");
     campaign_button = UI_FindFrame("CampaignButton");
+    skirmish_button = UI_FindFrame("SkirmishButton");
     cancel_button = UI_FindFrame("CancelButton");
     back_button = UI_FindFrame("BackButton");
 
@@ -1843,6 +1906,10 @@ static void test_single_player_campaign_profile(BOOL tft) {
         uiimport = saved;
         return;
     }
+    if (!require_not_null(skirmish_button)) {
+        uiimport = saved;
+        return;
+    }
     if (!require_not_null(cancel_button)) {
         uiimport = saved;
         return;
@@ -1850,18 +1917,22 @@ static void test_single_player_campaign_profile(BOOL tft) {
     if (!require_not_null(back_button)) { uiimport = saved; return; }
     T_ASSERT(!root->hidden);
     T_STREQ(campaign_button->OnClick, "menu_single_player_campaign");
+    T_STREQ(skirmish_button->OnClick, "menu_single_player_skirmish");
     T_STREQ(cancel_button->OnClick, "menu_main");
+    T_STREQ(back_button->OnClick, "menu_single_player_campaign_back");
 
     SinglePlayerMenu_ShowCampaign();
     campaign_select_frame = UI_FindFrame("CampaignSelectFrame");
+    human_button = UI_FindFrame("HumanButton");
     campaign_list_box = campaign_select_frame
         ? UI_FindChildFrame(campaign_select_frame, "MapListBox")
         : NULL;
 
-    if (!require_not_null(campaign_list_box)) {
+    if (!require_not_null(human_button) || !require_not_null(campaign_list_box)) {
         uiimport = saved;
         return;
     }
+    T_ASSERT(human_button->hidden);
     T_ASSERT(!campaign_list_box->hidden);
     T_FEQ(campaign_list_box->Width, 0.34f, 0.001f);
     T_FEQ(campaign_list_box->Height, 0.11f, 0.001f);
@@ -1870,6 +1941,7 @@ static void test_single_player_campaign_profile(BOOL tft) {
     T_ASSERT(campaign_list_box->Points.x[FPP_MIN].relativeTo == back_button);
     T_ASSERT(campaign_list_box->Points.y[FPP_MAX].relativeTo == back_button);
     T_ASSERT(campaign_list_box->MapListControl.State != NULL);
+    T_NOT_NULL(campaign_list_box->event_handler);
     T_EQ((int)campaign_list_box->MapListControl.State->count, 4);
     T_STREQ(campaign_list_box->MapListControl.State->items[0].name,
                   tft
@@ -1882,13 +1954,74 @@ static void test_single_player_campaign_profile(BOOL tft) {
 
     captured_command[0] = '\0';
     SinglePlayerMenu_LaunchCampaignIndex(tft ? 1 : 0);
+    T_STREQ(captured_command, "");
+
+    mission_select_frame = UI_FindFrame("MissionSelectFrame");
+    mission_name = UI_FindFrame("MissionName");
+    mission_name_header = UI_FindFrame("MissionNameHeader");
+    mission_list_box = mission_select_frame
+        ? UI_FindChildFrame(mission_select_frame, "MapListBox")
+        : NULL;
+    if (!require_not_null(mission_select_frame) ||
+        !require_not_null(mission_name) ||
+        !require_not_null(mission_name_header) ||
+        !require_not_null(mission_list_box)) {
+        uiimport = saved;
+        return;
+    }
+    T_ASSERT(campaign_select_frame->hidden);
+    T_ASSERT(!mission_select_frame->hidden);
+    T_ASSERT(!mission_list_box->hidden);
+    T_STREQ(mission_name->Text,
+            tft ? "Curse of the Blood Elves" : "The Scourge of Lordaeron");
+    T_STREQ(mission_name_header->Text,
+            tft ? "Alliance Campaign" : "Human Campaign");
+    T_EQ((int)mission_list_box->MapListControl.State->count, 3);
+    T_STREQ(mission_list_box->MapListControl.State->items[0].name,
+            tft ? "Chapter One: Misconceptions" : "The Defense of Strahnbrad");
+    T_STREQ(mission_list_box->MapListControl.State->items[1].name,
+            tft ? "Chapter Two: A Dark Covenant" : "Blackrock & Roll");
+    T_STREQ(mission_list_box->MapListControl.SelectCommand,
+            "menu_single_player_mission_select %u");
+    T_NOT_NULL(mission_list_box->event_handler);
+
+    UI_MenuCommandLocal(back_button->OnClick);
+    T_ASSERT(!campaign_select_frame->hidden);
+    T_ASSERT(mission_select_frame->hidden);
+
+    captured_cvar_name[0] = '\0';
+    captured_cvar_value[0] = '\0';
+    SinglePlayerMenu_SetDifficulty(2);
+    T_STREQ(captured_cvar_name, "wc3_campaign_difficulty");
+    T_STREQ(captured_cvar_value, "2");
+    difficulty_title = UI_FindFrame("CampaignPopupMenuTitleTextTemplate");
+    if (difficulty_title) {
+        T_STREQ(difficulty_title->Text, UI_GetString("HARD"));
+    }
+
+    test_campaign_mission_visibility = "played";
+    test_campaign_played_mission = 1;
+    SinglePlayerMenu_LaunchCampaignIndex(tft ? 1 : 0);
+    T_EQ((int)mission_list_box->MapListControl.State->count, 1);
+    T_EQ((int)mission_list_box->MapListControl.State->items[0].flags, 1);
+    T_STREQ(mission_list_box->MapListControl.State->items[0].name,
+            tft ? "Chapter Two: A Dark Covenant" : "Blackrock & Roll");
+
+    captured_command[0] = '\0';
+    captured_cvar_name[0] = '\0';
+    captured_cvar_value[0] = '\0';
+    SinglePlayerMenu_LaunchMissionIndex(0);
+    T_STREQ(captured_cvar_name, "wc3_campaign_played_human_1");
+    T_STREQ(captured_cvar_value, "1");
     T_STREQ(captured_command,
                   tft
-                      ? "map \"Maps\\FrozenThrone\\Campaign\\HumanX01.w3x\""
-                      : "map \"Maps\\Campaign\\Human01.w3m\"");
+                      ? "map \"Maps\\FrozenThrone\\Campaign\\HumanX02.w3x\""
+                      : "map \"Maps\\Campaign\\Human02.w3m\"");
 
     hide_expansion_campaign_file = false;
     test_fs_expansion = false;
+    test_campaign_mission_visibility = NULL;
+    test_campaign_played_mission = -1;
     uiimport = saved;
 }
 

--- a/games/warcraft-3/ui/screens/game_setup.c
+++ b/games/warcraft-3/ui/screens/game_setup.c
@@ -911,6 +911,8 @@ static void GameSetup_Init(void) {
     if (!setup.ready) {
         return;
     }
+    UI_SetOnClick(setup.cancel_button,
+                  LAN_IsSinglePlayerCreate() ? "menu_single_player_skirmish" : "menu_startserver");
     GameSetup_LoadSelectedMap();
     GameSetup_SetTextIfPresent(setup.game_name, "%s", setup.map_name[0] ? setup.map_name : "Local Game");
     GameSetup_UpdateMapInfo();
@@ -931,7 +933,9 @@ static void GameSetup_Draw(void) {
         return;
     }
 
-    UI_DrawGlueScene("MultiplayerPreGameChat Stand");
+    UI_DrawGlueScene(LAN_IsSinglePlayerCreate()
+                     ? "SinglePlayerSkirmish Stand"
+                     : "MultiplayerPreGameChat Stand");
     UI_DrawFrame(setup.root);
 }
 

--- a/games/warcraft-3/ui/screens/lan_join.c
+++ b/games/warcraft-3/ui/screens/lan_join.c
@@ -29,6 +29,7 @@
 typedef enum {
     LAN_MODE_BROWSER,
     LAN_MODE_CREATE,
+    LAN_MODE_SINGLE_PLAYER_CREATE,
 } lanMode_t;
 
 typedef struct lan_join_state_s {
@@ -613,10 +614,13 @@ static BOOL LAN_BuildCreateFrames(void) {
 
     UI_SetHidden(lan.create_frames.MapInfoPanel, false);
     UI_SetHidden(lan.create_frames.AdvancedOptionsPanel, true);
-    UI_SetOnClick(lan.create_frames.MapInfoButton, "menu_startserver");
-    UI_SetOnClick(lan.create_frames.AdvancedOptionsButton, "menu_startserver");
+    UI_SetOnClick(lan.create_frames.MapInfoButton,
+                  lan.mode == LAN_MODE_SINGLE_PLAYER_CREATE ? "menu_single_player_skirmish" : "menu_startserver");
+    UI_SetOnClick(lan.create_frames.AdvancedOptionsButton,
+                  lan.mode == LAN_MODE_SINGLE_PLAYER_CREATE ? "menu_single_player_skirmish" : "menu_startserver");
     UI_SetOnClick(lan.play_button, "menu_lan_start");
-    UI_SetOnClick(lan.create_frames.CancelButton, "menu_multiplayer");
+    UI_SetOnClick(lan.create_frames.CancelButton,
+                  lan.mode == LAN_MODE_SINGLE_PLAYER_CREATE ? "menu_game" : "menu_multiplayer");
     return true;
 }
 
@@ -686,8 +690,10 @@ static void LANJoin_Draw(void) {
 
     UI_DrawGlueScene(lan.mode == LAN_MODE_BROWSER
                      ? "BattlenetCustom Stand"
-                     : "BattlenetCustomCreate Stand");
-    if (lan.mode == LAN_MODE_CREATE) {
+                     : lan.mode == LAN_MODE_SINGLE_PLAYER_CREATE
+                         ? "SinglePlayerSkirmish Stand"
+                         : "BattlenetCustomCreate Stand");
+    if (lan.mode != LAN_MODE_BROWSER) {
         LAN_UpdateGameSpeed();
     }
     UI_DrawFrame(lan.root);
@@ -787,24 +793,39 @@ void LAN_JoinSelectedGame(void) {
     uiimport.LAN_ConnectServer(lan.games.items[lan.games.selected].flags);
 }
 
-void LAN_ShowBrowser(void) {
-    LAN_BuildFrames(LAN_MODE_BROWSER);
+static void LAN_ShowMode(lanMode_t mode) {
+    lan.mode = mode;
+    if (UI_GetCurrentScreen() != &lanJoinScreen) {
+        return;
+    }
+    LAN_BuildFrames(mode);
     if (!lan.ready) {
         return;
     }
-    LAN_ClearGames();
-    LAN_RequestServerRefresh();
-    LAN_LoadGames();
+    if (mode == LAN_MODE_BROWSER) {
+        LAN_ClearGames();
+        LAN_RequestServerRefresh();
+        LAN_LoadGames();
+    } else {
+        LAN_LoadMaps();
+    }
     LAN_UpdateControls();
 }
 
+void LAN_ShowBrowser(void) {
+    LAN_ShowMode(LAN_MODE_BROWSER);
+}
+
 void LAN_ShowCreate(void) {
-    LAN_BuildFrames(LAN_MODE_CREATE);
-    if (!lan.ready) {
-        return;
-    }
-    LAN_LoadMaps();
-    LAN_UpdateControls();
+    LAN_ShowMode(LAN_MODE_CREATE);
+}
+
+void LAN_ShowSinglePlayerCreate(void) {
+    LAN_ShowMode(LAN_MODE_SINGLE_PLAYER_CREATE);
+}
+
+BOOL LAN_IsSinglePlayerCreate(void) {
+    return lan.mode == LAN_MODE_SINGLE_PLAYER_CREATE;
 }
 
 void LAN_RefreshMaps(void) {

--- a/games/warcraft-3/ui/screens/single_player.c
+++ b/games/warcraft-3/ui/screens/single_player.c
@@ -408,6 +408,10 @@ static void SinglePlayer_SetView(singlePlayerView_t view) {
     SinglePlayer_SetHidden(single_player.CampaignBackdrop_2, true);
     SinglePlayer_SetHidden(single_player.CampaignSelectFrame, view != SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT);
     SinglePlayer_SetHidden(single_player.MissionSelectFrame, view != SINGLE_PLAYER_VIEW_MISSION_SELECT);
+    SinglePlayer_SetHidden(single_player.TutorialFrame, true);
+    SinglePlayer_SetHidden(single_player.HumanFrame, true);
+    SinglePlayer_SetHidden(single_player.TutorialButton, true);
+    SinglePlayer_SetHidden(single_player.HumanButton, true);
     SinglePlayer_SetHidden(single_player.SlidingDoors, true);
     SinglePlayer_SetHidden(campaign_list_frame,
                            view != SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT);

--- a/games/warcraft-3/ui/screens/single_player.c
+++ b/games/warcraft-3/ui/screens/single_player.c
@@ -13,10 +13,13 @@
 
 #define SINGLE_PLAYER_MAX_CAMPAIGNS 16
 #define SINGLE_PLAYER_MAX_MISSIONS 128
+#define SINGLE_PLAYER_MISSION_VISIBLE_ROWS 14
+#define SINGLE_PLAYER_MISSION_VISIBILITY_CVAR "wc3_campaign_mission_visibility"
 
 typedef enum {
     SINGLE_PLAYER_VIEW_MAIN,
     SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT,
+    SINGLE_PLAYER_VIEW_MISSION_SELECT,
 } singlePlayerView_t;
 
 typedef struct {
@@ -42,7 +45,10 @@ static DWORD campaign_order[SINGLE_PLAYER_MAX_CAMPAIGNS];
 static DWORD campaign_order_count;
 static uiMapListState_t campaign_list;
 static LPFRAMEDEF campaign_list_frame;
+static uiMapListState_t mission_list;
+static LPFRAMEDEF mission_list_frame;
 static DWORD campaign_background_model = 0;
+static DWORD selected_campaign_index = SINGLE_PLAYER_MAX_CAMPAIGNS;
 static singlePlayerView_t current_view = SINGLE_PLAYER_VIEW_MAIN;
 
 static BOOL SinglePlayerMenu_LoadScreen(void) {
@@ -375,22 +381,22 @@ static LPCSTR SinglePlayer_FirstMissionMap(singlePlayerCampaign_t const *campaig
     return NULL;
 }
 
+static singlePlayerCampaign_t const *SinglePlayer_SelectedCampaign(void) {
+    if (selected_campaign_index >= campaign_count) {
+        return NULL;
+    }
+    return &campaigns[selected_campaign_index];
+}
+
 static void SinglePlayer_SetHidden(LPFRAMEDEF frame, BOOL hidden) {
     if (frame) {
         UI_SetHidden(frame, hidden);
     }
 }
 
-static BOOL SinglePlayer_HasStaticCampaignButtons(void) {
-    return single_player.HumanButton ||
-           single_player.OrcButton ||
-           single_player.UndeadButton ||
-           single_player.NightElfButton ||
-           single_player.TutorialButton;
-}
-
 static void SinglePlayer_SetView(singlePlayerView_t view) {
-    BOOL const show_campaign = view == SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT;
+    BOOL const show_campaign = view == SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT ||
+                               view == SINGLE_PLAYER_VIEW_MISSION_SELECT;
 
     current_view = view;
 
@@ -400,10 +406,13 @@ static void SinglePlayer_SetView(singlePlayerView_t view) {
 
     SinglePlayer_SetHidden(single_player.CampaignMenu, !show_campaign);
     SinglePlayer_SetHidden(single_player.CampaignBackdrop_2, true);
-    SinglePlayer_SetHidden(single_player.CampaignSelectFrame, false);
-    SinglePlayer_SetHidden(single_player.MissionSelectFrame, true);
+    SinglePlayer_SetHidden(single_player.CampaignSelectFrame, view != SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT);
+    SinglePlayer_SetHidden(single_player.MissionSelectFrame, view != SINGLE_PLAYER_VIEW_MISSION_SELECT);
     SinglePlayer_SetHidden(single_player.SlidingDoors, true);
-    SinglePlayer_SetHidden(campaign_list_frame, !show_campaign || SinglePlayer_HasStaticCampaignButtons());
+    SinglePlayer_SetHidden(campaign_list_frame,
+                           view != SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT);
+    SinglePlayer_SetHidden(mission_list_frame,
+                           view != SINGLE_PLAYER_VIEW_MISSION_SELECT);
 }
 
 static void SinglePlayer_SetCampaignBackdrop(singlePlayerCampaign_t const *campaign) {
@@ -436,15 +445,117 @@ static void SinglePlayer_DrawCampaignBackdrop(void) {
     }
 }
 
-static void SinglePlayer_LaunchCampaign(singlePlayerCampaign_t const *campaign) {
-    char command[256];
-    LPCSTR map_path = SinglePlayer_FirstMissionMap(campaign);
+static void SinglePlayer_MissionPlayedCvar(singlePlayerCampaign_t const *campaign,
+                                           DWORD mission_index,
+                                           LPSTR out,
+                                           DWORD out_size) {
+    char campaign_key[64];
+    DWORD used = 0;
 
-    if (!map_path || !*map_path) {
+    if (!out || !out_size) {
         return;
     }
+    memset(campaign_key, 0, sizeof(campaign_key));
+    if (campaign) {
+        for (LPCSTR p = campaign->key; *p && used + 1 < sizeof(campaign_key); p++) {
+            unsigned char ch = (unsigned char)*p;
+            campaign_key[used++] = isalnum(ch) ? (char)tolower(ch) : '_';
+        }
+    }
+    snprintf(out, out_size, "wc3_campaign_played_%s_%u",
+             campaign_key[0] ? campaign_key : "campaign",
+             (unsigned)mission_index);
+}
+
+static BOOL SinglePlayer_ShowMission(singlePlayerCampaign_t const *campaign, DWORD mission_index) {
+    LPCSTR mode = uiimport.Cvar_String
+        ? uiimport.Cvar_String(SINGLE_PLAYER_MISSION_VISIBILITY_CVAR, "all")
+        : "all";
+
+    if (!mode || strcasecmp(mode, "played")) {
+        return true;
+    }
+
+    char cvar_name[128];
+    SinglePlayer_MissionPlayedCvar(campaign, mission_index, cvar_name, sizeof(cvar_name));
+    LPCSTR played = uiimport.Cvar_String ? uiimport.Cvar_String(cvar_name, "0") : "0";
+    return played && atoi(played) != 0;
+}
+
+static void SinglePlayer_MarkMissionPlayed(singlePlayerCampaign_t const *campaign, DWORD mission_index) {
+    char cvar_name[128];
+
+    if (!campaign || !uiimport.Cvar_Set) {
+        return;
+    }
+    SinglePlayer_MissionPlayedCvar(campaign, mission_index, cvar_name, sizeof(cvar_name));
+    uiimport.Cvar_Set(cvar_name, "1");
+}
+
+static void SinglePlayer_LaunchMission(singlePlayerCampaign_t const *campaign, DWORD mission_index) {
+    char command[256];
+    LPCSTR map_path;
+
+    if (!campaign || mission_index >= campaign->num_missions) {
+        return;
+    }
+    map_path = campaign->missions[mission_index].map_path;
+    if (!map_path[0]) {
+        return;
+    }
+    SinglePlayer_MarkMissionPlayed(campaign, mission_index);
     snprintf(command, sizeof(command), "map \"%s\"", map_path);
     UI_MenuCommandLocal(command);
+}
+
+static void SinglePlayer_PopulateMissionList(singlePlayerCampaign_t const *campaign) {
+    memset(&mission_list, 0, sizeof(mission_list));
+    if (!campaign) {
+        return;
+    }
+
+    FOR_LOOP(i, campaign->num_missions) {
+        singlePlayerMission_t const *mission = &campaign->missions[i];
+        uiMapListItem_t *item;
+
+        if (!mission->map_path[0] || !SinglePlayer_ShowMission(campaign, i)) {
+            continue;
+        }
+        if (mission_list.count >= UI_MAX_MAP_LIST_ITEMS) {
+            break;
+        }
+        item = &mission_list.items[mission_list.count++];
+        if (mission->header[0] && mission->name[0]) {
+            snprintf(item->name, sizeof(item->name), "%.52s: %.73s", mission->header, mission->name);
+        } else {
+            snprintf(item->name, sizeof(item->name), "%s", mission->name[0] ? mission->name : mission->map_path);
+        }
+        snprintf(item->path, sizeof(item->path), "%s", mission->map_path);
+        item->flags = i;
+    }
+}
+
+static void SinglePlayer_PopulateMissionSelect(singlePlayerCampaign_t const *campaign) {
+    if (!campaign) {
+        return;
+    }
+    if (single_player.MissionName) {
+        UI_SetText(single_player.MissionName, "%s", campaign->name[0] ? campaign->name : campaign->key);
+    }
+    if (single_player.MissionNameHeader) {
+        UI_SetText(single_player.MissionNameHeader, "%s", campaign->header);
+    }
+    SinglePlayer_PopulateMissionList(campaign);
+}
+
+static void SinglePlayer_SelectCampaign(singlePlayerCampaign_t const *campaign) {
+    if (!campaign) {
+        return;
+    }
+    selected_campaign_index = (DWORD)(campaign - campaigns);
+    SinglePlayer_SetCampaignBackdrop(campaign);
+    SinglePlayer_PopulateMissionSelect(campaign);
+    SinglePlayer_SetView(SINGLE_PLAYER_VIEW_MISSION_SELECT);
 }
 
 static void SinglePlayer_PopulateCampaignList(void) {
@@ -469,13 +580,14 @@ static void SinglePlayer_PopulateCampaignList(void) {
         }
         snprintf(item->path, sizeof(item->path), "%s", campaign->key);
         item->players = 1;
+        item->flags = campaign_index;
     }
 }
 
 static void SinglePlayer_CreateCampaignList(void) {
     LPFRAMEDEF template_frame;
 
-    if (campaign_list_frame || SinglePlayer_HasStaticCampaignButtons() || !single_player.CampaignSelectFrame) {
+    if (campaign_list_frame || !single_player.CampaignSelectFrame) {
         return;
     }
 
@@ -500,6 +612,37 @@ static void SinglePlayer_CreateCampaignList(void) {
     UI_BindMapList(campaign_list_frame, &campaign_list, single_player.DifficultySelectLabel, 4, "menu_single_player_campaign_select %u");
 }
 
+static void SinglePlayer_CreateMissionList(void) {
+    LPFRAMEDEF template_frame;
+
+    if (mission_list_frame || !single_player.MissionSelectFrame) {
+        return;
+    }
+
+    template_frame = UI_FindFrame("MapListBox");
+    if (!template_frame) {
+        return;
+    }
+
+    mission_list_frame = UI_CloneFrameTree(template_frame, single_player.MissionSelectFrame);
+    if (!mission_list_frame) {
+        return;
+    }
+
+    UI_SetSize(mission_list_frame, 0.34f, 0.28f);
+    UI_SetPoint(mission_list_frame,
+                FRAMEPOINT_BOTTOMLEFT,
+                single_player.BackButton,
+                FRAMEPOINT_TOPLEFT,
+                -0.14f,
+                0.04f);
+    UI_BindMapList(mission_list_frame,
+                   &mission_list,
+                   single_player.DifficultySelectLabel,
+                   SINGLE_PLAYER_MISSION_VISIBLE_ROWS,
+                   "menu_single_player_mission_select %u");
+}
+
 static void SinglePlayer_BindMainMenu(void) {
     if (!single_player.SinglePlayerMenu) {
         return;
@@ -508,23 +651,43 @@ static void SinglePlayer_BindMainMenu(void) {
     UI_SetOnClick(single_player.CampaignButton, "menu_single_player_campaign");
     UI_SetOnClick(single_player.LoadSavedButton, "");
     UI_SetOnClick(single_player.ViewReplayButton, "");
-    UI_SetOnClick(single_player.SkirmishButton, "");
+    UI_SetOnClick(single_player.SkirmishButton, "menu_single_player_skirmish");
     UI_SetOnClick(single_player.ProfileButton, "");
     UI_SetOnClick(single_player.CancelButton, "menu_main");
     if (single_player.ProfileNameText) {
-        UI_SetText(single_player.ProfileNameText, "Player");
+        LPCSTR name = uiimport.Cvar_String ? uiimport.Cvar_String("name", "Player") : "Player";
+        UI_SetText(single_player.ProfileNameText, "%s", name && name[0] ? name : "Player");
+    }
+}
+
+static LPCSTR SinglePlayer_DifficultyName(DWORD difficulty) {
+    switch (difficulty) {
+        case 0: return UI_GetString("EASY");
+        case 2: return UI_GetString("HARD");
+        default: return UI_GetString("NORMAL");
+    }
+}
+
+static void SinglePlayer_UpdateDifficultyTitle(DWORD difficulty) {
+    LPFRAMEDEF title = single_player.DifficultySelect
+        ? UI_FindChildFrame(single_player.DifficultySelect, "CampaignPopupMenuTitleTextTemplate")
+        : NULL;
+
+    if (title) {
+        UI_SetText(title, "%s", SinglePlayer_DifficultyName(difficulty));
     }
 }
 
 static void SinglePlayer_BindCampaignMenu(void) {
     LPFRAMEDEF DifficultyMenu;
-    LPFRAMEDEF DifficultyTitle;
+    DWORD difficulty = 1;
+    LPCSTR difficulty_value;
 
     if (!single_player.CampaignMenu) {
         return;
     }
 
-    UI_SetOnClick(single_player.BackButton, "menu_game");
+    UI_SetOnClick(single_player.BackButton, "menu_single_player_campaign_back");
     UI_SetOnClick(single_player.HumanButton, "menu_single_player_campaign_human");
     UI_SetOnClick(single_player.OrcButton, "menu_single_player_campaign_orc");
     UI_SetOnClick(single_player.UndeadButton, "menu_single_player_campaign_undead");
@@ -534,10 +697,6 @@ static void SinglePlayer_BindCampaignMenu(void) {
     DifficultyMenu = single_player.DifficultySelect
         ? UI_FindChildFrame(single_player.DifficultySelect, "CampaignPopupMenuMenu")
         : NULL;
-    DifficultyTitle = single_player.DifficultySelect
-        ? UI_FindChildFrame(single_player.DifficultySelect, "CampaignPopupMenuTitleTextTemplate")
-        : NULL;
-
     if (DifficultyMenu) {
         UI_MenuClearItems(DifficultyMenu);
         UI_MenuAddItem(DifficultyMenu, UI_GetString("EASY"), 0);
@@ -546,9 +705,15 @@ static void SinglePlayer_BindCampaignMenu(void) {
         UI_SetOnClick(DifficultyMenu, "menu_single_player_difficulty %u");
         UI_SetHidden(DifficultyMenu, true);
     }
-    if (DifficultyTitle) {
-        UI_SetText(DifficultyTitle, "NORMAL");
+    difficulty_value = uiimport.Cvar_String
+        ? uiimport.Cvar_String("wc3_campaign_difficulty", "1") : "1";
+    if (difficulty_value) {
+        LONG value = atoi(difficulty_value);
+        if (value >= 0 && value <= 2) {
+            difficulty = (DWORD)value;
+        }
     }
+    SinglePlayer_UpdateDifficultyTitle(difficulty);
 }
 
 static void SinglePlayerMenu_Init(void) {
@@ -556,7 +721,9 @@ static void SinglePlayerMenu_Init(void) {
     UI_PreloadGlueSceneModels();
     SinglePlayer_LoadCampaignData();
     campaign_list_frame = NULL;
+    mission_list_frame = NULL;
     memset(&campaign_list, 0, sizeof(campaign_list));
+    memset(&mission_list, 0, sizeof(mission_list));
 
     if (single_player.WarCraftIIILogo) {
         single_player.WarCraftIIILogo->Portrait.model = UI_LoadModel("CampaignLogo", true);
@@ -565,7 +732,9 @@ static void SinglePlayerMenu_Init(void) {
     SinglePlayer_BindMainMenu();
     SinglePlayer_BindCampaignMenu();
     SinglePlayer_CreateCampaignList();
+    SinglePlayer_CreateMissionList();
     SinglePlayer_SetCampaignBackdrop(SinglePlayer_DefaultCampaign());
+    selected_campaign_index = SINGLE_PLAYER_MAX_CAMPAIGNS;
     SinglePlayer_SetView(SINGLE_PLAYER_VIEW_MAIN);
 }
 
@@ -577,7 +746,8 @@ static void SinglePlayerMenu_Refresh(int msec) {
 }
 
 static void SinglePlayerMenu_Draw(void) {
-    if (current_view == SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT) {
+    if (current_view == SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT ||
+        current_view == SINGLE_PLAYER_VIEW_MISSION_SELECT) {
         SinglePlayer_DrawCampaignBackdrop();
         if (single_player.CampaignMenu) {
             UI_DrawFrame(single_player.CampaignMenu);
@@ -597,31 +767,67 @@ static void SinglePlayerMenu_KeyEvent(int key, BOOL down) {
 }
 
 void SinglePlayerMenu_ShowMain(void) {
+    if (single_player.ProfileNameText) {
+        LPCSTR name = uiimport.Cvar_String ? uiimport.Cvar_String("name", "Player") : "Player";
+        UI_SetText(single_player.ProfileNameText, "%s", name && name[0] ? name : "Player");
+    }
     SinglePlayer_SetView(SINGLE_PLAYER_VIEW_MAIN);
 }
 
 void SinglePlayerMenu_ShowCampaign(void) {
     SinglePlayer_SetCampaignBackdrop(SinglePlayer_DefaultCampaign());
+    selected_campaign_index = SINGLE_PLAYER_MAX_CAMPAIGNS;
     SinglePlayer_SetView(SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT);
+}
+
+void SinglePlayerMenu_BackCampaign(void) {
+    if (current_view == SINGLE_PLAYER_VIEW_MISSION_SELECT) {
+        SinglePlayer_SetView(SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT);
+        return;
+    }
+    UI_ShowSinglePlayerMenu();
 }
 
 void SinglePlayerMenu_LaunchCampaign(LPCSTR name) {
     singlePlayerCampaign_t const *campaign = SinglePlayer_FindCampaign(name);
-    SinglePlayer_SetCampaignBackdrop(campaign);
-    SinglePlayer_LaunchCampaign(campaign);
+    SinglePlayer_SelectCampaign(campaign);
 }
 
 void SinglePlayerMenu_LaunchCampaignIndex(DWORD index) {
     DWORD campaign_index;
 
-    if (index >= campaign_list.count || index >= campaign_order_count) {
+    if (index >= campaign_list.count) {
         return;
     }
     campaign_list.selected = index;
-    campaign_index = campaign_order[index];
+    campaign_index = campaign_list.items[index].flags;
     if (campaign_index < campaign_count) {
-        SinglePlayer_SetCampaignBackdrop(&campaigns[campaign_index]);
-        SinglePlayer_LaunchCampaign(&campaigns[campaign_index]);
+        SinglePlayer_SelectCampaign(&campaigns[campaign_index]);
+    }
+}
+
+void SinglePlayerMenu_LaunchMissionIndex(DWORD index) {
+    singlePlayerCampaign_t const *campaign = SinglePlayer_SelectedCampaign();
+    DWORD mission_index;
+
+    if (!campaign || index >= mission_list.count) {
+        return;
+    }
+    mission_list.selected = index;
+    mission_index = mission_list.items[index].flags;
+    SinglePlayer_LaunchMission(campaign, mission_index);
+}
+
+void SinglePlayerMenu_SetDifficulty(DWORD difficulty) {
+    char value[8];
+
+    if (difficulty > 2) {
+        return;
+    }
+    SinglePlayer_UpdateDifficultyTitle(difficulty);
+    if (uiimport.Cvar_Set) {
+        snprintf(value, sizeof(value), "%u", (unsigned)difficulty);
+        uiimport.Cvar_Set("wc3_campaign_difficulty", value);
     }
 }
 

--- a/games/warcraft-3/ui/ui_main.c
+++ b/games/warcraft-3/ui/ui_main.c
@@ -132,13 +132,18 @@ void UI_ShowCreditsMenu(void) {
 }
 
 void UI_ShowLanCreateMenu(void) {
-    UI_SetScreen(&lanJoinScreen);
     LAN_ShowCreate();
+    UI_SetScreen(&lanJoinScreen);
+}
+
+static void UI_ShowSinglePlayerSkirmishMenu(void) {
+    LAN_ShowSinglePlayerCreate();
+    UI_SetScreen(&lanJoinScreen);
 }
 
 void UI_ShowLanBrowserMenu(void) {
-    UI_SetScreen(&lanJoinScreen);
     LAN_ShowBrowser();
+    UI_SetScreen(&lanJoinScreen);
 }
 
 void UI_ShowGameSetupMenu(void) {
@@ -228,6 +233,10 @@ static void UI_MenuSinglePlayerCampaign_f(void) {
     SinglePlayerMenu_ShowCampaign();
 }
 
+static void UI_MenuSinglePlayerSkirmish_f(void) {
+    UI_ShowSinglePlayerSkirmishMenu();
+}
+
 static void UI_MenuLANRefresh_f(void) {
     LAN_RefreshMaps();
 }
@@ -275,6 +284,7 @@ static uiMenuCommandDef_t const ui_menu_command_defs[] = {
     { "menu_options_sound", UI_MenuOptionsSound_f },
     { "menu_options_apply", UI_MenuOptionsApply_f },
     { "menu_single_player_campaign", UI_MenuSinglePlayerCampaign_f },
+    { "menu_single_player_skirmish", UI_MenuSinglePlayerSkirmish_f },
     { "menu_lan_refresh", UI_MenuLANRefresh_f },
     { "menu_lan_start", UI_MenuLANStart_f },
     { "menu_lan_join", UI_MenuLANJoin_f },
@@ -683,6 +693,14 @@ void UI_MenuCommandLocal(LPCSTR command) {
         UI_MenuSinglePlayerCampaign_f();
         return;
     }
+    if (!strcmp(command, "menu_single_player_skirmish")) {
+        UI_MenuSinglePlayerSkirmish_f();
+        return;
+    }
+    if (!strcmp(command, "menu_single_player_campaign_back")) {
+        SinglePlayerMenu_BackCampaign();
+        return;
+    }
     if (!strcmp(command, "menu_single_player_campaign_human")) {
         SinglePlayerMenu_LaunchCampaign("human");
         return;
@@ -707,7 +725,12 @@ void UI_MenuCommandLocal(LPCSTR command) {
         SinglePlayerMenu_LaunchCampaignIndex(value);
         return;
     }
+    if (sscanf(command, "menu_single_player_mission_select %u", &value) == 1) {
+        SinglePlayerMenu_LaunchMissionIndex(value);
+        return;
+    }
     if (sscanf(command, "menu_single_player_difficulty %u", &value) == 1) {
+        SinglePlayerMenu_SetDifficulty(value);
         return;
     }
     if (!strcmp(command, "menu_lan_refresh")) {

--- a/games/warcraft-3/ui/ui_render.c
+++ b/games/warcraft-3/ui/ui_render.c
@@ -112,6 +112,8 @@ static BOOL UI_FrameIsInteractive(LPCFRAMEDEF frame) {
         case FT_POPUPMENU: case FT_GLUEPOPUPMENU:
         case FT_LISTBOX:
             return TRUE;
+        case FT_CONTROL:
+            return frame->MapListControl.State != NULL;
         case FT_FRAME: case FT_SIMPLEFRAME:
             return frame->OnClick[0] || frame->MapListControl.State != NULL;
         default:
@@ -580,8 +582,14 @@ __attribute__((visibility("hidden"))) void UI_WireFrameTypeFunctions(LPFRAMEDEF 
         case FT_POPUPMENU: case FT_GLUEPOPUPMENU:
             frame->event_handler = UI_PopupEventHandler;
             break;
+        case FT_CONTROL:
+            /* Warcraft MapListBox templates are CONTROL roots. */
+            if (frame->MapListControl.State) {
+                frame->event_handler = UI_MapListEventHandler;
+            }
+            break;
         case FT_FRAME: case FT_SIMPLEFRAME:
-            /* FT_FRAME with MapListControl is a map list */
+            /* Programmatic map-list roots may also be plain FRAMEs. */
             if (frame->MapListControl.State) {
                 frame->event_handler = UI_MapListEventHandler;
                 frame->draw = UI_DrawMapListControl;

--- a/games/warcraft-3/ui/ui_screen.h
+++ b/games/warcraft-3/ui/ui_screen.h
@@ -57,16 +57,21 @@ void OptionsMenu_Apply(void);
 
 void SinglePlayerMenu_ShowMain(void);
 void SinglePlayerMenu_ShowCampaign(void);
+void SinglePlayerMenu_BackCampaign(void);
 void SinglePlayerMenu_LaunchCampaign(LPCSTR name);
 void SinglePlayerMenu_LaunchCampaignIndex(DWORD index);
+void SinglePlayerMenu_LaunchMissionIndex(DWORD index);
+void SinglePlayerMenu_SetDifficulty(DWORD difficulty);
 
 void LAN_ShowCreate(void);
+void LAN_ShowSinglePlayerCreate(void);
 void LAN_ShowBrowser(void);
 void LAN_RefreshMaps(void);
 void LAN_SelectMapIndex(DWORD index);
 void LAN_StartSelectedMap(void);
 void LAN_JoinSelectedGame(void);
 void LAN_ApplyPlayerName(void);
+BOOL LAN_IsSinglePlayerCreate(void);
 
 BOOL GameSetup_StartGame(void);
 void GameSetup_LoadMap(LPCSTR map_path);


### PR DESCRIPTION
Add data-driven campaign and mission selection, including clickable CONTROL-backed map lists and all/played mission visibility.

Wire campaign difficulty into game startup, reuse the existing local map browser and Game Setup for Single Player Custom Game, and use the configured player name in the Single Player UI.

Update WC3 UI tests, fixtures, and architecture documentation to cover the new campaign, mission, difficulty, and custom-game flows.