### PR TITLE
Groups in selections

### DIFF
--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -636,6 +636,30 @@ void SCR_LayoutUpdateBuildQueue(LPCUIFRAME frame, LPCRECT screen) {
 #define HP_BAR_HEIGHT_RATIO  0.175f
 #define HP_BAR_SPACING_RATIO 0.02f
 
+static DWORD SCR_LayoutMultiselectEntityAt(LPCUIFRAME frame, LPCVECTOR2 point) {
+    uiMultiselect_t const *ms;
+    DWORD count;
+
+    if (!frame || frame->flags.type != FT_MULTISELECT || !point ||
+        !frame->buffer.data || frame->buffer.size < sizeof(uiMultiselect_t)) {
+        return 0;
+    }
+    ms = frame->buffer.data;
+    if (!ms->numcolumns) return 0;
+    count = (frame->buffer.size - sizeof(uiMultiselect_t)) / sizeof(uiMultiselectItem_t);
+    count = MIN((DWORD)ms->numitems, count);
+    FOR_LOOP(i, count) {
+        RECT cell = *SCR_LayoutRect(frame);
+        DWORD column = i % ms->numcolumns;
+        DWORD row = i / ms->numcolumns;
+
+        cell.x += ms->offset.x * column;
+        cell.y += ms->offset.y * row;
+        if (Rect_contains(&cell, point)) return ms->items[i].entity;
+    }
+    return 0;
+}
+
 void SCR_LayoutDrawMultiSelect(LPCUIFRAME frame, LPCRECT scrn) {
     RECT screen = *scrn;
     uiMultiselect_t const *ms = frame->buffer.data;
@@ -1033,8 +1057,14 @@ void SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param) {
         SCR_LayoutPrepare(layout, NULL);
         for (DWORD i = SCR_NumFrames(); i > 0; i--) {
             LPCUIFRAME frame = SCR_Frame(i - 1);
-            if (!frame || !SCR_LayoutFrameHasClickCommand(frame)) continue;
-            if (Rect_contains(SCR_LayoutRect(frame), &point)) {
+            BOOL hit;
+
+            if (!frame) continue;
+            if (frame->flags.type == FT_MULTISELECT)
+                hit = SCR_LayoutMultiselectEntityAt(frame, &point) != 0;
+            else
+                hit = SCR_LayoutFrameHasClickCommand(frame) && Rect_contains(SCR_LayoutRect(frame), &point);
+            if (hit) {
                 layout_hovered_number = frame->number;
                 layout_hovered = layout;
                 break;
@@ -1056,7 +1086,18 @@ void SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param) {
         SCR_LayoutPrepare(layout, NULL);
         for (DWORD i = SCR_NumFrames(); i > 0; i--) {
             LPCUIFRAME frame = SCR_Frame(i - 1);
-            if (!frame || !SCR_LayoutFrameHasClickCommand(frame)) continue;
+
+            if (!frame) continue;
+            if (frame->flags.type == FT_MULTISELECT) {
+                DWORD entity = SCR_LayoutMultiselectEntityAt(frame, &point);
+                if (entity) {
+                    MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
+                    SZ_Printf(&cls.netchan.message, "focus %u", (unsigned)entity);
+                    return;
+                }
+                continue;
+            }
+            if (!SCR_LayoutFrameHasClickCommand(frame)) continue;
             if (Rect_contains(SCR_LayoutRect(frame), &point)) {
                 SCR_LayoutSendFrameCommand(frame);
                 return;
@@ -1188,6 +1229,10 @@ BOOL SCR_LayoutHitTest(int x, int y) {
             /* Persistent controls may intentionally sit over the world instead
              * of over a console texture. Any clickable server-authored frame
              * is gameplay UI and must suppress world selection underneath it. */
+            if (frame->flags.type == FT_MULTISELECT) {
+                if (SCR_LayoutMultiselectEntityAt(frame, &point)) return true;
+                continue;
+            }
             if (frame->flags.type != FT_TEXTURE && !SCR_LayoutFrameHasClickCommand(frame)) continue;
             if (Rect_contains(SCR_LayoutRect(frame), &point)) return true;
         }

--- a/docs/games/warcraft-3/inventory-and-items.md
+++ b/docs/games/warcraft-3/inventory-and-items.md
@@ -32,6 +32,15 @@ Its first data slot is Warcraft III field `inv1` (Item Capacity). `AB_Data`
 resolves the archive-version spelling (`Data11` in ROC, `DataA1` in TFT).
 Capacity is clamped to the six-slot OpenRealm storage/UI ceiling.
 
+Reign of Chaos heroes have one compatibility exception. Warsmash adds the
+stock `AInv` ability to a hero when the ROC map (`war3map.w3i` format version
+`<= 24`) does not already author an inventory-derived ability in the unit's
+normal ability list. OpenRealm mirrors that at capacity resolution time rather
+than mutating immutable unit metadata: an ROC hero with no authored inventory
+ability receives stock `AInv` capacity, while TFT-format maps do not get this
+fallback. An explicitly authored inventory-derived ability still wins, including
+the existing Backpack gating rules for stock non-hero inventory abilities.
+
 Consequently a normal hero inventory resolves to six slots, while a custom
 inventory ability may expose fewer slots. Pickup, explicit slot insertion,
 client item use/drop commands, JASS slot operations, and HUD enumeration all
@@ -42,6 +51,14 @@ respect the resolved capacity.
 A client right-click still produces the existing `smart <entity>` command.
 The server recognizes a world item before harvest, attack, or move handling and
 starts a pickup order for each selected inventory-capable unit.
+
+Smart target dispatch is per selected unit, not per primary subgroup. The
+server walks every controllable selected unit and asks its normal Smart resolver
+to accept the same item target. A Footman rejecting the item therefore does not
+veto a later selected Hero: the Hero's inventory capability starts the pickup
+order, while the Footman receives no replacement order. This is especially
+important for ROC campaign heroes whose implicit `AInv` fallback is not present
+in `UnitAbilities.slk`.
 
 The order keeps the item as its goal and checks it every simulation tick. It
 moves while the center-to-center distance is greater than
@@ -196,12 +213,15 @@ another engine's item implementation.
 ## Validation
 
 The `wc3_items.*` in-engine tests cover world-state initialization, data-driven
-capacity (including reduced, zero, and above-storage-limit cases),
+capacity (including reduced, zero, above-storage-limit, and implicit ROC Hero
+`AInv` cases),
 first-empty-slot insertion,
 full-inventory failure, pickup range and revalidation, drop identity, renderer
 visibility flags, carried-item removal, connection-state refresh gating, charge
 initialization/preservation, carried-charge refresh/no-op behavior, JASS charge
 access, and generic `spro` Art/Tip/Ubertip/charge presentation.
+They also cover mixed-selection Smart pickup where a non-inventory unit is the
+first selected entity and a later ROC Hero must still receive the item order.
 Minimal `AbilityData.slk`, `UnitAbilities.slk`, `ItemData.slk`, `ItemFunc.txt`,
 `ItemStrings.txt`, and `war3skins.txt` fixtures keep these tests data-driven in
 both ROC and TFT test runs. Inventory-panel tests additionally cover the

--- a/docs/games/warcraft-3/inventory-and-items.md
+++ b/docs/games/warcraft-3/inventory-and-items.md
@@ -85,8 +85,16 @@ shows its initial charge count of `1`. No HUD code checks for `spro`.
 ### Selected-unit inventory panel state
 
 Inventory visibility is capability-defined independently of hero presentation.
-For one selected unit, `LAYER_INVENTORY` resolves `G_InventoryCapacity` and
-authors one of three states:
+For any non-empty selection, `LAYER_INVENTORY` resolves the current focused unit
+through `G_GetMainSelectedUnit()` and authors that unit's inventory state. A
+multi-selection never merges inventories and does not search for the first unit
+that happens to have inventory capacity: focusing a Footman covers the inventory
+area, while focusing a Hero in the same still-selected group immediately authors
+that Hero's slots. `inventory <slot>` and `dropitem <slot>` already use the same
+focused-unit lookup, so the displayed inventory and the unit receiving the item
+action stay aligned.
+
+The focused unit authors one of three states:
 
 - capacity `0`: cover the underlying six-slot console area with the local
   player's race-skin `ConsoleInventoryCoverTexture`;

--- a/docs/games/warcraft-3/selection-and-control.md
+++ b/docs/games/warcraft-3/selection-and-control.md
@@ -26,6 +26,41 @@ Persistent Hero and idle-worker HUD shortcuts reuse this authority boundary but 
 
 Targeted ability callbacks (`menu.on_entity_selected`) are a separate path: a left click completes the pending target action instead of replacing the unit selection.
 
+## Focused Unit In A Multi-Selection
+
+Selection membership and focused-unit presentation are separate state. The server
+retains one focused entity from the current selection; `G_GetMainSelectedUnit()`
+returns that entity while it remains selected, then falls back to the first live
+selected entity if the focus becomes invalid. `G_SelectEntity()` establishes the
+first unit as focus for a new selection, while `G_FocusSelectedUnit()` changes
+focus without changing any selection bits. Focus is transient UI/input state and
+is reset when map-player state is initialized rather than being added to the save
+format.
+
+`FT_MULTISELECT` is one packed frame, but each payload item already carries its
+entity number. `client/cl_scrn.c` therefore hit-tests the authored icon grid using
+the frame rectangle plus `uiMultiselect_t.offset`, sends `focus <entity>` on a
+left-button release over an icon, and treats every icon as gameplay UI so a click
+does not leak through to world selection. The server validates that the entity is
+still selected before accepting the focus change.
+
+When an entity-target command is active, the same multiselect-icon click is routed
+to `menu.on_entity_selected` instead of changing focus. This preserves the
+Warsmash behavior where a selected-unit portrait can be used as the target of the
+active command. Point-only target modes do not change selection focus from such a
+click.
+
+Focused-unit consumers include the command card, inventory use/drop commands and
+order-response selection. The complete selection remains authoritative for
+multi-unit Smart/Move/Attack-style orders. Inventory presentation follows the
+same focused-unit rule; see [Inventory And World Items](inventory-and-items.md).
+
+OpenRealm still does not reproduce Warsmash's type-wide
+`SelectedSubgroupHighlight`, focused/unfocused icon scaling, keyboard subgroup
+cycling, or the Warsmash behavior where clicking the already-focused exact icon
+collapses the group to that one unit. Those are presentation/navigation gaps, not
+reasons to merge inventory state across the group.
+
 ## Relationship Presentation
 
 `G_CustomizeEntity` converts `G_SelectionRelation` to recipient-relative entity flags:

--- a/docs/games/warcraft-3/selection-and-control.md
+++ b/docs/games/warcraft-3/selection-and-control.md
@@ -85,6 +85,15 @@ FOR_CONTROLLABLE_SELECTED_UNITS(client, ent)
 
 The controllable filter is used by Smart/SmartPoint, Move, Attack/Attack-move, Stop, Hold Position, Patrol, Repair, Harvest/Return Resources, and Rally target callbacks. `CMD_Button`, `CMD_Research`, inventory use/drop, cancellation, training, and Rally command entry also validate the focused unit before acting.
 
+Entity Smart orders are resolved independently for every controllable selected
+unit. One unit rejecting a target must not abort the loop. For example, when a
+Footman and a Hero are selected and the player right-clicks a world item, the
+Footman may reject that widget while the Hero's inventory accepts it and starts
+pickup. The first/primary selected entity is used for focused HUD/response
+presentation, not as a capability gate for the rest of the selection. See
+[Inventory And World Items](inventory-and-items.md) for the ROC Hero `AInv`
+fallback and item lifecycle.
+
 `Get_Commands_f` clears the command card for a selected unit that the local player cannot control. A foreign building may still use the ordinary inspection panel, but its production queue is not serialized to the viewer. Shared-control units retain command-card access.
 
 Selection acknowledgement voices are queued only for controllable selections. Ordinary non-Neutral-Passive foreign selections use the `InterfaceClick` UI sound instead of playing the selected unit's authored `What` response. Neutral Passive critter-specific response rules remain unresolved, so that owner class is not forced through the generic click path.
@@ -117,7 +126,7 @@ Do not bypass these gaps by weakening `G_UnitCanControl` or by restoring owner c
 
 ## Verification
 
-In-engine coverage is in `games/warcraft-3/game/tests/t_api.c` and `t_unit.c` for relationship classification, visible foreign selectability, shared-control authority, dead-unit non-selectability, selection removal, and Hero revival restoring selectability.
+In-engine coverage is in `games/warcraft-3/game/tests/t_api.c` and `t_unit.c` for relationship classification, visible foreign selectability, shared-control authority, dead-unit non-selectability, selection removal, and Hero revival restoring selectability. `t_items.c` additionally covers mixed-selection Smart item pickup with a non-inventory unit first in the selection.
 
 Useful targeted commands after building the test binary:
 

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -3,18 +3,56 @@
 #define CLIENTCOMMAND(NAME) void CMD_##NAME(LPEDICT clent, DWORD argc, LPCSTR argv[])
 #define WC3_SELECTION_LIMIT 12
 
+/* Focus is presentation/input state within an existing selection, not a saved
+ * gameplay relationship. Keep it out of GAMECLIENT so save compatibility does
+ * not depend on which multiselect subgroup happened to own the HUD. */
+static DWORD selection_focus[MAX_CLIENTS];
+
+static DWORD *G_SelectionFocusSlot(LPGAMECLIENT client) {
+    LONG index;
+
+    if (!client || !game.clients) return NULL;
+    index = (LONG)(client - game.clients);
+    if (index < 0 || index >= MAX_CLIENTS) return NULL;
+    return &selection_focus[index];
+}
+
 static BOOL G_TargetModeActive(LPGAMECLIENT client) {
     return client && (client->menu.on_entity_selected || client->menu.on_location_selected);
 }
 
 LPEDICT G_GetMainSelectedUnit(LPGAMECLIENT client) {
+    DWORD *focus = G_SelectionFocusSlot(client);
+
+    if (focus && *focus > 0 && *focus < globals.num_edicts) {
+        LPEDICT ent = &globals.edicts[*focus];
+        if (G_IsEntitySelected(client, ent)) return ent;
+    }
     FOR_SELECTED_UNITS(client, ent) {
+        if (focus) *focus = ent->s.number;
         return ent;
     }
+    if (focus) *focus = 0;
     return NULL;
 }
 
+BOOL G_FocusSelectedUnit(LPGAMECLIENT client, LPEDICT ent) {
+    DWORD *focus = G_SelectionFocusSlot(client);
+
+    if (!focus || !G_IsEntitySelected(client, ent)) return false;
+    *focus = ent->s.number;
+    return true;
+}
+
+void G_ResetSelectionFocus(LPGAMECLIENT client) {
+    DWORD *focus = G_SelectionFocusSlot(client);
+    if (focus) *focus = 0;
+}
+
 LPEDICT G_GetMainControllableUnit(LPGAMECLIENT client) {
+    LPEDICT main = G_GetMainSelectedUnit(client);
+
+    if (main && G_UnitCanControl(client, main)) return main;
     FOR_CONTROLLABLE_SELECTED_UNITS(client, ent) {
         return ent;
     }
@@ -22,14 +60,27 @@ LPEDICT G_GetMainControllableUnit(LPGAMECLIENT client) {
 }
 
 void G_SelectEntity(LPGAMECLIENT client, LPEDICT ent) {
+    BOOL had_selection = false;
+
     /* Corpses remain networked while their death/decay presentation runs, but
      * they are no longer valid gameplay selection targets. */
     if (!client || !ent || !ent->inuse) return;
     if (M_IsDead(ent) || (ent->s.flags & EF_NOT_SELECTABLE)) return;
+    FOR_SELECTED_UNITS(client, selected) {
+        (void)selected;
+        had_selection = true;
+        break;
+    }
     ent->selected |= 1 << client->ps.number;
+    if (!had_selection) G_FocusSelectedUnit(client, ent);
 }
 
 void G_DeselectEntity(LPGAMECLIENT client, LPEDICT ent) {
+    DWORD *focus;
+
+    if (!client || !ent) return;
+    focus = G_SelectionFocusSlot(client);
+    if (focus && *focus == ent->s.number) *focus = 0;
     ent->selected &= ~(1 << client->ps.number);
 }
 
@@ -272,6 +323,35 @@ void G_SendPointConfirmation(LPEDICT clent, LPCVECTOR2 point, BOOL attack) {
     gi.Write(PF_BYTE, &(LONG){ attack ? TE_ATTACK_CONFIRMATION : TE_MOVE_CONFIRMATION });
     gi.Write(PF_POSITION, &(VECTOR3){ point->x, point->y, 0 });
     gi.unicast(clent);
+}
+
+CLIENTCOMMAND(Focus) {
+    LPGAMECLIENT client = clent ? clent->client : NULL;
+    DWORD number;
+    LPEDICT target;
+
+    if (!client || argc < 2) return;
+    number = (DWORD)atoi(argv[1]);
+    if (number >= globals.num_edicts) return;
+    target = &globals.edicts[number];
+    if (!G_IsEntitySelected(client, target)) return;
+
+    /* Warsmash treats a multiselect portrait as the clicked unit while an
+     * entity-target command is active. Do not silently change subgroup focus
+     * instead of completing/cancelling that target interaction. */
+    if (G_TargetModeActive(client)) {
+        if (client->menu.on_entity_selected &&
+            client->menu.on_entity_selected(clent, target)) {
+            Get_Commands_f(clent);
+        }
+        return;
+    }
+    if (!G_FocusSelectedUnit(client, target)) return;
+
+    /* Selection membership is unchanged. Only focused-unit presentation and
+     * focused-unit commands need to be rebuilt. */
+    G_RefreshInventoryLayer(clent);
+    Get_Commands_f(clent);
 }
 
 CLIENTCOMMAND(Point) {
@@ -723,6 +803,7 @@ clientCommand_t clientCommands[] = {
     { "inventory", CMD_Inventory },
     { "dropitem", CMD_DropItem },
     { "select", CMD_Select },
+    { "focus", CMD_Focus },
     { "herobutton", CMD_HeroButton },
     { "herokey", CMD_HeroKey },
     { "idleworker", CMD_IdleWorker },

--- a/games/warcraft-3/game/g_items.c
+++ b/games/warcraft-3/game/g_items.c
@@ -145,23 +145,42 @@ static BOOL G_InventoryAbilityAvailable(LPCEDICT unit, LPCSTR ability) {
     return G_GetPlayerTechResearchedLevel(owner, required_upgrade) > 0;
 }
 
+static DWORD G_InventoryAbilityCapacity(LPCEDICT unit, LPCSTR ability) {
+    LONG capacity;
+
+    if (!unit || !ability || strlen(ability) != 4) return 0;
+    capacity = (LONG)AB_Data(ability, 1, 1); /* inv1 / Item Capacity */
+    if (capacity <= 0) {
+        fprintf(stderr, "G_InventoryCapacity: %.4s inventory ability %.4s has invalid inv1=%ld\n",
+                (char *)&unit->class_id, ability, (long)capacity);
+        return 0;
+    }
+    return (DWORD)MIN(capacity, MAX_INVENTORY);
+}
+
 DWORD G_InventoryCapacity(LPCEDICT unit) {
-    LPCSTR abilities;
+    LPCSTR abilities = NULL;
+    BOOL has_inventory_ability = false;
 
-    if (!unit || !unit->inuse || !unit->UnitAbilities || !(abilities = unit->UnitAbilities->abilList)) return 0;
-    PARSE_LIST(abilities, abil, parse_segment) {
-        LONG capacity;
-
-        /* Typed AbilityData resolves custom inventory abilities without returning to the removed sheet cache. */
-        if (G_AbilityCodeName(abil) != MAKEFOURCC('A','I','n','v')) continue;
-        if (!G_InventoryAbilityAvailable(unit, abil)) continue;
-        capacity = (LONG)AB_Data(abil, 1, 1); /* inv1 / Item Capacity */
-        if (capacity <= 0) {
-            fprintf(stderr, "G_InventoryCapacity: %.4s inventory ability %.4s has invalid inv1=%ld\n",
-                    (char *)&unit->class_id, abil, (long)capacity);
-            return 0;
+    if (!unit || !unit->inuse) return 0;
+    if (unit->UnitAbilities) abilities = unit->UnitAbilities->abilList;
+    if (abilities) {
+        PARSE_LIST(abilities, abil, parse_segment) {
+            /* Typed AbilityData resolves custom inventory abilities without returning to the removed sheet cache. */
+            if (G_AbilityCodeName(abil) != MAKEFOURCC('A','I','n','v')) continue;
+            has_inventory_ability = true;
+            if (!G_InventoryAbilityAvailable(unit, abil)) continue;
+            return G_InventoryAbilityCapacity(unit, abil);
         }
-        return (DWORD)MIN(capacity, MAX_INVENTORY);
+    }
+
+    /* Warsmash restores the classic ROC hero contract by adding the stock
+     * AInv ability when a hero has no inventory ability authored in its normal
+     * ability list.  ROC map formats are <= 24; TFT/custom data may intentionally
+     * omit inventory, so do not synthesize AInv there. */
+    if (!has_inventory_ability && level.mapinfo && level.mapinfo->fileFormat > 0 &&
+        level.mapinfo->fileFormat <= 24 && G_UnitIsHero(unit)) {
+        return G_InventoryAbilityCapacity(unit, "AInv");
     }
     return 0;
 }

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -1519,6 +1519,8 @@ extern BYTE g_numTreeFallSounds;
 void G_SelectEntity(LPGAMECLIENT, LPEDICT);
 void G_DeselectEntity(LPGAMECLIENT, LPEDICT);
 BOOL G_IsEntitySelected(LPGAMECLIENT, LPEDICT);
+BOOL G_FocusSelectedUnit(LPGAMECLIENT, LPEDICT);
+void G_ResetSelectionFocus(LPGAMECLIENT);
 BOOL G_UnitCanBeSelected(LPGAMECLIENT, LPCEDICT);
 BOOL G_UnitCanControl(LPGAMECLIENT, LPCEDICT);
 selectionRelation_t G_SelectionRelation(DWORD viewer, LPCEDICT ent);

--- a/games/warcraft-3/game/g_spawn.c
+++ b/games/warcraft-3/game/g_spawn.c
@@ -319,6 +319,7 @@ static void G_InitMapPlayer(LPEDICT clent, LPCMAPINFO mapinfo, DWORD playernum) 
     LPCMAPPLAYER player = mapinfo ? mapinfo->players + playernum : NULL;
     LPPLAYER ps = &clent->client->ps;
     G_SetClientConnected(clent, false);
+    G_ResetSelectionFocus(clent->client);
     clent->client->commands_dirty = false;
     memset(&clent->client->jass, 0, sizeof(clent->client->jass));
     memset(clent->client->tech, 0, sizeof(clent->client->tech));

--- a/games/warcraft-3/game/hud/hud_infopanel.c
+++ b/games/warcraft-3/game/hud/hud_infopanel.c
@@ -1018,8 +1018,11 @@ static void WriteInventory(LPEDICT player, LPEDICT ent) {
 }
 
 static void UI_SendInventoryLayer(LPEDICT ent, LPEDICT *selected, DWORD count) {
+    LPEDICT focused = count > 0 && ent && ent->client ? G_GetMainSelectedUnit(ent->client) : NULL;
+
+    (void)selected;
     UI_WriteStart(LAYER_INVENTORY);
-    if (count == 1) WriteInventory(ent, selected[0]);
+    if (focused) WriteInventory(ent, focused);
     UI_WriteEnd(ent);
 }
 

--- a/games/warcraft-3/game/tests/t_api.c
+++ b/games/warcraft-3/game/tests/t_api.c
@@ -845,6 +845,30 @@ TEST(wc3_api, selection_accepts_visible_foreign_unit_but_rejects_invalid_states)
     T_ASSERT(!G_UnitCanBeSelected(client, &ent));
 }
 
+TEST(wc3_api, multiselect_focus_tracks_one_selected_unit_and_falls_back_when_removed) {
+    LPGAMECLIENT client = &game.clients[0];
+    LPEDICT first = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0, 0);
+    LPEDICT second = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 32, 0);
+
+    client->ps.number = 0;
+    first->s.player = second->s.player = 0;
+    first->svflags |= SVF_MONSTER;
+    second->svflags |= SVF_MONSTER;
+    G_ResetSelectionFocus(client);
+
+    G_SelectEntity(client, first);
+    G_SelectEntity(client, second);
+    T_ASSERT(G_GetMainSelectedUnit(client) == first);
+    T_ASSERT(G_FocusSelectedUnit(client, second));
+    T_ASSERT(G_GetMainSelectedUnit(client) == second);
+    T_ASSERT(G_IsEntitySelected(client, first));
+    T_ASSERT(G_IsEntitySelected(client, second));
+
+    G_DeselectEntity(client, second);
+    T_ASSERT(G_GetMainSelectedUnit(client) == first);
+    T_ASSERT(!G_FocusSelectedUnit(client, second));
+}
+
 TEST(wc3_api, selection_revalidation_clears_hidden_raw_selection_bit) {
     LPGAMECLIENT client = &game.clients[0];
     LPEDICT ent = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);

--- a/games/warcraft-3/game/tests/t_items.c
+++ b/games/warcraft-3/game/tests/t_items.c
@@ -146,7 +146,7 @@ TEST(wc3_items, roc_hero_without_authored_inventory_gets_default_ainv_capacity) 
     LPEDICT hero;
 
     setup_test_world();
-    level.mapinfo->fileFormat = 24;
+    ((LPMAPINFO)level.mapinfo)->fileFormat = 24;
     hero = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 0, 0);
     hero->UnitAbilities = &no_inventory;
 
@@ -159,7 +159,7 @@ TEST(wc3_items, tft_hero_without_authored_inventory_does_not_get_roc_default) {
     LPEDICT hero;
 
     setup_test_world();
-    level.mapinfo->fileFormat = 25;
+    ((LPMAPINFO)level.mapinfo)->fileFormat = 25;
     hero = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 0, 0);
     hero->UnitAbilities = &no_inventory;
 
@@ -646,7 +646,7 @@ TEST(wc3_items, mixed_selection_smart_item_orders_roc_hero_even_when_nonhero_is_
     LPCSTR command[] = { "smart", item_number };
 
     setup_test_world();
-    level.mapinfo->fileFormat = 24;
+    ((LPMAPINFO)level.mapinfo)->fileFormat = 24;
     clent = &g_edicts[0];
     client = clent->client;
     gi.Write = item_noop_write;

--- a/games/warcraft-3/game/tests/t_items.c
+++ b/games/warcraft-3/game/tests/t_items.c
@@ -422,6 +422,47 @@ TEST(wc3_items, inventory_panel_leaves_all_slots_visible_at_full_capacity) {
     T_EQ(G_InventoryCapacity(unit), MAX_INVENTORY); T_EQ(inventory_panel_image_count, 0);
 }
 
+TEST(wc3_items, multiselect_inventory_panel_follows_focused_selected_unit) {
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(LPEDICT) = gi.unicast;
+    int (*old_image_index)(LPCSTR) = gi.ImageIndex;
+    LPEDICT player, peasant, inventory_unit;
+    LPGAMECLIENT client;
+
+    setup_test_world();
+    player = &g_edicts[0]; client = player->client;
+    peasant = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    inventory_unit = alloc_test_unit(MAKEFOURCC('H','0','0','1'), 32, 0);
+    client->ps.race = kPlayerRaceHuman;
+    G_ResetSelectionFocus(client);
+    G_SelectEntity(client, peasant);
+    G_SelectEntity(client, inventory_unit);
+
+    T_ASSERT(G_GetMainSelectedUnit(client) == peasant);
+    T_ASSERT(G_IsEntitySelected(client, peasant));
+    T_ASSERT(G_IsEntitySelected(client, inventory_unit));
+
+    reset_inventory_panel_capture();
+    gi.Write = capture_inventory_refresh_write; gi.unicast = capture_inventory_refresh_unicast;
+    gi.ImageIndex = capture_inventory_panel_image; G_RefreshInventoryLayer(player);
+    gi.Write = old_write; gi.unicast = old_unicast; gi.ImageIndex = old_image_index;
+    T_EQ(inventory_panel_image_count, 1);
+    T_STREQ(inventory_panel_images[0], "TestUI\\Textures\\human-inventory-cover.blp");
+
+    T_ASSERT(G_FocusSelectedUnit(client, inventory_unit));
+    T_ASSERT(G_GetMainSelectedUnit(client) == inventory_unit);
+    T_ASSERT(G_IsEntitySelected(client, peasant));
+    T_ASSERT(G_IsEntitySelected(client, inventory_unit));
+
+    reset_inventory_panel_capture();
+    gi.Write = capture_inventory_refresh_write; gi.unicast = capture_inventory_refresh_unicast;
+    gi.ImageIndex = capture_inventory_panel_image; G_RefreshInventoryLayer(player);
+    gi.Write = old_write; gi.unicast = old_unicast; gi.ImageIndex = old_image_index;
+    T_EQ(inventory_panel_image_count, 4);
+    FOR_LOOP(i, 4)
+        T_STREQ(inventory_panel_images[i], "TestUI\\Textures\\human-inventory-no-capacity.blp");
+}
+
 TEST(wc3_items, inventory_ui_resolves_scroll_metadata_and_charge) {
     gameInventoryItem_t items[MAX_INVENTORY];
     LPEDICT unit;

--- a/games/warcraft-3/game/tests/t_items.c
+++ b/games/warcraft-3/game/tests/t_items.c
@@ -20,6 +20,15 @@ static DWORD inventory_panel_image_count;
 static uiFrame_t inventory_panel_frame;
 static BOOL inventory_panel_frame_seen;
 
+static void item_noop_write(pfWriteType_t type, void const *value) {
+    (void)type;
+    (void)value;
+}
+
+static void item_noop_unicast(LPEDICT ent) {
+    (void)ent;
+}
+
 static int capture_inventory_panel_image(LPCSTR name) {
     DWORD index = inventory_panel_image_count;
     if (index < sizeof(inventory_panel_images) / sizeof(inventory_panel_images[0]))
@@ -130,6 +139,32 @@ TEST(wc3_items, inventory_capacity_comes_from_inventory_ability_data) {
     T_EQ(G_InventoryCapacity(standard), 6);
     T_EQ(G_InventoryCapacity(small), 2);
     T_EQ(G_InventoryCapacity(none), 0);
+}
+
+TEST(wc3_items, roc_hero_without_authored_inventory_gets_default_ainv_capacity) {
+    UnitAbilities_t no_inventory = { .abilList = "", .heroAbilList = "AHhb" };
+    LPEDICT hero;
+
+    setup_test_world();
+    level.mapinfo->fileFormat = 24;
+    hero = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 0, 0);
+    hero->UnitAbilities = &no_inventory;
+
+    T_ASSERT(G_UnitIsHero(hero));
+    T_EQ(G_InventoryCapacity(hero), 6);
+}
+
+TEST(wc3_items, tft_hero_without_authored_inventory_does_not_get_roc_default) {
+    UnitAbilities_t no_inventory = { .abilList = "", .heroAbilList = "AHhb" };
+    LPEDICT hero;
+
+    setup_test_world();
+    level.mapinfo->fileFormat = 25;
+    hero = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 0, 0);
+    hero->UnitAbilities = &no_inventory;
+
+    T_ASSERT(G_UnitIsHero(hero));
+    T_EQ(G_InventoryCapacity(hero), 0);
 }
 
 TEST(wc3_items, inventory_capacity_rejects_zero_and_clamps_above_storage_limit) {
@@ -596,6 +631,53 @@ TEST(wc3_items, pickup_order_waits_for_simulation_tick) {
     T_ASSERT(unit->inventory[0] == item);
     T_ASSERT(!item->item.in_world);
     T_NULL(unit->goalentity);
+}
+
+TEST(wc3_items, mixed_selection_smart_item_orders_roc_hero_even_when_nonhero_is_first) {
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(LPEDICT) = gi.unicast;
+    UnitAbilities_t no_inventory = { .abilList = "", .heroAbilList = "AHhb" };
+    LPEDICT clent;
+    LPGAMECLIENT client;
+    LPEDICT footman;
+    LPEDICT hero;
+    LPEDICT item;
+    char item_number[16];
+    LPCSTR command[] = { "smart", item_number };
+
+    setup_test_world();
+    level.mapinfo->fileFormat = 24;
+    clent = &g_edicts[0];
+    client = clent->client;
+    gi.Write = item_noop_write;
+    gi.unicast = item_noop_unicast;
+
+    /* Allocate the ordinary unit first so it is also the server's primary
+     * selected unit. Smart target dispatch must still reach the later hero. */
+    footman = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0, 0);
+    hero = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 32, 0);
+    item = make_item_test_world_item(MAKEFOURCC('r','a','t','f'), 96, 0);
+    footman->s.player = hero->s.player = client->ps.number;
+    footman->svflags |= SVF_MONSTER;
+    hero->svflags |= SVF_MONSTER;
+    hero->UnitAbilities = &no_inventory;
+    footman->stand = unit_stand;
+    hero->stand = unit_stand;
+    unit_stand(footman);
+    unit_stand(hero);
+    G_SelectEntity(client, footman);
+    G_SelectEntity(client, hero);
+    snprintf(item_number, sizeof(item_number), "%u", (unsigned)item->s.number);
+
+    G_ClientCommand(clent, 2, command);
+
+    T_NULL(footman->goalentity);
+    T_ASSERT(hero->goalentity == item);
+    T_NOT_NULL(hero->currentmove);
+    T_STREQ(hero->currentmove->animation, "walk");
+
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
 }
 
 TEST(wc3_items, pickup_order_moves_and_revalidates_item) {


### PR DESCRIPTION
when you have lots of units selected 

in the status panel you can click sub groups 

also changes hero inventory content based on this 

and in a group of units a hero is the only one that gets the command to collect a loot chest 

matches retail behaviour 

still needs the subgroup selection glow graphics 