### PR TITLE
wc3: implement victory and defeat lifecycle and result menu

### DIFF
--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -16,6 +16,9 @@
 #include "ui_layout.h"
 #include "sound/s_local.h"
 #include "common/net_platform.h"
+#ifdef BZ_TESTS
+#include "shared/test.h"
+#endif
 
 refExport_t re;
 uiExport_t ui;
@@ -29,6 +32,20 @@ static DWORD cl_last_packet_time = 0;
 static DWORD cl_realtime = 0;
 static char cl_pending_game_commands[8][256];
 static DWORD cl_pending_game_command_count;
+
+typedef enum {
+    CL_MENU_ACTION_NONE,
+    CL_MENU_ACTION_MAP,
+    CL_MENU_ACTION_MENU,
+    CL_MENU_ACTION_QUIT,
+} clMenuActionType_t;
+
+typedef struct {
+    clMenuActionType_t type;
+    PATHSTR arg;
+} clPendingMenuAction_t;
+
+static clPendingMenuAction_t cl_pending_menu_action;
 
 static BOOL CL_IsDeferredGameCommand(LPCSTR text) {
     return text && (!strncmp(text, "give ", 5) || !strcmp(text, "give") ||
@@ -563,19 +580,76 @@ static void CL_Quit_f(void) {
     Com_Quit();
 }
 
-/* Map-or-quit dispatcher called from the server game import (gi.MenuAction). */
+/* Game modules request session-boundary actions through gi.MenuAction while
+ * their simulation/JASS call stack may still be active.  Never tear down or
+ * replace the current world inline from that callback.  Copy the request and
+ * execute it from the following client frame, after SV_Frame has returned. */
 void MenuAction(LPCSTR action, LPCSTR arg) {
+    clPendingMenuAction_t pending = { 0 };
+
+    if (!action || !*action) return;
     if (!strcmp(action, "map")) {
-        PATHSTR map;
         if (!arg || !*arg) return;
-        if (!Com_ResolveMapArgument(arg, map, sizeof(map))) return;
-        CL_SetGameplayBindings();
-        CL_BeginLoadingMap(map);
-        SV_Map(map);
+        if (!Com_ResolveMapArgument(arg, pending.arg, sizeof(pending.arg))) return;
+        pending.type = CL_MENU_ACTION_MAP;
+    } else if (!strcmp(action, "menu")) {
+        pending.type = CL_MENU_ACTION_MENU;
+        if (arg && *arg) strlcpy(pending.arg, arg, sizeof(pending.arg));
     } else if (!strcmp(action, "quit")) {
+        pending.type = CL_MENU_ACTION_QUIT;
+    } else {
+        return;
+    }
+
+    if (cl_pending_menu_action.type != CL_MENU_ACTION_NONE) {
+        fprintf(stderr, "MenuAction: replacing pending session action %u with %u\n",
+                (unsigned)cl_pending_menu_action.type, (unsigned)pending.type);
+    }
+    cl_pending_menu_action = pending;
+}
+
+static void CL_ProcessPendingMenuAction(void) {
+    clPendingMenuAction_t pending;
+
+    if (cl_pending_menu_action.type == CL_MENU_ACTION_NONE) return;
+
+    /* Clear first: the transition may initialize a new game module which can
+     * itself publish a later session action without being overwritten here. */
+    pending = cl_pending_menu_action;
+    memset(&cl_pending_menu_action, 0, sizeof(cl_pending_menu_action));
+
+    switch (pending.type) {
+    case CL_MENU_ACTION_MAP:
+        CL_SetGameplayBindings();
+        CL_BeginLoadingMap(pending.arg);
+        SV_Map(pending.arg);
+        break;
+    case CL_MENU_ACTION_MENU:
+        CL_Disconnect("Game ended.", false);
+        if (pending.arg[0] && strcmp(pending.arg, "menu_main")) CL_MenuCommand(pending.arg);
+        break;
+    case CL_MENU_ACTION_QUIT:
         CL_Quit_f();
+        break;
+    case CL_MENU_ACTION_NONE:
+        break;
     }
 }
+
+#ifdef BZ_TESTS
+TEST(client_session, menu_action_map_is_deferred_until_client_frame) {
+    memset(&cl_pending_menu_action, 0, sizeof(cl_pending_menu_action));
+
+    MenuAction("map", "Maps\\Campaign\\Human02.w3m");
+
+    T_EQ(cl_pending_menu_action.type, CL_MENU_ACTION_MAP);
+    T_STREQ(cl_pending_menu_action.arg, "Maps\\Campaign\\Human02.w3m");
+
+    /* Do not call CL_ProcessPendingMenuAction here: the regression contract is
+     * specifically that MenuAction itself cannot enter SV_Map re-entrantly. */
+    memset(&cl_pending_menu_action, 0, sizeof(cl_pending_menu_action));
+}
+#endif
 
 void CL_Init(void) {
     VIDEOMODE mode;
@@ -833,6 +907,7 @@ void CL_Frame(DWORD msec) {
     cl_realtime += msec;
     cl.time += msec;
 
+    CL_ProcessPendingMenuAction();
     CL_Input();
     CL_ReadPackets();
     CL_CheckTimeout();

--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -343,6 +343,13 @@ void CL_ParseLayout(LPSIZEBUF msg) {
         return;
     }
 
+    if (Cvar_Integer("ui_layout_debug", 0)) {
+        fprintf(stderr, "UI_LAYOUT_DEBUG begin layer=%u packet_read=%u packet_size=%u uiflags=0x%08x hidden=%u\n",
+            (unsigned)layer, (unsigned)msg->readcount, (unsigned)msg->cursize,
+            (unsigned)cl.playerstate.uiflags,
+            (unsigned)((cl.playerstate.uiflags & (1u << layer)) != 0));
+    }
+
     SCR_ClearLayoutLayer(layer);
     SAFE_DELETE(cl.layout[layer], MemFree);
     DWORD start = msg->readcount;
@@ -386,6 +393,9 @@ void CL_ParseLayout(LPSIZEBUF msg) {
      * allocated terminator-only blob: callers use a non-NULL layer as evidence
      * that the layer exists, including generic modal ownership. */
     if (!has_frames) {
+        if (Cvar_Integer("ui_layout_debug", 0)) {
+            fprintf(stderr, "UI_LAYOUT_DEBUG clear layer=%u\n", (unsigned)layer);
+        }
         return;
     }
     payload_size = msg->readcount - start;
@@ -398,6 +408,11 @@ void CL_ParseLayout(LPSIZEBUF msg) {
     memcpy(cl.layout[layer], &payload_size, sizeof(payload_size));
     memcpy((LPBYTE)cl.layout[layer] + sizeof(payload_size), msg->data + start, payload_size);
     SCR_SetLayoutLayer(layer, cl.layout[layer]);
+    if (Cvar_Integer("ui_layout_debug", 0)) {
+        fprintf(stderr, "UI_LAYOUT_DEBUG stored layer=%u payload=%u uiflags=0x%08x hidden=%u\n",
+            (unsigned)layer, (unsigned)payload_size, (unsigned)cl.playerstate.uiflags,
+            (unsigned)((cl.playerstate.uiflags & (1u << layer)) != 0));
+    }
 #ifdef BZ_TESTS
     {
         static BOOL quest_layout_screenshot_done;

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -116,6 +116,8 @@ SDL owns the native platform cursor on macOS, Linux, Windows, and other supporte
 
 Early commands (`+set`, `+<cvar>`) are processed during `Com_Init()`, before module registration. Late commands (`+map`, `+menu_main`, etc.) are processed after `CL_Init()` when all command handlers are registered.
 
+Game-module `gi.MenuAction` requests are also deferred. The callback only copies a validated map/menu/quit request; the next `CL_Frame` consumes it after `SV_Frame` has returned. This prevents a `ChangeLevel` native from entering `SV_Map` while the old game's VM or gameplay callback is still on the stack. Do not make `MenuAction("map", ...)` synchronously replace the world.
+
 In code, always use the bare command name: `"map ..."`, not `"+map ..."`.
 
 ### Standard Invocations

--- a/docs/architecture/ui-payloads.md
+++ b/docs/architecture/ui-payloads.md
@@ -142,6 +142,8 @@ author.
 
 When a layout reports `malformed layer N`:
 
+`ui_layout_debug 1` prints generic client-side `svc_layout` begin/clear/store breadcrumbs, including the layer number, payload size, UI flags, and whether the layer is hidden. Use it only while tracing transport or layer-state problems; game modules should keep their own semantic diagnostics on the game side.
+
 1. Inspect `PF_Write(PF_UIFRAME)` and `CL_ParseLayout` together; verify frame
    number, raw payload byte, decoded payload size, read offset, and message size.
 2. Reproduce with a serialization test that writes delta-frame metadata, the

--- a/docs/games/warcraft-3/architecture/ui-flow.md
+++ b/docs/games/warcraft-3/architecture/ui-flow.md
@@ -149,6 +149,69 @@ Single Player Custom Game deliberately reuses the existing local map-selection a
 of duplicating their W3I parsing, map info, slot, race, team, color, and game-speed logic. The source mode only
 changes glue presentation and Cancel destinations; the final local-server launch path remains shared.
 
+### Victory / defeat handoff
+
+`RemovePlayer` owns authoritative per-player result state, not campaign navigation. It records
+`PLAYER_STATE_GAME_RESULT`, moves the runtime slot to `PLAYER_SLOT_STATE_LEFT`, and publishes the appropriate player
+result event. Because map result handlers may start an ending cinematic, the temporary native `GameResultDialog`
+fallback is queued rather than written inline. `UI_FlushPendingGameResults()` normally writes it only after queued
+JASS result work and outside `CLIENT_UI_CINEMATIC`.
+
+There is one terminal exception. Stock Blizzard.j `CustomVictoryBJ` / `CustomDefeatBJ` calls `RemovePlayer` and then
+its single-player result dialog path calls `PauseGame(true)`. When `RemovePlayer` ran from JASS work scheduled by the
+frame's first event pass, the new VICTORY/DEFEAT event was otherwise stranded: the server pause prevented the next
+simulation frame that would consume it. `G_DrainPausedResultEvents()` therefore drains only result events actively
+blocking pending result handoffs before the paused scheduler takes over. Once that event has run, a script-paused
+result fallback may overlay `CLIENT_UI_CINEMATIC`, because waiting for a later cinematic-to-game transition would
+again require a simulation frame that the script pause has intentionally frozen. `UI_ShowGameResult()` clears only
+the `LAYER_GAME_RESULT` hide bit from `playerState_t.uiflags`; it does not restore the rest of the gameplay HUD over
+the ending cinematic.
+
+The fallback exists because the stock Blizzard.j result path still cannot build its normal ScriptDialogs: generic
+`DialogCreate` / `DialogAddButton` / `DialogDisplay` and dialog-button event support remain incomplete. It therefore
+does not try to recreate every campaign/melee policy. It uses Warcraft `GAMEOVER_*` global strings where available,
+uses Restart/Load/Quit Mission for the supported single-player defeat subset, uses Continue/Continue Game for
+victory, and routes those executable actions through game/session boundaries. Observer continuation remains deferred
+until observer-on-death simulation policy exists.
+
+End-of-session operations cross `gi.MenuAction` instead of making the WC3 HUD own client teardown:
+
+```text
+JASS / result UI
+  -> G_RequestEndGame / G_RequestChangeLevel / G_RequestRestartGame
+      -> gi.MenuAction
+          -> client MenuAction (copy/defer request)
+              -> next CL_Frame after SV_Frame returns
+                  -> frontend menu or SV_Map
+```
+
+`gi.MenuAction` is deliberately a deferred session boundary. A JASS native such as `ChangeLevel` can run while the
+old map's VM is still on the C stack; calling `SV_Map` inline from that native destroys/reinitializes map-owned state
+under the active VM. `MenuAction` therefore copies the resolved map/menu argument and `CL_Frame` consumes it only
+after the enclosing `SV_Frame` has returned. Keep `CustomVictoryOkBJ` itself synchronous so its `PauseGame(false)`
+executes, but keep the actual world replacement deferred.
+
+`EndGame(doScoreScreen)` currently returns to the frontend and consumes but cannot yet honor `doScoreScreen`; there
+is no score-screen controller. `ChangeLevel` loads its map, `RestartGame` reloads the current `map` cvar,
+`DisplayLoadDialog` enters the frontend load-game screen, and `ForceCampaignSelectScreen` returns to
+`menu_single_player_campaign`. On single-player victory, the fallback Continue button delegates to Blizzard.j's
+`CustomVictoryOkBJ`, preserving its `bj_changeLevelMapName` decision instead of guessing the next map in HUD code.
+Because `CustomVictoryDialogBJ` has already paused single-player simulation, this fallback invocation is synchronous:
+queuing `CustomVictoryOkBJ` as a coroutine would leave its `PauseGame(false)` and `ChangeLevel(...)` calls stranded
+behind the very pause they are supposed to release. Multiplayer victory Continue still only dismisses the fallback.
+
+For result-lifecycle diagnosis, `wc3_game_result_debug 1` enables game-module `WC3_RESULT` breadcrumbs for
+`RemovePlayer` arguments and player/client mapping, result-event publication and matching trigger dispatch, pending-result
+deferral (`event_queue`, `cinematic`, or `disconnected`), paused-result event draining/cinematic override, FDF binding,
+server layout emission, and result-button session actions. Pair it with the shared `ui_layout_debug 1` transport trace when client receipt/storage must also be observed;
+that generic trace logs every UI layer and the server-side result breadcrumb identifies the numeric result layer to correlate.
+Both diagnostics are runtime-gated and keep Warcraft-specific knowledge out of shared client code.
+
+Single-player result pausing is also intentionally still missing. Result UI should reuse the existing WC3 pause/modal
+ownership path rather than suppressing `SV_Frame` or creating a second clock-freeze mechanism. `PauseGame` and
+single-client modal pausing already flow through the generic server scheduler, which freezes simulation time while
+continuing network reads and client traffic.
+
 ### Remaining frontend lifecycle gaps
 
 The following Warsmash/retail-style lifecycle work is intentionally not approximated in the current UI code:

--- a/docs/games/warcraft-3/jass-native-coverage.md
+++ b/docs/games/warcraft-3/jass-native-coverage.md
@@ -63,8 +63,6 @@ Known examples include:
   `boolexpr` filter. Counted variants must apply the filter before decrementing
   the accepted-unit limit.
 - `ForceEnumPlayers` and its variants do not yet evaluate filters.
-- `GetPlayerSlotState` derives only empty/playing from W3I and cannot report the
-  runtime `PLAYER_SLOT_STATE_LEFT` transition.
 - `ForcePlayerStartLocation` changes the index but does not reserve it against
   random placement.
 
@@ -90,6 +88,38 @@ callbacks therefore need mutable per-level state initialized from `MAPINFO`;
 casting away `level.mapinfo` constness is not the long-term ownership model.
 
 Camera bounds are an example of client-visible runtime state rather than mutable map metadata: each WC3 `PLAYER` receives a `BOX2 camera_bounds` initialized from W3I, `SetCameraBounds` changes that per-player copy, and the snapshot transports it so camera prediction uses the same limits as the server. `GetCameraMargin` is not a direct read of the W3I complement integers: it returns the geometric inset between the complement-derived playable rectangle and the W3I default camera rectangle. This distinction matters because World Editor generated `SetCameraBounds` calls use playable-edge constants plus/minus `GetCameraMargin`.
+
+## Player Result / End-Game Lifecycle
+
+`RemovePlayer` now consumes all four `PLAYER_GAME_RESULT_*` values, stores the result in
+`PLAYER_STATE_GAME_RESULT`, marks the runtime player slot `PLAYER_SLOT_STATE_LEFT`, stops that player's bot, and
+publishes `EVENT_PLAYER_VICTORY` / `EVENT_PLAYER_DEFEAT` for the two corresponding results. Repeated removal is
+idempotent. `TIE` and `NEUTRAL` record the result and slot transition without inventing victory/defeat events.
+
+The native FDF `GameResultDialog` remains a temporary compatibility fallback while the generic ScriptDialog native
+family is incomplete. Result presentation is queued by `RemovePlayer` and normally flushed after JASS result events;
+if the player is in `CLIENT_UI_CINEMATIC`, the fallback normally waits until cinematic UI returns to gameplay. Stock
+Blizzard.j single-player result dialogs are the exception: `CustomVictoryBJ` / `CustomDefeatBJ` call `RemovePlayer`
+and then `PauseGame(true)`. A result event published from that late JASS action must be drained before the pause can
+stop future simulation frames, and the fallback may then display over cinematic UI because the paused scheduler cannot
+advance that UI state. When this override is used, only `LAYER_GAME_RESULT` is unhidden in `playerState_t.uiflags`;
+the rest of the cinematic HUD suppression remains intact. The fallback uses `GlobalStrings.fdf` `GAMEOVER_*` labels
+where available, distinguishes the safe single-player/multiplayer button subset, and only exposes actions the current
+engine can execute.
+
+`EndGame`, `ChangeLevel`, `RestartGame`, `DisplayLoadDialog`, and `ForceCampaignSelectScreen` now cross the existing
+`gi.MenuAction` session boundary. `EndGame` returns the local client to the frontend, `ChangeLevel` loads the requested
+map, `RestartGame` reloads the current `map` cvar, `DisplayLoadDialog` enters the frontend load-game screen, and
+`ForceCampaignSelectScreen` returns to campaign selection. The `doScoreScreen` parameter is consumed but score-screen
+presentation is not implemented yet.
+
+`GetDefaultDifficulty` / `SetDefaultDifficulty` now own a per-level default distinct from mutable
+`GetGameDifficulty()` state. Campaign map startup seeds both values from `wc3_campaign_difficulty`; scripts may then
+change current and default difficulty independently.
+
+Still incomplete: the generic `Dialog*` / dialog-button event natives, `DialogAddQuitButton`, actual score-screen
+presentation, Reduce Difficulty/observer-on-death result policy, and result-dialog ownership of single-player modal
+pausing. The existing `PauseGame` / modal path should be reused for that work rather than adding a second pause model.
 
 ## Campaign Game Cache
 

--- a/docs/games/warcraft-3/save-load.md
+++ b/docs/games/warcraft-3/save-load.md
@@ -6,9 +6,9 @@ The WC3 game module owns save/load. `GetGameAPI()` exposes `SaveGame` and `LoadG
 
 `WriteGame()` writes the current game state to a versioned binary file. The file contains:
 
-- `W3SV` magic, format version 1, canonical map path, `sizeof(edict_t)`, entity count, client count, script identity, and native-handle registry counts;
+- `W3SV` magic, format version 2, canonical map path, `sizeof(edict_t)`, entity count, client count, script identity, and native-handle registry counts;
 - level frame/time, authoritative Warcraft time-of-day state, and started/script-started flags;
-- each client `GAMECLIENT` state, including its `PLAYER` state, JASS settings, researched tech, text storage, camera values, messages, and HUD caches;
+- each client `GAMECLIENT` state, including its `PLAYER` state, JASS settings, runtime removed/result-presentation state, researched tech, text storage, camera values, messages, and HUD caches;
 - each camera target as an entity index;
 - the quest and quest-item graph's strings and status flags;
 - the fixed point-order waypoint edict ring and its circular allocation cursor;
@@ -18,7 +18,7 @@ The WC3 game module owns save/load. `GetGameAPI()` exposes `SaveGame` and `LoadG
 
 `WriteGame()` removes the destination when any record or footer write fails. `ReadGame()` validates the commit footer, checksum, format, script identity, and quest/group/trigger/timer/event registry counts before mutating clients or entities. A truncated or rejected partial write therefore cannot become a loadable artifact or clear the live world. A header mismatch names the failing field and prints saved versus live counts; do not treat a generic `header mismatch` line as complete.
 
-The version 1 layout includes the authoritative `level.timeofday` record plus game-state event condition fields (`state`, `limitop`, `limitval`).
+The version 2 layout retains the authoritative `level.timeofday` record and game-state event condition fields (`state`, `limitop`, `limitval`) from version 1, and adds the client removal/pending-result fields used by victory/defeat presentation.
 
 Groups, timers, triggers, and event handlers may grow after `main()`. The header accepts a save that has *at least* as many of those objects as the freshly initialized map, then `RestoreRegistrySlots()` allocates the extras. A live count higher than the save still rejects. Quests remain an exact match because they are restored in place.
 

--- a/games/warcraft-3/game/api/api_misc.h
+++ b/games/warcraft-3/game/api/api_misc.h
@@ -702,16 +702,19 @@ DWORD GetFoodUsed(LPJASS j) {
 }
 
 DWORD EndGame(LPJASS j) {
-    //BOOL doScoreScreen = jass_checkboolean(j, 1);
+    BOOL doScoreScreen = jass_checkboolean(j, 1);
+    G_RequestEndGame(doScoreScreen);
     return 0;
 }
 DWORD ChangeLevel(LPJASS j) {
-    //LPCSTR newLevel = jass_checkstring(j, 1);
-    //BOOL doScoreScreen = jass_checkboolean(j, 2);
+    LPCSTR newLevel = jass_checkstring(j, 1);
+    BOOL doScoreScreen = jass_checkboolean(j, 2);
+    G_RequestChangeLevel(newLevel, doScoreScreen);
     return 0;
 }
 DWORD RestartGame(LPJASS j) {
-    //BOOL doScoreScreen = jass_checkboolean(j, 1);
+    BOOL doScoreScreen = jass_checkboolean(j, 1);
+    G_RequestRestartGame(doScoreScreen);
     return 0;
 }
 DWORD ReloadGame(LPJASS j) {
@@ -746,6 +749,7 @@ DWORD SetCampaignMenuRace(LPJASS j) {
     return 0;
 }
 DWORD ForceCampaignSelectScreen(LPJASS j) {
+    G_RequestCampaignSelect();
     return 0;
 }
 DWORD SyncSelections(LPJASS j) {
@@ -799,10 +803,11 @@ DWORD SetEdCinematicAvailable(LPJASS j) {
     return 0;
 }
 DWORD GetDefaultDifficulty(LPJASS j) {
-    return jass_pushnullhandle(j, "gamedifficulty");
+    return JassPushGameDifficultyHandle(j, level.setup.default_difficulty);
 }
 DWORD SetDefaultDifficulty(LPJASS j) {
-    //HANDLE g = jass_checkhandle(j, 1, "gamedifficulty");
+    DWORD *difficulty = jass_checkhandle(j, 1, "gamedifficulty");
+    if (difficulty) level.setup.default_difficulty = MIN(*difficulty, 3);
     return 0;
 }
 DWORD DialogCreate(LPJASS j) {
@@ -1297,6 +1302,7 @@ DWORD ForceUICancel(LPJASS j) {
     return 0;
 }
 DWORD DisplayLoadDialog(LPJASS j) {
+    G_RequestLoadGameMenu();
     return 0;
 }
 DWORD CreateTrackable(LPJASS j) {

--- a/games/warcraft-3/game/api/api_player.h
+++ b/games/warcraft-3/game/api/api_player.h
@@ -111,7 +111,9 @@ DWORD GetPlayerSlotState(LPJASS j) {
     LPGAMECLIENT client = whichPlayer ? PLAYER_CLIENT(whichPlayer) : NULL;
     LONG state = 0;
 
-    if (client && client->mapplayer &&
+    if (client && client->jass.removed) {
+        state = 2;
+    } else if (client && client->mapplayer &&
         (client->mapplayer->playerType == kPlayerTypeHuman ||
          client->mapplayer->playerType == kPlayerTypeComputer))
     {
@@ -392,28 +394,82 @@ DWORD SetPlayerState(LPJASS j) {
     return 0;
 }
 DWORD RemovePlayer(LPJASS j) {
-    /* Ghidra: RemovePlayer (FUN_00401220) -> worker FUN_003b32c0 marks the
-     * player removed and records their game result (PLAYER_GAME_RESULT_*:
-     * 0=VICTORY, 1=DEFEAT, 2=TIE, 3=NEUTRAL), driving the victory/defeat
-     * notification.  Our equivalent of that notification is the player victory/
-     * defeat game event the map registers via TriggerRegisterPlayerEventVictory
-     * /Defeat (EVENT_PLAYER_VICTORY=14 / EVENT_PLAYER_DEFEAT=13), so publishing
-     * it here fires the mission's end-of-level triggers (e.g. CustomVictoryBJ
-     * -> RemovePlayer -> the victory dialog/quest completion). */
+    /* Warcraft records a per-player result and transitions that slot to LEFT.
+     * Victory/defeat are player events; TIE/NEUTRAL still remove the slot but do
+     * not synthesize victory/defeat events. The temporary native result overlay
+     * is deferred until queued JASS events have had a chance to enter cinematic
+     * mode, so an ending cinematic is not covered by the fallback UI. */
     LPPLAYER whichPlayer = jass_checkhandle(j, 1, "player");
     DWORD *gameResult = jass_checkhandle(j, 2, "playergameresult");
-    if (whichPlayer && gameResult) {
-        LPEDICT pent = PLAYER_ENT(whichPlayer);
-        G_BotRequestStop(PLAYER_NUM(whichPlayer));
-        if (pent) {
-            if (*gameResult == 0) {
-                G_PublishEvent(pent, EVENT_PLAYER_VICTORY);
-                UI_ShowGameResult(pent, true);
-            } else if (*gameResult == 1) {
-                G_PublishEvent(pent, EVENT_PLAYER_DEFEAT);
-                UI_ShowGameResult(pent, false);
-            }
-        }
+    LPGAMECLIENT client;
+    LPEDICT pent;
+    DWORD player_num;
+
+    G_GameResultDebug("RemovePlayer enter player_handle=%p result_handle=%p result=%ld events=%u/%u",
+        (void *)whichPlayer, (void *)gameResult,
+        gameResult ? (long)*gameResult : -1L,
+        (unsigned)level.events.read, (unsigned)level.events.write);
+
+    if (!whichPlayer || !gameResult || *gameResult > 3) {
+        G_GameResultDebug("RemovePlayer ignored reason=invalid_args player=%p result=%ld",
+            (void *)whichPlayer, gameResult ? (long)*gameResult : -1L);
+        return 0;
+    }
+
+    player_num = PLAYER_NUM(whichPlayer);
+    client = PLAYER_CLIENT(whichPlayer);
+    G_GameResultDebug("RemovePlayer resolved player=%u client_index=%ld connected=%u removed=%u ui=%u",
+        (unsigned)player_num,
+        client ? (long)(client - game.clients) : -1L,
+        client ? (unsigned)client->connected : 0u,
+        client ? (unsigned)client->jass.removed : 0u,
+        client ? (unsigned)client->ps.client_ui_state : 0u);
+
+    if (!client) {
+        G_GameResultDebug("RemovePlayer ignored player=%u reason=no_client", (unsigned)player_num);
+        return 0;
+    }
+    if (client->jass.removed) {
+        G_GameResultDebug("RemovePlayer ignored player=%u reason=already_removed stored_result=%u",
+            (unsigned)player_num, (unsigned)client->ps.stats[PLAYERSTATE_GAME_RESULT]);
+        return 0;
+    }
+
+    client->ps.stats[PLAYERSTATE_GAME_RESULT] = (USHORT)*gameResult;
+    client->jass.removed = true;
+    client->jass.pending_game_result = 0;
+    client->jass.pending_game_result_event = level.events.read;
+    G_BotRequestStop(player_num);
+
+    pent = PLAYER_ENT(whichPlayer);
+    G_GameResultDebug("RemovePlayer state player=%u result=%u pent=%p ent=%ld inuse=%u owner=%u",
+        (unsigned)player_num, (unsigned)*gameResult, (void *)pent,
+        pent ? (long)pent->s.number : -1L,
+        pent ? (unsigned)pent->inuse : 0u,
+        pent ? (unsigned)pent->s.player : 0u);
+    if (!pent) {
+        G_GameResultDebug("RemovePlayer player=%u result=%u has no player edict; no result event/UI queued",
+            (unsigned)player_num, (unsigned)*gameResult);
+        return 0;
+    }
+
+    if (*gameResult == 0) {
+        G_PublishEvent(pent, EVENT_PLAYER_VICTORY);
+        client->jass.pending_game_result = 1;
+        client->jass.pending_game_result_event = level.events.write;
+        G_GameResultDebug("RemovePlayer queued VICTORY player=%u wait_event=%u events=%u/%u",
+            (unsigned)player_num, (unsigned)client->jass.pending_game_result_event,
+            (unsigned)level.events.read, (unsigned)level.events.write);
+    } else if (*gameResult == 1) {
+        G_PublishEvent(pent, EVENT_PLAYER_DEFEAT);
+        client->jass.pending_game_result = 2;
+        client->jass.pending_game_result_event = level.events.write;
+        G_GameResultDebug("RemovePlayer queued DEFEAT player=%u wait_event=%u events=%u/%u",
+            (unsigned)player_num, (unsigned)client->jass.pending_game_result_event,
+            (unsigned)level.events.read, (unsigned)level.events.write);
+    } else {
+        G_GameResultDebug("RemovePlayer player=%u result=%u records removal only; no victory/defeat UI",
+            (unsigned)player_num, (unsigned)*gameResult);
     }
     return 0;
 }

--- a/games/warcraft-3/game/api/api_trigger.h
+++ b/games/warcraft-3/game/api/api_trigger.h
@@ -142,6 +142,12 @@ DWORD TriggerRegisterPlayerEvent(LPJASS j) {
     LPEVENT evt = G_MakeEvent(*whichPlayerEvent);
     evt->subject = PLAYER_ENT(whichPlayer);
     evt->trigger = whichTrigger;
+    if (*whichPlayerEvent == EVENT_PLAYER_VICTORY || *whichPlayerEvent == EVENT_PLAYER_DEFEAT) {
+        G_GameResultDebug("register player event type=%s player=%u trigger=%p subject_ent=%ld",
+            *whichPlayerEvent == EVENT_PLAYER_VICTORY ? "VICTORY" : "DEFEAT",
+            whichPlayer ? (unsigned)PLAYER_NUM(whichPlayer) : 0u,
+            (void *)whichTrigger, evt->subject ? (long)evt->subject->s.number : -1L);
+    }
     return jass_pushlighthandle(j, evt, "event");
 }
 DWORD GetTriggerPlayer(LPJASS j) {

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -738,16 +738,39 @@ CLIENTCOMMAND(Log) {
 }
 
 CLIENTCOMMAND(HideGameResult) {
+    DWORD result = clent && clent->client ? clent->client->ps.stats[PLAYERSTATE_GAME_RESULT] : 3;
+    G_GameResultDebug("command hidegameresult ent=%u result=%u",
+        clent ? (unsigned)clent->s.number : 0u, (unsigned)result);
     UI_HideGameResult(clent);
+    if (result == 0 && G_IsSinglePlayer() && level.vm) {
+        /* The fallback has no copy of Blizzard.j's bj_changeLevelMapName. Let
+         * the stock continuation own EndGame vs ChangeLevel when available. */
+        /* The stock dialog-button action runs even while CustomVictoryDialogBJ
+         * has the single-player simulation paused.  Running this as a queued
+         * coroutine would strand it behind that pause, so execute the Blizzard.j
+         * continuation synchronously from the button command. */
+        G_GameResultDebug("command hidegameresult calling CustomVictoryOkBJ synchronously");
+        jass_callbyname(level.vm, "CustomVictoryOkBJ", false);
+    }
 }
 
-/* TODO: restart / quit require engine-level session teardown not yet plumbed. */
 CLIENTCOMMAND(GameResultRestart) {
     (void)clent; (void)argc; (void)argv;
+    G_GameResultDebug("command gameresult_restart");
+    G_RequestRestartGame(true);
+}
+
+CLIENTCOMMAND(GameResultLoad) {
+    (void)clent; (void)argc; (void)argv;
+    G_GameResultDebug("command gameresult_load");
+    G_RequestLoadGameMenu();
 }
 
 CLIENTCOMMAND(GameResultQuit) {
     (void)clent; (void)argc; (void)argv;
+    G_GameResultDebug("command gameresult_quit single_player=%u", (unsigned)G_IsSinglePlayer());
+    if (G_IsSinglePlayer()) level.setup.difficulty = level.setup.default_difficulty;
+    G_RequestEndGame(true);
 }
 
 /* F10 and the authored Menu button share this route. Submenu transitions
@@ -949,6 +972,7 @@ clientCommand_t clientCommands[] = {
     { "log", CMD_Log },
     { "hidegameresult", CMD_HideGameResult },
     { "gameresult_restart", CMD_GameResultRestart },
+    { "gameresult_load", CMD_GameResultLoad },
     { "gameresult_quit", CMD_GameResultQuit },
     { "debugspawn", CMD_DebugSpawn },
     { "menu", CMD_Menu },

--- a/games/warcraft-3/game/g_events.c
+++ b/games/warcraft-3/game/g_events.c
@@ -4,6 +4,16 @@ BOOL jass_calltrigger(LPJASS j, LPTRIGGER trigger, LPEDICT unit, LPEDICT source)
 
 static void G_ExecuteEvent(GAMEEVENT *evt) {
     LPEDICT subject = evt->edict;
+    BOOL result_event = evt->type == EVENT_PLAYER_VICTORY || evt->type == EVENT_PLAYER_DEFEAT;
+    DWORD matching_handlers = 0, invoked_handlers = 0;
+
+    if (result_event) {
+        G_GameResultDebug("execute event type=%s subject_ent=%ld owner=%u",
+            evt->type == EVENT_PLAYER_VICTORY ? "VICTORY" : "DEFEAT",
+            subject ? (long)subject->s.number : -1L,
+            subject ? (unsigned)subject->s.player : 0u);
+    }
+
     FOR_EACH_LIST(EVENT, e, level.events.handlers) {
         switch (e->type) {
             case EVENT_GAME_VICTORY:
@@ -53,13 +63,33 @@ static void G_ExecuteEvent(GAMEEVENT *evt) {
                  *    player.  Either way the triggering unit is passed as the
                  *    context unit so GetTriggerUnit()/GetDyingUnit() resolve to
                  *    it (e.g. Naga_Victory_Check counts the dying naga). */
-                if (e->type == evt->type && subject &&
-                    (e->subject == subject ||
-                     e->subject == G_GetPlayerEntityByNumber(subject->s.player))) {
-                    jass_calltrigger(level.vm, e->trigger, subject, evt->source);
+                if (e->type == evt->type) {
+                    BOOL direct = subject && e->subject == subject;
+                    BOOL owner_match = subject &&
+                        e->subject == G_GetPlayerEntityByNumber(subject->s.player);
+                    if (result_event) {
+                        matching_handlers++;
+                        G_GameResultDebug("event handler candidate trigger=%p handler_subject=%ld direct=%u owner_match=%u",
+                            (void *)e->trigger,
+                            e->subject ? (long)e->subject->s.number : -1L,
+                            (unsigned)direct, (unsigned)owner_match);
+                    }
+                    if (direct || owner_match) {
+                        BOOL queued = jass_calltrigger(level.vm, e->trigger, subject, evt->source);
+                        if (result_event) {
+                            invoked_handlers++;
+                            G_GameResultDebug("event handler dispatch trigger=%p queued=%u",
+                                (void *)e->trigger, (unsigned)queued);
+                        }
+                    }
                 }
                 break;
         }
+    }
+    if (result_event) {
+        G_GameResultDebug("execute event complete type=%s matching_handlers=%u invoked_handlers=%u",
+            evt->type == EVENT_PLAYER_VICTORY ? "VICTORY" : "DEFEAT",
+            (unsigned)matching_handlers, (unsigned)invoked_handlers);
     }
 }
 
@@ -132,6 +162,46 @@ void G_RunEntities(void) {
 void G_RunEvents(void) {
     for (LEVELEVENTS *e = &level.events; e->read < e->write; e->read++) {
         GAMEEVENT *evt = &e->queue[e->read % MAX_EVENT_QUEUE];
+        if (evt->type == EVENT_PLAYER_VICTORY || evt->type == EVENT_PLAYER_DEFEAT) {
+            G_GameResultDebug("run event ordinal=%u/%u type=%s",
+                (unsigned)(e->read + 1), (unsigned)e->write,
+                evt->type == EVENT_PLAYER_VICTORY ? "VICTORY" : "DEFEAT");
+        }
         G_ExecuteEvent(evt);
     }
+}
+
+/* Warcraft's stock CustomVictoryDialogBJ/CustomDefeatDialogBJ pauses a
+ * single-player game after RemovePlayer().  If RemovePlayer ran from a JASS
+ * action queued by this frame's first event pass, its result event was
+ * published too late for that pass and the server scheduler will stop before
+ * the next frame.  Drain only result events that are actively blocking a
+ * pending result handoff; repeat for chained player removals, bounded by the
+ * number of player slots. */
+void G_DrainPausedResultEvents(void) {
+    DWORD passes = 0;
+
+    if (!level.script_paused || !level.vm) return;
+
+    while (passes++ < MAX_PLAYERS) {
+        BOOL waiting = false;
+
+        FOR_LOOP(i, game.max_clients) {
+            LPGAMECLIENT client = game.clients + i;
+            if (client->jass.pending_game_result &&
+                level.events.read < client->jass.pending_game_result_event) {
+                waiting = true;
+                break;
+            }
+        }
+        if (!waiting) return;
+
+        G_GameResultDebug("frame drain paused result events pass=%u events=%u/%u",
+            (unsigned)passes, (unsigned)level.events.read, (unsigned)level.events.write);
+        G_RunEvents();
+        jass_runevents(level.vm);
+    }
+
+    G_GameResultDebug("frame drain paused result events stopped after %u passes events=%u/%u",
+        (unsigned)MAX_PLAYERS, (unsigned)level.events.read, (unsigned)level.events.write);
 }

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -377,6 +377,9 @@ struct client_s {
         BYTE tax[MAX_PLAYERS][PLAYERSTATE_LUMBER_GATHERED + 1];
         FLOAT handicap, handicap_xp;
         BOOL race_selectable, on_score_screen;
+        BOOL removed;
+        BYTE pending_game_result; /* 0 = none, PLAYER_GAME_RESULT_* + 1 while fallback UI is deferred */
+        DWORD pending_game_result_event; /* level.events.read must reach this write ordinal before fallback UI */
         char name[MAX_PATHLEN];
     } jass;
     playerTechState_t tech[MAX_PLAYER_TECH_STATE];
@@ -1180,7 +1183,7 @@ struct level_locals {
     struct {
         char name[MAX_PATHLEN], description[MAX_TRIGSTR_LENGTH];
         DWORD teams, players, game_types, game_type, map_flags;
-        DWORD placement, speed, difficulty, resource_density, creature_density;
+        DWORD placement, speed, difficulty, default_difficulty, resource_density, creature_density;
         DWORD forced_start_locations;
         struct {
             DWORD count;
@@ -1229,6 +1232,14 @@ void G_InitJassHost(void);
 LPEDICT G_GetPlayerEntityByNumber(DWORD);
 LPGAMECLIENT G_GetPlayerClientByNumber(DWORD);
 void G_SetClientConnected(LPEDICT player, BOOL connected);
+BOOL G_GameResultDebugEnabled(void);
+void G_GameResultDebug(LPCSTR format, ...);
+BOOL G_IsSinglePlayer(void);
+void G_RequestEndGame(BOOL do_score_screen);
+void G_RequestChangeLevel(LPCSTR map, BOOL do_score_screen);
+void G_RequestRestartGame(BOOL do_score_screen);
+void G_RequestLoadGameMenu(void);
+void G_RequestCampaignSelect(void);
 void G_SetScriptPaused(BOOL paused);
 void G_SetClientModal(LPEDICT player, DWORD modal, BOOL open);
 void G_SetQuestDialogOpen(LPEDICT player, BOOL open);
@@ -1585,7 +1596,8 @@ LPCSTR UI_TestResolveTypedInfoPanelIcon(LPCSTR prefix, LPCSTR type, BOOL has_upg
 void UI_WriteLayout(LPEDICT, LPCFRAMEDEF, DWORD);
 void UI_WriteStart(DWORD);
 void UI_ClearLayer(LPEDICT, DWORD);
-void UI_ShowGameResult(LPEDICT, BOOL);
+void UI_ShowGameResult(LPEDICT, DWORD);
+void UI_FlushPendingGameResults(void);
 void UI_HideGameResult(LPEDICT);
 void UI_ShowQuests(LPEDICT);
 void UI_HideQuests(LPEDICT);
@@ -1794,6 +1806,7 @@ void jass_runevents(LPJASS);
 // g_events.c
 void G_RunEntities(void);
 void G_RunEvents(void);
+void G_DrainPausedResultEvents(void);
 
 // g_items.c
 void SP_SpawnItem(LPEDICT);

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -25,6 +25,7 @@
 #include "common/common.h"
 #include "g_local.h"
 #include "jass/jass.h"
+#include <stdarg.h>
 
 struct game_export globals;
 struct game_import gi;
@@ -520,6 +521,63 @@ static void G_StartScripts(void) {
     G_SetDestructableScriptBinding(false);
 }
 
+BOOL G_IsSinglePlayer(void) {
+    DWORD humans = 0;
+
+    if (!level.mapinfo) return true;
+    FOR_LOOP(i, MAX_PLAYERS) {
+        LPCMAPPLAYER player = level.mapinfo->players + i;
+        if (player->used && player->playerType == kPlayerTypeHuman) humans++;
+    }
+    return humans <= 1;
+}
+
+BOOL G_GameResultDebugEnabled(void) {
+    return gi.CvarString && atoi(gi.CvarString("wc3_game_result_debug", "0")) != 0;
+}
+
+void G_GameResultDebug(LPCSTR format, ...) {
+    va_list args;
+
+    if (!G_GameResultDebugEnabled()) return;
+    fprintf(stderr, "WC3_RESULT ");
+    va_start(args, format);
+    vfprintf(stderr, format, args);
+    va_end(args);
+    fputc('\n', stderr);
+}
+
+void G_RequestEndGame(BOOL do_score_screen) {
+    /* Score-screen transport is not implemented yet. Keep the argument at the
+     * game/session boundary so EndGame(true) does not get baked into HUD code. */
+    G_GameResultDebug("request EndGame score_screen=%u menu_action=%u",
+        (unsigned)do_score_screen, (unsigned)(gi.MenuAction != NULL));
+    if (gi.MenuAction) gi.MenuAction("menu", "menu_main");
+}
+
+void G_RequestChangeLevel(LPCSTR map, BOOL do_score_screen) {
+    G_GameResultDebug("request ChangeLevel map=%s score_screen=%u menu_action=%u",
+        map ? map : "(null)", (unsigned)do_score_screen, (unsigned)(gi.MenuAction != NULL));
+    if (gi.MenuAction && map && *map) gi.MenuAction("map", map);
+}
+
+void G_RequestRestartGame(BOOL do_score_screen) {
+    LPCSTR map = gi.CvarString ? gi.CvarString("map", "") : "";
+    G_GameResultDebug("request RestartGame map=%s score_screen=%u menu_action=%u",
+        map ? map : "(null)", (unsigned)do_score_screen, (unsigned)(gi.MenuAction != NULL));
+    if (gi.MenuAction && map && *map) gi.MenuAction("map", map);
+}
+
+void G_RequestLoadGameMenu(void) {
+    G_GameResultDebug("request LoadGameMenu menu_action=%u", (unsigned)(gi.MenuAction != NULL));
+    if (gi.MenuAction) gi.MenuAction("menu", "menu_loadgame");
+}
+
+void G_RequestCampaignSelect(void) {
+    G_GameResultDebug("request CampaignSelect menu_action=%u", (unsigned)(gi.MenuAction != NULL));
+    if (gi.MenuAction) gi.MenuAction("menu", "menu_single_player_campaign");
+}
+
 /* One complete server-frame simulation step.
  * Skipped until the first map has been started; on the very first frame after
  * a map loads, the JASS "main" function is invoked to run map initialization
@@ -539,6 +597,12 @@ static void G_RunFrame(void) {
     G_RunTimers();
     G_RunEvents();
     jass_runevents(level.vm);
+
+    /* A result action may call RemovePlayer() and then PauseGame(true) from
+     * the JASS work above.  The pause takes effect immediately at the server
+     * boundary, so consume the newly published terminal result event before
+     * this becomes the last simulation frame. */
+    G_DrainPausedResultEvents();
     G_BotRunFrame();
 
     G_RunClients();
@@ -560,6 +624,11 @@ static void G_RunFrame(void) {
     G_UpdateClientInfoPanels();
     G_UpdateClientResourceBars();
     G_UpdateClientUnitShortcuts();
+
+    /* RemovePlayer queues its fallback result UI instead of writing it inline.
+     * This gives victory/defeat event handlers a chance to enter cinematic mode
+     * first; the overlay is emitted once that cinematic has returned to gameplay. */
+    UI_FlushPendingGameResults();
 
     G_SolveCollisions();
     G_FowUpdate();
@@ -614,6 +683,14 @@ GAMEEVENT *G_PublishEventWithSource(LPEDICT edict, EVENTTYPE type, LPEDICT sourc
     evt->type = type;
     evt->edict = edict;
     evt->source = source;
+    if (type == EVENT_PLAYER_VICTORY || type == EVENT_PLAYER_DEFEAT) {
+        G_GameResultDebug("publish event type=%s ordinal=%u subject_ent=%ld owner=%u read=%u write=%u",
+            type == EVENT_PLAYER_VICTORY ? "VICTORY" : "DEFEAT",
+            (unsigned)(index + 1),
+            edict ? (long)edict->s.number : -1L,
+            edict ? (unsigned)edict->s.player : 0u,
+            (unsigned)level.events.read, (unsigned)level.events.write);
+    }
     return evt;
 }
 

--- a/games/warcraft-3/game/g_save.c
+++ b/games/warcraft-3/game/g_save.c
@@ -2,7 +2,7 @@
 
 static DWORD const save_magic = MAKEFOURCC('W', '3', 'S', 'V');
 static DWORD const save_commit = MAKEFOURCC('W', '3', 'O', 'K');
-static DWORD const save_version = 1;
+static DWORD const save_version = 2;
 #define MAX_SAVE_STRING (1u << 20) // bytes; bounds quest-string allocations from corrupt saves
 
 typedef struct {

--- a/games/warcraft-3/game/g_spawn.c
+++ b/games/warcraft-3/game/g_spawn.c
@@ -388,6 +388,7 @@ void G_SpawnEntities(void) {
     if (difficulty < 0) difficulty = 0;
     if (difficulty > 3) difficulty = 3;
     level.setup.difficulty = (DWORD)difficulty;
+    level.setup.default_difficulty = (DWORD)difficulty;
     level.setup.resource_density = level.setup.creature_density = 2;
     if (mapinfo) {
         strlcpy(level.setup.name, mapinfo->mapName ? mapinfo->mapName : "", sizeof(level.setup.name));

--- a/games/warcraft-3/game/hud/hud_game_result.c
+++ b/games/warcraft-3/game/hud/hud_game_result.c
@@ -1,34 +1,152 @@
 /*
- * hud_game_result.c — Victory / Defeat result dialog.
+ * hud_game_result.c — temporary native victory / defeat fallback dialog.
  *
- * Shows the GameResultDialog FDF overlay to the player whose game has ended.
- * Called by RemovePlayer() for both single-player and multiplayer.
+ * Warcraft normally lets Blizzard.j build custom/melee result dialogs from the
+ * generic ScriptDialog natives. Those natives are not complete yet, so this
+ * FDF-backed overlay remains a compatibility fallback. RemovePlayer queues it;
+ * UI_FlushPendingGameResults emits it after queued result events. Cinematic UI
+ * normally defers the fallback, except when a script pause has frozen the
+ * scheduler for the stock single-player result dialog path.
  */
 
 #include "hud_local.h"
 
+static DWORD game_result_last_defer_log[MAX_PLAYERS];
+
 void UI_LoadHudGameResult(void) {
+    BOOL global_strings;
+    BOOL dialog_loaded;
+
     if (hud.result.GameResultDialog) return;
-    GameResultDialog_Load(&hud.result);
+    global_strings = UI_EnsureFDF("UI\\FrameDef\\GlobalStrings.fdf");
+    dialog_loaded = GameResultDialog_Load(&hud.result);
+    G_GameResultDebug("hud load global_strings=%u dialog_loaded=%u root=%p text=%p continue=%p restart=%p quit=%p",
+        (unsigned)global_strings, (unsigned)dialog_loaded,
+        (void *)hud.result.GameResultDialog, (void *)hud.result.GameResultText,
+        (void *)hud.result.GameResultContinueButton, (void *)hud.result.GameResultRestartButton,
+        (void *)hud.result.GameResultQuitButton);
 }
 
-/* UI_ShowGameResult — send the victory/defeat dialog to a single client.
- * No-ops gracefully when the FDF is not loaded (e.g., test environment). */
-void UI_ShowGameResult(LPEDICT ent, BOOL victory) {
-    if (!ent) return;
-    if (!hud.result.GameResultDialog) return; /* FDF unavailable — UI_WriteLayout would crash on NULL root */
-    UI_SetText(hud.result.GameResultText, "%s", victory ? "Victory!" : "Defeat!");
-    UI_SetText(hud.result.GameResultContinueButtonText, "Continue");
-    UI_SetOnClick(hud.result.GameResultContinueButton, "hidegameresult");
-    UI_SetText(hud.result.GameResultRestartButtonText, "Restart");
+static LPCSTR GameResultString(LPCSTR key, LPCSTR fallback) {
+    LPCSTR value = UI_GetString(key);
+    return value && *value && strcmp(value, key) ? value : fallback;
+}
+
+/* This fallback exposes only result actions the current engine can execute.
+ * Full Warcraft result policy belongs to Blizzard.j + ScriptDialog. */
+void UI_ShowGameResult(LPEDICT ent, DWORD result) {
+    BOOL victory, single_player;
+
+    G_GameResultDebug("hud show enter ent=%p number=%ld client=%p result=%u",
+        (void *)ent, ent ? (long)ent->s.number : -1L,
+        ent ? (void *)ent->client : NULL, (unsigned)result);
+    if (!ent || !ent->client || result > 1) {
+        G_GameResultDebug("hud show abort reason=invalid_args");
+        return;
+    }
+    victory = result == 0;
+    single_player = G_IsSinglePlayer();
+
+    if (!hud.result.GameResultDialog) {
+        G_GameResultDebug("hud show abort reason=missing_GameResultDialog_FDF");
+        return;
+    }
+
+    /* ShowInterface(false) hides every ordinary HUD layer while cinematic UI
+     * is active. Stock result dialogs are allowed to appear on top of that
+     * state, so explicitly expose only the result layer rather than restoring
+     * the whole gameplay interface. */
+    ent->client->ps.uiflags &= ~(1u << LAYER_GAME_RESULT);
+
+    UI_SetText(hud.result.GameResultText, "%s", GameResultString(
+        victory ? "GAMEOVER_VICTORY_MSG" : "GAMEOVER_DEFEAT_MSG",
+        victory ? "Victory!" : "Defeat!"));
+
+    UI_SetHidden(hud.result.GameResultContinueButton, !victory && !single_player);
+    UI_SetText(hud.result.GameResultContinueButtonText, "%s", GameResultString(
+        victory
+            ? (single_player ? "GAMEOVER_CONTINUE" : "GAMEOVER_CONTINUE_GAME")
+            : "GAMEOVER_LOAD",
+        victory ? (single_player ? "Continue" : "Continue Game") : "Load"));
+    UI_SetOnClick(hud.result.GameResultContinueButton,
+        !victory && single_player ? "gameresult_load" : "hidegameresult");
+
+    UI_SetHidden(hud.result.GameResultRestartButton, victory || !single_player);
+    UI_SetText(hud.result.GameResultRestartButtonText, "%s",
+        GameResultString("GAMEOVER_RESTART", "Restart"));
     UI_SetOnClick(hud.result.GameResultRestartButton, "gameresult_restart");
-    UI_SetText(hud.result.GameResultQuitButtonText, "Quit");
+
+    UI_SetHidden(hud.result.GameResultQuitButton, false);
+    UI_SetText(hud.result.GameResultQuitButtonText, "%s", GameResultString(
+        single_player ? "GAMEOVER_QUIT_MISSION" : "GAMEOVER_QUIT_GAME",
+        single_player ? "Quit Mission" : "Quit Game"));
     UI_SetOnClick(hud.result.GameResultQuitButton, "gameresult_quit");
+
+    G_GameResultDebug("hud show write layer=%u ent=%u connected=%u victory=%u single_player=%u uiflags=0x%08x hidden=%u",
+        (unsigned)LAYER_GAME_RESULT, (unsigned)ent->s.number,
+        (unsigned)ent->client->connected, (unsigned)victory, (unsigned)single_player,
+        (unsigned)ent->client->ps.uiflags,
+        (unsigned)((ent->client->ps.uiflags & (1u << LAYER_GAME_RESULT)) != 0));
     UI_WriteLayout(ent, hud.result.GameResultDialog, LAYER_GAME_RESULT);
+    G_GameResultDebug("hud show write complete layer=%u ent=%u",
+        (unsigned)LAYER_GAME_RESULT, (unsigned)ent->s.number);
 }
 
-/* UI_HideGameResult — clear the game result layer for a client. */
+void UI_FlushPendingGameResults(void) {
+    FOR_LOOP(i, game.max_clients) {
+        LPGAMECLIENT client = game.clients + i;
+        LPEDICT ent;
+        DWORD result;
+        DWORD now;
+
+        if (!client->jass.pending_game_result) {
+            if (i < MAX_PLAYERS) game_result_last_defer_log[i] = 0;
+            continue;
+        }
+
+        now = gi.GetTime ? gi.GetTime() : level.time;
+        if (!client->connected ||
+            level.events.read < client->jass.pending_game_result_event ||
+            (client->ps.client_ui_state == CLIENT_UI_CINEMATIC && !level.script_paused)) {
+            if (G_GameResultDebugEnabled() && i < MAX_PLAYERS &&
+                (!game_result_last_defer_log[i] || now - game_result_last_defer_log[i] >= 1000)) {
+                game_result_last_defer_log[i] = now;
+                G_GameResultDebug("flush defer client_index=%u player=%u pending=%u connected=%u ui=%u events=%u/%u wait_event=%u reason=%s",
+                    (unsigned)i, (unsigned)client->ps.number,
+                    (unsigned)client->jass.pending_game_result,
+                    (unsigned)client->connected,
+                    (unsigned)client->ps.client_ui_state,
+                    (unsigned)level.events.read, (unsigned)level.events.write,
+                    (unsigned)client->jass.pending_game_result_event,
+                    !client->connected ? "disconnected" :
+                    (level.events.read < client->jass.pending_game_result_event ? "event_queue" : "cinematic"));
+            }
+            continue;
+        }
+
+        if (client->ps.client_ui_state == CLIENT_UI_CINEMATIC && level.script_paused) {
+            G_GameResultDebug("flush cinematic override client_index=%u player=%u reason=script_paused_result_dialog",
+                (unsigned)i, (unsigned)client->ps.number);
+        }
+
+        result = (DWORD)client->jass.pending_game_result - 1;
+        client->jass.pending_game_result = 0;
+        client->jass.pending_game_result_event = 0;
+        if (i < MAX_PLAYERS) game_result_last_defer_log[i] = 0;
+        ent = G_GetPlayerEntityByNumber(client->ps.number);
+        G_GameResultDebug("flush ready client_index=%u player=%u result=%u ent=%p ent_number=%ld",
+            (unsigned)i, (unsigned)client->ps.number, (unsigned)result,
+            (void *)ent, ent ? (long)ent->s.number : -1L);
+        if (ent) {
+            UI_ShowGameResult(ent, result);
+        } else {
+            G_GameResultDebug("flush drop player=%u reason=no_player_edict", (unsigned)client->ps.number);
+        }
+    }
+}
+
 void UI_HideGameResult(LPEDICT ent) {
     if (!ent) return;
+    G_GameResultDebug("hud hide ent=%u", (unsigned)ent->s.number);
     UI_ClearLayer(ent, LAYER_GAME_RESULT);
 }

--- a/games/warcraft-3/game/hud/hud_local.h
+++ b/games/warcraft-3/game/hud/hud_local.h
@@ -153,7 +153,7 @@ void UI_ShowGameMenuEndGame(LPEDICT ent);
 void UI_ShowGameMenuConfirmExit(LPEDICT ent);
 
 /* Game result dialog (hud_game_result.c) */
-void UI_ShowGameResult(LPEDICT ent, BOOL victory);
+void UI_ShowGameResult(LPEDICT ent, DWORD result);
 void UI_HideGameResult(LPEDICT ent);
 
 /* Cinematic / interface (hud_cinematic.c) */

--- a/games/warcraft-3/game/tests/t_jass_map.c
+++ b/games/warcraft-3/game/tests/t_jass_map.c
@@ -36,6 +36,23 @@ static BOOL event_in_queue(EVENTTYPE type) {
     return false;
 }
 
+static char victory_menu_action[32];
+static char victory_menu_arg[256];
+
+static void capture_victory_menu_action(LPCSTR action, LPCSTR arg) {
+    strlcpy(victory_menu_action, action ? action : "", sizeof(victory_menu_action));
+    strlcpy(victory_menu_arg, arg ? arg : "", sizeof(victory_menu_arg));
+}
+
+static void victory_noop_write(pfWriteType_t type, void const *value) {
+    (void)type;
+    (void)value;
+}
+
+static void victory_noop_unicast(LPEDICT ent) {
+    (void)ent;
+}
+
 /* =========================================================================
  * Shared JASS/list lexer regressions
  * ========================================================================= */
@@ -126,6 +143,7 @@ TEST(wc3_jass_map, map_configuration_roundtrip) {
         "  call SetGamePlacement(MAP_PLACEMENT_FIXED)\n"
         "  call SetGameSpeed(MAP_SPEED_FAST)\n"
         "  call SetGameDifficulty(MAP_DIFFICULTY_HARD)\n"
+        "  call SetDefaultDifficulty(MAP_DIFFICULTY_EASY)\n"
         "  call SetResourceDensity(MAP_DENSITY_HEAVY)\n"
         "  call SetCreatureDensity(MAP_DENSITY_LIGHT)\n"
         "  call BJassAssert(GetTeams() == 3, \"team count\")\n"
@@ -137,6 +155,7 @@ TEST(wc3_jass_map, map_configuration_roundtrip) {
         "  call BJassAssert(GetGamePlacement() == MAP_PLACEMENT_FIXED, \"placement\")\n"
         "  call BJassAssert(GetGameSpeed() == MAP_SPEED_FAST, \"speed\")\n"
         "  call BJassAssert(GetGameDifficulty() == MAP_DIFFICULTY_HARD, \"difficulty\")\n"
+        "  call BJassAssert(GetDefaultDifficulty() == MAP_DIFFICULTY_EASY, \"default difficulty\")\n"
         "  call BJassAssert(GetResourceDensity() == MAP_DENSITY_HEAVY, \"resource density\")\n"
         "  call BJassAssert(GetCreatureDensity() == MAP_DENSITY_LIGHT, \"creature density\")\n"
         "endfunction\n"
@@ -375,6 +394,8 @@ TEST(wc3_jass_map, defeat_publishes_event) {
     BOOL ok = run_test_jass(
         "function main takes nothing returns nothing\n"
         "  call RemovePlayer(Player(0), PLAYER_GAME_RESULT_DEFEAT)\n"
+        "  call BJassAssert(GetPlayerState(Player(0), PLAYER_STATE_GAME_RESULT) == 1, \"defeat result\")\n"
+        "  call BJassAssert(GetPlayerSlotState(Player(0)) == PLAYER_SLOT_STATE_LEFT, \"defeated player left\")\n"
         "endfunction\n"
     );
     T_ASSERT(ok);
@@ -386,10 +407,109 @@ TEST(wc3_jass_map, victory_publishes_event) {
     BOOL ok = run_test_jass(
         "function main takes nothing returns nothing\n"
         "  call RemovePlayer(Player(0), PLAYER_GAME_RESULT_VICTORY)\n"
+        "  call BJassAssert(GetPlayerState(Player(0), PLAYER_STATE_GAME_RESULT) == 0, \"victory result\")\n"
+        "  call BJassAssert(GetPlayerSlotState(Player(0)) == PLAYER_SLOT_STATE_LEFT, \"victorious player left\")\n"
         "endfunction\n"
     );
     T_ASSERT(ok);
     T_ASSERT( event_in_queue(EVENT_PLAYER_VICTORY));
+    T_ASSERT(!event_in_queue(EVENT_PLAYER_DEFEAT));
+}
+
+TEST(wc3_jass_map, paused_victory_drains_result_event_and_releases_fallback) {
+    T_ASSERT(run_test_jass(
+        "globals\n"
+        "  boolean victoryFired = false\n"
+        "endglobals\n"
+        "function onEndCinematic takes nothing returns nothing\n"
+        "  call RemovePlayer(Player(0), PLAYER_GAME_RESULT_VICTORY)\n"
+        "  call PauseGame(true)\n"
+        "endfunction\n"
+        "function onVictory takes nothing returns nothing\n"
+        "  set victoryFired = true\n"
+        "endfunction\n"
+        "function verifyVictory takes nothing returns nothing\n"
+        "  call BJassAssert(victoryFired, \"victory event stranded behind pause\")\n"
+        "endfunction\n"
+        "function main takes nothing returns nothing\n"
+        "  local trigger endTrigger = CreateTrigger()\n"
+        "  local trigger victoryTrigger = CreateTrigger()\n"
+        "  call TriggerRegisterPlayerEvent(endTrigger, Player(0), EVENT_PLAYER_END_CINEMATIC)\n"
+        "  call TriggerAddAction(endTrigger, function onEndCinematic)\n"
+        "  call TriggerRegisterPlayerEvent(victoryTrigger, Player(0), EVENT_PLAYER_VICTORY)\n"
+        "  call TriggerAddAction(victoryTrigger, function onVictory)\n"
+        "endfunction\n"
+    ));
+
+    game.clients[0].connected = true;
+    game.clients[0].ps.client_ui_state = CLIENT_UI_CINEMATIC;
+    G_PublishEvent(&g_edicts[0], EVENT_PLAYER_END_CINEMATIC);
+
+    /* This is the normal frame ordering: the first event pass schedules a
+     * JASS action, and that action publishes VICTORY too late for the pass. */
+    G_RunEvents();
+    jass_runevents(level.vm);
+    T_ASSERT(level.script_paused);
+    T_EQ(game.clients[0].jass.pending_game_result, 1);
+    T_ASSERT(level.events.read < game.clients[0].jass.pending_game_result_event);
+
+    G_DrainPausedResultEvents();
+    T_EQ(level.events.read, level.events.write);
+    jass_callbyname(level.vm, "verifyVictory", true);
+    jass_runevents(level.vm);
+    T_ASSERT(!jass_rterror_pending(level.vm));
+
+    /* Stock CustomVictoryDialogBJ pauses while the map can still be in
+     * cinematic UI state. The fallback must not wait for another sim frame. */
+    UI_FlushPendingGameResults();
+    T_EQ(game.clients[0].jass.pending_game_result, 0);
+}
+
+
+TEST(wc3_jass_map, victory_continue_runs_blizzard_continuation_while_paused) {
+    void (*old_menu_action)(LPCSTR, LPCSTR) = gi.MenuAction;
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(LPEDICT) = gi.unicast;
+    LPCSTR command[] = { "hidegameresult" };
+
+    T_ASSERT(run_test_jass(
+        "function CustomVictoryOkBJ takes nothing returns nothing\n"
+        "  call PauseGame(false)\n"
+        "  call ChangeLevel(\"Maps\\Campaign\\Human03.w3m\", false)\n"
+        "endfunction\n"
+        "function main takes nothing returns nothing\n"
+        "endfunction\n"
+    ));
+
+    victory_menu_action[0] = '\0';
+    victory_menu_arg[0] = '\0';
+    gi.MenuAction = capture_victory_menu_action;
+    gi.Write = victory_noop_write;
+    gi.unicast = victory_noop_unicast;
+    level.script_paused = true;
+    game.clients[0].ps.stats[PLAYERSTATE_GAME_RESULT] = 0;
+
+    G_ClientCommand(&g_edicts[0], 1, command);
+
+    T_ASSERT(!level.script_paused);
+    T_STREQ(victory_menu_action, "map");
+    T_STREQ(victory_menu_arg, "Maps\\Campaign\\Human03.w3m");
+
+    gi.MenuAction = old_menu_action;
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+}
+
+TEST(wc3_jass_map, neutral_remove_records_result_without_victory_or_defeat_event) {
+    BOOL ok = run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  call RemovePlayer(Player(0), PLAYER_GAME_RESULT_NEUTRAL)\n"
+        "  call BJassAssert(GetPlayerState(Player(0), PLAYER_STATE_GAME_RESULT) == 3, \"neutral result\")\n"
+        "  call BJassAssert(GetPlayerSlotState(Player(0)) == PLAYER_SLOT_STATE_LEFT, \"neutral player left\")\n"
+        "endfunction\n"
+    );
+    T_ASSERT(ok);
+    T_ASSERT(!event_in_queue(EVENT_PLAYER_VICTORY));
     T_ASSERT(!event_in_queue(EVENT_PLAYER_DEFEAT));
 }
 

--- a/games/warcraft-3/tests/resources-src/Scripts/common.j
+++ b/games/warcraft-3/tests/resources-src/Scripts/common.j
@@ -32,6 +32,7 @@ type gamedifficulty  extends handle
 type aidifficulty    extends handle
 type gamespeed       extends handle
 type playerstate     extends handle
+type playerslotstate extends handle
 type gamestate        extends handle
 type fgamestate       extends gamestate
 type limitop          extends handle
@@ -58,6 +59,7 @@ native TriggerAddAction           takes trigger whichTrigger, code actionFunc re
 native GetLocalPlayer             takes nothing returns player
 native ShowInterface              takes boolean flag, real fadeDuration returns nothing
 native EnableUserControl          takes boolean b returns nothing
+native PauseGame                  takes boolean flag returns nothing
 native ResetToGameCamera          takes real duration returns nothing
 native PanCameraTo                takes real x, real y returns nothing
 native SetCameraPosition          takes real x, real y returns nothing
@@ -81,6 +83,7 @@ native ConvertGameDifficulty takes integer i returns gamedifficulty
 native ConvertAIDifficulty   takes integer i returns aidifficulty
 native ConvertGameSpeed      takes integer i returns gamespeed
 native ConvertPlayerState    takes integer i returns playerstate
+native ConvertPlayerSlotState takes integer i returns playerslotstate
 native ConvertFGameState     takes integer i returns fgamestate
 native ConvertLimitOp        takes integer i returns limitop
 native ConvertFogState       takes integer i returns fogstate
@@ -110,6 +113,8 @@ native SetGameSpeed          takes gamespeed whichSpeed returns nothing
 native GetGameSpeed          takes nothing returns gamespeed
 native SetGameDifficulty     takes gamedifficulty whichDifficulty returns nothing
 native GetGameDifficulty     takes nothing returns gamedifficulty
+native GetDefaultDifficulty  takes nothing returns gamedifficulty
+native SetDefaultDifficulty  takes gamedifficulty whichDifficulty returns nothing
 native GetAIDifficulty       takes player num returns aidifficulty
 native SetResourceDensity    takes mapdensity whichDensity returns nothing
 native GetResourceDensity    takes nothing returns mapdensity
@@ -136,6 +141,8 @@ native SetPlayerTechResearched takes player whichPlayer, integer techid, integer
 native GetPlayerTechResearched takes player whichPlayer, integer techid, boolean specificonly returns boolean
 native GetPlayerTechCount      takes player whichPlayer, integer techid, boolean specificonly returns integer
 native SetPlayerOnScoreScreen takes player whichPlayer, boolean flag returns nothing
+native GetPlayerState         takes player whichPlayer, playerstate whichPlayerState returns integer
+native GetPlayerSlotState     takes player whichPlayer returns playerslotstate
 native Rect                   takes real minx, real miny, real maxx, real maxy returns rect
 native SetRect                takes rect whichRect, real minx, real miny, real maxx, real maxy returns nothing
 native GetRectMinX            takes rect whichRect returns real
@@ -239,6 +246,7 @@ globals
     constant integer CAMERA_MARGIN_RIGHT  = 1
     constant integer CAMERA_MARGIN_TOP    = 2
     constant integer CAMERA_MARGIN_BOTTOM = 3
+    constant playerevent     EVENT_PLAYER_VICTORY       = ConvertPlayerEvent(14)
     constant playerevent     EVENT_PLAYER_END_CINEMATIC = ConvertPlayerEvent(17)
     constant playerunitevent EVENT_PLAYER_UNIT_DEATH   = ConvertPlayerUnitEvent(20)
     constant fogstate FOG_OF_WAR_MASKED  = ConvertFogState(1)
@@ -261,10 +269,13 @@ globals
     constant startlocprio MAP_LOC_PRIO_NOT = ConvertStartLocPrio(2)
     constant mapdensity MAP_DENSITY_LIGHT = ConvertMapDensity(1)
     constant mapdensity MAP_DENSITY_HEAVY = ConvertMapDensity(3)
+    constant gamedifficulty MAP_DIFFICULTY_EASY = ConvertGameDifficulty(0)
     constant gamedifficulty MAP_DIFFICULTY_HARD = ConvertGameDifficulty(2)
     constant aidifficulty AI_DIFFICULTY_NORMAL = ConvertAIDifficulty(1)
     constant gamespeed MAP_SPEED_FAST = ConvertGameSpeed(3)
+    constant playerstate PLAYER_STATE_GAME_RESULT = ConvertPlayerState(0)
     constant playerstate PLAYER_STATE_RESOURCE_GOLD = ConvertPlayerState(1)
+    constant playerslotstate PLAYER_SLOT_STATE_LEFT = ConvertPlayerSlotState(2)
     constant fgamestate GAME_STATE_TIME_OF_DAY = ConvertFGameState(2)
     constant limitop LESS_THAN = ConvertLimitOp(0)
     constant limitop LESS_THAN_OR_EQUAL = ConvertLimitOp(1)


### PR DESCRIPTION
Add Warcraft III-style player victory/defeat state handling and end-game presentation.

* track per-player victory and defeat results
* expose result state through the Warcraft III scripting layer
* show the game result dialog when a local player wins or loses
* add Continue, Restart, Load, and Quit result-menu actions
* route campaign and single-player completion through the result lifecycle
* preserve result state in save data
* add fallback result-menu behavior when Warcraft UI data is incomplete
* update Warcraft III lifecycle documentation and coverage