### PR TITLE
wc3: implement in-game menu flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 camera viewport/bounds, cinematic camera state, world-overlay clipping | [docs/games/warcraft-3/cinematics.md](docs/games/warcraft-3/cinematics.md) |
 | WC3 triggered dialogue, gameplay/cinematic presentation split, message and transmission lifetimes | [docs/games/warcraft-3/triggered-dialogue.md](docs/games/warcraft-3/triggered-dialogue.md) |
 | WC3 Quest journal, single-player Message Log, upper-button wiring, retained message history | [docs/games/warcraft-3/quest-and-message-log-ui.md](docs/games/warcraft-3/quest-and-message-log-ui.md) |
+| WC3 in-game Menu/F10 overlay, EscMenu panel flow, modal pause/input, leave/exit actions | [docs/games/warcraft-3/in-game-menu.md](docs/games/warcraft-3/in-game-menu.md) |
 | WC3 Hero skill tree, skill points, rank requirements, learning UI, JASS progression | [docs/games/warcraft-3/hero-abilities.md](docs/games/warcraft-3/hero-abilities.md) |
 | WC3 gathering, immobile units, construction HUD, overhead bars | [docs/games/warcraft-3/economy-and-unit-presentation.md](docs/games/warcraft-3/economy-and-unit-presentation.md) |
 | WC3 enemy/neutral selection, relationship colours, command authority, fog/death deselection | [docs/games/warcraft-3/selection-and-control.md](docs/games/warcraft-3/selection-and-control.md) |

--- a/client/cl_window.c
+++ b/client/cl_window.c
@@ -89,9 +89,19 @@ static LPCUIFRAME CL_WindowClickableAt(clientWindow_t *window, LPCVECTOR2 point)
 /* Consume client-owned button actions locally; ordinary layout actions remain server commands. */
 static void CL_WindowActivateFrame(clientWindow_t *window, LPCUIFRAME frame) {
     if (!frame) return;
-    if (!strcmp(frame->onclick, UI_WINDOW_CLOSE_ACTION)) CL_WindowClose(window->id);
-    else if (!strcmp(frame->onclick, UI_WINDOW_CLOSE_NOTIFY_ACTION)) CL_WindowClose(window->id);
-    else SCR_LayoutSendFrameCommand(frame);
+    if (!strcmp(frame->onclick, UI_WINDOW_CLOSE_ACTION) ||
+        !strcmp(frame->onclick, UI_WINDOW_CLOSE_NOTIFY_ACTION)) {
+        CL_WindowClose(window->id);
+    } else if (!strcmp(frame->onclick, UI_WINDOW_DISCONNECT_ACTION)) {
+        /* Server-authored menus may offer a leave action, but the local client
+         * owns session teardown and only performs it after explicit input. */
+        CL_Disconnect("Left game.", false);
+    } else if (!strcmp(frame->onclick, UI_WINDOW_QUIT_ACTION)) {
+        /* Defer normal application shutdown until input dispatch returns. */
+        Cbuf_AddText("quit\n");
+    } else {
+        SCR_LayoutSendFrameCommand(frame);
+    }
 }
 
 void CL_WindowOpen(uiWindowDef_t const *def, HANDLE layout) {

--- a/common/shared.h
+++ b/common/shared.h
@@ -451,6 +451,8 @@ typedef enum {
 #define UI_WINDOW_UNIQUE  (1u << 2) // flag bit; keeps one instance per class; used by singleton inventory and journal windows
 #define UI_WINDOW_CLOSE_ACTION "close_window" // client action; closes the owning window without a server command
 #define UI_WINDOW_CLOSE_NOTIFY_ACTION "close_window_notify" // client action; closes locally and notifies server of modal release
+#define UI_WINDOW_DISCONNECT_ACTION "disconnect_game" // client action; leaves the current server/map and returns to the front-end
+#define UI_WINDOW_QUIT_ACTION "quit_application" // client action; exits the application after an explicit local click
 
 typedef struct {
     DWORD id, class_id, flags;

--- a/docs/architecture/client-windows.md
+++ b/docs/architecture/client-windows.md
@@ -60,6 +60,19 @@ retained arena; it does not duplicate strings.
 - A modal window blocks world hit testing, control groups, bindings, minimap actions, and manual camera movement.
 - Key-up still reaches gameplay `+command` releases so opening or focusing a window cannot leave an input held.
 
+### Client-owned button actions
+
+Most authored window `onclick` strings are sent back to the game server. Four explicit action tokens are consumed locally by
+`client/cl_window.c` instead:
+
+- `UI_WINDOW_CLOSE_ACTION` (`close_window`) closes the owning window;
+- `UI_WINDOW_CLOSE_NOTIFY_ACTION` (`close_window_notify`) closes it and therefore participates in modal-list pause synchronization;
+- `UI_WINDOW_DISCONNECT_ACTION` (`disconnect_game`) leaves the current game and returns to the front-end;
+- `UI_WINDOW_QUIT_ACTION` (`quit_application`) queues normal application shutdown.
+
+Disconnect and quit are intended for explicit local activation in server-authored menus. They are never executed merely because a
+window packet is received. Submenu/navigation actions remain ordinary server commands.
+
 ## Legacy UI Windows
 
 `svc_ui_window` retains the older WoW `ui.ShowWindow` named-XML toggle. It is migration debt and does not participate in the

--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -113,10 +113,12 @@ sends the same command with a leading `-` on mouse-up even if the pointer has le
 modules may use it for press-and-hold controls without adding game-specific branches to `client/`.
 
 Configstrings are also live server state, not connect-time-only metadata. A game-side `gi.configstring()` call reaches
-`PF_Confignstring()`, which delegates storage and sync-bit invalidation to the core server's `SV_SetConfigString()`. At the start of a later
+`PF_Confignstring()`, which delegates storage to the generic server-owned `SV_SetConfigString()`. That helper clears
+`sv.syncstrings[index]`; `SV_FindIndex()` uses the same path when it creates model/sound/image entries. At the start of a later
 `SV_SendClientMessages()` pass, each unsynced entry is sent reliably with `svc_configstring` before normal spawned-client datagrams.
-Code that mutates `sv.configstrings[]` through this API must not leave the sync bit true, or already-connected clients will retain the
-old value.
+Do not mutate `sv.configstrings[]` directly for runtime values, or already-connected clients may retain stale data. Keeping the
+mutation helper in `server/` also lets standalone server-network tests cover the real resync implementation without linking the
+game-import wrapper in `sv_game.c`.
 
 Server-authored text frames may also bind to live snapshot values instead of forcing a complete layout resend whenever a number changes.
 `playerState.stats[18..21]` are reserved generic selection-UI slots (current/max health and current/max mana), serialized as the two

--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -425,9 +425,10 @@ The displayed name comes from the race/campaign `Units\\*UnitStrings.txt` `Name`
 for example, `Units\\NeutralUnitStrings.txt` defines `[nvil] Name=Villager`. `G_CustomizeEntity` interns that text into `CS_GENERAL`
 and sends its 1-based pool index through `entityState_t.name`; the generic `UI_STAT_CONTEXT_NAME` binding resolves that index while
 drawing `LAYER_WORLD_HOVER`. Runtime-created units/buildings may allocate a new pooled name only after a client is already spawned.
-`PF_Confignstring()` must therefore clear `sv.syncstrings[index]` whenever game code changes a configstring, allowing
-`SV_SendClientMessages()` to reliably flush the new value to connected clients. Leaving the sync bit set produces the specific
-regression where pre-existing hover names work but a newly constructed building has an empty hover label. Health and mana use the
+`PF_Confignstring()` therefore delegates to the server-owned `SV_SetConfigString()`, which clears `sv.syncstrings[index]` whenever
+game code changes a configstring and lets `SV_SendClientMessages()` reliably flush the new value to connected clients. Leaving the
+sync bit set produces the specific regression where pre-existing hover names work but a newly constructed building has an empty hover
+label. Health and mana use the
 corresponding context bindings over the snapshot's compressed stat bytes. A configstring is NUL-terminated on the wire, so its sixteen fixed-width name records use
 ASCII Unit Separator (`0x1f`) as padding and retain a single final NUL. `CL_ParseConfigString` converts the separators back to NULs
 after receipt, preserving ordinary fixed-offset C strings for renderer and UI consumers. Embedded NUL records truncate at the first

--- a/docs/games/warcraft-3/in-game-menu.md
+++ b/docs/games/warcraft-3/in-game-menu.md
@@ -1,0 +1,108 @@
+# Warcraft III In-Game Menu
+
+## Contract
+
+The in-game Menu is a Warcraft FDF overlay, not a front-end screen transition. The upper HUD
+`UpperButtonBarMenuButton` and default F10 binding both send the server command `menu`. The game module serializes Blizzard's
+`EscMenuMainPanel` plus its separately authored `EscMenuBackdrop` as one singleton `svc_window` with
+`UI_WINDOW_MODAL | UI_WINDOW_UNIQUE`.
+
+The current reachable flow is:
+
+```text
+Menu/F10 -> MainPanel
+  Pause/Return -> close menu / resume
+  End Game     -> EndGamePanel
+    Previous   -> MainPanel
+    Quit       -> leave current game/front-end
+    Exit       -> ConfirmQuitPanel
+      Cancel   -> EndGamePanel
+      Confirm  -> exit application
+```
+
+Save, Load, Options, Help, Tips, and Restart remain visibly disabled until their underlying behavior exists. Current Warsmash also
+disables `PauseButton`; OpenRealm deliberately retains its newer pause-menu behavior and labels that button `Resume Game`, with the
+same close action as Return.
+
+## OpenRealm Data Flow
+
+```text
+games/warcraft-3/share/config.cfg
+  F10 -> cmd menu
+
+hud/hud_console.c
+  UpperButtonBarMenuButton -> menu
+
+G_ClientCommand
+  menu              -> UI_ShowMainMenu
+  menu_endgame      -> UI_ShowGameMenuEndGame
+  menu_confirm_exit -> UI_ShowGameMenuConfirmExit
+
+hud/hud_menu.c
+  EscMenuMainPanelGame_Load()
+  -> bind EscMenuMainPanel + EscMenuBackdrop + child panels
+  -> select visible panel
+  -> size controller and backdrop to active panel
+  -> svc_window(BZ_WC3_WINDOW_MENU, MODAL|UNIQUE)
+
+client/cl_window.c
+  first modal window            -> pause 1
+  ordinary onclick              -> server command
+  close_window[_notify]         -> close local window
+  disconnect_game               -> CL_Disconnect(..., false)
+  quit_application              -> queue normal `quit` command
+  last modal closes/disconnects -> modal ownership released
+```
+
+Submenu changes replace the existing unique menu window. `CL_WindowOpen()` therefore preserves local window identity and the client
+still sees a modal in the list, so moving MainPanel -> EndGamePanel -> ConfirmQuitPanel does not pulse pause ownership off and on.
+
+## Layout
+
+`EscMenuMainPanel.fdf` declares `EscMenuBackdrop` separately from `EscMenuMainPanel`. OpenRealm reparents the backdrop under the
+controller and the authored panel subtrees beneath the backdrop so decoration is serialized/drawn before controls. Each panel change
+copies the active panel's assigned width and height to both the controller and backdrop, matching Warsmash's
+`updateEscMenuCurrentPanel()` sizing rule. The latest OpenRealm implementation centers the bounded controller/backdrop; this rebase
+preserves that existing policy rather than restoring the older direct TOP/-0.05 anchor experiment.
+
+The recipient's Warcraft race skin must be active before the FDF is first resolved because the Esc-menu art uses `DecorateFileNames`
+skin keys. Keep menu load/write between `UI_SetCurrentClient(client)` and `UI_SetCurrentClient(NULL)`.
+
+## Pause And Modal Input
+
+The menu uses the generic client-window modal lifecycle documented in [Pause And Modal UI](pause-and-modal-ui.md). Opening the first
+client modal sends `pause 1`; closing the final modal sends `pause 0`. Warcraft game code maps that client modal owner to an
+authoritative simulation pause only for the supported single-client policy, while server/network transport continues.
+
+Do not stop `SV_Frame` wholesale. While the menu is open, modal input blocks world selection/orders, control groups, minimap input,
+and manual camera movement; transport remains live so submenu and close commands can still arrive and the client cannot time out.
+
+## Client-Owned Menu Actions
+
+`UI_WINDOW_CLOSE_ACTION`, `UI_WINDOW_CLOSE_NOTIFY_ACTION`, `UI_WINDOW_DISCONNECT_ACTION`, and `UI_WINDOW_QUIT_ACTION` are interpreted
+locally by `client/cl_window.c` rather than forwarded as game commands. The server authors which button exposes those tokens, but leave
+and application-exit only happen after explicit local activation.
+
+Use ordinary `onclick` strings for server-owned state transitions such as `menu_endgame` and `menu_confirm_exit`.
+
+## Known Gaps
+
+- Save, Load, Options, Help, Tips, and Restart remain disabled.
+- The in-game pause button is an OpenRealm extension over the cited current Warsmash behavior: both Pause and Return resume/close.
+- F10 opens the menu through the established OpenRealm binding. Current Warsmash Java itself wires the upper menu button but not its
+  keyboard F10 route.
+
+## Validation
+
+Do not validate this from the front-end menu: `svc_window` requires an active game connection. On a campaign map, verify:
+
+1. Mouse Menu and F10 both open MainPanel.
+2. The first modal acquires pause only after the client receives the window; transport and UI remain responsive.
+3. Save/Load/Options/Help/Tips render disabled and do nothing.
+4. Pause and Return close the window and release the modal pause owner.
+5. End Game opens EndGamePanel; Restart is disabled and pause remains owned continuously.
+6. Previous returns to MainPanel without closing/reopening the modal lifecycle.
+7. Quit leaves the map and returns to the Warcraft front-end.
+8. Exit opens ConfirmQuitPanel; Cancel returns to EndGamePanel.
+9. Confirm exits the application.
+10. Leaving the menu open beyond the client timeout interval does not disconnect or advance paused simulation.

--- a/docs/games/warcraft-3/quest-and-message-log-ui.md
+++ b/docs/games/warcraft-3/quest-and-message-log-ui.md
@@ -216,8 +216,9 @@ F12 -> cmd log
 `hud_console.c` assigns the same four command names to the authored upper
 system buttons. F10 therefore no longer defaults to the engine screenshot
 command: the retail `(F10)` Menu label and the default key action now agree.
-The `menu` and `allies` command routes are present for mouse/key parity, but
-their in-game dialogs are not implemented by this Quest/Log work.
+The `menu` and `allies` command routes are present for mouse/key parity. The
+Menu route opens the separate modal Esc-menu window documented in
+[in-game-menu.md](in-game-menu.md); Allies rendering is implemented separately.
 
 ## Known Gaps
 

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -695,10 +695,22 @@ CLIENTCOMMAND(GameResultQuit) {
     (void)clent; (void)argc; (void)argv;
 }
 
-/* F10 and the authored Menu button share this route; client open acknowledgement acquires pause. */
+/* F10 and the authored Menu button share this route. Submenu transitions
+ * replace the same unique modal window, so the client keeps pause ownership
+ * until the menu is actually closed. */
 CLIENTCOMMAND(Menu) {
     (void)argc; (void)argv;
     UI_ShowMainMenu(clent);
+}
+
+CLIENTCOMMAND(MenuEndGame) {
+    (void)argc; (void)argv;
+    UI_ShowGameMenuEndGame(clent);
+}
+
+CLIENTCOMMAND(MenuConfirmExit) {
+    (void)argc; (void)argv;
+    UI_ShowGameMenuConfirmExit(clent);
 }
 
 CLIENTCOMMAND(Resume) {
@@ -857,6 +869,8 @@ clientCommand_t clientCommands[] = {
     { "gameresult_quit", CMD_GameResultQuit },
     { "debugspawn", CMD_DebugSpawn },
     { "menu", CMD_Menu },
+    { "menu_endgame", CMD_MenuEndGame },
+    { "menu_confirm_exit", CMD_MenuConfirmExit },
     { "resume", CMD_Resume },
     { "pause", CMD_Pause },
     { "allies", CMD_Allies },

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -1443,6 +1443,8 @@ void UI_WriteDialoguePresentation(LPEDICT);
 LPCSTR GetBuildCommand(unitRace_t);
 void UI_RenderRoute(LPEDICT, LPCSTR);
 void UI_ShowMainMenu(LPEDICT);
+void UI_ShowGameMenuEndGame(LPEDICT);
+void UI_ShowGameMenuConfirmExit(LPEDICT);
 void UI_ShowRealmSelect(LPEDICT, BOOL);
 void UI_ShowSinglePlayerMenu(LPEDICT);
 void UI_ShowMultiplayerMenu(LPEDICT);

--- a/games/warcraft-3/game/hud/hud_local.h
+++ b/games/warcraft-3/game/hud/hud_local.h
@@ -81,6 +81,8 @@ void UI_MessageLogAppend(LPEDICT ent, LPCSTR text);
 void UI_ShowLog(LPEDICT ent);
 void UI_ShowAllies(LPEDICT ent);
 void UI_ShowMainMenu(LPEDICT ent);
+void UI_ShowGameMenuEndGame(LPEDICT ent);
+void UI_ShowGameMenuConfirmExit(LPEDICT ent);
 
 /* Game result dialog (hud_game_result.c) */
 void UI_ShowGameResult(LPEDICT ent, BOOL victory);

--- a/games/warcraft-3/game/hud/hud_menu.c
+++ b/games/warcraft-3/game/hud/hud_menu.c
@@ -4,45 +4,113 @@
 #include "../generated/esc_menu_main_panel.h"
 
 static EscMenuMainPanelGame_t menu;
-static BOOL menu_loaded;
+static BOOL menu_loaded, menu_valid;
+
+typedef enum {
+    MENU_PANEL_MAIN,
+    MENU_PANEL_END_GAME,
+    MENU_PANEL_CONFIRM_QUIT,
+} menuPanel_t;
+
+static LPFRAMEDEF MenuPanel(menuPanel_t panel) {
+    switch (panel) {
+        case MENU_PANEL_END_GAME: return menu.EndGamePanel;
+        case MENU_PANEL_CONFIRM_QUIT: return menu.ConfirmQuitPanel;
+        case MENU_PANEL_MAIN:
+        default: return menu.MainPanel;
+    }
+}
 
 static BOOL MenuEnsureLoaded(void) {
-    if (menu_loaded) return menu.EscMenuMainPanel != NULL;
+    if (menu_loaded) return menu_valid;
     menu_loaded = true;
     if (!EscMenuMainPanelGame_Load(&menu)) return false;
     if (!menu.EscMenuBackdrop) {
         fprintf(stderr, "WC3 menu: missing EscMenuBackdrop\n");
         return false;
     }
-    /* Blizzard sizes the all-points controller from the active panel; leaving
-     * it full-screen made its TOP/BOTTOM content anchors span the canvas. */
-    UI_SetSize(menu.EscMenuMainPanel, menu.MainPanel->Width, menu.MainPanel->Height);
-    UI_CenterFrame(menu.EscMenuMainPanel);
-    UI_SetParent(menu.EscMenuBackdrop, menu.EscMenuMainPanel);
-    /* The separate backdrop root loads after MainPanel; nesting controls wire
-     * order so decoration draws first while explicit anchors still target the controller. */
-    UI_SetParent(menu.MainPanel, menu.EscMenuBackdrop);
-    UI_CenterFrame(menu.EscMenuBackdrop);
-    UI_SetHidden(menu.MainPanel, false);
-    UI_SetHidden(menu.EndGamePanel, true);
-    UI_SetHidden(menu.ConfirmQuitPanel, true);
-    UI_SetHidden(menu.HelpPanel, true);
-    UI_SetHidden(menu.TipsPanel, true);
-    return true;
-}
 
-void UI_ShowMainMenu(LPEDICT ent) {
-    if (!ent || !ent->client || !ent->client->connected) return;
-    /* Decorated Esc-menu art is resolved while the FDF is first loaded, so
-     * establish the recipient's race skin before entering the template cache. */
-    UI_SetCurrentClient(ent->client);
-    if (!MenuEnsureLoaded()) { UI_SetCurrentClient(NULL); return; }
+    UI_SetParent(menu.EscMenuBackdrop, menu.EscMenuMainPanel);
+    /* The separate backdrop root loads after the panels. Nest all Esc-menu
+     * panel subtrees below it so decoration serializes/draws before controls;
+     * explicit anchors still target the bounded controller. */
+    UI_SetParent(menu.MainPanel, menu.EscMenuBackdrop);
+    UI_SetParent(menu.EndGamePanel, menu.EscMenuBackdrop);
+    UI_SetParent(menu.ConfirmQuitPanel, menu.EscMenuBackdrop);
+    UI_SetParent(menu.HelpPanel, menu.EscMenuBackdrop);
+    UI_SetParent(menu.TipsPanel, menu.EscMenuBackdrop);
+
+    /* Current Warsmash leaves these authored controls present but disabled.
+     * OpenRealm's newer pause lifecycle intentionally reuses PauseButton as a
+     * second Resume action, so only features that remain unimplemented stay
+     * disabled here. */
+    UI_SetEnabled(menu.SaveGameButton, false);
+    UI_SetEnabled(menu.LoadGameButton, false);
+    UI_SetEnabled(menu.OptionsButton, false);
+    UI_SetEnabled(menu.HelpButton, false);
+    UI_SetEnabled(menu.TipsButton, false);
+    UI_SetEnabled(menu.RestartButton, false);
+
     UI_SetText(menu.PauseButtonText, "Resume Game");
     UI_SetText(menu.ReturnButtonText, "Return to Game");
     UI_SetOnClick(menu.PauseButton, UI_WINDOW_CLOSE_NOTIFY_ACTION);
     UI_SetOnClick(menu.ReturnButton, UI_WINDOW_CLOSE_NOTIFY_ACTION);
+    UI_SetOnClick(menu.EndGameButton, "menu_endgame");
+    UI_SetOnClick(menu.PreviousButton, "menu");
+    UI_SetOnClick(menu.QuitButton, UI_WINDOW_DISCONNECT_ACTION);
+    UI_SetOnClick(menu.ExitButton, "menu_confirm_exit");
+    UI_SetOnClick(menu.ConfirmQuitCancelButton, "menu_endgame");
+    UI_SetOnClick(menu.ConfirmQuitQuitButton, UI_WINDOW_QUIT_ACTION);
+    menu_valid = true;
+    return true;
+}
+
+static void MenuSelectPanel(menuPanel_t panel) {
+    LPFRAMEDEF active = MenuPanel(panel);
+
+    UI_SetHidden(menu.EscMenuMainPanel, false);
+    UI_SetHidden(menu.EscMenuBackdrop, false);
+    UI_SetHidden(menu.MainPanel, panel != MENU_PANEL_MAIN);
+    UI_SetHidden(menu.EndGamePanel, panel != MENU_PANEL_END_GAME);
+    UI_SetHidden(menu.ConfirmQuitPanel, panel != MENU_PANEL_CONFIRM_QUIT);
+    UI_SetHidden(menu.HelpPanel, true);
+    UI_SetHidden(menu.TipsPanel, true);
+
+    /* Warsmash sizes both the wrapper and backdrop from the active authored
+     * panel. Keep the latest OpenRealm centering policy while updating those
+     * dimensions for EndGame/ConfirmQuit instead of retaining MainPanel size. */
+    if (active && active->Width > 0.0f && active->Height > 0.0f) {
+        UI_SetSize(menu.EscMenuMainPanel, active->Width, active->Height);
+        UI_SetSize(menu.EscMenuBackdrop, active->Width, active->Height);
+    }
+    UI_CenterFrame(menu.EscMenuMainPanel);
+    UI_CenterFrame(menu.EscMenuBackdrop);
+}
+
+static void MenuWrite(LPEDICT ent, menuPanel_t panel) {
+    if (!ent || !ent->client || !ent->client->connected) return;
+    /* Decorated Esc-menu art is resolved while the FDF is first loaded, so
+     * establish the recipient's race skin before entering the template cache. */
+    UI_SetCurrentClient(ent->client);
+    if (!MenuEnsureLoaded()) {
+        UI_SetCurrentClient(NULL);
+        return;
+    }
+    MenuSelectPanel(panel);
     UI_WriteWindow(ent, menu.EscMenuMainPanel, &MAKE(uiWindowDef_t,
         .id = BZ_WC3_WINDOW_MENU, .class_id = BZ_WC3_WINDOW_MENU,
         .flags = UI_WINDOW_MODAL | UI_WINDOW_UNIQUE));
     UI_SetCurrentClient(NULL);
+}
+
+void UI_ShowMainMenu(LPEDICT ent) {
+    MenuWrite(ent, MENU_PANEL_MAIN);
+}
+
+void UI_ShowGameMenuEndGame(LPEDICT ent) {
+    MenuWrite(ent, MENU_PANEL_END_GAME);
+}
+
+void UI_ShowGameMenuConfirmExit(LPEDICT ent) {
+    MenuWrite(ent, MENU_PANEL_CONFIRM_QUIT);
 }

--- a/games/warcraft-3/tests/test_server_net.c
+++ b/games/warcraft-3/tests/test_server_net.c
@@ -334,7 +334,7 @@ static void drain_client_packets(void) {
     }
 }
 
-TEST(server_net, game_configstring_change_marks_value_for_reliable_resync) {
+TEST(server_net, runtime_configstring_change_marks_value_for_reliable_resync) {
     DWORD const index = CS_GENERAL + 7;
 
     reset_server_state(1);

--- a/games/warcraft-3/tests/test_server_net.c
+++ b/games/warcraft-3/tests/test_server_net.c
@@ -345,6 +345,20 @@ TEST(server_net, runtime_configstring_change_marks_value_for_reliable_resync) {
     T_ASSERT(!sv.syncstrings[index]);
 }
 
+TEST(server_net, findindex_new_slot_marks_value_for_reliable_resync) {
+    int first, second;
+
+    reset_server_state(1);
+    first = SV_FontIndex("ReviewFont", 12);
+    T_ASSERT(first > 0);
+    sv.syncstrings[CS_FONTS + first] = true;
+    second = SV_FontIndex("ReviewFontBold", 13);
+
+    T_EQ(second, first + 1);
+    T_STREQ(sv.configstrings[CS_FONTS + second], "ReviewFontBold,13");
+    T_ASSERT(!sv.syncstrings[CS_FONTS + second]);
+}
+
 TEST(server_net, udp_multi_client_connects_register_distinct_slots) {
     int c1 = open_client_socket();
     int c2 = open_client_socket();

--- a/server/sv_main.c
+++ b/server/sv_main.c
@@ -22,6 +22,10 @@ void SV_SetConfigString(DWORD index, LPCSTR value, DWORD len) {
         fprintf(stderr, "configstring: bad index %u\n", index);
         return;
     }
+    if (!value) {
+        value = "";
+        len = 1;
+    }
     if (len > sizeof(sv.configstrings[index]) - 1) len = sizeof(sv.configstrings[index]) - 1;
     memset(sv.configstrings[index], 0, sizeof(sv.configstrings[index]));
     memcpy(sv.configstrings[index], value, len);
@@ -119,8 +123,7 @@ static int SV_FindIndex(LPCSTR name, int start, int max, bool create) {
                 name);
         return 0;
     }
-    strncpy(sv.configstrings[start+i], name, sizeof(*sv.configstrings) - 1);
-    sv.configstrings[start+i][sizeof(*sv.configstrings) - 1] = '\0';
+    SV_SetConfigString(start + i, name, (DWORD)(strlen(name) + 1));
     return i;
 }
 


### PR DESCRIPTION
Wire the Warcraft III upper Menu button and F10 binding into the authored EscMenu frames.

* open the main in-game menu from the HUD and F10
* implement Return, End Game, Previous, Quit, and Exit confirmation flows
* keep unsupported Pause, Save, Load, Options, Help, Tips, and Restart disabled
* reuse modal window input blocking while the menu is open
* return Quit to the front-end and confirm before exiting the application
* document current Warsmash menu behavior and remaining parity gaps