### PR TITLE
wc3: support scripted worker auto-harvest orders

### DIFF
--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -139,8 +139,15 @@ rg -n 'ngol|hpea|autoharvestgold|LocationOfGold' /tmp/human02.j
 
 The local ROC script places `gg_unit_ngol_0009` at (-4736,-3840). Its three initial gold workers are at
 (-4276.2,-3938.2), (-4147.5,-3873.2), and (-4067.4,-3981.1). Both the intro completion and cancellation paths remove/recreate
-these workers and issue `autoharvestgold`. `unit_issueimmediateorder` currently implements only `stop`, so automatic campaign
-gathering is unsupported; this is separate from a manually ordered worker remaining in walk at the mine.
+these workers and issue `autoharvestgold`. Human02 startup traces also show the preplaced lumber workers receiving
+`autoharvestlumber`; these are immediate orders with no explicit resource target.
+
+OpenRealm resolves both orders through `harvest_auto_start`. The worker must have the normal `Ahar` Harvest ability; gold selects
+the nearest live, non-empty Gold Mine and lumber selects the nearest live tree from the worker's current position. The selected
+resource is then handed to the existing targeted state machine (`harvest_gold_order` / `harvest_start`) so mine capacity, pathing,
+carried resources, drop-off selection, and resume behavior stay in one implementation. If no compatible live target exists, the
+immediate order returns false and does not invent a movement target. This fixes the Human02 scripted startup path independently of
+manually ordered workers that may later remain in walk because of pathing/crowding.
 
 At `8204597d`, bounded real-map runs after `cmd cancel` reproduced successful manual mining in both local archive modes.
 A temporary `G_RunFrame` probe at server time 7000 ms issued normal `unit_issuetargetorder(worker, "smart", mine)` calls for the

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -1680,6 +1680,8 @@ void S_GoldMineReleaseWorker(LPEDICT);
 void harvest_start(LPEDICT, LPEDICT);
 void harvest_gold_start(LPEDICT, LPEDICT);
 BOOL harvest_gold_order(LPEDICT, LPEDICT);
+BOOL harvest_auto_start_gold(LPEDICT);
+BOOL harvest_auto_start_lumber(LPEDICT);
 BOOL harvest_lumber_return_to(LPEDICT, LPEDICT);
 BOOL harvest_gold_return_to(LPEDICT, LPEDICT);
 void cargo_drop_all(LPEDICT);

--- a/games/warcraft-3/game/m_unit.c
+++ b/games/warcraft-3/game/m_unit.c
@@ -407,6 +407,10 @@ BOOL unit_issueimmediateorder(LPEDICT self, LPCSTR order) {
         order_stop(self);
         return true;
     }
+    if (!strcmp(order, "autoharvestgold"))
+        return harvest_auto_start_gold(self);
+    if (!strcmp(order, "autoharvestlumber"))
+        return harvest_auto_start_lumber(self);
     return false;
 }
 

--- a/games/warcraft-3/game/skills/s_harvest_lumber.c
+++ b/games/warcraft-3/game/skills/s_harvest_lumber.c
@@ -151,6 +151,40 @@ static LPEDICT find_another_tree(LPEDICT ent) {
     return ent ? find_another_tree_near(&ent->s.origin2) : NULL;
 }
 
+/* Automatic harvest orders have no explicit target.  Retail resolves them
+ * from the worker's current position, then continues through the ordinary
+ * targeted Harvest state machine.  Keep target discovery here so JASS/order
+ * dispatch does not need to know what counts as a live resource. */
+static LPEDICT harvest_find_nearest_resource(LPEDICT worker, returnResource_t resource) {
+    LPEDICT best = NULL;
+    FLOAT best_dist = 0.0f;
+
+    if (!worker)
+        return NULL;
+
+    FOR_LOOP(i, globals.num_edicts) {
+        LPEDICT target = globals.edicts + i;
+        FLOAT dist;
+
+        if (resource == RETURN_RESOURCE_GOLD) {
+            if (!S_GoldMineCanHarvest(target))
+                continue;
+        } else if (resource == RETURN_RESOURCE_LUMBER) {
+            if (!target->inuse || target->targtype != TARG_TREE || M_IsDead(target))
+                continue;
+        } else {
+            return NULL;
+        }
+
+        dist = Vector2_distance(&worker->s.origin2, &target->s.origin2);
+        if (!best || dist < best_dist) {
+            best = target;
+            best_dist = dist;
+        }
+    }
+    return best;
+}
+
 /* Tree interaction keeps the closest direct legal chop point.  Dynamic
  * Peasant separation belongs to the resource-worker local avoidance policy:
  * same-stream workers queue instead of pre-allocating angular lanes, while
@@ -290,6 +324,36 @@ BOOL G_ActorHasSkill(LPEDICT ent, LPCSTR id) {
     if (!id || strlen(id) != 4) return false;
     memcpy(&code, id, sizeof(code));
     return actor_has_skill(ent, code);
+}
+
+static BOOL harvest_auto_start(LPEDICT self, returnResource_t resource) {
+    LPEDICT target;
+
+    /* autoharvestgold/autoharvestlumber are worker-internal immediate orders,
+     * not substitutes for giving Harvest to arbitrary units.  OpenRealm's
+     * normal Smart resource path already keys worker authority off Ahar. */
+    if (!self || !G_ActorHasSkill(self, "Ahar") || (self->aiflags & AI_IMMOBILE))
+        return false;
+
+    target = harvest_find_nearest_resource(self, resource);
+    if (!target)
+        return false;
+
+    if (resource == RETURN_RESOURCE_GOLD)
+        return harvest_gold_order(self, target);
+    if (resource == RETURN_RESOURCE_LUMBER) {
+        harvest_start(self, target);
+        return true;
+    }
+    return false;
+}
+
+BOOL harvest_auto_start_gold(LPEDICT self) {
+    return harvest_auto_start(self, RETURN_RESOURCE_GOLD);
+}
+
+BOOL harvest_auto_start_lumber(LPEDICT self) {
+    return harvest_auto_start(self, RETURN_RESOURCE_LUMBER);
 }
 
 BOOL G_ActorAddSkill(LPEDICT ent, DWORD code) {

--- a/games/warcraft-3/game/tests/t_unit.c
+++ b/games/warcraft-3/game/tests/t_unit.c
@@ -77,7 +77,7 @@ static LPEDICT make_world_item(DWORD class_id) {
     return item;
 }
 
-static LPEDICT make_harvest_tree(FLOAT x, FLOAT y) {
+static LPEDICT unit_make_harvest_tree(FLOAT x, FLOAT y) {
     LPEDICT tree = G_Spawn();
     tree->s.origin2 = (VECTOR2){x, y};
     tree->s.origin.x = x;
@@ -87,7 +87,7 @@ static LPEDICT make_harvest_tree(FLOAT x, FLOAT y) {
     return tree;
 }
 
-static LPEDICT make_harvest_goldmine(FLOAT x, FLOAT y) {
+static LPEDICT unit_make_harvest_goldmine(FLOAT x, FLOAT y) {
     static UnitAbilities_t const abilities = { .abilList = "Agld" };
     LPEDICT mine = G_Spawn();
     mine->s.origin2 = (VECTOR2){x, y};
@@ -614,9 +614,9 @@ TEST(wc3_unit, issueimmediateorder_stop) {
 TEST(wc3_unit, issueimmediateorder_autoharvestlumber_uses_nearest_live_tree) {
     reset_test_entities();
     LPEDICT worker = make_unit(0, 0);
-    LPEDICT far_tree = make_harvest_tree(300.0f, 0.0f);
-    LPEDICT dead_tree = make_harvest_tree(25.0f, 0.0f);
-    LPEDICT near_tree = make_harvest_tree(100.0f, 0.0f);
+    LPEDICT far_tree = unit_make_harvest_tree(300.0f, 0.0f);
+    LPEDICT dead_tree = unit_make_harvest_tree(25.0f, 0.0f);
+    LPEDICT near_tree = unit_make_harvest_tree(100.0f, 0.0f);
     (void)far_tree;
     dead_tree->health.value = 0.0f;
 
@@ -629,9 +629,9 @@ TEST(wc3_unit, issueimmediateorder_autoharvestlumber_uses_nearest_live_tree) {
 TEST(wc3_unit, issueimmediateorder_autoharvestgold_uses_nearest_live_mine) {
     reset_test_entities();
     LPEDICT worker = make_unit(0, 0);
-    LPEDICT far_mine = make_harvest_goldmine(300.0f, 0.0f);
-    LPEDICT empty_mine = make_harvest_goldmine(25.0f, 0.0f);
-    LPEDICT near_mine = make_harvest_goldmine(100.0f, 0.0f);
+    LPEDICT far_mine = unit_make_harvest_goldmine(300.0f, 0.0f);
+    LPEDICT empty_mine = unit_make_harvest_goldmine(25.0f, 0.0f);
+    LPEDICT near_mine = unit_make_harvest_goldmine(100.0f, 0.0f);
     (void)far_mine;
     empty_mine->resources = 0;
 

--- a/games/warcraft-3/game/tests/t_unit.c
+++ b/games/warcraft-3/game/tests/t_unit.c
@@ -77,6 +77,28 @@ static LPEDICT make_world_item(DWORD class_id) {
     return item;
 }
 
+static LPEDICT make_harvest_tree(FLOAT x, FLOAT y) {
+    LPEDICT tree = G_Spawn();
+    tree->s.origin2 = (VECTOR2){x, y};
+    tree->s.origin.x = x;
+    tree->s.origin.y = y;
+    tree->targtype = TARG_TREE;
+    tree->health.value = tree->health.max_value = 100.0f;
+    return tree;
+}
+
+static LPEDICT make_harvest_goldmine(FLOAT x, FLOAT y) {
+    static UnitAbilities_t const abilities = { .abilList = "Agld" };
+    LPEDICT mine = G_Spawn();
+    mine->s.origin2 = (VECTOR2){x, y};
+    mine->s.origin.x = x;
+    mine->s.origin.y = y;
+    mine->UnitAbilities = &abilities;
+    mine->resources = 12500;
+    mine->health.value = mine->health.max_value = 1000.0f;
+    return mine;
+}
+
 TEST(wc3_unit, shared_test_unit_starts_alive) {
     LPEDICT ent = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
 
@@ -587,6 +609,45 @@ TEST(wc3_unit, issueimmediateorder_stop) {
     BOOL result = unit_issueimmediateorder(ent, "stop");
     T_ASSERT(result);
     T_STREQ(ent->currentmove->animation, "stand");
+}
+
+TEST(wc3_unit, issueimmediateorder_autoharvestlumber_uses_nearest_live_tree) {
+    reset_test_entities();
+    LPEDICT worker = make_unit(0, 0);
+    LPEDICT far_tree = make_harvest_tree(300.0f, 0.0f);
+    LPEDICT dead_tree = make_harvest_tree(25.0f, 0.0f);
+    LPEDICT near_tree = make_harvest_tree(100.0f, 0.0f);
+    (void)far_tree;
+    dead_tree->health.value = 0.0f;
+
+    T_ASSERT(unit_issueimmediateorder(worker, "autoharvestlumber"));
+    T_ASSERT(worker->goalentity == near_tree);
+    T_ASSERT(worker->secondarygoal == near_tree);
+    T_STREQ(worker->currentmove->animation, "walk");
+}
+
+TEST(wc3_unit, issueimmediateorder_autoharvestgold_uses_nearest_live_mine) {
+    reset_test_entities();
+    LPEDICT worker = make_unit(0, 0);
+    LPEDICT far_mine = make_harvest_goldmine(300.0f, 0.0f);
+    LPEDICT empty_mine = make_harvest_goldmine(25.0f, 0.0f);
+    LPEDICT near_mine = make_harvest_goldmine(100.0f, 0.0f);
+    (void)far_mine;
+    empty_mine->resources = 0;
+
+    T_ASSERT(unit_issueimmediateorder(worker, "autoharvestgold"));
+    T_ASSERT(worker->goalentity == near_mine);
+    T_ASSERT(worker->secondarygoal == near_mine);
+    T_STREQ(worker->currentmove->animation, "walk");
+}
+
+TEST(wc3_unit, issueimmediateorder_autoharvest_requires_resource_target) {
+    reset_test_entities();
+    LPEDICT worker = make_unit(0, 0);
+
+    T_ASSERT(!unit_issueimmediateorder(worker, "autoharvestlumber"));
+    T_ASSERT(!unit_issueimmediateorder(worker, "autoharvestgold"));
+    T_STREQ(worker->currentmove->animation, "stand");
 }
 
 TEST(wc3_unit, issueimmediateorder_unknown_returns_false) {


### PR DESCRIPTION
Implement Warcraft III's `autoharvestgold` and `autoharvestlumber` immediate orders used by campaign maps such as Human02.

The new handling:

* finds an appropriate nearby Gold Mine or tree
* ignores depleted mines and dead trees
* requires the worker's normal Harvest ability
* reuses the existing gold and lumber harvest state machines
* preserves existing mine capacity, return-resource, pathing, and drop-off behavior

Add regression coverage for both auto-harvest orders and document the Human02 startup behavior.

This fixes preplaced Human02 Peasants remaining idle because the map's scripted auto-harvest orders were previously reported as unsupported.