### PR TITLE
wc3: add Shift-queued unit orders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 Hero skill tree, skill points, rank requirements, learning UI, JASS progression | [docs/games/warcraft-3/hero-abilities.md](docs/games/warcraft-3/hero-abilities.md) |
 | WC3 gathering, immobile units, construction HUD, overhead bars | [docs/games/warcraft-3/economy-and-unit-presentation.md](docs/games/warcraft-3/economy-and-unit-presentation.md) |
 | WC3 enemy/neutral selection, relationship colours, command authority, fog/death deselection | [docs/games/warcraft-3/selection-and-control.md](docs/games/warcraft-3/selection-and-control.md) |
+| WC3 Shift command queuing, per-unit FIFO orders, target revalidation, replacement/Stop semantics | [docs/games/warcraft-3/order-queue.md](docs/games/warcraft-3/order-queue.md) |
 | WC3 persistent Hero and idle-worker HUD shortcuts, event-driven invalidation, F1-F8 cycling | [docs/games/warcraft-3/unit-shortcuts.md](docs/games/warcraft-3/unit-shortcuts.md) |
 | WC3 building menu, placement validation, Human construction and power building | [docs/games/warcraft-3/building-construction.md](docs/games/warcraft-3/building-construction.md) |
 | WC3 research queues, upgrade costs/requirements, player tech state, Blacksmith attack/armor effects | [docs/games/warcraft-3/research-and-upgrades.md](docs/games/warcraft-3/research-and-upgrades.md) |

--- a/client/cl_input.c
+++ b/client/cl_input.c
@@ -270,18 +270,21 @@ void IN_SelectUp(void) {
     DWORD entnum;
     VECTOR3 point;
     if (fabs(r.w)+fabs(r.h) < 10) {
+        BOOL const queue = (SDL_GetModState() & (KMOD_LSHIFT | KMOD_RSHIFT)) != 0;
         if (re.TraceEntity(&cl.viewDef, r.x, r.y, &entnum)) {
             MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
-            SZ_Printf(&cls.netchan.message, "select %d", entnum);
-            
-            /* Store selected entity and request UI data (Phase 8.6) */
+            SZ_Printf(&cls.netchan.message, queue ? "select %d queue" : "select %d", entnum);
+
+            /* The game resolves whether this click is command targeting or a
+             * selection change. Keep the local cache as a best-effort hint;
+             * authoritative WC3 selection remains server-owned. */
             cl.selection.num_selected = 1;
             cl.selection.entity_nums[0] = entnum;
             CL_RequestUnitUI(1, cl.selection.entity_nums);
-        }
-        if (re.TraceLocation(&cl.viewDef, r.x, r.y, &point)){
+        } else if (re.TraceLocation(&cl.viewDef, r.x, r.y, &point)){
             MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
-            SZ_Printf(&cls.netchan.message, "point %d %d", (int)point.x, (int)point.y);
+            SZ_Printf(&cls.netchan.message, queue ? "point %d %d queue" : "point %d %d",
+                      (int)point.x, (int)point.y);
             if (cl.selection.num_selected) {
                 CL_RequestUnitUI(cl.selection.num_selected, cl.selection.entity_nums);
             }

--- a/client/cl_input_w3.c
+++ b/client/cl_input_w3.c
@@ -29,6 +29,10 @@ static void CL_SetCameraPosition(VECTOR2 position) {
 static BOOL smart_click_active;
 static BOOL minimap_drag_active;
 
+static BOOL CL_OrderQueueModifierDown(void) {
+    return (SDL_GetModState() & (KMOD_LSHIFT | KMOD_RSHIFT)) != 0;
+}
+
 static BOOL CL_TracePan(float x, float y, LPVECTOR3 point) {
 #ifdef SC2
     return re.TraceCameraPlane(&cl.viewDef, x, y, point);
@@ -144,10 +148,13 @@ static void CL_SendSmartCommand(float x, float y) {
     }
     if (re.TraceEntity(&cl.viewDef, x, y, &entnum)) {
         MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
-        SZ_Printf(&cls.netchan.message, "smart %d", entnum);
+        SZ_Printf(&cls.netchan.message, CL_OrderQueueModifierDown()
+            ? "smart %d queue" : "smart %d", entnum);
     } else if (re.TraceLocation(&cl.viewDef, x, y, &point)) {
         MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
-        SZ_Printf(&cls.netchan.message, "smartpoint %d %d", (int)point.x, (int)point.y);
+        SZ_Printf(&cls.netchan.message, CL_OrderQueueModifierDown()
+            ? "smartpoint %d %d queue" : "smartpoint %d %d",
+            (int)point.x, (int)point.y);
     }
 
     if (cl.selection.num_selected) {

--- a/docs/games/warcraft-3/order-queue.md
+++ b/docs/games/warcraft-3/order-queue.md
@@ -1,0 +1,191 @@
+# Warcraft III Shift Order Queue
+
+## Contract
+
+Player-issued movement/combat orders use a per-unit pending FIFO that is separate from the current behavior and from a producer's training/research queue. The client captures either Shift key when the click is submitted and appends the literal `queue` modifier to the existing text command (`smart`, `smartpoint`, `select`, or `point`). The game module remains authoritative: it decides whether that modifier is meaningful for the active command, owns the queue, resolves targets, and starts the next order when the current behavior completes.
+
+The current implementation deliberately covers the high-confidence Warsmash-compatible core:
+
+- Shift + right-click point (`Smart`) queues movement for mobile units;
+- Shift + right-click entity queues Smart target resolution, including attack, harvest, repair, item pickup, and fallback movement when those existing Smart rules accept the target;
+- Shift + Move queues point movement;
+- Shift + Attack queues either an entity attack or point attack-move;
+- an idle/Stop/Hold unit starts the first Shift order immediately instead of leaving it pending;
+- a busy unit appends Shift orders in FIFO order;
+- a normal Move/Attack/Smart replacement clears pending Shift orders;
+- Stop and Hold Position clear pending Shift orders;
+- death clears pending Shift orders;
+- stale/recycled entity targets are skipped when their queued turn arrives;
+- invalid queued work is skipped and polling continues to the next pending order.
+
+Patrol multi-waypoint semantics, build/spell explicit queuing, queued-order waypoint models, and Blizzard 1.29 `BlzQueue*OrderById` natives remain separate work; see [Known gaps](#known-gaps).
+
+## Input protocol
+
+The client does not mutate a unit queue directly. When Shift is down, it sends the same command with a trailing modifier:
+
+```text
+smart 57 queue
+smartpoint 1024 768 queue
+select 57 queue
+point 1024 768 queue
+```
+
+Without Shift, the original command syntax is unchanged.
+
+`select` and `point` are also used to finish command-card targeting. `menu_t.supports_order_queue` gates the modifier on the server, so only an explicitly queue-capable targeting mode treats Shift as order queuing. Move and Attack set that flag. Other target modes ignore `queue`, preserving their existing lifecycle until their reservation/cost semantics are implemented deliberately.
+
+For a successful queue-capable target click, `Get_Commands_f()` is not called while Shift remains part of that click. This leaves the Move/Attack targeting callback armed so the player can add several targets/points without reopening the command button, matching the Warsmash input model. A successful non-Shift target returns to the normal command card as before.
+
+A small world click now sends either the entity target or the terrain point, not both. This prevents a unit-target completion from immediately being followed by a second point-target completion at the same cursor coordinate.
+
+## Simulation ownership
+
+`edict_s.order_queue` owns the pending player orders for that unit. The active order is represented by the existing `currentmove`/behavior state and is not duplicated at the front of the FIFO.
+
+Each pending entry stores:
+
+- the normalized order name (`smart`, `move`, or `attack` in the currently supported path);
+- point vs entity target kind;
+- the resolved point for a point order;
+- entity number plus `spawn_time` for an entity order;
+- the issuing player number for future error-routing work;
+- the movement group-speed cap for a queued formation Move leg.
+
+Entity pointers are intentionally not stored in the queue. An edict slot can be freed and reused before a delayed command reaches the head of the FIFO. Number + `spawn_time` re-resolution makes that stale command fail closed rather than retargeting the new occupant of the same slot.
+
+The FIFO is currently a bounded inline ring (`MAX_UNIT_ORDER_QUEUE`, 16 pending commands). Warsmash itself uses an unbounded `LinkedList<COrder>`; the OpenRealm cap is an implementation safety bound, not a claimed retail/Warsmash limit. Hitting the cap currently rejects the newest queued command without a dedicated command-error message.
+
+## Submission rules
+
+`G_IssueUnitPointOrder()` and `G_IssueUnitTargetOrder()` are the queue-aware entry points. Existing `unit_issueorder()` and `unit_issuetargetorder()` remain compatibility wrappers that submit `queue=false`.
+
+For a supported order:
+
+```text
+queue=false
+    -> clear pending FIFO
+    -> start the replacement order now
+
+queue=true + current active behavior
+    -> append to pending FIFO
+    -> leave current behavior untouched
+
+queue=true + no active behavior
+    -> start the order now
+    -> leave pending FIFO unchanged
+```
+
+The implementation treats a `umove_t` whose `ability` pointer is non-null as active player-order work. Normal stand/hold states have no ability and therefore accept a first Shift command immediately. The terminal blocked-Move hold pose is explicitly recognized as completed order work; a later Shift command can start from that state instead of becoming stranded behind it.
+
+Rally changes remain producer metadata, not unit behavior. Smart/set-rally changes are therefore applied immediately; they are not inserted into the movement/combat FIFO.
+
+## Move and formation behavior
+
+The existing `move_selectlocation()` formation allocator remains authoritative for a command-card or SmartPoint Move click. It resolves the per-unit slot and group speed at issue time.
+
+For a non-queued Move it retains the shared route-waypoint optimization and starts the existing Move behavior immediately. For a queued Move it stores each unit's resolved slot and group-speed cap in that unit's FIFO. When the leg begins later, OpenRealm creates the normal private waypoint and reuses the existing `order_move()` behavior.
+
+This preserves two important properties:
+
+1. each selected unit owns an independent queue and may advance to the next leg at a different time;
+2. queue support does not duplicate or replace the existing pathing, avoidance, formation-slot, and Move-completion code.
+
+## Attack and Smart behavior
+
+A queued point `attack` starts the existing `order_attackmove()` behavior when dequeued. This also corrects the generic `unit_issueorder(..., "attack", point)` path, which previously routed point Attack through ordinary Move.
+
+A queued entity `attack` re-resolves the target and calls the existing direct Attack behavior.
+
+A queued entity `smart` re-runs the existing Smart decision when the command begins rather than baking a guessed behavior into the queue. Depending on the target and current unit state, that can select:
+
+- inventory item pickup;
+- gold or lumber harvesting;
+- resource return;
+- destructable attack;
+- enemy attack;
+- Smart repair;
+- fallback movement to the target's then-current position.
+
+This revalidation is important because a delayed Smart target can change state before its turn arrives.
+
+## Completion and polling
+
+`unit_stand()` is the common completion edge for many existing unit behaviors. It now clears the transient finished-behavior presentation fields and calls `G_UnitStartNextQueuedOrder()` before installing the ordinary stand/hold default behavior.
+
+The blocked/unreachable Move terminal path (`move_hold`) also polls the FIFO before entering its legacy stationary pose. This avoids losing a queued chain when one Move leg cannot make further progress.
+
+`G_UnitStartNextQueuedOrder()` repeatedly pops FIFO entries until one starts successfully or the FIFO is empty. For an entity target it validates:
+
+```text
+target_number < globals.num_edicts
+entity is still in use
+entity spawn_time still matches
+```
+
+Only then does it run the existing order resolver. A stale or no-longer-accepted order is discarded and the next queued order is tried. This mirrors the important Warsmash property that delayed orders are validated when they actually begin rather than assumed valid forever.
+
+## Replacement, Stop, Hold, and death
+
+A normal queue-aware Move/Attack/Smart order clears the pending FIFO before starting. This gives the expected replacement behavior:
+
+```text
+current A
+pending B, C
+normal X
+
+=> X becomes current; B and C are discarded
+```
+
+`order_stop()` clears the FIFO before standing, so all Stop callers get the same cancellation policy. Hold Position explicitly clears the FIFO, then installs the existing holding-position state. `unit_die()` clears the FIFO before entering the death lifecycle.
+
+OpenRealm does not yet have Warsmash's per-ability `onCancelFromQueue()` reservation callback. The currently queued order families do not reserve mana/resources at insertion time, which is why this patch intentionally does not claim build/spell queue support.
+
+## Save/load
+
+The queue is inline numeric data inside `edict_t`; it contains no process pointers, so it persists with the existing raw-edict save record without adding an `F_EDICT` field. Entity targets remain number + `spawn_time` and are re-resolved only at execution.
+
+Adding the queue changes `sizeof(edict_t)`, and the new transient menu flags change `GAMECLIENT`. Save format version 7 therefore rejects older incompatible raw-struct saves. `WriteClient()` and `ReadClient()` explicitly clear `supports_order_queue` and `order_queued` because targeting callbacks/menu modes remain process-local transient state.
+
+The existing save/load limitation still applies: arbitrary active `umove_t` behavior identity is not semantically restored. Pending queue records are persisted, but exact mid-order resume requires the separate active-behavior save work described in [Save/Load](save-load.md).
+
+## Known gaps
+
+The following are intentionally not guessed in this patch:
+
+- **Queued waypoint models.** Warsmash derives waypoint indicators from the current queued order plus pending orders. OpenRealm has no server-to-client order-queue presentation channel yet.
+- **Patrol Shift extension.** Current OpenRealm Patrol owns two waypoints and cycles forever. Warsmash can append patrol points to an active patrol behavior; implementing that requires changing the patrol state representation rather than pretending it is a normal Move FIFO.
+- **Explicit spell queuing.** Spell mana/cooldown/target validation and cast lifecycle must define when cost/reservations happen before queueing is enabled.
+- **Build/repair command-card queuing.** Construction reservation, placement, worker behavior, and cancellation/refund semantics require their own queue hooks.
+- **Generic cancellation callbacks.** Warsmash abilities have `onCancelFromQueue()`; OpenRealm's supported queued families currently need no reservation cleanup.
+- **Uninterruptible replacement policy.** Warsmash can replace pending future work while letting an uninterruptible current behavior finish. OpenRealm does not yet expose a general `interruptable()` behavior contract.
+- **`BlzQueue*OrderById` natives.** The 1.29 native declarations exist in Warcraft data, but OpenRealm's current order-ID mapping is not yet a safe basis for implementing them here.
+- **Queue-full feedback and exact queue length parity.** The current 16-entry safety cap has no dedicated Warcraft command error and is not claimed as a retail limit.
+- **Shift-click selection toggle.** This remains a selection-system gap and is separate from Shift order queuing.
+
+## Verification
+
+The unit suite contains coverage for:
+
+- first Shift Move starting immediately while idle;
+- FIFO progression across later Shift Move legs;
+- a non-Shift replacement clearing pending work;
+- stale entity-target rejection followed by the next valid order;
+- Stop clearing the pending queue;
+- point `attack` selecting attack-move rather than ordinary Move.
+
+After building locally, useful targeted checks are:
+
+```bash
+make test-wc3-engine WC3_PATTERN='wc3_unit.*'
+```
+
+Runtime checks should additionally cover:
+
+1. select one unit, Shift-right-click three terrain points, and confirm they are visited in order;
+2. issue a normal Move halfway through and confirm the remaining chain is discarded;
+3. Shift-right-click an enemy after two Move points and confirm attack begins only after both legs;
+4. queue an enemy that dies before its turn, followed by another Move, and confirm the unit continues to the Move;
+5. select several units and confirm each advances independently through the same issued chain;
+6. click Move or Attack once, hold Shift, and click several valid targets/points without reopening the command button;
+7. press Stop or Hold Position with queued work and confirm no old queued command resumes afterward.

--- a/docs/games/warcraft-3/readme.md
+++ b/docs/games/warcraft-3/readme.md
@@ -99,6 +99,7 @@ File formats, renderer notes, UI/FDF behavior, and gameplay coverage work used b
 
 - [Economy And Unit Presentation](economy-and-unit-presentation.md)
 - [Unit Selection And Control](selection-and-control.md)
+- [Shift Order Queue](order-queue.md)
 - [Persistent Hero And Idle-Worker Shortcuts](unit-shortcuts.md)
 - [Pathfinding And Harvest Reachability](pathfinding.md)
 - [Inventory And World Items](inventory-and-items.md)

--- a/docs/games/warcraft-3/save-load.md
+++ b/docs/games/warcraft-3/save-load.md
@@ -6,7 +6,7 @@ The WC3 game module owns save/load. `GetGameAPI()` exposes `SaveGame` and `LoadG
 
 `WriteGame()` writes the current game state to a versioned binary file. The file contains:
 
-- `W3SV` magic, format version 6, `sizeof(edict_t)`, entity count, client count, script identity, and native-handle registry counts;
+- `W3SV` magic, format version 7, `sizeof(edict_t)`, entity count, client count, script identity, and native-handle registry counts;
 - level frame/time and started/script-started flags;
 - each client `GAMECLIENT` state, including its `PLAYER` state, JASS settings, researched tech, text storage, camera values, messages, and HUD caches;
 - each camera target as an entity index;
@@ -62,7 +62,7 @@ call LoadGame("chapter-01.w3save", false)
 
 `LoadGame` restores state in the already-loaded map; map selection and UI score-screen behavior remain separate work. The initialized map must have the same JASS program and deterministically recreated native registries.
 
-The format does not yet snapshot fog grids, bot runtime, mutable event-registration fields, alliances, stock state, or cinematic filter. Client message storage is part of `GAMECLIENT`, but transient presentation lifetimes are not reconstructed. Unit/destructable lifecycle callbacks are restored from class data, preventing resumed orders from calling stale or null process addresses; arbitrary active `umove_t` actions are not yet restored and require stable semantic move IDs. Menu callbacks are code pointers and are reset on load; restoring an active targeting/build submenu likewise requires a semantic menu-state enum rather than raw function addresses.
+The format does not yet snapshot fog grids, bot runtime, mutable event-registration fields, alliances, stock state, or cinematic filter. Client message storage is part of `GAMECLIENT`, but transient presentation lifetimes are not reconstructed. Unit/destructable lifecycle callbacks are restored from class data, preventing resumed orders from calling stale or null process addresses; arbitrary active `umove_t` actions are not yet restored and require stable semantic move IDs. Pending Shift-order FIFO records are pointer-free inline `edict_t` data and persist in version 7, while queued entity targets remain entity number + `spawn_time` for execution-time re-resolution. Menu callbacks and Shift-targeting flags are process-local and are reset on load; restoring an active targeting/build submenu likewise requires a semantic menu-state enum rather than raw function addresses.
 
 The checksum and header preflight protect normal partial/corrupt-file and wrong-map failures before mutation. Record-level semantic validation later in the stream is not fully transactional; do not treat save files as untrusted input until native records are decoded into temporary state before commit.
 

--- a/docs/games/warcraft-3/selection-and-control.md
+++ b/docs/games/warcraft-3/selection-and-control.md
@@ -111,6 +111,8 @@ Death has a stronger immediate path in `unit_die`: it sets health to zero, clear
 
 ## Known Gaps
 
+Shift order queuing is documented separately in [Shift Order Queue](order-queue.md); the remaining Shift-click item below is selection toggling, not command queuing.
+
 The following are deliberately not inferred by the current implementation:
 
 - invisibility/detection-aware selectability (`IsUnitDetected`/`IsUnitInvisible` coverage is incomplete);

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -21,6 +21,24 @@ static BOOL G_TargetModeActive(LPGAMECLIENT client) {
     return client && (client->menu.on_entity_selected || client->menu.on_location_selected);
 }
 
+static BOOL G_CommandQueueRequested(DWORD argc, LPCSTR argv[], DWORD first_optional) {
+    for (DWORD i = first_optional; i < argc; i++) {
+        if (!strcmp(argv[i], "queue")) return true;
+    }
+    return false;
+}
+
+static BOOL G_ParseEntityNumber(LPCSTR text, DWORD *number) {
+    char *end = NULL;
+    unsigned long value;
+
+    if (!text || !*text || !number) return false;
+    value = strtoul(text, &end, 10);
+    if (!end || *end || value >= globals.num_edicts) return false;
+    *number = (DWORD)value;
+    return true;
+}
+
 LPEDICT G_GetMainSelectedUnit(LPGAMECLIENT client) {
     DWORD *focus = G_SelectionFocusSlot(client);
 
@@ -252,21 +270,26 @@ void CMD_CancelCommand(LPEDICT ent) {
 CLIENTCOMMAND(Select) {
     LPGAMECLIENT client = clent->client;
     if (client->menu.on_entity_selected) {
-        DWORD number = atoi(argv[1]);
-        if (number >= globals.num_edicts)
-            return;
-        if (client->menu.on_entity_selected(clent, &globals.edicts[number])) {
-            Get_Commands_f(clent);
-        }
+        DWORD number;
+        BOOL const queued = client->menu.supports_order_queue &&
+                            G_CommandQueueRequested(argc, argv, 2);
+        BOOL accepted;
+
+        if (argc < 2 || !G_ParseEntityNumber(argv[1], &number)) return;
+        client->menu.order_queued = queued;
+        accepted = client->menu.on_entity_selected(clent, &globals.edicts[number]);
+        client->menu.order_queued = false;
+        /* Warsmash keeps a target command armed while Shift is held so the
+         * player can click several waypoints/targets without reopening it. */
+        if (accepted && !queued) Get_Commands_f(clent);
     } else {
         BOOL cleared = false;
         BOOL hasunits = false;
         LPEDICT voice = NULL;
         DWORD selected_count = 0;
         for (DWORD i = 1; i < argc; i++) {
-            DWORD number = atoi(argv[i]);
-            if (number >= globals.num_edicts)
-                continue;
+            DWORD number;
+            if (!G_ParseEntityNumber(argv[i], &number)) continue;
             LPEDICT e = &globals.edicts[number];
             if (G_UnitCanBeSelected(client, e) && G_UnitCanControl(client, e) &&
                 !G_UnitIsBuilding(e->class_id)) {
@@ -274,9 +297,8 @@ CLIENTCOMMAND(Select) {
             }
         }
         for (DWORD i = 1; i < argc; i++) {
-            DWORD number = atoi(argv[i]);
-            if (number >= globals.num_edicts)
-                continue;
+            DWORD number;
+            if (!G_ParseEntityNumber(argv[i], &number)) continue;
             LPEDICT e = &globals.edicts[number];
             if (G_UnitCanBeSelected(client, e)) {
                 if (hasunits && (!G_UnitCanControl(client, e) || G_UnitIsBuilding(e->class_id)))
@@ -356,11 +378,17 @@ CLIENTCOMMAND(Focus) {
 
 CLIENTCOMMAND(Point) {
     LPGAMECLIENT client = clent->client;
+    if (argc < 3) return;
     if (client->menu.on_location_selected) {
+        BOOL const queued = client->menu.supports_order_queue &&
+                            G_CommandQueueRequested(argc, argv, 3);
         VECTOR2 loc = { atoi(argv[1]), atoi(argv[2]) };
-        if (client->menu.on_location_selected(clent, &loc)) {
-            Get_Commands_f(clent);
-        }
+        BOOL accepted;
+
+        client->menu.order_queued = queued;
+        accepted = client->menu.on_location_selected(clent, &loc);
+        client->menu.order_queued = false;
+        if (accepted && !queued) Get_Commands_f(clent);
     }
 }
 
@@ -368,6 +396,7 @@ CLIENTCOMMAND(Smart) {
     LPGAMECLIENT client = clent->client;
     BOOL issued = false;
     BOOL rallied = false;
+    BOOL queued;
     DWORD number;
     LPEDICT target;
 
@@ -381,16 +410,13 @@ CLIENTCOMMAND(Smart) {
         Get_Commands_f(clent);
         return;
     }
-    if (argc < 2) {
-        return;
-    }
-    number = atoi(argv[1]);
-    if (number >= globals.num_edicts) {
+    if (argc < 2 || !G_ParseEntityNumber(argv[1], &number)) {
         return;
     }
     target = &globals.edicts[number];
+    queued = G_CommandQueueRequested(argc, argv, 2);
     FOR_CONTROLLABLE_SELECTED_UNITS(client, ent) {
-        if (unit_issuetargetorder(ent, "smart", target)) {
+        if (G_IssueUnitTargetOrder(ent, "smart", target, queued, client->ps.number)) {
             if (G_UnitHasRally(ent)) rallied = true;
             issued = true;
         }
@@ -408,6 +434,7 @@ CLIENTCOMMAND(SmartPoint) {
     BOOL rally = false;
     BOOL non_rally = false;
     BOOL issued = false;
+    BOOL queued;
 
     if (G_CancelBuildPlacement(clent) || G_CancelTargetMode(clent)) {
         return;
@@ -423,9 +450,11 @@ CLIENTCOMMAND(SmartPoint) {
         return;
     }
     loc = (VECTOR2){ atoi(argv[1]), atoi(argv[2]) };
+    queued = G_CommandQueueRequested(argc, argv, 3);
     FOR_CONTROLLABLE_SELECTED_UNITS(client, ent) {
         if (G_UnitHasRally(ent)) {
-            if (unit_issueorder(ent, "smart", &loc)) rally = true;
+            if (G_IssueUnitPointOrder(ent, "smart", &loc, queued, client->ps.number, 0.0f))
+                rally = true;
         } else {
             non_rally = true;
         }
@@ -433,7 +462,12 @@ CLIENTCOMMAND(SmartPoint) {
     /* Normal unit SmartPoint retains the existing formation-aware move path.
      * Selection rules normally keep production structures separate from mobile
      * units, so rally-capable selections do not enter this path. */
-    if (non_rally && move_selectlocation(clent, &loc)) issued = true;
+    if (non_rally) {
+        BOOL const old_queued = client->menu.order_queued;
+        client->menu.order_queued = queued;
+        if (move_selectlocation(clent, &loc)) issued = true;
+        client->menu.order_queued = old_queued;
+    }
     if (rally || issued) {
         G_QueueOrderSound(G_GetMainControllableUnit(client));
     }

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -111,6 +111,8 @@ typedef struct {
     void (*cmdbutton)(LPEDICT, DWORD);
     void (*refresh)(LPEDICT);
     DWORD ability_code;
+    BOOL supports_order_queue; /* active target mode accepts Shift chaining */
+    BOOL order_queued;         /* transient modifier for the current target callback */
 } menu_t;
 
 enum {
@@ -424,6 +426,34 @@ typedef struct {
     void (*endfunc)(LPEDICT);
     struct ability_s *ability;
 } umove_t;
+
+/* Player-issued WC3 Shift orders are simulation state, separate from the
+ * training/research queue. Targets are retained by edict number + spawn_time
+ * so a recycled slot cannot silently retarget an old queued command. */
+#define MAX_UNIT_ORDER_QUEUE 16
+#define UNIT_ORDER_NAME_SIZE 12
+
+typedef enum {
+    UNIT_ORDER_TARGET_NONE,
+    UNIT_ORDER_TARGET_POINT,
+    UNIT_ORDER_TARGET_ENTITY,
+} unitOrderTargetType_t;
+
+typedef struct {
+    char order[UNIT_ORDER_NAME_SIZE];
+    unitOrderTargetType_t target_type;
+    VECTOR2 point;
+    DWORD target_number;
+    DWORD target_spawn_time;
+    DWORD issuer_player;
+    FLOAT group_speed;
+} unitOrder_t;
+
+typedef struct {
+    unitOrder_t entries[MAX_UNIT_ORDER_QUEUE];
+    DWORD head;
+    DWORD count;
+} unitOrderQueue_t;
 
 #define ABILITY_PASSIVE  (1 << 0)
 #define ABILITY_TOGGLE   (1 << 1)
@@ -808,6 +838,7 @@ struct edict_s {
     } channel;
     DWORD unit_color;   // explicit per-unit color override (0 = use owner color)
     VECTOR2 old_origin;
+    unitOrderQueue_t order_queue;
     struct {
         VECTOR2 last_origin;
         FLOAT last_distance;
@@ -1550,6 +1581,11 @@ BOOL G_GetPlayerAlliance(LPCPLAYER, LPCPLAYER, PLAYERALLIANCE);
 BOOL unit_issueorder(LPEDICT, LPCSTR, LPCVECTOR2);
 BOOL unit_issueimmediateorder(LPEDICT, LPCSTR);
 BOOL unit_issuetargetorder(LPEDICT, LPCSTR, LPEDICT);
+BOOL G_IssueUnitPointOrder(LPEDICT, LPCSTR, LPCVECTOR2, BOOL, DWORD, FLOAT);
+BOOL G_IssueUnitTargetOrder(LPEDICT, LPCSTR, LPEDICT, BOOL, DWORD);
+BOOL G_UnitStartNextQueuedOrder(LPEDICT);
+void G_ClearUnitOrderQueue(LPEDICT);
+DWORD G_UnitQueuedOrderCount(LPCEDICT);
 void unit_birth(LPEDICT);
 void unit_die(LPEDICT, LPEDICT);
 LPEDICT unit_createorfind(DWORD, DWORD, LPCVECTOR2, FLOAT);
@@ -1629,6 +1665,7 @@ BOOL move_selectlocation(LPEDICT, LPCVECTOR2);
 BOOL move_should_arrive(LPEDICT, FLOAT);
 BOOL move_is_blocked(LPEDICT, FLOAT, FLOAT);
 BOOL move_is_settled_near_goal(LPEDICT, FLOAT, FLOAT);
+BOOL move_is_terminal_hold(LPCEDICT);
 void move_reset_progress(LPEDICT);
 LPEDICT G_FindNearestEnemy(LPEDICT, FLOAT);
 FLOAT G_AcquisitionRange(LPCEDICT);

--- a/games/warcraft-3/game/g_save.c
+++ b/games/warcraft-3/game/g_save.c
@@ -2,7 +2,7 @@
 
 static DWORD const save_magic = MAKEFOURCC('W', '3', 'S', 'V');
 static DWORD const save_commit = MAKEFOURCC('W', '3', 'O', 'K');
-static DWORD const save_version = 6;
+static DWORD const save_version = 7;
 #define MAX_SAVE_STRING (1u << 20) // bytes; bounds quest-string allocations from corrupt saves
 
 typedef struct {
@@ -525,6 +525,7 @@ static BOOL WriteClient(FILE *f, LPCGAMECLIENT client) {
     temp.mapplayer = NULL;
     temp.menu.on_entity_selected = NULL; temp.menu.on_location_selected = NULL;
     temp.menu.cmdbutton = NULL; temp.menu.refresh = NULL;
+    temp.menu.supports_order_queue = false; temp.menu.order_queued = false;
     temp.camera.target_controller = NULL;
     temp.rally_indicator = NULL;
     if (target < -1 || target >= (int)globals.max_edicts) return false;
@@ -540,6 +541,7 @@ static BOOL ReadClient(FILE *f, LPGAMECLIENT client, int *target) {
     client->mapplayer = level.mapinfo && client->ps.number < MAX_PLAYERS ? level.mapinfo->players + client->ps.number : NULL;
     client->menu.on_entity_selected = NULL; client->menu.on_location_selected = NULL;
     client->menu.cmdbutton = NULL; client->menu.refresh = NULL;
+    client->menu.supports_order_queue = false; client->menu.order_queued = false;
     client->camera.target_controller = NULL;
     client->rally_indicator = NULL;
     return true;

--- a/games/warcraft-3/game/m_unit.c
+++ b/games/warcraft-3/game/m_unit.c
@@ -91,6 +91,18 @@ BOOL unit_affectingcombat(LPEDICT self) {
 }
 
 void unit_stand(LPEDICT self) {
+    /* Reaching stand is the common completion edge for Move, direct Attack,
+     * Repair, Harvest, and several cast behaviors. Retire transient state first,
+     * then let a pending Shift order become authoritative before installing the
+     * idle/default stand behavior. */
+    self->build = NULL;
+    self->s.renderfx &= ~RF_NO_UBERSPLAT;
+    self->s.ability = 255;
+    self->movement.last_distance = 0;
+    self->movement.blocked_frames = 0;
+    if (G_UnitStartNextQueuedOrder(self)) {
+        return;
+    }
     if (self->movement.holding_position) {
         unit_setmove(self, unit_affectingcombat(self)
             ? &holdpos_move_stand_ready
@@ -100,17 +112,12 @@ void unit_stand(LPEDICT self) {
             ? &unit_move_stand_ready
             : &unit_move_stand);
     }
-    self->build = NULL;
-    self->s.renderfx &= ~RF_NO_UBERSPLAT;
-    self->s.ability = 255;
-    self->movement.last_distance = 0;
-    self->movement.blocked_frames = 0;
-    
 }
 
 void unit_die(LPEDICT self, LPEDICT attacker) {
     LPGAMECLIENT owner;
 
+    G_ClearUnitOrderQueue(self);
     G_InvalidateUnitShortcutsForUnit(self);
     self->health.value = 0.0f;
     if (self->training) G_ClearTrainingQueueFood(self);
@@ -178,19 +185,74 @@ static BOOL unit_smart_target_is_enemy(LPEDICT self, LPEDICT target) {
     return true;
 }
 
-BOOL unit_issuetargetorder(LPEDICT self, LPCSTR order, LPEDICT target) {
-    if (!self || !order || !target) {
-        return false;
+static BOOL unit_order_name_valid(LPCSTR order) {
+    return order && *order && strlen(order) < UNIT_ORDER_NAME_SIZE;
+}
+
+static BOOL unit_has_active_order(LPCEDICT self) {
+    return self && self->currentmove && self->currentmove->ability != NULL &&
+           !move_is_terminal_hold(self);
+}
+
+static BOOL unit_queue_push(LPEDICT self, LPCSTR order, unitOrderTargetType_t target_type,
+                            LPCVECTOR2 point, LPEDICT target, DWORD issuer_player,
+                            FLOAT group_speed) {
+    unitOrderQueue_t *queue;
+    unitOrder_t *queued;
+    DWORD slot;
+
+    if (!self || !unit_order_name_valid(order)) return false;
+    queue = &self->order_queue;
+    if (queue->count >= MAX_UNIT_ORDER_QUEUE) return false;
+    slot = (queue->head + queue->count) % MAX_UNIT_ORDER_QUEUE;
+    queued = &queue->entries[slot];
+    memset(queued, 0, sizeof(*queued));
+    snprintf(queued->order, sizeof(queued->order), "%s", order);
+    queued->target_type = target_type;
+    queued->issuer_player = issuer_player;
+    queued->group_speed = group_speed;
+    if (point) queued->point = *point;
+    if (target) {
+        DWORD const number = target->s.number;
+        if (number >= globals.num_edicts || globals.edicts + number != target) return false;
+        queued->target_number = number;
+        queued->target_spawn_time = target->spawn_time;
     }
+    queue->count++;
+    return true;
+}
+
+static BOOL unit_queue_pop(LPEDICT self, unitOrder_t *out) {
+    unitOrderQueue_t *queue;
+
+    if (!self || !out) return false;
+    queue = &self->order_queue;
+    if (!queue->count) return false;
+    *out = queue->entries[queue->head];
+    memset(&queue->entries[queue->head], 0, sizeof(queue->entries[queue->head]));
+    queue->head = (queue->head + 1) % MAX_UNIT_ORDER_QUEUE;
+    queue->count--;
+    if (!queue->count) queue->head = 0;
+    return true;
+}
+
+void G_ClearUnitOrderQueue(LPEDICT self) {
+    if (!self) return;
+    memset(&self->order_queue, 0, sizeof(self->order_queue));
+}
+
+DWORD G_UnitQueuedOrderCount(LPCEDICT self) {
+    return self ? self->order_queue.count : 0;
+}
+
+static BOOL unit_issueorder_now(LPEDICT self, LPCSTR order, LPCVECTOR2 point, FLOAT group_speed);
+
+static BOOL unit_issuetargetorder_now(LPEDICT self, LPCSTR order, LPEDICT target) {
+    if (!self || !order || !target) return false;
     if (M_IsDead(self)) return false;
-    /* Rally is producer metadata, not movement. It must be accepted before
-     * immobility/mining guards so structures and other producers can use both
-     * the explicit setrally order and Warcraft's Smart/right-click shortcut. */
-    if (!strcmp(order, "setrally") || (!strcmp(order, "smart") && G_UnitHasRally(self))) {
-        return G_SetRallyEntity(self, target);
-    }
-    if (S_GoldMineWorkerIsInside(self))
-        return false;
+    if (S_GoldMineWorkerIsInside(self)) return false;
+
+    self->movement.holding_position = false;
     if (!strcmp(order, "smart")) {
         if (G_IsItem(target)) {
             return G_OrderPickupItem(self, target);
@@ -224,7 +286,7 @@ BOOL unit_issuetargetorder(LPEDICT self, LPCSTR order, LPEDICT target) {
         if (S_RepairSmart(self, target)) {
             return true;
         }
-        return unit_issueorder(self, "move", &target->s.origin2);
+        return unit_issueorder_now(self, "move", &target->s.origin2, 0.0f);
     }
     if (!strcmp(order, "attack")) {
         if (G_IsDestructable(target) && !G_DestructableIsAttackable(target)) {
@@ -236,28 +298,100 @@ BOOL unit_issuetargetorder(LPEDICT self, LPCSTR order, LPEDICT target) {
     return false;
 }
 
-BOOL unit_issueorder(LPEDICT self, LPCSTR order, LPCVECTOR2 point) {
-//    printf("%.4s %s\n", &self->class_id, order);
-    if (!self || !order || !point) {
-        return false;
-    }
+static BOOL unit_issueorder_now(LPEDICT self, LPCSTR order, LPCVECTOR2 point, FLOAT group_speed) {
+    VECTOR2 target;
+    LPEDICT waypoint;
+
+    if (!self || !order || !point) return false;
     if (M_IsDead(self)) return false;
-    if (!strcmp(order, "setrally") || (!strcmp(order, "smart") && G_UnitHasRally(self))) {
-        return G_SetRallyPoint(self, point);
-    }
-    if (S_GoldMineWorkerIsInside(self))
-        return false;
-    if (self->aiflags & AI_IMMOBILE)
-        return false;
-    /* Smart + point resolves through ordinary movement for movable units. */
-    if (!strcmp(order, "smart") || !strcmp(order, "move") || !strcmp(order, "attack")) {
-        VECTOR2 target = *point;
-        CM_ClosestPathablePointForRadius(point, self->collision, &target);
-        LPEDICT waypoint = Waypoint_add(&target);
+    if (S_GoldMineWorkerIsInside(self)) return false;
+    if (self->aiflags & AI_IMMOBILE) return false;
+
+    target = *point;
+    CM_ClosestPathablePointForRadius(point, self->collision, &target);
+    waypoint = Waypoint_add(&target);
+    if (!waypoint) return false;
+    self->movement.holding_position = false;
+    if (!strcmp(order, "smart") || !strcmp(order, "move")) {
         order_move(self, waypoint);
+        self->movement.group_speed = group_speed;
+        return true;
+    }
+    if (!strcmp(order, "attack")) {
+        order_attackmove(self, waypoint);
         return true;
     }
     return false;
+}
+
+BOOL G_IssueUnitTargetOrder(LPEDICT self, LPCSTR order, LPEDICT target,
+                            BOOL queue, DWORD issuer_player) {
+    if (!self || !order || !target || !target->inuse || !unit_order_name_valid(order)) return false;
+    if (M_IsDead(self)) return false;
+    /* Rally is producer metadata rather than an interruptible unit behavior. */
+    if (!strcmp(order, "setrally") || (!strcmp(order, "smart") && G_UnitHasRally(self))) {
+        if (!queue) G_ClearUnitOrderQueue(self);
+        return G_SetRallyEntity(self, target);
+    }
+    if (S_GoldMineWorkerIsInside(self)) return false;
+    if (strcmp(order, "smart") && strcmp(order, "attack")) return false;
+
+    if (queue && unit_has_active_order(self)) {
+        return unit_queue_push(self, order, UNIT_ORDER_TARGET_ENTITY, NULL, target,
+                               issuer_player, 0.0f);
+    }
+    if (!queue) G_ClearUnitOrderQueue(self);
+    return unit_issuetargetorder_now(self, order, target);
+}
+
+BOOL G_IssueUnitPointOrder(LPEDICT self, LPCSTR order, LPCVECTOR2 point,
+                           BOOL queue, DWORD issuer_player, FLOAT group_speed) {
+    if (!self || !order || !point || !unit_order_name_valid(order)) return false;
+    if (M_IsDead(self)) return false;
+    /* Rally-point changes are metadata and apply immediately even when Shift is down. */
+    if (!strcmp(order, "setrally") || (!strcmp(order, "smart") && G_UnitHasRally(self))) {
+        if (!queue) G_ClearUnitOrderQueue(self);
+        return G_SetRallyPoint(self, point);
+    }
+    if (S_GoldMineWorkerIsInside(self)) return false;
+    if (self->aiflags & AI_IMMOBILE) return false;
+    if (strcmp(order, "smart") && strcmp(order, "move") && strcmp(order, "attack")) return false;
+
+    if (queue && unit_has_active_order(self)) {
+        return unit_queue_push(self, order, UNIT_ORDER_TARGET_POINT, point, NULL,
+                               issuer_player, group_speed);
+    }
+    if (!queue) G_ClearUnitOrderQueue(self);
+    return unit_issueorder_now(self, order, point, group_speed);
+}
+
+BOOL G_UnitStartNextQueuedOrder(LPEDICT self) {
+    unitOrder_t queued;
+
+    if (!self || M_IsDead(self)) return false;
+    while (unit_queue_pop(self, &queued)) {
+        if (queued.target_type == UNIT_ORDER_TARGET_POINT) {
+            if (unit_issueorder_now(self, queued.order, &queued.point, queued.group_speed))
+                return true;
+        } else if (queued.target_type == UNIT_ORDER_TARGET_ENTITY) {
+            LPEDICT target;
+            if (queued.target_number >= globals.num_edicts) continue;
+            target = globals.edicts + queued.target_number;
+            if (!target->inuse || target->spawn_time != queued.target_spawn_time) continue;
+            if (unit_issuetargetorder_now(self, queued.order, target)) return true;
+        }
+    }
+    return false;
+}
+
+BOOL unit_issuetargetorder(LPEDICT self, LPCSTR order, LPEDICT target) {
+    return G_IssueUnitTargetOrder(self, order, target, false,
+                                  self ? self->s.player : 0);
+}
+
+BOOL unit_issueorder(LPEDICT self, LPCSTR order, LPCVECTOR2 point) {
+    return G_IssueUnitPointOrder(self, order, point, false,
+                                 self ? self->s.player : 0, 0.0f);
 }
 
 BOOL unit_issueimmediateorder(LPEDICT self, LPCSTR order) {
@@ -269,6 +403,7 @@ BOOL unit_issueimmediateorder(LPEDICT self, LPCSTR order) {
     if (S_GoldMineWorkerIsInside(self))
         return false;
     if (!strcmp(order, "stop")) {
+        G_ClearUnitOrderQueue(self);
         order_stop(self);
         return true;
     }

--- a/games/warcraft-3/game/skills/s_attack.c
+++ b/games/warcraft-3/game/skills/s_attack.c
@@ -370,9 +370,11 @@ BOOL attack_menu_selecttarget(LPEDICT ent, LPEDICT target) {
     }
     FOR_CONTROLLABLE_SELECTED_UNITS(ent->client, e) {
         if (e == target) continue;
-        e->movement.attackmove_waypoint = NULL;
-        order_attack(e, target);
-        issued = true;
+        if (G_IssueUnitTargetOrder(e, "attack", target,
+                                   ent->client->menu.order_queued,
+                                   ent->client->ps.number)) {
+            issued = true;
+        }
     }
     return issued;
 }
@@ -428,8 +430,11 @@ static BOOL attackmove_selectlocation(LPEDICT clent, LPCVECTOR2 location) {
             continue;
         }
         CM_ClosestPathablePointForRadius(location, ent->collision, &target);
-        order_attackmove(ent, Waypoint_add(&target));
-        any = true;
+        if (G_IssueUnitPointOrder(ent, "attack", &target,
+                                  clent->client->menu.order_queued,
+                                  clent->client->ps.number, 0.0f)) {
+            any = true;
+        }
     }
     if (any) G_SendPointConfirmation(clent, location, true);
     return any;
@@ -439,6 +444,7 @@ void attack_command(LPEDICT ent) {
     UI_AddCancelButton(ent);
     ent->client->menu.on_entity_selected = attack_menu_selecttarget;
     ent->client->menu.on_location_selected = attackmove_selectlocation;
+    ent->client->menu.supports_order_queue = true;
 }
 
 ability_t a_attack = {

--- a/games/warcraft-3/game/skills/s_holdpos.c
+++ b/games/warcraft-3/game/skills/s_holdpos.c
@@ -18,6 +18,7 @@ static void holdpos_command(LPEDICT ent) {
     FOR_CONTROLLABLE_SELECTED_UNITS(ent->client, e) {
         if (S_GoldMineWorkerIsInside(e))
             continue;
+        G_ClearUnitOrderQueue(e);
         e->movement.holding_position = true;
         unit_leavecombat(e);
         unit_stand(e);

--- a/games/warcraft-3/game/skills/s_move.c
+++ b/games/warcraft-3/game/skills/s_move.c
@@ -270,7 +270,15 @@ BOOL move_is_settled_near_goal(LPEDICT ent, FLOAT distance, FLOAT move_distance)
 
 static umove_t move_move_hold = { "stand", NULL, NULL, &a_move };
 
+BOOL move_is_terminal_hold(LPCEDICT ent) {
+    return ent && ent->currentmove == &move_move_hold;
+}
+
 static void move_hold(LPEDICT ent) {
+    /* A terminal blocked/unreachable Move is complete for queue purposes.
+     * Continue a Shift chain instead of stranding pending commands behind the
+     * legacy hold pose. */
+    if (G_UnitStartNextQueuedOrder(ent)) return;
     ent->build = NULL;
     ent->s.renderfx &= ~RF_NO_UBERSPLAT;
     ent->s.ability = 0;
@@ -360,6 +368,7 @@ BOOL move_selectlocation(LPEDICT clent, LPCVECTOR2 location) {
     VECTOR2 center;
     VECTOR2 confirmation = *location;
     BOOL have_confirmation = false;
+    BOOL issued = false;
     DWORD num_units = move_collect_selected(clent->client, units, MAX_SELECTED_ENTITIES, &center);
     FLOAT spacing = move_slot_spacing(units, num_units);
     LPEDICT route_waypoint;
@@ -370,7 +379,7 @@ BOOL move_selectlocation(LPEDICT clent, LPCVECTOR2 location) {
     /* A multi-unit move travels at the slowest member's speed so the group
      * stays together (WC3).  A lone unit keeps its own speed (cap 0). */
     FLOAT const group_speed = num_units > 1 ? move_group_speed(units, num_units) : 0;
-    route_waypoint = Waypoint_add(location);
+    route_waypoint = clent->client->menu.order_queued ? NULL : Waypoint_add(location);
 
     FOR_LOOP(i, num_units) {
         LPEDICT ent = units[i];
@@ -389,22 +398,35 @@ BOOL move_selectlocation(LPEDICT clent, LPCVECTOR2 location) {
             CM_ClosestPathablePointForRadius(location, ent->collision, &target);
         }
         reserved[i] = (moveSlot_t){ target, ent->collision };
-        LPEDICT waypoint = Waypoint_add(&target);
-        waypoint->secondarygoal = route_waypoint;
         if (!have_confirmation) {
             confirmation = target;
             have_confirmation = true;
         }
-        order_move(ent, waypoint);
-        ent->movement.group_speed = group_speed;  /* after order_move, which resets it */
+        if (clent->client->menu.order_queued) {
+            /* Queued units may reach this leg at different times, so retain the
+             * resolved per-unit slot and speed in the unit's own FIFO. */
+            if (G_IssueUnitPointOrder(ent, "move", &target, true,
+                                      clent->client->ps.number, group_speed)) {
+                issued = true;
+            }
+        } else {
+            LPEDICT waypoint = Waypoint_add(&target);
+            waypoint->secondarygoal = route_waypoint;
+            G_ClearUnitOrderQueue(ent);
+            ent->movement.holding_position = false;
+            order_move(ent, waypoint);
+            ent->movement.group_speed = group_speed;  /* after order_move, which resets it */
+            issued = true;
+        }
     }
-    G_SendPointConfirmation(clent, &confirmation, false);
-    return true;
+    if (issued) G_SendPointConfirmation(clent, &confirmation, false);
+    return issued;
 }
 
 void move_command(LPEDICT ent) {
     UI_AddCancelButton(ent);
     ent->client->menu.on_location_selected = move_selectlocation;
+    ent->client->menu.supports_order_queue = true;
 }
 
 ability_t a_move = {

--- a/games/warcraft-3/game/skills/s_stop.c
+++ b/games/warcraft-3/game/skills/s_stop.c
@@ -6,6 +6,7 @@
 void order_stop(LPEDICT ent) {
     if (S_GoldMineWorkerIsInside(ent))
         return;
+    G_ClearUnitOrderQueue(ent);
     ent->movement.attackmove_waypoint = NULL;
     ent->movement.patrol_a = NULL;
     unit_leavecombat(ent);
@@ -14,7 +15,7 @@ void order_stop(LPEDICT ent) {
 
 static void stop_command(LPEDICT ent) {
     FOR_CONTROLLABLE_SELECTED_UNITS(ent->client, e) {
-        order_stop(e);
+        unit_issueimmediateorder(e, "stop");
     }
 }
 

--- a/games/warcraft-3/game/tests/t_unit.c
+++ b/games/warcraft-3/game/tests/t_unit.c
@@ -454,6 +454,91 @@ TEST(wc3_unit, issueorder_move_sets_walk_animation) {
     T_STREQ(ent->currentmove->animation, "walk");
 }
 
+TEST(wc3_unit, shift_move_starts_immediately_when_idle_then_queues_fifo) {
+    reset_test_entities();
+    LPEDICT ent = make_unit(0, 0);
+    VECTOR2 a = { 96.0f, 0.0f };
+    VECTOR2 b = { 192.0f, 0.0f };
+    VECTOR2 c = { 288.0f, 0.0f };
+
+    T_ASSERT(G_IssueUnitPointOrder(ent, "move", &a, true, 0, 0.0f));
+    T_EQ(G_UnitQueuedOrderCount(ent), 0);
+    T_STREQ(ent->currentmove->animation, "walk");
+    T_ASSERT(G_IssueUnitPointOrder(ent, "move", &b, true, 0, 0.0f));
+    T_ASSERT(G_IssueUnitPointOrder(ent, "move", &c, true, 0, 0.0f));
+    T_EQ(G_UnitQueuedOrderCount(ent), 2);
+
+    unit_stand(ent);
+    T_EQ(G_UnitQueuedOrderCount(ent), 1);
+    T_FEQ(ent->goalentity->s.origin2.x, b.x, 0.01f);
+
+    unit_stand(ent);
+    T_EQ(G_UnitQueuedOrderCount(ent), 0);
+    T_FEQ(ent->goalentity->s.origin2.x, c.x, 0.01f);
+}
+
+TEST(wc3_unit, nonqueued_move_replaces_pending_shift_orders) {
+    reset_test_entities();
+    LPEDICT ent = make_unit(0, 0);
+    VECTOR2 a = { 96.0f, 0.0f };
+    VECTOR2 b = { 192.0f, 0.0f };
+    VECTOR2 replacement = { 320.0f, 0.0f };
+
+    T_ASSERT(G_IssueUnitPointOrder(ent, "move", &a, true, 0, 0.0f));
+    T_ASSERT(G_IssueUnitPointOrder(ent, "move", &b, true, 0, 0.0f));
+    T_EQ(G_UnitQueuedOrderCount(ent), 1);
+
+    T_ASSERT(unit_issueorder(ent, "move", &replacement));
+    T_EQ(G_UnitQueuedOrderCount(ent), 0);
+    T_FEQ(ent->goalentity->s.origin2.x, replacement.x, 0.01f);
+}
+
+TEST(wc3_unit, stale_queued_entity_target_is_skipped_for_next_order) {
+    reset_test_entities();
+    LPEDICT ent = make_unit(0, 0);
+    LPEDICT target = make_unit(128, 0);
+    VECTOR2 a = { 64.0f, 0.0f };
+    VECTOR2 b = { 256.0f, 0.0f };
+
+    T_ASSERT(G_IssueUnitPointOrder(ent, "move", &a, true, 0, 0.0f));
+    T_ASSERT(G_IssueUnitTargetOrder(ent, "attack", target, true, 0));
+    T_ASSERT(G_IssueUnitPointOrder(ent, "move", &b, true, 0, 0.0f));
+    T_EQ(G_UnitQueuedOrderCount(ent), 2);
+
+    /* Simulate recycling the target slot before the queued Attack begins. */
+    target->spawn_time++;
+    unit_stand(ent);
+
+    T_EQ(G_UnitQueuedOrderCount(ent), 0);
+    T_STREQ(ent->currentmove->animation, "walk");
+    T_FEQ(ent->goalentity->s.origin2.x, b.x, 0.01f);
+}
+
+TEST(wc3_unit, stop_clears_pending_shift_orders) {
+    reset_test_entities();
+    LPEDICT ent = make_unit(0, 0);
+    VECTOR2 a = { 96.0f, 0.0f };
+    VECTOR2 b = { 192.0f, 0.0f };
+
+    T_ASSERT(G_IssueUnitPointOrder(ent, "move", &a, true, 0, 0.0f));
+    T_ASSERT(G_IssueUnitPointOrder(ent, "move", &b, true, 0, 0.0f));
+    T_EQ(G_UnitQueuedOrderCount(ent), 1);
+
+    T_ASSERT(unit_issueimmediateorder(ent, "stop"));
+    T_EQ(G_UnitQueuedOrderCount(ent), 0);
+    T_STREQ(ent->currentmove->animation, "stand");
+}
+
+TEST(wc3_unit, point_attack_order_uses_attack_move_behavior) {
+    reset_test_entities();
+    LPEDICT ent = make_unit(0, 0);
+    VECTOR2 dest = { 128.0f, 0.0f };
+
+    T_ASSERT(unit_issueorder(ent, "attack", &dest));
+    T_NOT_NULL(ent->movement.attackmove_waypoint);
+    T_ASSERT(ent->goalentity == ent->movement.attackmove_waypoint);
+}
+
 TEST(wc3_unit, issueorder_move_preserves_combat_state) {
     reset_test_entities();
     LPEDICT ent = make_unit(0, 0);

--- a/server/server.h
+++ b/server/server.h
@@ -101,6 +101,11 @@ extern struct server {
 
 extern struct game_export *ge;
 
+// sv_main.c
+void PF_Configstring(DWORD index, LPCSTR value);
+void PF_Confignstring(DWORD index, LPCSTR value, DWORD len);
+LPCSTR PF_GetConfigstring(DWORD index);
+
 // sv_init.c
 void SV_StartLobby(LPCSTR mapFilename);
 void SV_Map(LPCSTR pFilename);

--- a/server/sv_main.c
+++ b/server/sv_main.c
@@ -16,6 +16,39 @@ struct game_export *ge;
 struct server sv;
 struct server_static svs;
 
+void PF_Confignstring(DWORD index, LPCSTR value, DWORD len) {
+    if (index >= MAX_CONFIGSTRINGS) {
+        fprintf(stderr, "configstring: bad index %u\n", (unsigned)index);
+        return;
+    }
+    if (!value) {
+        value = "";
+        len = 1;
+    }
+    if (len > sizeof(sv.configstrings[index]) - 1) {
+        len = sizeof(sv.configstrings[index]) - 1;
+    }
+    memset(sv.configstrings[index], 0, sizeof(sv.configstrings[index]));
+    if (len) {
+        memcpy(sv.configstrings[index], value, len);
+    }
+    sv.syncstrings[index] = false;
+}
+
+void PF_Configstring(DWORD index, LPCSTR value) {
+    if (!value) {
+        value = "";
+    }
+    PF_Confignstring(index, value, (DWORD)(strlen(value) + 1));
+}
+
+LPCSTR PF_GetConfigstring(DWORD index) {
+    if (index >= MAX_CONFIGSTRINGS) {
+        return "";
+    }
+    return sv.configstrings[index];
+}
+
 void SV_WriteConfigString(LPSIZEBUF msg, DWORD i) {
     MSG_WriteByte(msg, svc_configstring);
     MSG_WriteShort(msg, i);


### PR DESCRIPTION
* add per-unit FIFO order queues for Shift-issued commands
* preserve queued Smart, Move, Attack, harvest, repair, and item orders
* start the first queued order immediately when a unit is idle
* advance queued orders as the current behavior completes
* clear pending orders on normal replacement commands, Stop, Hold, and death
* re-resolve entity targets when queued orders execute
* skip stale queued targets without blocking later orders
* keep Move and Attack targeting active while Shift is held
* route point Attack orders through attack-move behavior
* persist pointer-free queued order state and bump WC3 saves to v7
* add order-queue documentation and regression coverage