### PR TITLE
wc3: restore save/load along the Quake 2 map lifecycle

### DIFF
--- a/client/cl_input_w3.c
+++ b/client/cl_input_w3.c
@@ -10,16 +10,6 @@ static struct {
     VECTOR3 anchor;
 } camera_drag;
 
-VECTOR2 CL_ClampCameraPosition(VECTOR2 position) {
-#ifdef WC3
-    if (cl.playerstate.camera_bounds.max.x > cl.playerstate.camera_bounds.min.x)
-        position.x = MAX(cl.playerstate.camera_bounds.min.x, MIN(cl.playerstate.camera_bounds.max.x, position.x));
-    if (cl.playerstate.camera_bounds.max.y > cl.playerstate.camera_bounds.min.y)
-        position.y = MAX(cl.playerstate.camera_bounds.min.y, MIN(cl.playerstate.camera_bounds.max.y, position.y));
-#endif
-    return position;
-}
-
 static BOOL smart_click_active;
 
 static BOOL CL_OrderQueueModifierDown(void) {

--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -18,19 +18,6 @@
 #include "games/starcraft-2/common/sc2_map.h"
 #endif
 
-#ifdef WC3
-/* Keep predicted camera targets inside the server-authored WC3 camera bounds. */
-VECTOR2 CL_ClampCameraPosition(VECTOR2 position) {
-    if (cl.playerstate.camera_bounds.max.x > cl.playerstate.camera_bounds.min.x)
-        position.x = MAX(cl.playerstate.camera_bounds.min.x,
-                         MIN(cl.playerstate.camera_bounds.max.x, position.x));
-    if (cl.playerstate.camera_bounds.max.y > cl.playerstate.camera_bounds.min.y)
-        position.y = MAX(cl.playerstate.camera_bounds.min.y,
-                         MIN(cl.playerstate.camera_bounds.max.y, position.y));
-    return position;
-}
-#endif
-
 static LPCSTR CL_LobbySlotTypeName(lobbySlotType_t type) {
     switch (type) {
         case LOBBY_SLOT_OPEN: return "open";
@@ -220,8 +207,6 @@ static void CL_ParseConfigString(LPSIZEBUF msg) {
          * slot and the talking-head portrait will never be registered.  After
          * refresh, however, model configstrings are genuinely dynamic and must
          * refresh both caches together. Identical late resends keep the loaded
-         * handles so begin/load does not reload every model. */
-        if (cl.refresh_prepped && !CL_SameResource(cl.models[model], olds, name)) {
          * handles so begin/load does not reload every model. */
         if (cl.refresh_prepped && !CL_SameResource(cl.models[model], olds, name)) {
             if (cl.models[model]) {

--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -18,6 +18,19 @@
 #include "games/starcraft-2/common/sc2_map.h"
 #endif
 
+#ifndef WOW
+/* Keep predicted camera targets inside the server-authored camera bounds. */
+VECTOR2 CL_ClampCameraPosition(VECTOR2 position) {
+#ifdef WC3
+    if (cl.playerstate.camera_bounds.max.x > cl.playerstate.camera_bounds.min.x)
+        position.x = MAX(cl.playerstate.camera_bounds.min.x, MIN(cl.playerstate.camera_bounds.max.x, position.x));
+    if (cl.playerstate.camera_bounds.max.y > cl.playerstate.camera_bounds.min.y)
+        position.y = MAX(cl.playerstate.camera_bounds.min.y, MIN(cl.playerstate.camera_bounds.max.y, position.y));
+#endif
+    return position;
+}
+#endif
+
 static LPCSTR CL_LobbySlotTypeName(lobbySlotType_t type) {
     switch (type) {
         case LOBBY_SLOT_OPEN: return "open";

--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -222,6 +222,8 @@ static void CL_ParseConfigString(LPSIZEBUF msg) {
          * refresh both caches together. Identical late resends keep the loaded
          * handles so begin/load does not reload every model. */
         if (cl.refresh_prepped && !CL_SameResource(cl.models[model], olds, name)) {
+         * handles so begin/load does not reload every model. */
+        if (cl.refresh_prepped && !CL_SameResource(cl.models[model], olds, name)) {
             if (cl.models[model]) {
                 re.ReleaseModel((LPMODEL)cl.models[model]);
                 cl.models[model] = NULL;


### PR DESCRIPTION
## Summary

`F6` / `save quick` then `load quick` showed the loading screen and never returned to the game. The save was found and the local server came back, then load diverged from Quake 2's map lifecycle.

## What was wrong

Quake 2 (`data/Quake-2-master`) does:

1. `SpawnEntities` (map baseline)
2. `SV_ClearWorld`
3. `ReadLevel` (overwrite edicts, `linkentity`)
4. `reconnect` — an already-connected client only sends `new`
5. `CL_ParseServerData` → `CL_ClearState` zeros `refresh_prepped`

We were:

- Overwriting edicts **without** clearing the spatial tree (cyclic area lists, hang in `SV_AreaEdicts_r`)
- Calling `CL_Connect` after `SV_Map` had already sent loopback `client_connect` (netchan wipe / handshake race)
- Keeping `begin_sent` / `refresh_prepped` across a same-map load, so `begin` never went out and the plaque never ended
- Rejecting saves whose JASS trigger/event counts grew after `main()`
- Printing a generic header mismatch instead of the failing field

## Fix

- `ReadGame` clears the world, then links restored edicts once
- Extra groups/timers/triggers/events created after `main()` are allocated from the save; trigger actions and event registrations round-trip
- Header mismatch names the field and prints saved vs live counts
- `CL_BeginLoadingMap` resets refresh like Q2 `CL_ClearState`
- `load` does **not** `CL_Connect`; `SV_Map` already sent `client_connect` (Q2 `reconnect`)
- `SV_LoadGame` runs `ReadGame` immediately after `SV_Map`, before `PrepRefresh`/`begin`

## JASS pointers

Do **not** replace VM `HANDLE` / `LPCJASSFUNC` / `LPEDICT` with integers at runtime. Q2 keeps pointers in memory and remaps them in `WriteField1` / `ReadField` (`F_EDICT`, `F_FUNCTION`). Host natives already snapshot as ordinals; `code` snapshots as function names. New pointer fields belong in the field/codec table, not as a VM rewrite.

## Paths

Saves are `~/.local/share/warcraft-3/saves/<name>.sav` on Unix, including macOS. `$XDG_DATA_HOME` is not read. macOS does not use `~/Library/Application Support`.

## Test plan

- [x] `make test-commands test-server-net`
- [x] `make test-wc3-engine WC3_PATTERN='wc3_save.*'` (ROC and TFT)
- [x] Human02 CFG replay: `save quick` then `load quick` — `WC3 LoadGame: restored` then `CL_SendBegin`, no header mismatch (ROC)
- [x] `make test`
- [ ] Repeat Human02 load in the GUI (`F6`, `load quick`)