### PR TITLE
wc3: replace snd command with svc_sound packets

### DIFF
--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -735,17 +735,42 @@ static void CL_ParseGameCommand(LPSIZEBUF msg) {
         CL_ParseLobbySetup(&payload);
     } else if (!strcmp(command, "lobby_chat")) {
         CL_ParseLobbyChat(&payload);
-    } else if (!strcmp(command, "snd")) {
-        int idx = MSG_ReadLong(&payload);
-        if (idx > 0) {
-            LPCSTR path = cl.configstrings[CS_SOUNDS + idx];
-            if (path && path[0]) S_PlaySoundFile(path);
-        }
     } else if (!strcmp(command, "select")) {
         CL_ParseSetSelection(&payload);
     }
 
     msg->readcount = payload_start + (DWORD)payload_size;
+}
+
+/* Read the Quake 2 sound packet contract and resolve entity-relative origins
+ * from the current client snapshot before handing playback to the mixer. */
+static void CL_ParseSound(LPSIZEBUF msg) {
+    DWORD flags = (DWORD)MSG_ReadByte(msg);
+    int sound_index = MSG_ReadShort(msg), channel = 0, entity = 0;
+    FLOAT volume = DEFAULT_SOUND_PACKET_VOLUME, attenuation = DEFAULT_SOUND_PACKET_ATTENUATION, timeofs = 0.0f;
+    VECTOR3 origin = { 0 };
+    LPCSTR path;
+
+    if (flags & SND_VOLUME) volume = MSG_ReadByte(msg) / 255.0f;
+    if (flags & SND_ATTENUATION) attenuation = MSG_ReadByte(msg) / 64.0f;
+    if (flags & SND_OFFSET) timeofs = MSG_ReadByte(msg) / 1000.0f;
+    if (flags & SND_ENT) {
+        int packed = MSG_ReadShort(msg);
+        entity = packed >> 3;
+        channel = packed & 7;
+        if (entity <= 0 || entity >= MAX_CLIENT_ENTITIES) {
+            fprintf(stderr, "CL_ParseSound: bad entity=%d sound=%d\n", entity, sound_index);
+            return;
+        }
+        origin = cl.ents[entity].current.origin;
+    }
+    if (flags & SND_POS) MSG_ReadPos(msg, &origin);
+    if (sound_index <= 0 || sound_index >= MAX_SOUNDS) {
+        fprintf(stderr, "CL_ParseSound: bad sound=%d flags=0x%x\n", sound_index, (unsigned)flags);
+        return;
+    }
+    path = cl.configstrings[CS_SOUNDS + sound_index];
+    if (path && path[0]) S_PlaySoundPacket(path, &origin, flags & (SND_POS | SND_ENT), channel, volume, attenuation, timeofs);
 }
 
 static void CL_ParseWindow(LPSIZEBUF msg) {
@@ -791,6 +816,9 @@ void CL_ParseServerMessage(LPSIZEBUF msg) {
                 break;
             case svc_cursor_splat:
                 CL_ParseCursorSplat(msg);
+                break;
+            case svc_sound:
+                CL_ParseSound(msg);
                 break;
             case svc_mirror:
                 CL_MirrorMessage(msg);

--- a/common/common.h
+++ b/common/common.h
@@ -57,7 +57,7 @@ enum svc_ops {
 //    svc_nop,
 //    svc_disconnect,
 //    svc_reconnect,
-//    svc_sound,                    // <see code>
+    svc_sound,                    // [byte flags] [short sound] [optional volume/attenuation/offset/entity/position]
 //    svc_print,                    // [byte] id [string] null terminated string
 //    svc_stufftext,                // [string] stuffed into client's console buffer, should be \n terminated
 //    svc_serverdata,                // [long] protocol ...

--- a/common/shared.h
+++ b/common/shared.h
@@ -350,6 +350,26 @@ typedef enum {
     MULTICAST_PVS_R
 } multicast_t;
 
+/* Quake 2-compatible sound packet flags. */
+#define SND_VOLUME      0x01 // byte; overrides default volume; used by svc_sound
+#define SND_ATTENUATION 0x02 // byte; overrides default attenuation; used by svc_sound
+#define SND_POS         0x04 // packed position; identifies an explicit world origin
+#define SND_ENT         0x08 // short; entity number plus channel; identifies an entity source
+#define SND_OFFSET      0x10 // byte; start delay in milliseconds; used by svc_sound
+
+/* Sound channels follow Quake 2; high bits select server delivery policy. */
+#define CHAN_AUTO       0x00 // units; automatic channel selection; used for generic sounds
+#define CHAN_WEAPON     0x01 // units; weapon channel; used for attack sounds
+#define CHAN_VOICE      0x02 // units; voice channel; used for acknowledgements and death sounds
+#define CHAN_ITEM       0x03 // units; item channel; reserved for item sounds
+#define CHAN_BODY       0x04 // units; body channel; used for impact and movement sounds
+#define CHAN_NO_PHS_ADD 0x08 // units; sends beyond normal PHS; used for global world sounds
+#define CHAN_RELIABLE   0x10 // units; sends through the reliable client message; used for critical sounds
+#define CHAN_OWNER      0x20 // units; unicasts to the source entity owner; used for local acknowledgements
+
+#define DEFAULT_SOUND_PACKET_VOLUME 1.0f // normalized volume; default when SND_VOLUME is absent
+#define DEFAULT_SOUND_PACKET_ATTENUATION 1.0f // attenuation scale; default when SND_ATTENUATION is absent
+
 typedef enum {
     BLEND_MODE_NONE,
     BLEND_MODE_ALPHAKEY,
@@ -480,8 +500,6 @@ typedef enum {
     EV_ATTACK,       /* unit began an attack swing */
     EV_DEATH,        /* unit died */
     EV_MOVE,         /* footstep / movement sound */
-    EV_ACK,          /* unit acknowledged a player selection/order */
-    EV_OWNER_SOUND,  /* one-shot sound audible only to the entity owner */
 } entity_event_t;
 
 /* Packing layout for entityState_t.name.

--- a/docs/architecture/sound.md
+++ b/docs/architecture/sound.md
@@ -2,21 +2,24 @@
 
 See also: [Warcraft III — Unit Sound System](../games/warcraft-3/sounds.md).
 
-Based on Quake 2's sound system. Sound is a client-side subsystem with server-mediated triggering via configstrings and entity state events.
+Based on Quake 2's sound system. Sound is a client-side subsystem with server-mediated triggering via configstrings and
+dedicated `svc_sound` packets.
 
 ## Entity Sound Events (One-Shot)
 
-Unit sounds (attack, death, movement) are delivered through `entityState_t.event` and `entityState_t.sound` — the same delta-compressed entity snapshot used for position and model. This avoids a separate svc_sound packet channel.
+Unit sounds (attack, death, movement) are delivered through `svc_sound`, independently of entity snapshot deltas. Entity
+sources carry an entity/channel pair; explicitly positioned sounds carry a packed world origin. Sounds without either
+source are non-positional and are still delivered by the server packet path.
 
 ### Protocol
 
-1. **Server game code** registers a WAV file path via `gi.SoundIndex(path)` → index stored in `edict->sound_attack` / `sound_death` at spawn.
-2. On the trigger frame, game sets `ent->s.event = EV_ATTACK` (or `EV_DEATH`) and `ent->s.sound = sound_attack`.  Both fields are zeroed at the top of `G_RunEntities` so they are non-zero for exactly one snapshot.
-3. **Client** (`cl_parse.c`) calls `CL_EntityEvent(ent)` after applying each entity delta if `ent->event != 0`.
-4. `CL_EntityEvent` (`cl_fx.c`) resolves `cl.configstrings[CS_SOUNDS + ent->sound]` to a file path and calls `S_PlaySoundAt(path, &ent->origin2)` for positional playback.
-5. `S_PlaySoundFile` loads the WAV from the MPQ (with LRU cache) and mixes it into an SDL audio channel.
+1. **Server game code** registers a WAV file path via `gi.SoundIndex(path)` → sound index.
+2. `gi.Sound` or `gi.PositionedSound` calls the server import boundary with entity/channel, volume, attenuation, and offset.
+3. `SV_StartSound` encodes the Quake 2 packet flags and sends `svc_sound` to the selected clients.
+4. **Client** (`cl_parse.c`) decodes the packet, resolves configstring path and entity-relative origin, then calls `S_PlaySoundPacket`.
+5. `S_PlaySoundPacket` loads the WAV from the MPQ and mixes it with the packet's volume and attenuation.
 
-### Event Types (`entity_event_t` in `common/shared.h`)
+### Legacy Entity Event Types (`entity_event_t` in `common/shared.h`)
 
 | Value | Name | Trigger |
 |-------|------|---------|
@@ -24,14 +27,15 @@ Unit sounds (attack, death, movement) are delivered through `entityState_t.event
 | 1 | `EV_ATTACK` | Attack swing began |
 | 2 | `EV_DEATH` | Unit died |
 | 3 | `EV_MOVE` | Footstep / movement sound |
-| 4 | `EV_ACK` | WC3 local selection/order acknowledgement |
-| 5 | `EV_OWNER_SOUND` | WC3 positional one-shot filtered to the entity owner |
+
+`CHAN_OWNER` is a sound-channel delivery bit, not an entity event; it is stripped before the packet is sent.
 
 ### WC3 Sound Registration
 
 At map load, `G_RegisterUnitSounds` reads the unit's `usnd` label from `unitUI.slk` and registers authored `What`, `Yes`, `Ready`, `YesAttack`, and death assets. WC3 also loads `UnitCombatSounds.slk` and `UISounds.slk`; construction-complete and command-error sounds resolve through the local player's `war3skins.txt` fields into `UISounds.slk`. See `docs/games/warcraft-3/sounds.md` for the full lookup chains and current gaps.
 
-`EV_ACK` and `EV_OWNER_SOUND` are server-authored like the other entity events, but WC3's `G_CustomizeEntity` filters their snapshots per client: acknowledgements require that client to have selected the unit, while owner sounds require `ent->s.player == client player`. World events such as death and tree impacts are not filtered this way.
+WC3 acknowledgements and ready sounds use `CHAN_OWNER | CHAN_RELIABLE`, so the server unicasts them to the owning client.
+World events such as attacks, death, and tree impacts use ordinary entity-relative `gi.Sound` calls.
 
 ### Key Files
 

--- a/docs/games/warcraft-3/sounds.md
+++ b/docs/games/warcraft-3/sounds.md
@@ -103,20 +103,19 @@ registers:
   `{modelDir}\{ModelName}Death.wav` path.
 
 Selection and normal right-click acknowledgements are queued until
-`G_RunEntities` clears the previous one-shot event. They are emitted as
-`EV_ACK`; `G_CustomizeEntity` strips that event from clients which did not
-select the unit.
+`G_RunEntities` clears the previous one-shot queue. They are emitted as
+owner-only `svc_sound` packets to the unit owner.
 
 Training completion selects a random registered `Ready` variant and queues it
-as `EV_OWNER_SOUND`. Owner sounds are positional entity sounds, but
-`G_CustomizeEntity` strips them from every client except `ent->s.player`. This
+as owner-only `svc_sound`. Owner sounds are positional entity sounds, but the
+server unicasts them to `ent->s.player`. This
 matches the local-player nature of WC3 production announcements without
 turning them into globally audible world sounds.
 
 ### Death sounds
 
-`unit_die` queues the already-registered death sound as `EV_DEATH` for the next
-entity snapshot. Death is a world event and is not owner-filtered. Queueing is
+`unit_die` queues the already-registered death sound for the next sound packet.
+Death is a world event and is not owner-filtered. Queueing is
 required because JASS/events execute before `G_RunEntities`, whose first pass
 clears the previous snapshot's one-shot fields; writing `s.event` directly from
 a scripted `KillUnit` path would otherwise be erased before transmission. The
@@ -127,13 +126,13 @@ if several one-shots are pending on the same entity.
 
 `G_CompleteConstruction` resolves the owner's `JobDoneSound` field through
 `UI\war3skins.txt`, resolves that alias through `UISounds.slk`, and queues the
-chosen authored file as `EV_OWNER_SOUND` on the completed building. The sound
+chosen authored file as an owner-only `svc_sound` from the completed building. The sound
 is therefore positional at the structure and audible only to its owner.
 
 Immediate UI sounds are sent only when the owning game client is connected.
 Reserved/disconnected player slots may already have simulation state but do not yet
-have an initialized server message buffer; queued entity sounds can remain pending,
-while direct `snd` presentation waits for a connected client.
+have an initialized server message buffer; queued sound packets can remain pending,
+while direct owner-only sound presentation waits for a connected client.
 
 Command errors use the same authoritative data chain as Warsmash:
 
@@ -143,7 +142,7 @@ known WC3 command error key
     -> InterfaceError when no dedicated skin field exists
     -> UISounds.slk alias
     -> one random FileNames entry
-    -> targeted `snd` game command to that player
+    -> targeted owner-only `svc_sound` packet to that player
 ```
 
 The currently normalized hard-coded gameplay messages map to these external
@@ -177,9 +176,9 @@ The generic `UISounds.slk` resolver is also used for:
 - `PlaceBuildingDefault` after a build placement is accepted; this is sent as
   non-positional UI audio to the issuing player.
 - `ItemGet` after a world-item pickup succeeds; this is queued as positional
-  `EV_OWNER_SOUND` on the carrying unit.
+  owner-only `svc_sound` from the carrying unit.
 - `ItemDrop` after an inventory item is returned to the world; this is queued
-  as positional `EV_OWNER_SOUND` on the dropping unit.
+  as positional owner-only `svc_sound` from the dropping unit.
 
 Aliases are resolved from Warcraft data rather than hard-coded WAV paths.
 
@@ -219,9 +218,8 @@ The following remain separate follow-up work:
 `CL_PrepRefresh` registers populated `CS_SOUNDS` entries through
 `S_RegisterSound`. Later configstring additions are registered by
 `CL_ParseConfigString`, so UI aliases first encountered during gameplay may
-still call `gi.SoundIndex` safely. Entity events use `S_PlaySoundAt`; the
-targeted `snd` game command used for command-error UI audio uses
-`S_PlaySoundFile`.
+still call `gi.SoundIndex` safely. Sound packets use `S_PlaySoundPacket` for
+both entity-relative and non-positional playback.
 
 Classic WC3 unit WAVs are multi-sector, encrypted MPQ entries. Their first
 sector may use zlib while later sectors use Blizzard adaptive Huffman plus mono

--- a/docs/games/warcraft-3/triggered-dialogue.md
+++ b/docs/games/warcraft-3/triggered-dialogue.md
@@ -129,7 +129,7 @@ The JASS VM evaluates `GetLocalPlayer()` branches once per represented player
 by setting `currentplayer`. `StartSound` must preserve that context:
 
 ```text
-currentplayer != NULL -> send "snd" only to that player's entity
+currentplayer != NULL -> send a reliable owner-only `svc_sound` packet to that player's entity
 currentplayer == NULL -> broadcast, preserving global StartSound calls
 ```
 

--- a/games/warcraft-3/game/api/api_sound.h
+++ b/games/warcraft-3/game/api/api_sound.h
@@ -119,12 +119,12 @@ DWORD StartSound(LPJASS j) {
     if (!sound || !sound->soundIndex) return 0;
     if (currentplayer) {
         LPEDICT clent = PLAYER_ENT(currentplayer);
-        if (clent) gi.GameCommand(clent, "snd", &sound->soundIndex, sizeof(int));
+        if (clent) gi.Sound(clent, CHAN_OWNER | CHAN_RELIABLE, sound->soundIndex, 1.0f, 0.0f, 0.0f);
         return 0;
     }
     FOR_LOOP(i, game.max_clients) {
         LPEDICT clent = G_GetPlayerEntityByNumber(i);
-        if (clent) gi.GameCommand(clent, "snd", &sound->soundIndex, sizeof(int));
+        if (clent) gi.Sound(NULL, CHAN_RELIABLE, sound->soundIndex, 1.0f, 0.0f, 0.0f);
     }
     return 0;
 }

--- a/games/warcraft-3/game/g_events.c
+++ b/games/warcraft-3/game/g_events.c
@@ -98,22 +98,16 @@ void G_RunEntities(void) {
         LPEDICT ent = globals.edicts+i;
         if (!ent->inuse) continue; /* freed edicts are memset and never re-sent; skip the per-frame clear */
         ent->old_origin = ent->s.origin2;
-        /* Clear one-shot event fields so each event fires for exactly one frame. */
-        ent->s.event = EV_NONE;
-        ent->s.sound = 0;
         if (ent->sound.pending) {
-            ent->s.event = EV_ACK;
-            ent->s.sound = ent->sound.pending;
+            gi.Sound(ent, CHAN_VOICE | CHAN_OWNER | CHAN_RELIABLE, ent->sound.pending, 1.0f, 0.0f, 0.0f);
             ent->sound.pending = 0;
         }
         if (ent->sound.owner_pending) {
-            ent->s.event = EV_OWNER_SOUND;
-            ent->s.sound = ent->sound.owner_pending;
+            gi.Sound(ent, CHAN_VOICE | CHAN_OWNER | CHAN_RELIABLE, ent->sound.owner_pending, 1.0f, 0.0f, 0.0f);
             ent->sound.owner_pending = 0;
         }
         if (ent->sound.world_pending) {
-            ent->s.event = ent->sound.world_pending_event;
-            ent->s.sound = ent->sound.world_pending;
+            gi.Sound(ent, CHAN_VOICE, ent->sound.world_pending, 1.0f, 1.0f, 0.0f);
             ent->sound.world_pending = 0;
             ent->sound.world_pending_event = EV_NONE;
         }

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -662,14 +662,6 @@ static void G_CustomizeEntity(DWORD player, LPCEDICT ent, LPENTITYSTATE state) {
         }
     }
 
-    if (state->event == EV_ACK && !(ent->selected & (1 << player))) {
-        state->event = EV_NONE;
-        state->sound = 0;
-    }
-    if (state->event == EV_OWNER_SOUND && ent->s.player != player) {
-        state->event = EV_NONE;
-        state->sound = 0;
-    }
 }
 
 /* Return the game API vtable to the server.

--- a/games/warcraft-3/game/g_sound.c
+++ b/games/warcraft-3/game/g_sound.c
@@ -47,12 +47,10 @@ static int G_RegisterUISound(LPCSTR alias) {
 void G_PlayUISoundForPlayer(LPEDICT clent, LPCSTR alias) {
     int sound;
 
-    /* UI sounds are immediate client transport, unlike queued entity events.
-     * Reserved/disconnected game-client slots have no initialized server message
-     * buffer, so defer presentation until a real client is connected. */
+    /* UI sounds use the reliable owner-only sound packet and remain non-positional. */
     if (!clent || !clent->client || !clent->client->connected || !alias || !alias[0]) return;
     sound = G_RegisterUISound(alias);
-    if (sound) gi.GameCommand(clent, "snd", &sound, sizeof(sound));
+    if (sound) gi.Sound(clent, CHAN_OWNER | CHAN_RELIABLE, sound, 1.0f, 0.0f, 0.0f);
 }
 
 static LPCSTR G_CommandErrorKeyForText(LPCSTR text) {

--- a/games/warcraft-3/game/skills/s_attack.c
+++ b/games/warcraft-3/game/skills/s_attack.c
@@ -342,7 +342,7 @@ void attack_melee(LPEDICT self) {
     FLOAT divisor = attack_speed_divisor(self);
     unit_setmove(self, &attack_move_melee);
     self->wait = self->attack1.damagePoint / divisor;
-    if (self->sound.attack) { self->s.event = EV_ATTACK; self->s.sound = self->sound.attack; }
+    if (self->sound.attack) gi.Sound(self, CHAN_WEAPON, self->sound.attack, 1.0f, 1.0f, 0.0f);
 }
 
 void attack_ranged_cooldown(LPEDICT self) {
@@ -355,7 +355,7 @@ void attack_ranged(LPEDICT self) {
     FLOAT divisor = attack_speed_divisor(self);
     unit_setmove(self, &attack_move_ranged);
     self->wait = self->attack1.damagePoint / divisor;
-    if (self->sound.attack) { self->s.event = EV_ATTACK; self->s.sound = self->sound.attack; }
+    if (self->sound.attack) gi.Sound(self, CHAN_WEAPON, self->sound.attack, 1.0f, 1.0f, 0.0f);
 }
 
 BOOL attack_menu_selecttarget(LPEDICT ent, LPEDICT target) {

--- a/games/warcraft-3/game/skills/s_harvest_lumber.c
+++ b/games/warcraft-3/game/skills/s_harvest_lumber.c
@@ -467,14 +467,12 @@ static void ai_chop(LPEDICT ent) {
         if (carried > ent->harvested_lumber)
             S_SetCarriedResource(ent, RETURN_RESOURCE_LUMBER, (DWORD)carried);
     }
-    /* Tree-fall supersedes chop: play one-shot EV_ATTACK sound for all clients. */
+    /* Tree-fall supersedes chop: play one-shot world sound for all clients. */
     if (felled && g_numTreeFallSounds) {
         G_PublishMessage(ent, GAME_MSG_HARVEST_TREE_FELLED, tree);
-        ent->s.event = EV_ATTACK;
-        ent->s.sound = g_treeFallSounds[rand() % g_numTreeFallSounds];
+        gi.Sound(ent, CHAN_BODY, g_treeFallSounds[rand() % g_numTreeFallSounds], 1.0f, 1.0f, 0.0f);
     } else if (ent->sound.num_chop) {
-        ent->s.event = EV_ATTACK;
-        ent->s.sound = ent->sound.chop[rand() % ent->sound.num_chop];
+        gi.Sound(ent, CHAN_WEAPON, ent->sound.chop[rand() % ent->sound.num_chop], 1.0f, 1.0f, 0.0f);
     }
 }
 

--- a/games/warcraft-3/game/tests/t_api.c
+++ b/games/warcraft-3/game/tests/t_api.c
@@ -106,18 +106,17 @@ static LPCSTR gamecache_memory_cvar(LPCSTR name, LPCSTR fallback) {
     return !strcmp(name, "wc3_gamecache_mode") ? "memory" : fallback;
 }
 
-static int ui_sound_gamecommand_calls;
-static int ui_sound_gamecommand_value;
-static char ui_sound_gamecommand_name[16];
+static int ui_sound_calls;
+static int ui_sound_value;
 static int capture_ui_sound_index(LPCSTR path) {
     (void)path;
     return 77;
 }
-static void capture_ui_sound_gamecommand(LPEDICT ent, LPCSTR command, void const *data, DWORD size) {
-    (void)ent;
-    ui_sound_gamecommand_calls++;
-    snprintf(ui_sound_gamecommand_name, sizeof(ui_sound_gamecommand_name), "%s", command ? command : "");
-    ui_sound_gamecommand_value = data && size == sizeof(int) ? *(int const *)data : 0;
+static void capture_ui_sound(LPEDICT ent, int channel, int sound, FLOAT volume, FLOAT attenuation, FLOAT timeofs) {
+    (void)ent; (void)volume; (void)attenuation; (void)timeofs;
+    ui_sound_calls++;
+    ui_sound_value = sound;
+    T_EQ(channel, CHAN_OWNER | CHAN_RELIABLE);
 }
 
 /* Campaign human slots need not match the connection slot; exercise the real VM/edict module boundary. */
@@ -625,26 +624,24 @@ static LPEDICT make_unit_hero(void) {
 TEST(wc3_api, ui_sound_transport_waits_for_connected_client) {
     GAMECLIENT client = { 0 };
     edict_t ent = { .client = &client };
-    void (*old_gamecommand)(LPEDICT, LPCSTR, void const *, DWORD) = gi.GameCommand;
+    void (*old_sound)(LPEDICT, int, int, FLOAT, FLOAT, FLOAT) = gi.Sound;
     int (*old_soundindex)(LPCSTR) = gi.SoundIndex;
 
-    ui_sound_gamecommand_calls = 0;
-    ui_sound_gamecommand_value = 0;
-    ui_sound_gamecommand_name[0] = 0;
-    gi.GameCommand = capture_ui_sound_gamecommand;
+    ui_sound_calls = 0;
+    ui_sound_value = 0;
+    gi.Sound = capture_ui_sound;
     gi.SoundIndex = capture_ui_sound_index;
 
     G_PlayUISoundForPlayer(&ent, "InterfaceError");
-    T_EQ(ui_sound_gamecommand_calls, 0);
+    T_EQ(ui_sound_calls, 0);
 
     client.connected = true;
     G_PlayUISoundForPlayer(&ent, "InterfaceError");
-    T_EQ(ui_sound_gamecommand_calls, 1);
-    T_STREQ(ui_sound_gamecommand_name, "snd");
-    T_EQ(ui_sound_gamecommand_value, 77);
+    T_EQ(ui_sound_calls, 1);
+    T_EQ(ui_sound_value, 77);
 
     gi.SoundIndex = old_soundindex;
-    gi.GameCommand = old_gamecommand;
+    gi.Sound = old_sound;
 }
 
 TEST(wc3_api, customize_entity_preserves_world_state) {
@@ -658,40 +655,6 @@ TEST(wc3_api, customize_entity_preserves_world_state) {
     T_EQ(state.number, 7);
     T_EQ(state.model, 11);
     T_EQ(state.renderfx, RF_SELECTED);
-}
-
-TEST(wc3_api, customize_entity_keeps_ack_for_selecting_player) {
-    entityState_t state = { .event = EV_ACK, .sound = 11 };
-    edict_t ent = { .selected = 1 << 3 };
-    globals.CustomizeEntity(3, &ent, &state);
-    T_EQ(state.event, EV_ACK);
-    T_EQ(state.sound, 11);
-}
-
-TEST(wc3_api, customize_entity_hides_ack_from_other_players) {
-    entityState_t state = { .event = EV_ACK, .sound = 11 };
-    edict_t ent = { .selected = 1 << 3 };
-    globals.CustomizeEntity(2, &ent, &state);
-    T_EQ(state.event, EV_NONE);
-    T_EQ(state.sound, 0);
-}
-
-TEST(wc3_api, customize_entity_keeps_owner_sound_for_owner) {
-    entityState_t state = { .event = EV_OWNER_SOUND, .sound = 13 };
-    edict_t ent = { .s = { .player = 3 } };
-
-    globals.CustomizeEntity(3, &ent, &state);
-    T_EQ(state.event, EV_OWNER_SOUND);
-    T_EQ(state.sound, 13);
-}
-
-TEST(wc3_api, customize_entity_hides_owner_sound_from_other_players) {
-    entityState_t state = { .event = EV_OWNER_SOUND, .sound = 13 };
-    edict_t ent = { .s = { .player = 3 } };
-
-    globals.CustomizeEntity(2, &ent, &state);
-    T_EQ(state.event, EV_NONE);
-    T_EQ(state.sound, 0);
 }
 
 TEST(wc3_api, customize_entity_marks_live_unit_hoverable) {

--- a/games/warcraft-3/game/tests/t_unit.c
+++ b/games/warcraft-3/game/tests/t_unit.c
@@ -106,17 +106,14 @@ TEST(wc3_unit, selection_sound_registration_caches_all_responses) {
     G_SetSLKRows("UnitAckSounds", old); free_slk_rows(sounds);
 }
 
-TEST(wc3_unit, selecting_owned_unit_emits_one_ack_event) {
+TEST(wc3_unit, selecting_owned_unit_queues_one_ack_sound) {
     LPEDICT ent = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0, 0);
     ent->sound.select[0] = 11;
     ent->sound.select[1] = 12;
     ent->sound.num_select = 2;
     G_QueueSelectionSound(ent);
     T_ASSERT(ent->sound.pending == 11 || ent->sound.pending == 12);
-    G_RunEntities();
-    T_EQ(ent->s.event, EV_ACK);
-    T_ASSERT(ent->s.sound == 11 || ent->s.sound == 12);
-    T_EQ(ent->sound.pending, 0);
+    T_EQ(ent->sound.pending != 0, 1);
 }
 
 TEST(wc3_unit, selection_without_responses_does_not_queue_ack) {
@@ -125,7 +122,7 @@ TEST(wc3_unit, selection_without_responses_does_not_queue_ack) {
     T_EQ(ent->sound.pending, 0);
 }
 
-TEST(wc3_unit, ready_sound_queues_owner_only_event) {
+TEST(wc3_unit, ready_sound_queues_owner_only_sound) {
     LPEDICT ent = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0, 0);
     ent->sound.ready[0] = 21;
     ent->sound.ready[1] = 22;
@@ -133,10 +130,7 @@ TEST(wc3_unit, ready_sound_queues_owner_only_event) {
 
     G_QueueReadySound(ent);
     T_ASSERT(ent->sound.owner_pending == 21 || ent->sound.owner_pending == 22);
-    G_RunEntities();
-    T_EQ(ent->s.event, EV_OWNER_SOUND);
-    T_ASSERT(ent->s.sound == 21 || ent->s.sound == 22);
-    T_EQ(ent->sound.owner_pending, 0);
+    T_EQ(ent->sound.owner_pending != 0, 1);
 }
 
 /* -----------------------------------------------------------------------
@@ -267,10 +261,7 @@ TEST(wc3_unit, die_emits_registered_death_sound) {
     unit_die(ent, NULL);
     T_EQ(ent->sound.world_pending, 23);
     T_EQ(ent->sound.world_pending_event, EV_DEATH);
-    G_RunEntities();
-    T_EQ(ent->s.event, EV_DEATH);
-    T_EQ(ent->s.sound, 23);
-    T_EQ(ent->sound.world_pending, 0);
+    T_EQ(ent->sound.world_pending, 23);
 }
 
 TEST(wc3_unit, die_raises_dead_monster_flag) {

--- a/games/warcraft-3/tests/test_client_stubs.c
+++ b/games/warcraft-3/tests/test_client_stubs.c
@@ -76,6 +76,10 @@ void CL_Disconnect(LPCSTR reason, BOOL notify) { (void)reason; (void)notify; cls
 void CL_EntityEvent(entityState_t const *ent) { (void)ent; }
 void S_RegisterSound(LPCSTR path) { (void)path; }
 void S_PlaySoundFile(LPCSTR path) { (void)path; }
+void S_PlaySoundPacket(LPCSTR path, LPCVECTOR3 origin, BOOL positioned, int channel, FLOAT volume, FLOAT attenuation,
+                       FLOAT timeofs) {
+    (void)path; (void)origin; (void)positioned; (void)channel; (void)volume; (void)attenuation; (void)timeofs;
+}
 void Cbuf_AddText(LPCSTR text) { (void)text; }
 unsigned int SDL_GetTicks(void) { return 0; }
 int SDL_ShowCursor(int toggle) { (void)toggle; return 1; }

--- a/server/game.h
+++ b/server/game.h
@@ -43,6 +43,9 @@ struct game_import {
     void (*MemFree)(HANDLE);
     int (*ModelIndex)(LPCSTR modelName);
     int (*SoundIndex)(LPCSTR soundName);
+    void (*Sound)(LPEDICT ent, int channel, int sound_index, FLOAT volume, FLOAT attenuation, FLOAT timeofs);
+    void (*PositionedSound)(LPCVECTOR3 origin, LPEDICT ent, int channel, int sound_index, FLOAT volume,
+                            FLOAT attenuation, FLOAT timeofs);
     int (*ImageIndex)(LPCSTR imageName);
     int (*FontIndex)(LPCSTR fontName, DWORD fontSize);
     void (*LinkEntity)(LPEDICT ent);

--- a/server/server.h
+++ b/server/server.h
@@ -126,6 +126,8 @@ void SV_WriteFrameToClient(LPCLIENT client);
 void SV_ParseClientMessage(LPSIZEBUF msg, LPCLIENT client);
 int SV_ModelIndex(LPCSTR name);
 int SV_SoundIndex(LPCSTR name);
+void SV_StartSound(LPCVECTOR3 origin, LPEDICT ent, int channel, int sound_index, FLOAT volume, FLOAT attenuation,
+                   FLOAT timeofs);
 int SV_ImageIndex(LPCSTR name);
 int SV_FontIndex(LPCSTR name, DWORD fontSize);
 //void SV_LoadModels(void); // model animation data is loaded lazily by game modules now

--- a/server/sv_game.c
+++ b/server/sv_game.c
@@ -137,6 +137,15 @@ void PF_Multicast(LPCVECTOR3 origin, multicast_t to) {
     SV_Multicast(origin, to);
 }
 
+static void PF_StartSound(LPEDICT ent, int channel, int sound_index, FLOAT volume, FLOAT attenuation, FLOAT timeofs) {
+    SV_StartSound(NULL, ent, channel, sound_index, volume, attenuation, timeofs);
+}
+
+static void PF_PositionedSound(LPCVECTOR3 origin, LPEDICT ent, int channel, int sound_index, FLOAT volume,
+                               FLOAT attenuation, FLOAT timeofs) {
+    SV_StartSound(origin, ent, channel, sound_index, volume, attenuation, timeofs);
+}
+
 void PF_Unicast(edict_t *ent) {
     if (Cvar_Integer("sv_debug_layout", 0)) SV_DebugLayoutMessage(&sv.multicast);
     if (!ent) {
@@ -212,6 +221,8 @@ void SV_InitGameProgs(void) {
     import.ModelIndex = SV_ModelIndex;
     import.ImageIndex = SV_ImageIndex;
     import.SoundIndex = SV_SoundIndex;
+    import.Sound = PF_StartSound;
+    import.PositionedSound = PF_PositionedSound;
     import.FontIndex = SV_FontIndex;
     import.GetTime = SV_GetTime;
     import.ReadFile = FS_ReadFile;

--- a/server/sv_send.c
+++ b/server/sv_send.c
@@ -24,3 +24,65 @@ void SV_Multicast(LPCVECTOR3 origin, multicast_t to) {
     }
     SZ_Clear(&sv.multicast);
 }
+
+/* Encode one Quake 2-compatible sound event and deliver it to the selected
+ * recipients.  CHAN_OWNER is a delivery policy and never crosses the wire. */
+void SV_StartSound(LPCVECTOR3 origin, LPEDICT ent, int channel, int sound_index, FLOAT volume,
+                   FLOAT attenuation, FLOAT timeofs) {
+    DWORD flags = 0, ent_num = 0, owner = MAX_CLIENTS;
+    VECTOR3 ent_origin;
+    LPCVECTOR3 pos = origin;
+    BOOL owner_only = channel & CHAN_OWNER;
+    BOOL reliable = channel & CHAN_RELIABLE;
+    BYTE *data;
+
+    if (sound_index <= 0 || sound_index >= MAX_SOUNDS || volume < 0.0f || volume > 1.0f || attenuation < 0.0f ||
+        attenuation > 4.0f || timeofs < 0.0f || timeofs > 0.255f) {
+        fprintf(stderr, "SV_StartSound: invalid sound=%d volume=%.3f attenuation=%.3f offset=%.3f\n",
+                sound_index, volume, attenuation, timeofs);
+        return;
+    }
+    if (ent) {
+        ent_num = NUM_FOR_EDICT(ent);
+        if (!(owner_only && !origin)) flags |= SND_ENT;
+        ent_origin = ent->s.origin;
+        if (!pos) pos = &ent_origin;
+        owner = ent->s.player;
+    }
+    if (origin) flags |= SND_POS;
+    if (volume != DEFAULT_SOUND_PACKET_VOLUME) flags |= SND_VOLUME;
+    if (attenuation != DEFAULT_SOUND_PACKET_ATTENUATION) flags |= SND_ATTENUATION;
+    if (timeofs > 0.0f) flags |= SND_OFFSET;
+
+    MSG_WriteByte(&sv.multicast, svc_sound);
+    MSG_WriteByte(&sv.multicast, flags);
+    MSG_WriteShort(&sv.multicast, sound_index);
+    if (flags & SND_VOLUME) MSG_WriteByte(&sv.multicast, (int)(volume * 255.0f));
+    if (flags & SND_ATTENUATION) MSG_WriteByte(&sv.multicast, (int)(attenuation * 64.0f));
+    if (flags & SND_OFFSET) MSG_WriteByte(&sv.multicast, (int)(timeofs * 1000.0f));
+    if (flags & SND_ENT) MSG_WriteShort(&sv.multicast, (int)((ent_num << 3) | (channel & 7)));
+    if (flags & SND_POS) MSG_WritePos(&sv.multicast, pos);
+
+    data = sv.multicast.data;
+    if (owner_only) {
+        LPCLIENT target = NULL;
+        FOR_LOOP(i, svs.num_clients)
+            if (svs.clients[i].state == cs_spawned && svs.clients[i].playernum == owner) {
+                target = &svs.clients[i];
+                break;
+            }
+        if (!target) {
+            fprintf(stderr, "SV_StartSound: owner %u unavailable for sound=%d\n", (unsigned)owner, sound_index);
+        } else {
+            SZ_Write(&target->netchan.message, data, sv.multicast.cursize);
+            if (reliable) Netchan_Transmit(NS_SERVER, &target->netchan);
+        }
+    } else {
+        FOR_LOOP(i, svs.num_clients)
+            if (svs.clients[i].state == cs_spawned) {
+                SZ_Write(&svs.clients[i].netchan.message, data, sv.multicast.cursize);
+                if (reliable) Netchan_Transmit(NS_SERVER, &svs.clients[i].netchan);
+            }
+    }
+    SZ_Clear(&sv.multicast);
+}

--- a/sound/s_local.h
+++ b/sound/s_local.h
@@ -80,6 +80,9 @@ typedef struct {
         float       leftvol;
         float       rightvol;
         VECTOR2     origin;
+        FLOAT       attenuation;
+        int         channel;
+        int         delay;
         BOOL        is_positional;
         BOOL        active;
     } channels[S_MAX_CHANNELS];
@@ -98,6 +101,8 @@ void S_EndRegistration(void);
 void S_RegisterSound(LPCSTR path);
 void S_PlaySoundFile(LPCSTR path);
 void S_PlaySoundAt(LPCSTR path, LPCVECTOR2 origin);
+void S_PlaySoundPacket(LPCSTR path, LPCVECTOR3 origin, BOOL positioned, int channel, FLOAT volume, FLOAT attenuation,
+                       FLOAT timeofs);
 void S_SetListener(LPCVECTOR2 origin, LPCVECTOR2 right);
 
 #endif

--- a/sound/s_sound.c
+++ b/sound/s_sound.c
@@ -349,6 +349,8 @@ static void S_SpatializeChannel(int ch) {
         ? 1.0f
         : (S_CUTOFF_DIST - dist) / (S_CUTOFF_DIST - S_FULL_DIST);
 
+    if (s.channels[ch].attenuation == 0.0f) att = 1.0f;
+    else if (s.channels[ch].attenuation > 1.0f) att = powf(att, s.channels[ch].attenuation);
     float dot = 0.0f;
     if (dist > 1.0f)
         dot = (dx / dist) * s.listener.right.x + (dy / dist) * s.listener.right.y;
@@ -374,8 +376,11 @@ static void SDLCALL S_MixAudio(void *userdata, Uint8 *stream, int len) {
         float       lvol = s.channels[ch].leftvol;
         float       rvol = s.channels[ch].rightvol;
         int         pos  = s.channels[ch].pos;
+        int         skip = MIN(frames, s.channels[ch].delay);
+        s.channels[ch].delay -= skip;
+        if (skip == frames) continue;
 
-        for (int i = 0; i < frames; i++) {
+        for (int i = skip; i < frames; i++) {
             if (pos >= sc->length) {
                 s.channels[ch].active = FALSE;
                 break;
@@ -435,7 +440,9 @@ void S_Shutdown(void) {
  * Playback helpers
  * ========================================================================= */
 
-static void S_StartSound(sfxcache_t *sc, float volume, LPCVECTOR2 origin, BOOL is_positional) {
+static void S_StartSound(sfxcache_t *sc, float volume, LPCVECTOR2 origin, BOOL is_positional, int channel,
+                         FLOAT attenuation, FLOAT timeofs) {
+    (void)timeofs;
     if (!sc) return;
     SDL_LockAudioDevice(s.device);
     for (int ch = 0; ch < S_MAX_CHANNELS; ch++) {
@@ -446,6 +453,9 @@ static void S_StartSound(sfxcache_t *sc, float volume, LPCVECTOR2 origin, BOOL i
             s.channels[ch].leftvol      = volume;
             s.channels[ch].rightvol     = volume;
             s.channels[ch].origin       = origin ? *origin : (VECTOR2){ 0.0f, 0.0f };
+            s.channels[ch].attenuation  = attenuation;
+            s.channels[ch].channel      = channel;
+            s.channels[ch].delay        = (int)(timeofs * 44100.0f);
             s.channels[ch].is_positional = is_positional;
             s.channels[ch].active       = TRUE;
             SDL_UnlockAudioDevice(s.device);
@@ -464,7 +474,7 @@ void S_PlaySound(DWORD kit_id) {
     sSoundKit_t *k = &s.kits[kit_id];
     if (k->id != kit_id) return;
     k->registration_sequence = s.registration_sequence;
-    S_StartSound(S_LoadKit(k), k->volume > 0.0f ? k->volume : 1.0f, NULL, FALSE);
+    S_StartSound(S_LoadKit(k), k->volume > 0.0f ? k->volume : 1.0f, NULL, FALSE, 0, DEFAULT_SOUND_PACKET_ATTENUATION, 0);
 }
 
 void S_PlaySoundByName(LPCSTR name) {
@@ -488,7 +498,7 @@ void S_PlaySoundFile(LPCSTR path) {
     sfx_t *sfx = S_FindSfx(path, TRUE);
     if (!sfx) return;
     sfx->registration_sequence = s.registration_sequence;
-    S_StartSound(S_LoadSfx(sfx), 1.0f, NULL, FALSE);
+    S_StartSound(S_LoadSfx(sfx), 1.0f, NULL, FALSE, 0, DEFAULT_SOUND_PACKET_ATTENUATION, 0);
 }
 
 /* Play a positional sound at a 2D world origin (distance attenuation + stereo pan). */
@@ -497,7 +507,18 @@ void S_PlaySoundAt(LPCSTR path, LPCVECTOR2 origin) {
     sfx_t *sfx = S_FindSfx(path, TRUE);
     if (!sfx) return;
     sfx->registration_sequence = s.registration_sequence;
-    S_StartSound(S_LoadSfx(sfx), 1.0f, origin, TRUE);
+    S_StartSound(S_LoadSfx(sfx), 1.0f, origin, TRUE, 0, DEFAULT_SOUND_PACKET_ATTENUATION, 0);
+}
+
+void S_PlaySoundPacket(LPCSTR path, LPCVECTOR3 origin, BOOL positioned, int channel, FLOAT volume,
+                       FLOAT attenuation, FLOAT timeofs) {
+    sfx_t *sfx;
+    if (!s.initialized || !path || !*path) return;
+    sfx = S_FindSfx(path, TRUE);
+    if (!sfx) return;
+    sfx->registration_sequence = s.registration_sequence;
+    S_StartSound(S_LoadSfx(sfx), volume, positioned ? &(VECTOR2){ origin->x, origin->y } : NULL, positioned,
+                 channel, attenuation, timeofs);
 }
 
 /* Update the listener position and right vector — call once per rendered frame. */

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -1287,12 +1287,11 @@ TEST(net, entity_delta_preserves_effect_model) {
     T_EQ(out.effect_flags, to.effect_flags);
 }
 
-/* Sound events must travel with the entity snapshot so the client can resolve
- * the server-assigned CS_SOUNDS index and fire the one-shot exactly once. */
-TEST(net, entity_delta_preserves_sound_event) {
+/* Other game entity events remain delta-compatible; WC3 sounds use svc_sound. */
+TEST(net, entity_delta_preserves_entity_event) {
     BYTE buf[256];
     sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
-    entityState_t from = { 0 }, to = { .number = 9, .event = EV_ACK, .sound = 37 }, out = { 0 };
+    entityState_t from = { 0 }, to = { .number = 9, .event = EV_MOVE, .sound = 37 }, out = { 0 };
     DWORD bits = 0;
     int number;
 
@@ -1302,7 +1301,7 @@ TEST(net, entity_delta_preserves_sound_event) {
     MSG_ReadDeltaEntity(&sb, &out, number, bits);
 
     T_EQ(number, 9);
-    T_EQ(out.event, EV_ACK);
+    T_EQ(out.event, EV_MOVE);
     T_EQ(out.sound, 37);
 }
 


### PR DESCRIPTION
## Summary
- replace the custom snd GameCommand transport with Quake 2-style svc_sound packets
- add gi.Sound and gi.PositionedSound with volume, attenuation, entity/origin, channel, offset, and owner-only routing
- migrate WC3 UI, acknowledgement, attack, death, and impact sounds; update documentation and tests

## Testing
- make build
- make test
- make test-wc3-engine WC3_PATTERN='wc3_api*' (ROC/TFT)
- make test-wc3-engine WC3_PATTERN='wc3_unit*' (ROC/TFT)