### PR TITLE
wc3: serialize JASS VM state in savegames

### DIFF
--- a/docs/games/warcraft-3/save-load.md
+++ b/docs/games/warcraft-3/save-load.md
@@ -6,16 +6,37 @@ The WC3 game module owns save/load. `GetGameAPI()` exposes `SaveGame` and `LoadG
 
 `WriteGame()` writes the current game state to a versioned binary file. The file contains:
 
-- `W3SV` magic, format version, `sizeof(edict_t)`, entity count, and client count;
+- `W3SV` magic, format version 6, `sizeof(edict_t)`, entity count, client count, script identity, and native-handle registry counts;
 - level frame/time and started/script-started flags;
 - each client `GAMECLIENT` state, including its `PLAYER` state, JASS settings, researched tech, text storage, camera values, messages, and HUD caches;
 - each camera target as an entity index;
 - the quest and quest-item graph's strings and status flags;
-- one used flag per entity slot and a raw `edict_t` block for used slots.
+- one used flag per entity slot and a raw `edict_t` block for used slots;
+- group membership, trigger enabled state, timer state, unread gameplay events, and a semantic JASS VM snapshot;
+- a `W3OK` commit footer and FNV-1a checksum over the complete preceding payload.
+
+`WriteGame()` removes the destination when any record or footer write fails. `ReadGame()` validates the commit footer, checksum, format, script identity, and quest/group/trigger/timer/event registry counts before mutating clients or entities. A truncated or rejected partial write therefore cannot become a loadable artifact or clear the live world.
 
 The current format is process-independent for entity relationships: `F_EDICT` fields and camera targets are written as entity indexes and resolved back to `g_edicts[index]` by `ReadGame()`. Client pointers are restored from player slots, player names from inline JASS name storage, and map-player rows from the loaded map plus `PLAYER.number`. Malformed headers, truncated records, and entity indexes reject the load; client pointers are never read from the file as addresses.
 
 Quest objects and items are restored in place so the running JASS VM's light handles keep their object identity. Loading rejects a quest or item count mismatch instead of leaving those handles dangling. This supports the normal `+map ... +loadgame ...` path, where map initialization recreates the same quest graph before applying saved state.
+
+Groups, triggers, timers, and events use deterministic creation ordinals. Group membership is stored as entity indexes. Trigger enabled state is restored in place. Timers preserve their handler name, duration, remaining time, periodic/paused/running flags, and resume relative to the load time. Timer callbacks and timer-expire trigger actions enter the normal coroutine queue and retain `GetExpiredTimer()` context.
+
+The unread portion of the bounded gameplay event ring preserves event type, subject/source entity indexes, and the target registration ordinal. Consumed queue entries are not saved. Loads reject queue overflow and unresolved entity or registration IDs.
+
+## JASS Snapshot
+
+The embedded snapshot starts with `JSVM`, snapshot format version 1, a program-identity hash, mutable-global count, and sleeping-coroutine count. It stores:
+
+- mutable scalar globals and sparse array entries;
+- integer, real, boolean, string, code, null, and supported typed-handle values;
+- shared-handle identity by stable native-domain ID;
+- sleeping coroutine frames as function/block token ordinals, locals, operand stack values, wake delay, and event context.
+
+The snapshot never writes parser pointers, dictionary links, refcount addresses, stack pointers, or `jmp_buf`. Code values and coroutine PCs resolve against the already-parsed program after the identity hash matches. Handles relocate through game-owned codecs for entities (`unit`, `widget`, `destructable`, `item`, `effect`), players, quests, quest items, events, triggers, groups, and timers. Unsupported non-null handle types reject the save with a diagnostic instead of writing an address or silently dropping the value.
+
+Saving is allowed only at a VM safe point. `jass_writesnapshot()` rejects a request while a synchronous JASS call or coroutine is actively executing. Yielded `TriggerSleepAction` coroutines are safe and resume from their saved semantic PC after load.
 
 ## Field Table
 
@@ -24,7 +45,7 @@ Quest objects and items are restored in place so the running JASS VM's light han
 `EDICTFIELD(x, type)` describes one scalar field with `array_size == 0`. `EDICTFIELD(x, type, count)` describes a contiguous array from the base offset; the serializer walks `count` elements using the field type's element size. For example, the six inventory pointers use `EDICTFIELD(inventory, F_EDICT, MAX_INVENTORY)` rather than six duplicate descriptors.
 
 - Add every persistent `edict_t` entity pointer to `fields[]` as `F_EDICT`, including array elements and nested fields.
-- Do not add process-owned pointers such as path textures, metadata rows, animations, movement callbacks, or function pointers. `WriteEdict()` clears those pointers and `ReadEdict()` rebinds class metadata; spatial links are rebuilt with `gi.LinkEntity`.
+- Do not add process-owned pointers such as path textures, metadata rows, animations, movement callbacks, or function pointers. `WriteEdict()` clears those pointers and `ReadEdict()` rebinds class metadata plus class-owned unit/destructable lifecycle callbacks; spatial links are rebuilt with `gi.LinkEntity`.
 - When adding a new pointer or changing an existing edict field, update the table and the round-trip test together. A raw pointer omitted from the table can write an address into the save file.
 - Keep the table sentinel `{ NULL, 0, 0, 0 }`; all serializer loops stop at `field->name == NULL`.
 
@@ -39,11 +60,11 @@ call SaveGame("chapter-01.w3save")
 call LoadGame("chapter-01.w3save", false)
 ```
 
-`LoadGame` currently restores the loaded state in the already-loaded map; map selection and UI score-screen behavior remain separate work.
+`LoadGame` restores state in the already-loaded map; map selection and UI score-screen behavior remain separate work. The initialized map must have the same JASS program and deterministically recreated native registries.
 
-Unlike Quake 2's separate `WriteLevel()` path, this WC3 format does not yet snapshot the JASS VM, fog grids, bot runtime, events, messages, alliances, stock state, or cinematic filter. Menu callbacks are code pointers and are reset on load; restoring an active targeting/build submenu requires a semantic menu-state enum rather than raw function addresses.
+The format does not yet snapshot fog grids, bot runtime, mutable event-registration fields, alliances, stock state, or cinematic filter. Client message storage is part of `GAMECLIENT`, but transient presentation lifetimes are not reconstructed. Unit/destructable lifecycle callbacks are restored from class data, preventing resumed orders from calling stale or null process addresses; arbitrary active `umove_t` actions are not yet restored and require stable semantic move IDs. Menu callbacks are code pointers and are reset on load; restoring an active targeting/build submenu likewise requires a semantic menu-state enum rather than raw function addresses.
 
-The JASS VM cannot be dumped as a raw block. `jass_s` owns linked dictionaries, heap values and refcounts, parser tokens, coroutine frames, stack pointers, `jmp_buf` state, and native light handles that point into game objects. A VM save requires a structured serializer for globals, arrays, coroutines, and typed native handles, followed by pointer reconstruction against loaded entities, players, quests, timers, triggers, and other handle classes.
+The checksum and header preflight protect normal partial/corrupt-file and wrong-map failures before mutation. Record-level semantic validation later in the stream is not fully transactional; do not treat save files as untrusted input until native records are decoded into temporary state before commit.
 
 ## Console Usage
 
@@ -53,7 +74,7 @@ The server registers Quake 2-style `savegame` and `loadgame` commands. Save name
 build/bin/openwarcraft3 -data "data/Warcraft III" +map "Maps/(2)Rivercross.w3m" +loadgame chapter-01.w3save
 ```
 
-The shipped WC3 config binds `F9` to `savegame quick`. The load command must run after `+map`, because loading restores state into the already-loaded map.
+The shipped WC3 config binds `F9` to `savegame quick`. The load command must run after `+map`, because loading restores state into the already-loaded map. For command-line save diagnostics, place `+wait` between the map and `+savegame` commands so map initialization and `main()` have created the authoritative native registries first.
 
 ## Verification
 
@@ -63,4 +84,4 @@ Run the serializer round trip against both ROC and TFT test environments:
 make test-wc3-engine WC3_PATTERN='wc3_save.*'
 ```
 
-The test checks representative integer, float, vector, scalar and array entity fields, level timing flags, player resources and names, camera state and target fixups, quest strings and flags, quest-item state, and mutable `GAMECLIENT` state. It also verifies restoration of player client/map bindings and stable quest object identities. ROC and TFT are both executed by the target.
+The tests cover entity/client fields and pointer fixups, quests, mutable globals and sparse arrays, code values, handle aliases, group membership, trigger state, paused/periodic timers, direct and trigger timer callbacks, `GetExpiredTimer`, sleeping-coroutine resume, checksum rejection, script mismatch, and native-registry mismatch. Corruption and preflight tests assert that rejection leaves representative live entity state unchanged. ROC and TFT are both executed by the target.

--- a/games/warcraft-3/game/api/api_group.h
+++ b/games/warcraft-3/game/api/api_group.h
@@ -9,7 +9,7 @@ BOOL group_add_entity(ggroup_t *group, LPEDICT ent) {
 
 DWORD CreateGroup(LPJASS j) {
     API_ALLOC(ggroup_t, group);
-    (void)group;
+    if (!G_RegisterJassGroup(group)) jass_rterror(j, "CreateGroup: group registry is full");
     return 1;
 }
 DWORD DestroyGroup(LPJASS j) {

--- a/games/warcraft-3/game/api/api_misc.h
+++ b/games/warcraft-3/game/api/api_misc.h
@@ -310,41 +310,43 @@ DWORD GetStartLocationLoc(LPJASS j) {
 }
 
 DWORD CreateTimer(LPJASS j) {
-    return jass_pushnullhandle(j, "timer");
+    API_ALLOC(GTIMER, timer);
+    if (!G_RegisterJassTimer(timer)) jass_rterror(j, "CreateTimer: timer registry is full");
+    return 1;
 }
 DWORD DestroyTimer(LPJASS j) {
-    //HANDLE whichTimer = jass_checkhandle(j, 1, "timer");
+    LPGTIMER whichTimer = jass_checkhandle(j, 1, "timer");
+    if (whichTimer) whichTimer->running = false;
     return 0;
 }
 DWORD TimerStart(LPJASS j) {
-    //HANDLE whichTimer = jass_checkhandle(j, 1, "timer");
-    //FLOAT timeout = jass_checknumber(j, 2);
-    //BOOL periodic = jass_checkboolean(j, 3);
-    //LPCJASSFUNC handlerFunc = jass_checkcode(j, 4);
+    LPGTIMER whichTimer = jass_checkhandle(j, 1, "timer");
+    FLOAT timeout = jass_checknumber(j, 2);
+    BOOL periodic = jass_checkboolean(j, 3);
+    LPCJASSFUNC handlerFunc = jass_checkcode(j, 4);
+    if (whichTimer) G_TimerStart(whichTimer, (DWORD)(MAX(0.0f, timeout) * 1000.0f), periodic, handlerFunc);
     return 0;
 }
 DWORD TimerGetElapsed(LPJASS j) {
-    //HANDLE whichTimer = jass_checkhandle(j, 1, "timer");
-    return jass_pushnumber(j, 0);
+    LPGTIMER whichTimer = jass_checkhandle(j, 1, "timer");
+    return jass_pushnumber(j, whichTimer ? (whichTimer->duration - G_TimerRemaining(whichTimer)) / 1000.0f : 0.0f);
 }
 DWORD TimerGetRemaining(LPJASS j) {
-    //HANDLE whichTimer = jass_checkhandle(j, 1, "timer");
-    return jass_pushnumber(j, 0);
+    LPGTIMER whichTimer = jass_checkhandle(j, 1, "timer");
+    return jass_pushnumber(j, G_TimerRemaining(whichTimer) / 1000.0f);
 }
 DWORD TimerGetTimeout(LPJASS j) {
-    //HANDLE whichTimer = jass_checkhandle(j, 1, "timer");
-    return jass_pushnumber(j, 0);
+    LPGTIMER whichTimer = jass_checkhandle(j, 1, "timer");
+    return jass_pushnumber(j, whichTimer ? whichTimer->duration / 1000.0f : 0.0f);
 }
 DWORD PauseTimer(LPJASS j) {
-    //HANDLE whichTimer = jass_checkhandle(j, 1, "timer");
-    return 0;
+    G_TimerPause(jass_checkhandle(j, 1, "timer")); return 0;
 }
 DWORD ResumeTimer(LPJASS j) {
-    //HANDLE whichTimer = jass_checkhandle(j, 1, "timer");
-    return 0;
+    G_TimerResume(jass_checkhandle(j, 1, "timer")); return 0;
 }
 DWORD GetExpiredTimer(LPJASS j) {
-    return jass_pushnullhandle(j, "timer");
+    return jass_pushlighthandle(j, jass_getcontext(j)->timer, "timer");
 }
 DWORD CreateForce(LPJASS j) {
     API_ALLOC(DWORD, force);

--- a/games/warcraft-3/game/api/api_trigger.h
+++ b/games/warcraft-3/game/api/api_trigger.h
@@ -1,6 +1,6 @@
 DWORD CreateTrigger(LPJASS j) {
     API_ALLOC(TRIGGER, trigger);
-    (void)trigger;
+    if (!G_RegisterJassTrigger(trigger)) jass_rterror(j, "CreateTrigger: trigger registry is full");
     return 1;
 }
 DWORD DestroyTrigger(LPJASS j) {
@@ -62,15 +62,23 @@ DWORD TriggerRegisterVariableEvent(LPJASS j) {
     return jass_pushnullhandle(j, "event");
 }
 DWORD TriggerRegisterTimerEvent(LPJASS j) {
-    //LPTRIGGER whichTrigger = jass_checkhandle(j, 1, "trigger");
-    //FLOAT timeout = jass_checknumber(j, 2);
-    //BOOL periodic = jass_checkboolean(j, 3);
-    return jass_pushnullhandle(j, "event");
+    LPTRIGGER whichTrigger = jass_checkhandle(j, 1, "trigger");
+    FLOAT timeout = jass_checknumber(j, 2);
+    BOOL periodic = jass_checkboolean(j, 3);
+    LPGTIMER timer = gi.MemAlloc(sizeof(*timer));
+    LPEVENT evt;
+    if (!whichTrigger || !G_RegisterJassTimer(timer)) { gi.MemFree(timer); return jass_pushnullhandle(j, "event"); }
+    G_TimerStart(timer, (DWORD)(MAX(0.0f, timeout) * 1000.0f), periodic, NULL);
+    evt = G_MakeEvent(EVENT_GAME_TIMER_EXPIRED); evt->trigger = whichTrigger; evt->timer = timer;
+    return jass_pushlighthandle(j, evt, "event");
 }
 DWORD TriggerRegisterTimerExpireEvent(LPJASS j) {
-    //LPTRIGGER whichTrigger = jass_checkhandle(j, 1, "trigger");
-    //HANDLE t = jass_checkhandle(j, 2, "timer");
-    return jass_pushnullhandle(j, "event");
+    LPTRIGGER whichTrigger = jass_checkhandle(j, 1, "trigger");
+    LPGTIMER timer = jass_checkhandle(j, 2, "timer");
+    LPEVENT evt;
+    if (!whichTrigger || !timer) return jass_pushnullhandle(j, "event");
+    evt = G_MakeEvent(EVENT_GAME_TIMER_EXPIRED); evt->trigger = whichTrigger; evt->timer = timer;
+    return jass_pushlighthandle(j, evt, "event");
 }
 DWORD TriggerRegisterGameStateEvent(LPJASS j) {
     //LPTRIGGER whichTrigger = jass_checkhandle(j, 1, "trigger");

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -76,6 +76,7 @@ KNOWN_AS(gcamerasetup_s, CAMERASETUP);
 KNOWN_AS(gregion_s, REGION);
 KNOWN_AS(gevent_s, EVENT);
 KNOWN_AS(gtrigger_s, TRIGGER);
+KNOWN_AS(gtimer_s, GTIMER);
 KNOWN_AS(gquest_s, QUEST);
 KNOWN_AS(gquestitem_s, QUESTITEM);
 
@@ -563,6 +564,21 @@ typedef struct {
     VECTOR2 origin;
 } gitem_t;
 
+#define MAX_GROUP_SIZE 256 // entities; Warcraft III group enumeration cap used by JASS group handles
+#define MAX_JASS_GROUPS 1024 // handles; bounds deterministic per-map group save IDs
+#define MAX_JASS_TRIGGERS 4096 // handles; bounds deterministic per-map trigger save IDs
+#define MAX_JASS_TIMERS 1024 // handles; bounds deterministic per-map timer save IDs
+typedef struct {
+    LPEDICT units[MAX_GROUP_SIZE];
+    DWORD num_units;
+} ggroup_t;
+
+struct gtimer_s {
+    struct jass_function const *handler;
+    DWORD started, duration, timeout, remaining;
+    BOOL periodic, paused, running;
+};
+
 struct gquestitem_s {
     LPSTR description;
     LPQUESTITEM next;
@@ -913,6 +929,7 @@ struct gevent_s {
     LPEDICT subject;
     EVENTTYPE type;
     LPTRIGGER trigger;
+    LPGTIMER timer;
     REGION region;
     FLOAT range;
 };
@@ -1055,6 +1072,12 @@ typedef struct {
 
 struct level_locals {
     LPJASS vm;
+    ggroup_t *groups[MAX_JASS_GROUPS];
+    DWORD num_groups;
+    LPTRIGGER triggers[MAX_JASS_TRIGGERS];
+    DWORD num_triggers;
+    LPGTIMER timers[MAX_JASS_TIMERS];
+    DWORD num_timers;
     bot_t bots[MAX_PLAYERS];
     LPCMAPINFO mapinfo;
     struct {
@@ -1176,6 +1199,7 @@ BOOL G_IsNight(void);
 LPEDICT G_Spawn(void);
 void SP_CallSpawn(LPEDICT);
 void G_BindEntityData(LPEDICT);
+void G_BindEntityRuntime(LPEDICT);
 void G_SpawnEntities(void);
 BOOL SP_FindEmptySpaceAround(LPEDICT, DWORD, LPVECTOR2, FLOAT *);
 BOOL SP_FindUnitExitPosition(LPEDICT producer, LPEDICT unit, LPVECTOR2 out, FLOAT *angle);
@@ -1184,10 +1208,23 @@ LPEDICT G_CreateDestructable(DWORD class_id, FLOAT x, FLOAT y, FLOAT z, FLOAT fa
 LPEDICT G_CreateDeadDestructable(DWORD class_id, FLOAT x, FLOAT y, FLOAT z, FLOAT facing, FLOAT scale, DWORD variation);
 BOOL G_IsDestructable(LPCEDICT ent);
 void SP_monster_tree(LPEDICT);
+void tree_stand(LPEDICT);
+void tree_birth(LPEDICT);
+void tree_pain(LPEDICT);
 
 // g_save.c
 BOOL WriteGame(LPCSTR filename);
 BOOL ReadGame(LPCSTR filename);
+BOOL G_SaveJassHandle(LPCSTR type, HANDLE value, DWORD *id);
+HANDLE G_LoadJassHandle(LPCSTR type, DWORD id);
+BOOL G_RegisterJassGroup(ggroup_t *group);
+BOOL G_RegisterJassTrigger(LPTRIGGER trigger);
+BOOL G_RegisterJassTimer(LPGTIMER timer);
+void G_RunTimers(void);
+void G_TimerStart(LPGTIMER timer, DWORD timeout, BOOL periodic, struct jass_function const *handler);
+void G_TimerPause(LPGTIMER timer);
+void G_TimerResume(LPGTIMER timer);
+DWORD G_TimerRemaining(LPCGTIMER timer);
 
 LPEDICT Waypoint_add(LPCVECTOR2);
 void M_CheckGround (LPEDICT);
@@ -1511,6 +1548,8 @@ BOOL G_GetPlayerAlliance(LPCPLAYER, LPCPLAYER, PLAYERALLIANCE);
 BOOL unit_issueorder(LPEDICT, LPCSTR, LPCVECTOR2);
 BOOL unit_issueimmediateorder(LPEDICT, LPCSTR);
 BOOL unit_issuetargetorder(LPEDICT, LPCSTR, LPEDICT);
+void unit_birth(LPEDICT);
+void unit_die(LPEDICT, LPEDICT);
 LPEDICT unit_createorfind(DWORD, DWORD, LPCVECTOR2, FLOAT);
 BOOL unit_additemtoslot(LPEDICT, LPEDICT, DWORD);
 BOOL unit_additem(LPEDICT, LPEDICT);

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -407,7 +407,8 @@ static void G_RunFrame(void) {
         return;
 
     G_StartScripts();
-    
+
+    G_RunTimers();
     G_RunEvents();
     jass_runevents(level.vm);
     G_BotRunFrame();

--- a/games/warcraft-3/game/g_save.c
+++ b/games/warcraft-3/game/g_save.c
@@ -1,8 +1,16 @@
 #include "g_local.h"
 
 static DWORD const save_magic = MAKEFOURCC('W', '3', 'S', 'V');
-static DWORD const save_version = 4;
+static DWORD const save_commit = MAKEFOURCC('W', '3', 'O', 'K');
+static DWORD const save_version = 6;
 #define MAX_SAVE_STRING (1u << 20) // bytes; bounds quest-string allocations from corrupt saves
+
+typedef struct {
+    DWORD magic, version, edict_size, num_edicts, max_clients;
+    DWORD script_identity, quests, groups, triggers, timers, events;
+} SAVEHEADER;
+
+typedef struct { DWORD checksum, commit; } SAVEFOOTER;
 
 /* Every pointer in edict_s that survives a save must be represented here. */
 field_t fields[] = {
@@ -41,6 +49,327 @@ field_t fields[] = {
 
 static BOOL SaveBytes(FILE *f, LPCVOID data, size_t size) { return fwrite(data, 1, size, f) == size; }
 static BOOL LoadBytes(FILE *f, void *data, size_t size) { return fread(data, 1, size, f) == size; }
+static BOOL WriteJassBytes(void *context, void *data, DWORD size) { return SaveBytes(context, data, size); }
+static BOOL ReadJassBytes(void *context, void *data, DWORD size) { return LoadBytes(context, data, size); }
+static BOOL WriteString(FILE *f, LPCSTR text);
+static BOOL ReadString(FILE *f, LPSTR *text);
+
+static DWORD SaveHash(DWORD hash, LPCVOID data, size_t size) {
+    BYTE const *bytes = data;
+    while (size--) hash = (hash ^ *bytes++) * 16777619u;
+    return hash;
+}
+
+/* A committed checksum rejects truncation and corruption before ReadGame mutates live state. */
+static BOOL WriteFooter(FILE *f) {
+    BYTE bytes[4096];
+    long payload;
+    DWORD checksum = 2166136261u;
+    SAVEFOOTER footer;
+    if (fflush(f) || (payload = ftell(f)) < 0 || fseek(f, 0, SEEK_SET)) return false;
+    while (payload > 0) {
+        size_t size = MIN((size_t)payload, sizeof(bytes));
+        if (fread(bytes, 1, size, f) != size) return false;
+        checksum = SaveHash(checksum, bytes, size); payload -= (long)size;
+    }
+    footer = (SAVEFOOTER){ checksum, save_commit };
+    return fseek(f, 0, SEEK_END) == 0 && SaveBytes(f, &footer, sizeof(footer));
+}
+
+static BOOL ReadFooter(FILE *f) {
+    BYTE bytes[4096];
+    long payload;
+    DWORD checksum = 2166136261u;
+    SAVEFOOTER footer;
+    if (fseek(f, 0, SEEK_END) || (payload = ftell(f)) < (long)sizeof(footer)) return false;
+    payload -= sizeof(footer);
+    if (fseek(f, payload, SEEK_SET) || !LoadBytes(f, &footer, sizeof(footer)) || footer.commit != save_commit ||
+        fseek(f, 0, SEEK_SET)) return false;
+    for (long remaining = payload; remaining > 0;) {
+        size_t size = MIN((size_t)remaining, sizeof(bytes));
+        if (fread(bytes, 1, size, f) != size) return false;
+        checksum = SaveHash(checksum, bytes, size); remaining -= (long)size;
+    }
+    return checksum == footer.checksum && fseek(f, 0, SEEK_SET) == 0;
+}
+
+/* VM state follows native domains so load-side handle relocation sees restored objects. */
+static BOOL WriteJass(FILE *f) {
+    BOOL present = level.vm != NULL;
+    JASSSNAPSHOT snapshot = { f, WriteJassBytes };
+    return SaveBytes(f, &present, sizeof(present)) && (!present || jass_writesnapshot(level.vm, &snapshot));
+}
+
+static BOOL ReadJass(FILE *f) {
+    BOOL present;
+    JASSSNAPSHOT snapshot = { f, ReadJassBytes };
+    if (!LoadBytes(f, &present, sizeof(present)) || present > 1 || present != (level.vm != NULL)) {
+        fprintf(stderr, "WC3 LoadGame: JASS VM lifecycle does not match save\n");
+        return false;
+    }
+    return !present || jass_readsnapshot(level.vm, &snapshot);
+}
+
+BOOL G_RegisterJassGroup(ggroup_t *group) {
+    if (!group || level.num_groups >= MAX_JASS_GROUPS) return false;
+    level.groups[level.num_groups++] = group;
+    return true;
+}
+
+BOOL G_RegisterJassTrigger(LPTRIGGER trigger) {
+    if (!trigger || level.num_triggers >= MAX_JASS_TRIGGERS) return false;
+    level.triggers[level.num_triggers++] = trigger;
+    return true;
+}
+
+static DWORD QuestCount(void) {
+    DWORD count = 0;
+    FOR_EACH_LIST(QUEST const, quest, level.quests) count++;
+    return count;
+}
+
+static DWORD EventCount(void) {
+    DWORD count = 0;
+    FOR_EACH_LIST(EVENT const, event, level.events.handlers) count++;
+    return count;
+}
+
+static BOOL EventId(LPEVENT value, DWORD *id) {
+    DWORD index = 0;
+    if (!value) { *id = UINT32_MAX; return true; }
+    FOR_EACH_LIST(EVENT, event, level.events.handlers) {
+        if (event == value) { *id = index; return true; }
+        index++;
+    }
+    return false;
+}
+
+static LPEVENT EventById(DWORD id) {
+    FOR_EACH_LIST(EVENT, event, level.events.handlers) {
+        if (!id--) return event;
+    }
+    return NULL;
+}
+
+static BOOL WriteEvents(FILE *f) {
+    DWORD count = level.events.write - level.events.read;
+    if (count > MAX_EVENT_QUEUE || !SaveBytes(f, &count, sizeof(count))) return false;
+    FOR_LOOP(i, count) {
+        GAMEEVENT const *event = &level.events.queue[(level.events.read + i) % MAX_EVENT_QUEUE];
+        int edict = event->edict ? (int)(event->edict - g_edicts) : -1;
+        int source = event->source ? (int)(event->source - g_edicts) : -1;
+        DWORD response;
+        if (edict >= (int)globals.num_edicts || source >= (int)globals.num_edicts || !EventId(event->responseTo, &response) ||
+            !SaveBytes(f, &event->type, sizeof(event->type)) || !SaveBytes(f, &edict, sizeof(edict)) ||
+            !SaveBytes(f, &source, sizeof(source)) || !SaveBytes(f, &response, sizeof(response))) return false;
+    }
+    return true;
+}
+
+static BOOL ReadEvents(FILE *f) {
+    DWORD count;
+    if (!LoadBytes(f, &count, sizeof(count)) || count > MAX_EVENT_QUEUE) return false;
+    level.events.read = 0; level.events.write = count;
+    FOR_LOOP(i, count) {
+        GAMEEVENT *event = level.events.queue + i;
+        int edict, source;
+        DWORD response;
+        if (!LoadBytes(f, &event->type, sizeof(event->type)) || !LoadBytes(f, &edict, sizeof(edict)) ||
+            !LoadBytes(f, &source, sizeof(source)) || !LoadBytes(f, &response, sizeof(response)) ||
+            edict < -1 || edict >= (int)globals.num_edicts || source < -1 || source >= (int)globals.num_edicts ||
+            (response != UINT32_MAX && response >= EventCount())) return false;
+        event->edict = edict < 0 ? NULL : g_edicts + edict;
+        event->source = source < 0 ? NULL : g_edicts + source;
+        event->responseTo = response == UINT32_MAX ? NULL : EventById(response);
+    }
+    return true;
+}
+
+static BOOL WriteGroups(FILE *f) {
+    if (!SaveBytes(f, &level.num_groups, sizeof(level.num_groups))) return false;
+    FOR_LOOP(i, level.num_groups) {
+        ggroup_t const *group = level.groups[i];
+        if (!group || group->num_units > MAX_GROUP_SIZE || !SaveBytes(f, &group->num_units, sizeof(group->num_units))) return false;
+        FOR_LOOP(k, group->num_units) {
+            int index = group->units[k] ? (int)(group->units[k] - g_edicts) : -1;
+            if (index < 0 || index >= (int)globals.num_edicts || !SaveBytes(f, &index, sizeof(index))) return false;
+        }
+    }
+    return true;
+}
+
+static BOOL ReadGroups(FILE *f) {
+    DWORD count;
+    if (!LoadBytes(f, &count, sizeof(count)) || count != level.num_groups) {
+        fprintf(stderr, "WC3 LoadGame: JASS group count does not match initialized script\n"); return false;
+    }
+    FOR_LOOP(i, count) {
+        ggroup_t *group = level.groups[i];
+        DWORD units;
+        if (!group || !LoadBytes(f, &units, sizeof(units)) || units > MAX_GROUP_SIZE) return false;
+        group->num_units = 0;
+        FOR_LOOP(k, units) {
+            int index;
+            if (!LoadBytes(f, &index, sizeof(index)) || index < 0 || index >= (int)globals.num_edicts ||
+                !g_edicts[index].inuse) return false;
+            group->units[group->num_units++] = g_edicts + index;
+        }
+    }
+    return true;
+}
+
+static BOOL WriteTriggers(FILE *f) {
+    if (!SaveBytes(f, &level.num_triggers, sizeof(level.num_triggers))) return false;
+    FOR_LOOP(i, level.num_triggers)
+        if (!level.triggers[i] || !SaveBytes(f, &level.triggers[i]->disabled, sizeof(level.triggers[i]->disabled))) return false;
+    return true;
+}
+
+static BOOL ReadTriggers(FILE *f) {
+    DWORD count;
+    if (!LoadBytes(f, &count, sizeof(count)) || count != level.num_triggers) {
+        fprintf(stderr, "WC3 LoadGame: JASS trigger count does not match initialized script\n"); return false;
+    }
+    FOR_LOOP(i, count)
+        if (!level.triggers[i] || !LoadBytes(f, &level.triggers[i]->disabled, sizeof(level.triggers[i]->disabled))) return false;
+    return true;
+}
+
+static BOOL WriteTimers(FILE *f) {
+    if (!SaveBytes(f, &level.num_timers, sizeof(level.num_timers))) return false;
+    FOR_LOOP(i, level.num_timers) {
+        LPGTIMER timer = level.timers[i];
+        DWORD remaining = G_TimerRemaining(timer);
+        if (!timer || !SaveBytes(f, &timer->duration, sizeof(timer->duration)) ||
+            !SaveBytes(f, &remaining, sizeof(remaining)) || !SaveBytes(f, &timer->periodic, sizeof(timer->periodic)) ||
+            !SaveBytes(f, &timer->paused, sizeof(timer->paused)) || !SaveBytes(f, &timer->running, sizeof(timer->running)) ||
+            !WriteString(f, jass_functionname(timer->handler))) return false;
+    }
+    return true;
+}
+
+static BOOL ReadTimers(FILE *f) {
+    DWORD count;
+    if (!LoadBytes(f, &count, sizeof(count)) || count != level.num_timers) {
+        fprintf(stderr, "WC3 LoadGame: JASS timer count does not match initialized script\n"); return false;
+    }
+    FOR_LOOP(i, count) {
+        LPGTIMER timer = level.timers[i];
+        LPSTR handler = NULL;
+        if (!timer || !LoadBytes(f, &timer->duration, sizeof(timer->duration)) ||
+            !LoadBytes(f, &timer->remaining, sizeof(timer->remaining)) ||
+            !LoadBytes(f, &timer->periodic, sizeof(timer->periodic)) ||
+            !LoadBytes(f, &timer->paused, sizeof(timer->paused)) || !LoadBytes(f, &timer->running, sizeof(timer->running)) ||
+            !ReadString(f, &handler)) { free(handler); return false; }
+        timer->handler = handler ? jass_functionbyname(level.vm, handler) : NULL;
+        if (handler && !timer->handler) { free(handler); return false; }
+        free(handler);
+        timer->started = gi.GetTime(); timer->timeout = timer->remaining;
+    }
+    return true;
+}
+
+typedef enum {
+    JASS_HANDLE_ENTITY,
+    JASS_HANDLE_PLAYER,
+    JASS_HANDLE_QUEST,
+    JASS_HANDLE_QUESTITEM,
+    JASS_HANDLE_EVENT,
+    JASS_HANDLE_TRIGGER,
+    JASS_HANDLE_GROUP,
+    JASS_HANDLE_TIMER,
+} jassHandleDomain_t;
+
+static struct { LPCSTR type; jassHandleDomain_t domain; } const jass_handle_domains[] = {
+    { "unit", JASS_HANDLE_ENTITY },
+    { "widget", JASS_HANDLE_ENTITY },
+    { "destructable", JASS_HANDLE_ENTITY },
+    { "item", JASS_HANDLE_ENTITY },
+    { "effect", JASS_HANDLE_ENTITY },
+    { "player", JASS_HANDLE_PLAYER },
+    { "quest", JASS_HANDLE_QUEST },
+    { "questitem", JASS_HANDLE_QUESTITEM },
+    { "event", JASS_HANDLE_EVENT },
+    { "trigger", JASS_HANDLE_TRIGGER },
+    { "group", JASS_HANDLE_GROUP },
+    { "timer", JASS_HANDLE_TIMER },
+};
+
+static BOOL JassHandleDomain(LPCSTR type, jassHandleDomain_t *domain) {
+    FOR_LOOP(i, sizeof(jass_handle_domains) / sizeof(*jass_handle_domains)) {
+        if (!strcmp(type, jass_handle_domains[i].type)) { *domain = jass_handle_domains[i].domain; return true; }
+    }
+    return false;
+}
+
+static HANDLE JassListHandle(jassHandleDomain_t domain, DWORD id) {
+    DWORD index = 0;
+    if (domain == JASS_HANDLE_QUEST) {
+        FOR_EACH_LIST(QUEST, quest, level.quests) if (index++ == id) return quest;
+    } else if (domain == JASS_HANDLE_QUESTITEM) {
+        FOR_EACH_LIST(QUEST, quest, level.quests)
+            FOR_EACH_LIST(QUESTITEM, item, quest->items) if (index++ == id) return item;
+    } else if (domain == JASS_HANDLE_EVENT) {
+        FOR_EACH_LIST(EVENT, event, level.events.handlers) {
+            if (index++ != id) continue;
+            return event;
+        }
+    } else if (domain == JASS_HANDLE_TRIGGER && id < level.num_triggers) return level.triggers[id];
+    else if (domain == JASS_HANDLE_TIMER && id < level.num_timers) return level.timers[id];
+    return NULL;
+}
+
+/* Native pointers cross the save boundary only through stable domain-specific indexes. */
+BOOL G_SaveJassHandle(LPCSTR type, HANDLE value, DWORD *id) {
+    jassHandleDomain_t domain;
+    DWORD index = 0;
+    if (!JassHandleDomain(type, &domain) || !value) return false;
+    if (domain == JASS_HANDLE_ENTITY) {
+        LPEDICT ent = value;
+        if (ent < g_edicts || ent >= g_edicts + globals.num_edicts || !ent->inuse) return false;
+        *id = (DWORD)(ent - g_edicts); return true;
+    }
+    if (domain == JASS_HANDLE_PLAYER) {
+        FOR_LOOP(i, game.max_clients) if (value == &game.clients[i].ps) { *id = i; return true; }
+        return false;
+    }
+    if (domain == JASS_HANDLE_GROUP) {
+        FOR_LOOP(i, level.num_groups) if (level.groups[i] == value) { *id = i; return true; }
+        return false;
+    }
+    if (domain == JASS_HANDLE_TIMER) {
+        FOR_LOOP(i, level.num_timers) if (level.timers[i] == value) { *id = i; return true; }
+        return false;
+    }
+    if (domain == JASS_HANDLE_QUEST) {
+        FOR_EACH_LIST(QUEST, quest, level.quests) { if (quest == value) { *id = index; return true; } index++; }
+        return false;
+    }
+    if (domain == JASS_HANDLE_QUESTITEM) {
+        FOR_EACH_LIST(QUEST, quest, level.quests)
+            FOR_EACH_LIST(QUESTITEM, item, quest->items) { if (item == value) { *id = index; return true; } index++; }
+        return false;
+    }
+    if (domain == JASS_HANDLE_EVENT) {
+        FOR_EACH_LIST(EVENT, event, level.events.handlers) {
+            if (event == value) { *id = index; return true; }
+            index++;
+        }
+        return false;
+    }
+    FOR_LOOP(i, level.num_triggers) if (level.triggers[i] == value) { *id = i; return true; }
+    return false;
+}
+
+HANDLE G_LoadJassHandle(LPCSTR type, DWORD id) {
+    jassHandleDomain_t domain;
+    if (!JassHandleDomain(type, &domain)) return NULL;
+    if (domain == JASS_HANDLE_ENTITY) return id < globals.num_edicts && g_edicts[id].inuse ? g_edicts + id : NULL;
+    if (domain == JASS_HANDLE_PLAYER) return id < (DWORD)game.max_clients ? &game.clients[id].ps : NULL;
+    if (domain == JASS_HANDLE_GROUP) return id < level.num_groups ? level.groups[id] : NULL;
+    if (domain == JASS_HANDLE_TIMER) return id < level.num_timers ? level.timers[id] : NULL;
+    return JassListHandle(domain, id);
+}
 
 static BOOL WriteString(FILE *f, LPCSTR text) {
     size_t size = text ? strlen(text) + 1 : 0;
@@ -221,41 +550,55 @@ static BOOL ReadEdict(FILE *f, LPEDICT ent) {
 
     if (!LoadBytes(f, ent, sizeof(*ent))) return false;
     for (field = fields; field->name; field++) if (!ReadField(field, (BYTE *)ent)) return false;
-    if (ent->class_id) G_BindEntityData(ent);
+    /* Raw callback addresses are invalid across processes; class data determines the persistent callback family. */
+    if (ent->class_id) { G_BindEntityData(ent); G_BindEntityRuntime(ent); }
     return true;
 }
 
 BOOL WriteGame(LPCSTR filename) {
-    FILE *f = fopen(filename, "wb");
-    struct { DWORD magic, version, edict_size, num_edicts, max_clients; } header = {
-        save_magic, save_version, sizeof(edict_t), globals.num_edicts, game.max_clients
+    FILE *f = fopen(filename, "w+b");
+    SAVEHEADER header = {
+        save_magic, save_version, sizeof(edict_t), globals.num_edicts, game.max_clients,
+        level.vm ? jass_programidentity(level.vm) : 0, QuestCount(), level.num_groups, level.num_triggers, level.num_timers,
+        EventCount()
     };
 
+    BOOL ok = false;
     if (!f) return false;
     if (!SaveBytes(f, &header, sizeof(header)) || !SaveBytes(f, &level.framenum, sizeof(level.framenum)) ||
         !SaveBytes(f, &level.time, sizeof(level.time)) || !SaveBytes(f, &level.started, sizeof(level.started)) ||
-        !SaveBytes(f, &level.scriptsStarted, sizeof(level.scriptsStarted))) { fclose(f); return false; }
-    FOR_LOOP(i, game.max_clients) if (!WriteClient(f, game.clients + i)) { fclose(f); return false; }
-    if (!WriteQuests(f)) { fclose(f); return false; }
+        !SaveBytes(f, &level.scriptsStarted, sizeof(level.scriptsStarted))) goto done;
+    FOR_LOOP(i, game.max_clients) if (!WriteClient(f, game.clients + i)) goto done;
+    if (!WriteQuests(f)) goto done;
     FOR_LOOP(i, globals.num_edicts) {
         BOOL used = g_edicts[i].inuse;
-        if (!SaveBytes(f, &used, sizeof(used)) || (used && !SaveBytes(f, &i, sizeof(i)))) { fclose(f); return false; }
-        if (used && !WriteEdict(f, g_edicts + i)) { fclose(f); return false; }
+        if (!SaveBytes(f, &used, sizeof(used)) || (used && !SaveBytes(f, &i, sizeof(i)))) goto done;
+        if (used && !WriteEdict(f, g_edicts + i)) goto done;
     }
+    if (!WriteGroups(f) || !WriteTriggers(f) || !WriteTimers(f) || !WriteEvents(f) || !WriteJass(f) || !WriteFooter(f)) goto done;
+    ok = true;
+done:
     fclose(f);
-    return true;
+    if (!ok) remove(filename);
+    return ok;
 }
 
 BOOL ReadGame(LPCSTR filename) {
     FILE *f = fopen(filename, "rb");
-    struct { DWORD magic, version, edict_size, num_edicts, max_clients; } header;
+    SAVEHEADER header;
     DWORD index;
     int targets[MAX_CLIENTS];
 
     if (!f) return false;
+    if (!ReadFooter(f)) { fclose(f); return false; }
+    /* All native handle registries must match before clients or edicts are overwritten; timers were previously checked too late. */
     if (!LoadBytes(f, &header, sizeof(header)) || header.magic != save_magic || header.version != save_version ||
         header.edict_size != sizeof(edict_t) || header.num_edicts > globals.max_edicts ||
-        header.max_clients != game.max_clients) { fclose(f); return false; }
+        header.max_clients != game.max_clients || header.script_identity != (level.vm ? jass_programidentity(level.vm) : 0) ||
+        header.quests != QuestCount() || header.groups != level.num_groups || header.triggers != level.num_triggers ||
+        header.timers != level.num_timers || header.events != EventCount()) {
+        fclose(f); return false;
+    }
     if (!LoadBytes(f, &level.framenum, sizeof(level.framenum)) || !LoadBytes(f, &level.time, sizeof(level.time)) ||
         !LoadBytes(f, &level.started, sizeof(level.started)) || !LoadBytes(f, &level.scriptsStarted, sizeof(level.scriptsStarted))) {
         fclose(f); return false;
@@ -272,6 +615,7 @@ BOOL ReadGame(LPCSTR filename) {
             fclose(f); return false;
         }
     }
+    if (!ReadGroups(f) || !ReadTriggers(f) || !ReadTimers(f) || !ReadEvents(f) || !ReadJass(f)) { fclose(f); return false; }
     FOR_LOOP(i, game.max_clients) g_edicts[i].client = game.clients + i;
     FOR_LOOP(i, game.max_clients) game.clients[i].camera.target_controller = targets[i] < 0 ? NULL : g_edicts + targets[i];
     FOR_LOOP(i, globals.num_edicts) {

--- a/games/warcraft-3/game/g_spawn.c
+++ b/games/warcraft-3/game/g_spawn.c
@@ -13,6 +13,8 @@ void G_InitJassHost(void) {
         .ReadFile = gi.ReadFile,
         .natives = jass_funcs,
         .GetPlayerByNumber = G_GetPlayerByNumber,
+        .SaveHandle = G_SaveJassHandle,
+        .LoadHandle = G_LoadJassHandle,
     ));
 }
 
@@ -195,6 +197,17 @@ void G_BindEntityData(LPEDICT edict) {
     edict->Doodads = G_Doodad(edict->class_id);
     edict->ItemData = G_ItemData(edict->class_id);
     edict->DestructableData = G_DestructableData(edict->class_id);
+}
+
+/* Save files omit process addresses; restore class-owned callbacks without replaying spawn-time gameplay initialization. */
+void G_BindEntityRuntime(LPEDICT edict) {
+    if (edict->DestructableData->file) {
+        edict->stand = tree_stand; edict->birth = tree_birth; edict->pain = tree_pain; edict->die = tree_die;
+        edict->think = monster_think;
+    } else if (edict->UnitBalance->id || edict->UnitUI->modelFile) {
+        edict->stand = unit_stand; edict->birth = unit_birth; edict->die = unit_die;
+        edict->think = monster_think;
+    }
 }
 
 void SP_CallSpawn(LPEDICT edict) {

--- a/games/warcraft-3/game/g_timer.c
+++ b/games/warcraft-3/game/g_timer.c
@@ -1,0 +1,50 @@
+#include "g_local.h"
+#include "jass/jass.h"
+
+BOOL G_RegisterJassTimer(LPGTIMER timer) {
+    if (!timer || level.num_timers >= MAX_JASS_TIMERS) return false;
+    level.timers[level.num_timers++] = timer;
+    return true;
+}
+
+DWORD G_TimerRemaining(LPCGTIMER timer) {
+    DWORD now;
+    if (!timer || !timer->running) return timer ? timer->remaining : 0;
+    if (timer->paused) return timer->remaining;
+    now = gi.GetTime();
+    return now - timer->started >= timer->timeout ? 0 : timer->timeout - (now - timer->started);
+}
+
+void G_TimerStart(LPGTIMER timer, DWORD timeout, BOOL periodic, LPCJASSFUNC handler) {
+    timer->handler = handler; timer->started = gi.GetTime(); timer->duration = timeout;
+    timer->timeout = timeout; timer->remaining = timeout;
+    timer->periodic = periodic; timer->paused = false; timer->running = true;
+}
+
+void G_TimerPause(LPGTIMER timer) {
+    if (!timer || !timer->running || timer->paused) return;
+    timer->remaining = G_TimerRemaining(timer); timer->paused = true;
+}
+
+void G_TimerResume(LPGTIMER timer) {
+    if (!timer || !timer->running || !timer->paused) return;
+    timer->started = gi.GetTime(); timer->timeout = timer->remaining; timer->paused = false;
+}
+
+/* Timer callbacks enter the same coroutine/event path as authored map triggers. */
+void G_RunTimers(void) {
+    DWORD now = gi.GetTime();
+    FOR_LOOP(i, level.num_timers) {
+        LPGTIMER timer = level.timers[i];
+        if (!timer || !timer->running || timer->paused || now - timer->started < timer->timeout) continue;
+        timer->remaining = timer->periodic ? timer->duration : 0;
+        timer->started = now; timer->timeout = timer->duration; timer->running = timer->periodic;
+        if (timer->handler)
+            jass_startcoroutine(level.vm, &MAKE(JASSCONTEXT, .func = timer->handler, .timer = timer));
+        jass_settimercontext(timer);
+        FOR_EACH_LIST(EVENT, event, level.events.handlers)
+            if (event->type == EVENT_GAME_TIMER_EXPIRED && event->timer == timer)
+                jass_calltrigger(level.vm, event->trigger, NULL, NULL);
+        jass_settimercontext(NULL);
+    }
+}

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -1297,6 +1297,8 @@ TEST(wc3_save, round_trip_edict_and_player_state) {
     T_ASSERT(g_edicts[first - g_edicts].owner == &g_edicts[second - g_edicts]);
     T_ASSERT(g_edicts[first - g_edicts].inventory[2] == &g_edicts[second - g_edicts]);
     T_ASSERT(g_edicts[first - g_edicts].cargo.units[3] == &g_edicts[second - g_edicts]);
+    T_ASSERT(g_edicts[first - g_edicts].stand == unit_stand);
+    T_ASSERT(unit_issueimmediateorder(g_edicts + (first - g_edicts), "stop"));
     T_EQ(game.clients[0].ps.stats[PLAYERSTATE_RESOURCE_GOLD], 123);
     T_EQ(game.clients[0].ps.stats[PLAYERSTATE_RESOURCE_LUMBER], 45);
     T_EQ(game.clients[0].camera.state.fov, 61.0f);
@@ -1318,6 +1320,284 @@ TEST(wc3_save, round_trip_edict_and_player_state) {
     T_ASSERT(!ReadGame(filename));
     T_ASSERT(g_edicts[0].client == &game.clients[0]);
     free(item.description); free(quest.title); free(quest.description); free(quest.iconPath);
+    remove(filename);
+}
+
+BOOL run_test_jass(LPCSTR src);
+
+TEST(wc3_save, rebinds_process_owned_entity_callbacks) {
+    UnitBalance_t unit_row = { .id = MAKEFOURCC('h', 'p', 'e', 'a') };
+    UnitBalance_t no_unit = { 0 };
+    UnitUI_t unit_ui = { 0 };
+    DestructableData_t dest_row = { .file = "Tree" };
+    DestructableData_t no_dest = { 0 };
+    edict_t unit = { .UnitBalance = &unit_row, .UnitUI = &unit_ui, .DestructableData = &no_dest };
+    edict_t dest = { .UnitBalance = &no_unit, .UnitUI = &unit_ui, .DestructableData = &dest_row };
+    edict_t unknown = { .UnitBalance = &no_unit, .UnitUI = &unit_ui, .DestructableData = &no_dest };
+
+    G_BindEntityRuntime(&unit); G_BindEntityRuntime(&dest); G_BindEntityRuntime(&unknown);
+    T_ASSERT(unit.stand == unit_stand && unit.birth == unit_birth && unit.die == unit_die && unit.think == monster_think);
+    T_ASSERT(dest.stand == tree_stand && dest.birth == tree_birth && dest.pain == tree_pain && dest.die == tree_die);
+    T_ASSERT(dest.think == monster_think);
+    T_ASSERT(!unknown.stand && !unknown.birth && !unknown.pain && !unknown.die && !unknown.think);
+}
+
+TEST(wc3_save, round_trip_unread_event_queue) {
+    LPCSTR filename = "/tmp/openwarcraft3-wc3-event-save-test.bin";
+    LEVELEVENTS old_events = level.events;
+    EVENT handler = { .type = EVENT_UNIT_IN_RANGE };
+    LPEDICT subject, source;
+
+    reset_entities(); memset(&level.events, 0, sizeof(level.events)); level.events.handlers = &handler;
+    subject = alloc_test_unit(MAKEFOURCC('h', 'p', 'e', 'a'), 0.0f, 0.0f);
+    source = alloc_test_unit(MAKEFOURCC('h', 'f', 'o', 'o'), 64.0f, 0.0f);
+    G_PublishEventWithSource(subject, EVENT_UNIT_IN_RANGE, source)->responseTo = &handler;
+    T_ASSERT(WriteGame(filename));
+    level.events.read = level.events.write; memset(level.events.queue, 0, sizeof(level.events.queue));
+    T_ASSERT(ReadGame(filename));
+    T_EQ(level.events.read, 0); T_EQ(level.events.write, 1);
+    T_EQ(level.events.queue[0].type, EVENT_UNIT_IN_RANGE);
+    T_ASSERT(level.events.queue[0].edict == subject && level.events.queue[0].source == source);
+    T_ASSERT(level.events.queue[0].responseTo == &handler);
+    level.events = old_events; remove(filename);
+}
+
+TEST(wc3_save, round_trip_jass_globals) {
+    LPCSTR filename = "/tmp/openwarcraft3-wc3-jass-save-test.bin";
+    T_ASSERT(run_test_jass(
+        "type group extends handle\n"
+        "type trigger extends handle\n"
+        "globals\n"
+        "  integer savedInteger = 41\n"
+        "  real savedReal = 2.5\n"
+        "  boolean savedBoolean = true\n"
+        "  string savedString = \"before\"\n"
+        "  code savedCode = function SavedCallback\n"
+        "  unit savedNull = null\n"
+        "  player savedPlayer = null\n"
+        "  player savedPlayerAlias = null\n"
+        "  unit savedUnit = null\n"
+        "  unit savedUnitAlias = null\n"
+        "  quest savedQuest = null\n"
+        "  quest savedQuestAlias = null\n"
+        "  questitem savedQuestItem = null\n"
+        "  questitem savedQuestItemAlias = null\n"
+        "  group savedGroup = null\n"
+        "  group savedGroupAlias = null\n"
+        "  trigger savedTrigger = null\n"
+        "  trigger savedTriggerAlias = null\n"
+        "  integer array savedArray\n"
+        "endglobals\n"
+        "function SavedCallback takes nothing returns nothing\n"
+        "endfunction\n"
+        "function ChangedCallback takes nothing returns nothing\n"
+        "endfunction\n"
+        "function main takes nothing returns nothing\n"
+        "  set savedPlayer = Player(0)\n"
+        "  set savedPlayerAlias = savedPlayer\n"
+        "  set savedUnit = CreateUnit(savedPlayer, 'hpea', 0.0, 0.0, 0.0)\n"
+        "  set savedUnitAlias = savedUnit\n"
+        "  set savedQuest = CreateQuest()\n"
+        "  set savedQuestAlias = savedQuest\n"
+        "  set savedQuestItem = QuestCreateItem(savedQuest)\n"
+        "  set savedQuestItemAlias = savedQuestItem\n"
+        "  set savedGroup = CreateGroup()\n"
+        "  set savedGroupAlias = savedGroup\n"
+        "  call GroupAddUnit(savedGroup, savedUnit)\n"
+        "  set savedTrigger = CreateTrigger()\n"
+        "  set savedTriggerAlias = savedTrigger\n"
+        "  call DisableTrigger(savedTrigger)\n"
+        "  set savedArray[7] = 77\n"
+        "  set savedArray[4095] = 95\n"
+        "endfunction\n"
+        "function mutate takes nothing returns nothing\n"
+        "  set savedInteger = 0\n"
+        "  set savedReal = 0.0\n"
+        "  set savedBoolean = false\n"
+        "  set savedString = \"after\"\n"
+        "  set savedCode = function ChangedCallback\n"
+        "  set savedPlayer = null\n"
+        "  set savedPlayerAlias = null\n"
+        "  set savedUnit = null\n"
+        "  set savedUnitAlias = null\n"
+        "  set savedQuest = null\n"
+        "  set savedQuestAlias = null\n"
+        "  set savedQuestItem = null\n"
+        "  set savedQuestItemAlias = null\n"
+        "  call GroupClear(savedGroup)\n"
+        "  call EnableTrigger(savedTrigger)\n"
+        "  set savedArray[7] = 0\n"
+        "  set savedArray[4095] = 0\n"
+        "endfunction\n"
+        "function verify takes nothing returns nothing\n"
+        "  call BJassAssert(savedInteger == 41, \"integer snapshot mismatch\")\n"
+        "  call BJassAssert(savedReal == 2.5, \"real snapshot mismatch\")\n"
+        "  call BJassAssert(savedBoolean, \"boolean snapshot mismatch\")\n"
+        "  call BJassAssert(savedString == \"before\", \"string snapshot mismatch\")\n"
+        "  call BJassAssert(savedCode == function SavedCallback, \"code snapshot mismatch\")\n"
+        "  call BJassAssert(savedNull == null, \"null snapshot mismatch\")\n"
+        "  call BJassAssert(savedPlayer == savedPlayerAlias, \"player alias mismatch\")\n"
+        "  call BJassAssert(savedPlayer == Player(0), \"player handle mismatch\")\n"
+        "  call BJassAssert(savedUnit == savedUnitAlias, \"unit alias mismatch\")\n"
+        "  call BJassAssert(GetUnitTypeId(savedUnit) == 'hpea', \"unit handle mismatch\")\n"
+        "  call BJassAssert(savedQuest == savedQuestAlias, \"quest alias mismatch\")\n"
+        "  call BJassAssert(savedQuestItem == savedQuestItemAlias, \"quest item alias mismatch\")\n"
+        "  call BJassAssert(savedGroup == savedGroupAlias, \"group alias mismatch\")\n"
+        "  call BJassAssert(FirstOfGroup(savedGroup) == savedUnit, \"group membership mismatch\")\n"
+        "  call BJassAssert(savedTrigger == savedTriggerAlias, \"trigger alias mismatch\")\n"
+        "  call BJassAssert(not IsTriggerEnabled(savedTrigger), \"trigger state mismatch\")\n"
+        "  call BJassAssert(savedArray[7] == 77, \"sparse array mismatch\")\n"
+        "  call BJassAssert(savedArray[4095] == 95, \"high sparse array mismatch\")\n"
+        "endfunction\n"));
+    T_ASSERT(WriteGame(filename));
+    jass_callbyname(level.vm, "mutate", false);
+    T_ASSERT(ReadGame(filename));
+    jass_callbyname(level.vm, "verify", false);
+    T_ASSERT(!jass_rterror_pending(level.vm));
+    remove(filename);
+}
+
+TEST(wc3_save, round_trip_jass_timers) {
+    LPCSTR filename = "/tmp/openwarcraft3-wc3-jass-timer-save-test.bin";
+    T_ASSERT(run_test_jass(
+        "type timer extends handle\n"
+        "type trigger extends handle\n"
+        "type triggeraction extends handle\n"
+        "type event extends handle\n"
+        "globals\n"
+        "  timer pausedTimer = null\n"
+        "  timer pausedTimerAlias = null\n"
+        "  timer runningTimer = null\n"
+        "  timer runningTimerAlias = null\n"
+        "  trigger timerTrigger = null\n"
+        "  integer timerCallbacks = 0\n"
+        "endglobals\n"
+        "function TimerCallback takes nothing returns nothing\n"
+        "  call BJassAssert(GetExpiredTimer() == runningTimer, \"direct expired timer mismatch\")\n"
+        "  set timerCallbacks = timerCallbacks + 1\n"
+        "endfunction\n"
+        "function TimerTriggerAction takes nothing returns nothing\n"
+        "  call BJassAssert(GetExpiredTimer() == runningTimer, \"trigger expired timer mismatch\")\n"
+        "  set timerCallbacks = timerCallbacks + 10\n"
+        "endfunction\n"
+        "function TimerNoop takes nothing returns nothing\n"
+        "endfunction\n"
+        "function main takes nothing returns nothing\n"
+        "  set timerTrigger = CreateTrigger()\n"
+        "  set pausedTimer = CreateTimer()\n"
+        "  set pausedTimerAlias = pausedTimer\n"
+        "  call TimerStart(pausedTimer, 10.0, false, function TimerNoop)\n"
+        "  call PauseTimer(pausedTimer)\n"
+        "  set runningTimer = CreateTimer()\n"
+        "  set runningTimerAlias = runningTimer\n"
+        "  call TriggerAddAction(timerTrigger, function TimerTriggerAction)\n"
+        "  call TriggerRegisterTimerExpireEvent(timerTrigger, runningTimer)\n"
+        "  call TimerStart(runningTimer, 0.0, true, function TimerCallback)\n"
+        "endfunction\n"
+        "function mutate takes nothing returns nothing\n"
+        "  call DestroyTimer(pausedTimer)\n"
+        "  call DestroyTimer(runningTimer)\n"
+        "  set pausedTimerAlias = null\n"
+        "  set runningTimerAlias = null\n"
+        "  set timerCallbacks = 99\n"
+        "endfunction\n"
+        "function verifyRestored takes nothing returns nothing\n"
+        "  call BJassAssert(pausedTimer == pausedTimerAlias, \"paused timer alias mismatch\")\n"
+        "  call BJassAssert(runningTimer == runningTimerAlias, \"running timer alias mismatch\")\n"
+        "  call BJassAssert(TimerGetTimeout(pausedTimer) == 10.0, \"timer timeout mismatch\")\n"
+        "  call BJassAssert(TimerGetRemaining(pausedTimer) > 9.0, \"paused timer remaining mismatch\")\n"
+        "  call BJassAssert(TimerGetRemaining(pausedTimer) <= 10.0, \"paused timer remaining overflow\")\n"
+        "  call BJassAssert(timerCallbacks == 0, \"timer callback state mismatch\")\n"
+        "endfunction\n"
+        "function verifyExpired takes nothing returns nothing\n"
+        "  call BJassAssert(timerCallbacks > 0, \"direct timer callback did not run after load\")\n"
+        "  call BJassAssert(timerCallbacks == 11, \"timer trigger did not run after load\")\n"
+        "endfunction\n"
+        "function verifyPeriodic takes nothing returns nothing\n"
+        "  call BJassAssert(timerCallbacks == 22, \"periodic timer did not remain active after load\")\n"
+        "endfunction\n"
+        "function addTimer takes nothing returns nothing\n"
+        "  call CreateTimer()\n"
+        "endfunction\n"
+        "function addEvent takes nothing returns nothing\n"
+        "  call TriggerRegisterTimerExpireEvent(timerTrigger, runningTimer)\n"
+        "endfunction\n"));
+    T_ASSERT(WriteGame(filename));
+    jass_callbyname(level.vm, "mutate", false);
+    T_ASSERT(ReadGame(filename));
+    jass_callbyname(level.vm, "verifyRestored", false);
+    G_RunTimers();
+    jass_runevents(level.vm);
+    jass_callbyname(level.vm, "verifyExpired", false);
+    G_RunTimers();
+    jass_runevents(level.vm);
+    jass_callbyname(level.vm, "verifyPeriodic", false);
+    T_ASSERT(!jass_rterror_pending(level.vm));
+    jass_callbyname(level.vm, "addEvent", false);
+    T_ASSERT(!ReadGame(filename));
+    jass_callbyname(level.vm, "addTimer", false);
+    T_ASSERT(!ReadGame(filename));
+    remove(filename);
+}
+
+TEST(wc3_save, resumes_sleeping_jass_coroutine) {
+    LPCSTR filename = "/tmp/openwarcraft3-wc3-jass-coroutine-save-test.bin";
+    T_ASSERT(run_test_jass(
+        "globals\n"
+        "  integer coroutineStage = 0\n"
+        "endglobals\n"
+        "function main takes nothing returns nothing\n"
+        "  set coroutineStage = 1\n"
+        "  call TriggerSleepAction(0.0)\n"
+        "  set coroutineStage = 2\n"
+        "endfunction\n"
+        "function mutate takes nothing returns nothing\n"
+        "  set coroutineStage = 9\n"
+        "endfunction\n"
+        "function verify takes nothing returns nothing\n"
+        "  call BJassAssert(coroutineStage == 2, \"coroutine did not resume after sleep\")\n"
+        "endfunction\n"));
+    T_ASSERT(WriteGame(filename));
+    jass_callbyname(level.vm, "mutate", false);
+    T_ASSERT(ReadGame(filename));
+    jass_runevents(level.vm);
+    jass_callbyname(level.vm, "verify", false);
+    T_ASSERT(!jass_rterror_pending(level.vm));
+    remove(filename);
+}
+
+TEST(wc3_save, rejects_corruption_without_mutation) {
+    LPCSTR filename = "/tmp/openwarcraft3-wc3-corrupt-save-test.bin";
+    LPEDICT unit;
+    FILE *f;
+    BYTE byte = 0;
+    reset_entities();
+    unit = alloc_test_unit(MAKEFOURCC('h', 'p', 'e', 'a'), 0.0f, 0.0f);
+    unit->harvested_gold = 37;
+    T_ASSERT(WriteGame(filename));
+    f = fopen(filename, "r+b");
+    T_ASSERT(f != NULL && fseek(f, sizeof(DWORD), SEEK_SET) == 0 && fread(&byte, 1, 1, f) == 1);
+    byte ^= 0x80;
+    T_ASSERT(fseek(f, sizeof(DWORD), SEEK_SET) == 0 && fwrite(&byte, 1, 1, f) == 1);
+    fclose(f);
+    unit->harvested_gold = 99;
+    T_ASSERT(!ReadGame(filename));
+    T_EQ(unit->harvested_gold, 99);
+    remove(filename);
+}
+
+TEST(wc3_save, rejects_script_identity_without_mutation) {
+    LPCSTR filename = "/tmp/openwarcraft3-wc3-script-mismatch-save-test.bin";
+    char extra[] = "function AddedAfterSave takes nothing returns nothing\nendfunction\n";
+    LPEDICT unit;
+    T_ASSERT(run_test_jass("function main takes nothing returns nothing\nendfunction\n"));
+    unit = alloc_test_unit(MAKEFOURCC('h', 'p', 'e', 'a'), 0.0f, 0.0f);
+    unit->harvested_gold = 37;
+    T_ASSERT(WriteGame(filename));
+    T_ASSERT(jass_dobuffer(level.vm, extra));
+    unit->harvested_gold = 99;
+    T_ASSERT(!ReadGame(filename));
+    T_EQ(unit->harvested_gold, 99);
     remove(filename);
 }
 

--- a/games/warcraft-3/game/tests/t_utils.c
+++ b/games/warcraft-3/game/tests/t_utils.c
@@ -159,6 +159,8 @@ static BOOL run_test_jass_impl(LPCSTR src, LPCSTR expected) {
         .natives          = jass_funcs,
         .GetPlayerByNumber = G_GetPlayerByNumber,
         .RuntimeError     = ignore_jass_error,
+        .SaveHandle       = G_SaveJassHandle,
+        .LoadHandle       = G_LoadJassHandle,
     ));
     level.vm = jass_newstate();
 

--- a/games/warcraft-3/jass/jass.h
+++ b/games/warcraft-3/jass/jass.h
@@ -5,8 +5,6 @@
 #include "game/api/api_macros.h"
 #include "jass_api.h"
 
-#define MAX_GROUP_SIZE 256
-
 #define API_ALLOC(TYPE, NAME) TYPE *NAME = jass_newhandle(j, sizeof(TYPE), #NAME);
 
 KNOWN_AS(jass_type, JASSTYPE);
@@ -62,11 +60,6 @@ struct gtrigger_s {
 };
 
 typedef struct {
-    LPEDICT units[MAX_GROUP_SIZE];
-    DWORD num_units;
-} ggroup_t;
-
-typedef struct {
     PATHSTR fileName;
     BOOL looping;
     BOOL is3D;
@@ -88,6 +81,7 @@ struct jass_context {
     LPEDICT source;
     LPPLAYER playerState;
     LPPLAYER localPlayerState;
+    HANDLE timer;
     LPCJASSFUNC func;
 };
 
@@ -108,6 +102,8 @@ BOOL jass_coroutinedone(LPCJASSCOROUTINE co);
 void jass_runevents(LPJASS j);
 void jass_sleep(LPJASS j, DWORD msec);
 LPCSTR jass_functionname(LPCJASSFUNC func);
+LPCJASSFUNC jass_functionbyname(LPJASS j, LPCSTR name);
+void jass_settimercontext(HANDLE timer);
 BOOL jass_triggerdisabled(LPTRIGGER trigger);
 JASSTYPEID jass_gettype(LPJASS j, int index);
 DWORD jass_pushnull(LPJASS j);

--- a/games/warcraft-3/jass/jass_api.h
+++ b/games/warcraft-3/jass/jass_api.h
@@ -9,6 +9,12 @@ KNOWN_AS(jass_coroutine, JASSCOROUTINE);
 KNOWN_AS(jass_module, JASSMODULE);
 
 typedef DWORD (*LPJASSCFUNCTION)(LPJASS);
+typedef BOOL (*LPJASSSNAPSHOTIO)(void *context, void *data, DWORD size);
+
+typedef struct {
+    void *context;
+    LPJASSSNAPSHOTIO transfer;
+} JASSSNAPSHOT;
 
 struct jass_module {
     LPCSTR name;
@@ -32,6 +38,8 @@ typedef struct {
     LPCJASSMODULE galaxy_natives;
     struct playerState_s *(*GetPlayerByNumber)(DWORD number);
     void (*RuntimeError)(LPCSTR message);
+    BOOL (*SaveHandle)(LPCSTR type, HANDLE value, DWORD *id);
+    HANDLE (*LoadHandle)(LPCSTR type, DWORD id);
 } JASSHOST;
 
 /* VM lifecycle */
@@ -44,6 +52,9 @@ BOOL   jass_dobuffer(LPJASS j, LPSTR buffer);
 BOOL   jass_dobuffer_ex(LPJASS j, LPSTR buffer, JASSMODE mode);
 void   jass_callbyname(LPJASS j, LPCSTR name, BOOL spawn_coroutine);
 void   jass_runevents(LPJASS j);
+BOOL   jass_writesnapshot(LPJASS j, JASSSNAPSHOT *snapshot);
+BOOL   jass_readsnapshot(LPJASS j, JASSSNAPSHOT *snapshot);
+DWORD  jass_programidentity(LPJASS j);
 
 /* Heap allocation (via jass_host.MemAlloc/MemFree) */
 HANDLE jass_alloc(long size);
@@ -78,5 +89,6 @@ LPJASSCOROUTINE jass_startcoroutinebyname(LPJASS j, LPCSTR name);
 LPJASSCOROUTINE jass_startcoroutinebynameforplayer(LPJASS j, LPCSTR name, struct playerState_s *player);
 BOOL   jass_callcoroutinebyname(LPJASS j, LPCSTR name);
 void   jass_sleep(LPJASS j, DWORD msec);
+void   jass_settimercontext(HANDLE timer);
 
 #endif

--- a/games/warcraft-3/jass/jdo.c
+++ b/games/warcraft-3/jass/jdo.c
@@ -22,6 +22,9 @@
 #define INF_LOOP_PROTECTION 1000000  /* SC2 Galaxy scripts have large but legitimate loops */
 #define SYNTAX_C_OPERATORS 1 // bitmask; enables Galaxy symbolic logic and shift operators
 #define SYNTAX_INCLUDES    2 // bitmask; enables Galaxy include preprocessing
+#define BZ_JASS_SNAPSHOT_VERSION 1 // format version; rejects snapshots with incompatible semantic records
+#define BZ_JASS_SNAPSHOT_MAX_COUNT (1u << 20) // records; bounds allocations and list walks from corrupt snapshots
+#define BZ_JASS_SNAPSHOT_MAX_STRING (1u << 20) // bytes; bounds strings from corrupt snapshots
 
 #define assert_type(var, type) assert(jass_checktype(var, type))
 #define JASSALLOC(type) jass_alloc(sizeof(type))
@@ -69,6 +72,7 @@ DWORD NAME(LPJASS j) { \
 LPPLAYER currentplayer = NULL;
 LPEDICT currentunit = NULL;
 LPPLAYER currentenumplayer = NULL;
+static HANDLE currenttimer = NULL;
 
 LPCSTR keywords[] = {
     "elseif", "else", "endif", "set", "endfunction", "local", "then", NULL
@@ -202,7 +206,7 @@ JASS_CMPOP(__ge, >=);
 JASS_CMPOP(__gt, >);
 JASS_CMPOP(__lt, <);
 
-static BOOL var_eq(LPCJASSVAR a, LPCJASSVAR b) {
+static BOOL jass_valuehandle(LPCSTR type) {
     static LPCSTR const value_handles[] = {
         "race", "alliancetype", "racepreference", "igamestate", "fgamestate", "playerstate",
         "playergameresult", "unitstate", "gameevent", "playerevent", "playerunitevent", "widgetevent",
@@ -211,6 +215,11 @@ static BOOL var_eq(LPCJASSVAR a, LPCJASSVAR b) {
         "playercolor", "playerslotstate", "volumegroup", "camerafield", "blendmode", "raritycontrol",
         "texmapflags", "fogstate", "effecttype"
     };
+    FOR_LOOP(i, sizeof(value_handles) / sizeof(value_handles[0])) if (!strcmp(type, value_handles[i])) return true;
+    return false;
+}
+
+static BOOL var_eq(LPCJASSVAR a, LPCJASSVAR b) {
     switch ((a->value == NULL) + (b->value == NULL)) {
         case 2: return true;
         case 1: return false;
@@ -226,9 +235,7 @@ static BOOL var_eq(LPCJASSVAR a, LPCJASSVAR b) {
         case jasstype_handle:
             if (a->value == b->value) return true;
             if (a->type != b->type) return false;
-            FOR_LOOP(i, sizeof(value_handles) / sizeof(value_handles[0]))
-                if (!strcmp(a->type->name, value_handles[i])) return !memcmp(a->value, b->value, sizeof(DWORD));
-            return false;
+            return jass_valuehandle(a->type->name) && !memcmp(a->value, b->value, sizeof(DWORD));
     }
     return false;
 }
@@ -532,6 +539,9 @@ BOOL jass_callcoroutinebyname(LPJASS j, LPCSTR name) {
 LPCSTR jass_functionname(LPCJASSFUNC func) {
     return func ? func->name : NULL;
 }
+
+LPCJASSFUNC jass_functionbyname(LPJASS j, LPCSTR name) { return find_function(jass_root(j), name); }
+void jass_settimercontext(HANDLE timer) { currenttimer = timer; }
 
 BOOL jass_triggerdisabled(LPTRIGGER trigger) {
     return trigger ? trigger->disabled : false;
@@ -879,6 +889,7 @@ static BOOL jass_evaluatetriggercontext(LPJASS j,
         tmp_state.context.source = source;
         tmp_state.context.playerState = player;
         tmp_state.context.localPlayerState = currentplayer;
+        tmp_state.context.timer = currenttimer;
         jass_pushfunction(&tmp_state, cond->expr);
         LPEDICT previous_unit = currentunit;
         currentunit = unit;
@@ -944,6 +955,7 @@ static void jass_executetriggercontext(LPJASS j,
                                   .source = source,
                                   .playerState = player,
                                   .localPlayerState = currentplayer,
+                                  .timer = currenttimer,
                               ));
     }
 }
@@ -1923,6 +1935,412 @@ BOOL jass_dobuffer_ex(LPJASS j, LPSTR buffer, JASSMODE mode) {
 
 BOOL jass_dobuffer(LPJASS j, LPSTR buffer) {
     return jass_dobuffer_ex(j, buffer, JASS_MODE_JASS);
+}
+
+typedef struct {
+    DWORD magic, version, identity, globals, coroutines;
+} JASSSNAPSHOTHEADER;
+
+static DWORD const jass_snapshot_magic = MAKEFOURCC('J', 'S', 'V', 'M');
+
+/* Snapshot identity hashes immutable parser metadata, never process-local addresses. */
+static DWORD jass_snapshot_hashbytes(DWORD hash, LPCVOID data, size_t size) {
+    BYTE const *bytes = data;
+    while (size--) hash = (hash ^ *bytes++) * 16777619u;
+    return hash;
+}
+
+static DWORD jass_snapshot_hashstr(DWORD hash, LPCSTR text) {
+    DWORD len = text ? (DWORD)strlen(text) : 0;
+    hash = jass_snapshot_hashbytes(hash, &len, sizeof(len));
+    return len ? jass_snapshot_hashbytes(hash, text, len) : hash;
+}
+
+static DWORD jass_snapshot_hashtokens(DWORD hash, LPCTOKEN token) {
+    FOR_EACH_LIST(TOKEN const, item, token) {
+        hash = jass_snapshot_hashbytes(hash, &item->type, sizeof(item->type));
+        hash = jass_snapshot_hashbytes(hash, &item->flags, sizeof(item->flags));
+        hash = jass_snapshot_hashstr(hash, item->primary);
+        hash = jass_snapshot_hashstr(hash, item->secondary);
+        hash = jass_snapshot_hashtokens(hash, item->init);
+        hash = jass_snapshot_hashtokens(hash, item->body);
+        hash = jass_snapshot_hashtokens(hash, item->args);
+        hash = jass_snapshot_hashtokens(hash, item->condition);
+        hash = jass_snapshot_hashtokens(hash, item->elseblock);
+        hash = jass_snapshot_hashtokens(hash, item->index);
+    }
+    return hash;
+}
+
+static DWORD jass_snapshot_identity(LPCJASS j) {
+    DWORD hash = 2166136261u;
+    FOR_EACH_LIST(JASSPROGRAM const, program, j->programs) hash = jass_snapshot_hashtokens(hash, program->tokens);
+    return hash;
+}
+
+DWORD jass_programidentity(LPJASS j) { return jass_snapshot_identity(jass_root(j)); }
+
+static BOOL jass_snapshot_io(JASSSNAPSHOT *snapshot, void *data, size_t size) {
+    return size <= UINT32_MAX && snapshot && snapshot->transfer && snapshot->transfer(snapshot->context, data, (DWORD)size);
+}
+
+static BOOL jass_snapshot_writestr(JASSSNAPSHOT *snapshot, LPCSTR text) {
+    DWORD len = text ? (DWORD)strlen(text) + 1 : 0;
+    return jass_snapshot_io(snapshot, &len, sizeof(len)) && (!len || jass_snapshot_io(snapshot, (void *)text, len));
+}
+
+static BOOL jass_snapshot_readstr(JASSSNAPSHOT *snapshot, LPSTR *text) {
+    DWORD len;
+    LPSTR value = NULL;
+    if (!jass_snapshot_io(snapshot, &len, sizeof(len)) || len > BZ_JASS_SNAPSHOT_MAX_STRING) return false;
+    if (len) {
+        value = jass_alloc(len);
+        if (!value || !jass_snapshot_io(snapshot, value, len) || value[len - 1]) { SAFE_DELETE(value, jass_free); return false; }
+    }
+    *text = value;
+    return true;
+}
+
+static DWORD jass_snapshot_arraycount(LPCJASSARRAY array) {
+    DWORD count = 0;
+    FOR_EACH_LIST(JASSARRAY const, item, array) count++;
+    return count;
+}
+
+/* Values carry their declared type so changed scripts and corrupt tags reject before mutation. */
+static BOOL jass_snapshot_writevar(LPJASS j, JASSSNAPSHOT *snapshot, LPCJASSVAR var) {
+    DWORD present = var->value || var->_array, count = jass_snapshot_arraycount(var->_array);
+    JASSTYPEID base;
+    if (!var->type) { fprintf(stderr, "JASS snapshot: value has no declared type\n"); return false; }
+    base = jass_getvarbasetype(var);
+    if (!jass_snapshot_writestr(snapshot, var->type ? var->type->name : NULL) ||
+        !jass_snapshot_io(snapshot, &present, sizeof(present)) ||
+        !jass_snapshot_io(snapshot, &count, sizeof(count))) return false;
+    FOR_EACH_LIST(JASSARRAY const, item, var->_array)
+        if (!jass_snapshot_io(snapshot, (void *)&item->index, sizeof(item->index)) ||
+            !jass_snapshot_writevar(j, snapshot, &item->value)) return false;
+    if (!present || count) return true;
+    switch (base) {
+    case jasstype_integer: return jass_snapshot_io(snapshot, var->value, sizeof(LONG));
+    case jasstype_real: return jass_snapshot_io(snapshot, var->value, sizeof(FLOAT));
+    case jasstype_boolean: return jass_snapshot_io(snapshot, var->value, sizeof(BOOL));
+    case jasstype_string: return jass_snapshot_writestr(snapshot, var->value);
+    case jasstype_code: return jass_snapshot_writestr(snapshot, jass_functionname(var->value));
+    case jasstype_handle: {
+        DWORD id;
+        if (jass_valuehandle(var->type->name)) return jass_snapshot_io(snapshot, var->value, sizeof(DWORD));
+        if (!jass_host.SaveHandle || !jass_host.SaveHandle(var->type->name, var->value, &id)) {
+            fprintf(stderr, "JASS snapshot: cannot encode %s handle\n", var->type->name);
+            return false;
+        }
+        return jass_snapshot_io(snapshot, &id, sizeof(id));
+    }
+    default: fprintf(stderr, "JASS snapshot: unsupported value type %s\n", var->type->name); return false;
+    }
+}
+
+static BOOL jass_snapshot_readvar(LPJASS j, JASSSNAPSHOT *snapshot, LPJASSVAR var) {
+    LPSTR type = NULL, text = NULL;
+    DWORD present, count;
+    LPCJASSTYPE declared;
+    if (!jass_snapshot_readstr(snapshot, &type) || !type || !(declared = find_type(j, type)) ||
+        !jass_snapshot_io(snapshot, &present, sizeof(present)) || present > 1 ||
+        !jass_snapshot_io(snapshot, &count, sizeof(count)) || count > BZ_JASS_SNAPSHOT_MAX_COUNT) {
+        SAFE_DELETE(type, jass_free); return false;
+    }
+    SAFE_DELETE(type, jass_free);
+    var->type = declared;
+    FOR_LOOP(i, count) {
+        DWORD index;
+        if (!jass_snapshot_io(snapshot, &index, sizeof(index)) ||
+            !jass_snapshot_readvar(j, snapshot, ensure_array_value(j, var, index))) return false;
+    }
+    if (!present || count) return present == !!count;
+    switch (jass_getvarbasetype(var)) {
+    case jasstype_integer: return (var->value = jass_alloc(sizeof(LONG))) && jass_snapshot_io(snapshot, var->value, sizeof(LONG));
+    case jasstype_real: return (var->value = jass_alloc(sizeof(FLOAT))) && jass_snapshot_io(snapshot, var->value, sizeof(FLOAT));
+    case jasstype_boolean: return (var->value = jass_alloc(sizeof(BOOL))) && jass_snapshot_io(snapshot, var->value, sizeof(BOOL));
+    case jasstype_string:
+        if (!jass_snapshot_readstr(snapshot, &text) || !text) return false;
+        var->value = text; return true;
+    case jasstype_code:
+        if (!jass_snapshot_readstr(snapshot, &text) || !text) return false;
+        var->value = (HANDLE)find_function(j, text); SAFE_DELETE(text, jass_free); return var->value != NULL;
+    case jasstype_handle: {
+        DWORD id;
+        HANDLE value;
+        if (!jass_snapshot_io(snapshot, &id, sizeof(id))) return false;
+        if (jass_valuehandle(var->type->name)) {
+            var->value = jass_alloc(sizeof(DWORD));
+            if (!var->value) return false;
+            *(LPDWORD)var->value = id;
+            var->refcount = jass_alloc(sizeof(DWORD));
+            if (!var->refcount) return false;
+            *var->refcount = 0;
+            return true;
+        }
+        if (!jass_host.LoadHandle || !(value = jass_host.LoadHandle(var->type->name, id))) {
+            fprintf(stderr, "JASS snapshot: cannot resolve %s handle\n", var->type->name);
+            return false;
+        }
+        var->refcount = jass_alloc(sizeof(DWORD));
+        if (!var->refcount) return false;
+        var->value = value;
+        *var->refcount = 1;
+        return true;
+    }
+    default: fprintf(stderr, "JASS snapshot: unsupported value type %s\n", var->type->name); return false;
+    }
+}
+
+static DWORD jass_snapshot_globalcount(LPCJASS j) {
+    DWORD count = 0;
+    FOR_EACH_LIST(JASSDICT const, item, j->globals) if (!item->value.constant) count++;
+    return count;
+}
+
+static DWORD jass_snapshot_coroutinecount(LPCJASS j) {
+    DWORD count = 0;
+    FOR_EACH_LIST(JASSCOROUTINE const, co, j->coroutines) if (!co->done) count++;
+    return count;
+}
+
+static BOOL jass_snapshot_findtoken(LPCTOKEN token, LPCTOKEN wanted, DWORD *ordinal, DWORD *found) {
+    FOR_EACH_LIST(TOKEN const, item, token) {
+        DWORD current = (*ordinal)++;
+        if (item == wanted) { *found = current; return true; }
+        if (jass_snapshot_findtoken(item->init, wanted, ordinal, found) ||
+            jass_snapshot_findtoken(item->body, wanted, ordinal, found) ||
+            jass_snapshot_findtoken(item->args, wanted, ordinal, found) ||
+            jass_snapshot_findtoken(item->condition, wanted, ordinal, found) ||
+            jass_snapshot_findtoken(item->elseblock, wanted, ordinal, found) ||
+            jass_snapshot_findtoken(item->index, wanted, ordinal, found)) return true;
+    }
+    return false;
+}
+
+static DWORD jass_snapshot_tokenid(LPCJASS j, LPCTOKEN wanted) {
+    DWORD ordinal = 0, found = UINT32_MAX;
+    if (!wanted) return UINT32_MAX;
+    FOR_EACH_LIST(JASSPROGRAM const, program, j->programs)
+        if (jass_snapshot_findtoken(program->tokens, wanted, &ordinal, &found)) return found;
+    return UINT32_MAX;
+}
+
+static LPCTOKEN jass_snapshot_gettoken(LPCTOKEN token, DWORD wanted, DWORD *ordinal) {
+    FOR_EACH_LIST(TOKEN const, item, token) {
+        if ((*ordinal)++ == wanted) return item;
+        LPCTOKEN found = jass_snapshot_gettoken(item->init, wanted, ordinal);
+        if (!found) found = jass_snapshot_gettoken(item->body, wanted, ordinal);
+        if (!found) found = jass_snapshot_gettoken(item->args, wanted, ordinal);
+        if (!found) found = jass_snapshot_gettoken(item->condition, wanted, ordinal);
+        if (!found) found = jass_snapshot_gettoken(item->elseblock, wanted, ordinal);
+        if (!found) found = jass_snapshot_gettoken(item->index, wanted, ordinal);
+        if (found) return found;
+    }
+    return NULL;
+}
+
+static LPCTOKEN jass_snapshot_token(LPCJASS j, DWORD wanted) {
+    DWORD ordinal = 0;
+    if (wanted == UINT32_MAX) return NULL;
+    FOR_EACH_LIST(JASSPROGRAM const, program, j->programs) {
+        LPCTOKEN found = jass_snapshot_gettoken(program->tokens, wanted, &ordinal);
+        if (found) return found;
+    }
+    return NULL;
+}
+
+static DWORD jass_snapshot_dictcount(LPCJASSDICT dict) {
+    DWORD count = 0;
+    FOR_EACH_LIST(JASSDICT const, item, dict) count++;
+    return count;
+}
+
+static BOOL jass_snapshot_writedict(LPJASS j, JASSSNAPSHOT *snapshot, LPCJASSDICT dict) {
+    DWORD count = jass_snapshot_dictcount(dict);
+    if (!jass_snapshot_io(snapshot, &count, sizeof(count))) return false;
+    FOR_EACH_LIST(JASSDICT const, item, dict)
+        if (!jass_snapshot_writestr(snapshot, item->key) || !jass_snapshot_writevar(j, snapshot, &item->value)) return false;
+    return true;
+}
+
+static BOOL jass_snapshot_readdict(LPJASS j, JASSSNAPSHOT *snapshot, LPJASSDICT *dict) {
+    DWORD count;
+    if (!jass_snapshot_io(snapshot, &count, sizeof(count)) || count > BZ_JASS_SNAPSHOT_MAX_COUNT) return false;
+    FOR_LOOP(i, count) {
+        LPJASSDICT item = JASSALLOC(JASSDICT);
+        LPSTR name = NULL;
+        if (!jass_snapshot_readstr(snapshot, &name) || !name || find_dict(*dict, name)) {
+            SAFE_DELETE(name, jass_free); jass_free(item); return false;
+        }
+        item->key = name;
+        if (!jass_snapshot_readvar(j, snapshot, &item->value)) { jass_deletedict(item); return false; }
+        PUSH_BACK(JASSDICT, item, *dict);
+    }
+    return true;
+}
+
+static BOOL jass_snapshot_writecontext(JASSSNAPSHOT *snapshot, LPCJASSCONTEXT context) {
+    struct { LPCSTR type; HANDLE value; } handles[] = {
+        { "trigger", context->trigger }, { "unit", context->unit }, { "unit", context->source },
+        { "player", context->playerState }, { "player", context->localPlayerState }, { "timer", context->timer },
+    };
+    if (!jass_snapshot_writestr(snapshot, jass_functionname(context->func))) return false;
+    FOR_LOOP(i, sizeof(handles) / sizeof(*handles)) {
+        DWORD present = handles[i].value != NULL, id = 0;
+        if (!jass_snapshot_io(snapshot, &present, sizeof(present))) return false;
+        if (present && (!jass_host.SaveHandle || !jass_host.SaveHandle(handles[i].type, handles[i].value, &id) ||
+            !jass_snapshot_io(snapshot, &id, sizeof(id)))) return false;
+    }
+    return true;
+}
+
+static BOOL jass_snapshot_readcontext(LPJASS j, JASSSNAPSHOT *snapshot, LPJASSCONTEXT context) {
+    struct { LPCSTR type; HANDLE *value; } handles[] = {
+        { "trigger", (HANDLE *)&context->trigger }, { "unit", (HANDLE *)&context->unit },
+        { "unit", (HANDLE *)&context->source }, { "player", (HANDLE *)&context->playerState },
+        { "player", (HANDLE *)&context->localPlayerState }, { "timer", &context->timer },
+    };
+    LPSTR func = NULL;
+    BOOL has_func;
+    if (!jass_snapshot_readstr(snapshot, &func)) return false;
+    has_func = func != NULL;
+    context->func = func ? find_function(j, func) : NULL;
+    SAFE_DELETE(func, jass_free);
+    if (has_func && !context->func) return false;
+    FOR_LOOP(i, sizeof(handles) / sizeof(*handles)) {
+        DWORD present, id;
+        if (!jass_snapshot_io(snapshot, &present, sizeof(present)) || present > 1) return false;
+        if (present && (!jass_snapshot_io(snapshot, &id, sizeof(id)) || !jass_host.LoadHandle ||
+            !(*handles[i].value = jass_host.LoadHandle(handles[i].type, id)))) return false;
+    }
+    return true;
+}
+
+static BOOL jass_snapshot_writecoroutines(LPJASS j, JASSSNAPSHOT *snapshot) {
+    DWORD count = jass_snapshot_coroutinecount(j), now = jass_gettime();
+    if (!jass_snapshot_io(snapshot, &count, sizeof(count))) return false;
+    FOR_EACH_LIST(JASSCOROUTINE const, co, j->coroutines) {
+        DWORD frames = 0, remaining = co->wake_time > now ? co->wake_time - now : 0;
+        if (co->done) continue;
+        FOR_EACH_LIST(JASSCOROUTINEFRAME const, frame, co->frames) frames++;
+        if (!jass_snapshot_writecontext(snapshot, &co->state->context) ||
+            !jass_snapshot_io(snapshot, &remaining, sizeof(remaining)) ||
+            !jass_snapshot_io(snapshot, &frames, sizeof(frames))) return false;
+        FOR_EACH_LIST(JASSCOROUTINEFRAME const, frame, co->frames) {
+            DWORD body = jass_snapshot_tokenid(j, frame->body), pc = jass_snapshot_tokenid(j, frame->pc);
+            if ((frame->body && body == UINT32_MAX) || (frame->pc && pc == UINT32_MAX) ||
+                !jass_snapshot_io(snapshot, (void *)&frame->type, sizeof(frame->type)) ||
+                !jass_snapshot_writestr(snapshot, jass_functionname(frame->func)) ||
+                !jass_snapshot_io(snapshot, &body, sizeof(body)) || !jass_snapshot_io(snapshot, &pc, sizeof(pc)) ||
+                !jass_snapshot_io(snapshot, (void *)&frame->loop_count, sizeof(frame->loop_count)) ||
+                !jass_snapshot_writedict(j, snapshot, frame->locals)) return false;
+        }
+    }
+    return true;
+}
+
+static BOOL jass_snapshot_readcoroutines(LPJASS j, JASSSNAPSHOT *snapshot, LPJASSCOROUTINE *list) {
+    DWORD count, now = jass_gettime();
+    if (!jass_snapshot_io(snapshot, &count, sizeof(count)) || count > BZ_JASS_SNAPSHOT_MAX_COUNT) return false;
+    FOR_LOOP(i, count) {
+        LPJASS state = JASSALLOC(JASS);
+        LPJASSCOROUTINE co = JASSALLOC(JASSCOROUTINE);
+        LPJASSCOROUTINEFRAME *tail = &co->frames;
+        DWORD remaining, frames;
+        memcpy(state, j, sizeof(*state));
+        memset(state->stack, 0, sizeof(state->stack));
+        memset(&state->context, 0, sizeof(state->context));
+        state->stack_pointer = state->stack; state->num_stack = 0; state->root = j;
+        state->coroutines = NULL; state->current_coroutine = NULL;
+        co->state = state; co->wake_time = now; co->yielded = true;
+        if (!jass_snapshot_readcontext(j, snapshot, &state->context) ||
+            !jass_snapshot_io(snapshot, &remaining, sizeof(remaining)) ||
+            !jass_snapshot_io(snapshot, &frames, sizeof(frames)) || !frames || frames > BZ_JASS_SNAPSHOT_MAX_COUNT) {
+            jass_free_coroutine(co); return false;
+        }
+        co->wake_time += remaining;
+        FOR_LOOP(k, frames) {
+            LPJASSCOROUTINEFRAME frame = JASSALLOC(JASSCOROUTINEFRAME);
+            LPSTR func = NULL;
+            DWORD body, pc;
+            memset(frame, 0, sizeof(*frame));
+            if (!jass_snapshot_io(snapshot, &frame->type, sizeof(frame->type)) || frame->type > JASS_FRAME_LOOP ||
+                !jass_snapshot_readstr(snapshot, &func) ||
+                !jass_snapshot_io(snapshot, &body, sizeof(body)) || !jass_snapshot_io(snapshot, &pc, sizeof(pc)) ||
+                !jass_snapshot_io(snapshot, &frame->loop_count, sizeof(frame->loop_count)) ||
+                !jass_snapshot_readdict(j, snapshot, &frame->locals)) {
+                SAFE_DELETE(func, jass_free); jass_free(frame); jass_free_coroutine(co); return false;
+            }
+            frame->func = func ? find_function(j, func) : NULL;
+            SAFE_DELETE(func, jass_free);
+            frame->body = jass_snapshot_token(j, body); frame->pc = jass_snapshot_token(j, pc);
+            if ((body != UINT32_MAX && !frame->body) || (pc != UINT32_MAX && !frame->pc) ||
+                (frame->type == JASS_FRAME_FUNCTION && !frame->func)) {
+                jass_free_frame(co, frame); jass_free_coroutine(co); return false;
+            }
+            *tail = frame; tail = &frame->next;
+        }
+        PUSH_BACK(JASSCOROUTINE, co, *list);
+    }
+    return true;
+}
+
+BOOL jass_writesnapshot(LPJASS j, JASSSNAPSHOT *snapshot) {
+    LPJASS root = jass_root(j);
+    JASSSNAPSHOTHEADER header = {
+        jass_snapshot_magic, BZ_JASS_SNAPSHOT_VERSION, jass_snapshot_identity(root), jass_snapshot_globalcount(root),
+        jass_snapshot_coroutinecount(root)
+    };
+    if (root->current_coroutine || root->sync_rterror_jmp_set) {
+        fprintf(stderr, "JASS snapshot: save requested inside an active VM frame\n"); return false;
+    }
+    if (!jass_snapshot_io(snapshot, &header, sizeof(header))) return false;
+    FOR_EACH_LIST(JASSDICT const, item, root->globals)
+        if (!item->value.constant && (!jass_snapshot_writestr(snapshot, item->key) ||
+            !jass_snapshot_writevar(root, snapshot, &item->value))) return false;
+    return jass_snapshot_writecoroutines(root, snapshot);
+}
+
+BOOL jass_readsnapshot(LPJASS j, JASSSNAPSHOT *snapshot) {
+    LPJASS root = jass_root(j);
+    JASSSNAPSHOTHEADER header;
+    LPJASSDICT staged = NULL;
+    LPJASSCOROUTINE coroutines = NULL;
+    BOOL ok = false;
+    if (root->current_coroutine || root->sync_rterror_jmp_set || !jass_snapshot_io(snapshot, &header, sizeof(header)) ||
+        header.magic != jass_snapshot_magic || header.version != BZ_JASS_SNAPSHOT_VERSION ||
+        header.identity != jass_snapshot_identity(root) || header.globals != jass_snapshot_globalcount(root) ||
+        header.globals > BZ_JASS_SNAPSHOT_MAX_COUNT || header.coroutines > BZ_JASS_SNAPSHOT_MAX_COUNT) return false;
+    FOR_LOOP(i, header.globals) {
+        LPSTR name = NULL;
+        LPJASSDICT item = NULL;
+        LPJASSVAR live;
+        if (!jass_snapshot_readstr(snapshot, &name) || !name || find_dict(staged, name) ||
+            !(live = find_global(root, name)) || live->constant) { SAFE_DELETE(name, jass_free); goto done; }
+        item = JASSALLOC(JASSDICT);
+        item->key = name;
+        if (!jass_snapshot_readvar(root, snapshot, &item->value)) { jass_deletedict(item); goto done; }
+        ADD_TO_LIST(item, staged);
+    }
+    if (!jass_snapshot_readcoroutines(root, snapshot, &coroutines) ||
+        header.coroutines != jass_snapshot_coroutinecount(&(JASS){ .coroutines = coroutines })) goto done;
+    FOR_EACH_LIST(JASSDICT, item, staged) {
+        LPJASSVAR live = find_global(root, item->key);
+        if (live->type != item->value.type) goto done;
+    }
+    FOR_EACH_LIST(JASSDICT, item, staged) jass_copy(root, find_global(root, item->key), &item->value);
+    while (root->coroutines) {
+        LPJASSCOROUTINE next = root->coroutines->next;
+        jass_free_coroutine(root->coroutines); root->coroutines = next;
+    }
+    root->coroutines = coroutines; coroutines = NULL;
+    ok = true;
+done:
+    SAFE_DELETE(staged, jass_deletedict);
+    while (coroutines) { LPJASSCOROUTINE next = coroutines->next; jass_free_coroutine(coroutines); coroutines = next; }
+    return ok;
 }
 
 LPJASS jass_newstate(void) {


### PR DESCRIPTION
Closes #247

## Summary
- serialize mutable JASS globals, sparse arrays, code references, and sleeping coroutine frames semantically instead of dumping pointer-rich VM memory
- relocate supported native handles through stable IDs and persist groups, triggers, timers, and unread gameplay events
- add the game-owned JASS timer scheduler, timer event dispatch, and `GetExpiredTimer()` context restoration
- validate script identity and registry counts before mutation, then verify a committed checksummed v6 save payload
- rebind process-owned unit and destructable callbacks after loading, fixing the Human02 `IssueImmediateOrder(..., "stop")` crash
- document the save format, diagnostics, lifecycle, and current coverage limits

## Validation
- `make test-wc3-engine WC3_PATTERN='wc3_save.*'`: ROC 71/71 and TFT 71/71 assertions passed
- `make test`: passed
- bounded Human02 save and load: 100 fast-forward frames each without crash or save/load diagnostics
- `git diff --check`

## Remaining limitations
- arbitrary active `umove_t` actions are not restored because static move functions do not yet have stable semantic IDs
- native records are preflighted before world mutation, but intentionally malformed checksummed records are not yet fully transactional
- fog grids, bot runtime, mutable event-registration fields, alliances, stock state, cinematic filters, and some transient presentation state remain outside the save payload