### PR TITLE
Refactor minimap into generic client subsystem

### DIFF
--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -105,6 +105,7 @@ void CL_ClearState(void) {
     SAFE_DELETE(cl.fow.visible, MemFree);
     SAFE_DELETE(cl.fow.explored, MemFree);
     SAFE_DELETE(cl.fow.texture, MemFree);
+    SAFE_DELETE(cl.minimap_model, re.ReleaseModel);
 
     FOR_LOOP(layer, MAX_LAYOUT_LAYERS) {
         SCR_ClearLayoutLayer(layer);
@@ -801,6 +802,7 @@ void CL_Shutdown(void) {
         SAFE_DELETE(cl.models[modelIndex], re.ReleaseModel);
         SAFE_DELETE(cl.portraits[modelIndex], re.ReleaseModel);
     }
+    SAFE_DELETE(cl.minimap_model, re.ReleaseModel);
     FOR_LOOP(imageIndex, MAX_DYNAMIC_IMAGES) {
         SAFE_DELETE(cl.dynamicPics[imageIndex], re.ReleaseTexture);
     }

--- a/client/cl_minimap.c
+++ b/client/cl_minimap.c
@@ -3,14 +3,14 @@
 
 #define CL_MINIMAP_PING_COUNT 16 // markers; bounds simultaneous transient minimap attention effects
 #define CL_MINIMAP_RECENT_COUNT 8 // positions; bounds Warcraft-style recent-alert Space recall
-#define CL_MINIMAP_PACKET_SIZE 19 // bytes; fixed svc_minimap_ping payload size used for bounds validation
+#define CL_MINIMAP_PACKET_SIZE 17 // bytes; fixed svc_minimap_ping payload size used for bounds validation
 
 typedef struct {
     BOOL active;
     VECTOR2 position;
     COLOR32 color;
     DWORD start_time, end_time;
-    DWORD flags, model;
+    DWORD flags;
 } minimapPing_t;
 
 static BOOL minimap_drag_active;
@@ -62,10 +62,10 @@ void CL_ParseMinimapPing(LPSIZEBUF msg) {
     ping.position.x = MSG_ReadFloat(msg); ping.position.y = MSG_ReadFloat(msg);
     duration = MSG_ReadFloat(msg);
     ping.color = MAKE(COLOR32, MSG_ReadByte(msg), MSG_ReadByte(msg), MSG_ReadByte(msg), MSG_ReadByte(msg));
-    ping.flags = (DWORD)MSG_ReadByte(msg); ping.model = (DWORD)MSG_ReadShort(msg);
+    ping.flags = (DWORD)MSG_ReadByte(msg);
     if (!isfinite(ping.position.x) || !isfinite(ping.position.y) || !isfinite(duration) || duration <= 0.0f ||
-        duration > MINIMAP_PING_DURATION_MAX || ping.model >= MAX_MODELS) {
-        fprintf(stderr, "CL_ParseMinimapPing: invalid duration=%.3f model=%u\n", duration, (unsigned)ping.model);
+        duration > MINIMAP_PING_DURATION_MAX) {
+        fprintf(stderr, "CL_ParseMinimapPing: invalid duration=%.3f\n", duration);
         return;
     }
     ping.end_time = cl.time + (DWORD)MAX(1.0f, duration * 1000.0f);
@@ -82,7 +82,6 @@ void CL_ParseMinimapPing(LPSIZEBUF msg) {
 
 /* Draw authored models when supplied; otherwise use a generic colored attention marker. */
 static void CL_DrawMinimapPings(void) {
-    static DWORD last_missing_model = MAX_MODELS;
     FOR_LOOP(i, CL_MINIMAP_PING_COUNT) {
         minimapPing_t *ping = &minimap_pings[i];
         VECTOR2 screen;
@@ -91,13 +90,9 @@ static void CL_DrawMinimapPings(void) {
         if (!ping->active) continue;
         if ((LONG)(cl.time - ping->end_time) >= 0) { ping->active = false; continue; }
         if (!re.WorldToMinimap(&ping->position, &screen)) continue;
-        if (ping->model && cl.models[ping->model]) {
-            re.DrawSprite(cl.models[ping->model], "Stand", screen.x, screen.y);
+        if (cl.minimap_model) {
+            re.DrawSprite(cl.minimap_model, "Stand", screen.x, screen.y);
             continue;
-        }
-        if (ping->model && ping->model != last_missing_model) {
-            fprintf(stderr, "CL_DrawMinimapPings: model %u unavailable; drawing generic marker\n", (unsigned)ping->model);
-            last_missing_model = ping->model;
         }
         pulse = 3.0f + (FLOAT)((cl.time - ping->start_time) % 500) / 250.0f;
         marker = MAKE(RECT, screen.x - pulse, screen.y - 1.0f, pulse * 2.0f, 2.0f);
@@ -109,6 +104,17 @@ static void CL_DrawMinimapPings(void) {
             re.DrawFill(&marker, ping->color);
         }
     }
+}
+
+/* Load the authored alert model named by the Quake-style CS_MINIMAP slot. */
+void CL_UpdateMinimapModel(void) {
+    LPCSTR name = cl.configstrings[CS_MINIMAP];
+
+    SAFE_DELETE(cl.minimap_model, re.ReleaseModel);
+    if (!name[0]) return;
+    cl.minimap_model = re.LoadModel(name);
+    if (!cl.minimap_model)
+        fprintf(stderr, "CL_UpdateMinimapModel: failed to load %s\n", name);
 }
 
 /* Draw the server-authored minimap frame and all transient attention markers. */

--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -260,6 +260,8 @@ static void CL_ParseConfigString(LPSIZEBUF msg) {
                 cl.pics[pic] = re.LoadTexture(name);
         }
     }
+    if (index == CS_MINIMAP && cl.refresh_prepped && strcmp(olds, cl.configstrings[index]))
+        CL_UpdateMinimapModel();
     if (cl.refresh_prepped && index > CS_SOUNDS && index < CS_SOUNDS + MAX_SOUNDS && cl.configstrings[index][0])
         S_RegisterSound(cl.configstrings[index]);
     if (index > CS_FONTS && index < CS_FONTS + MAX_FONTSTYLES) {

--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -459,6 +459,7 @@ void CL_PrepRefresh(void) {
             cl.portraits[i] = re.LoadModel(portrait);
         }
     }
+    CL_UpdateMinimapModel();
 
     for (DWORD i = 1; i < MAX_IMAGES; i++) {
         if (!*cl.configstrings[CS_IMAGES + i]) {

--- a/client/client.h
+++ b/client/client.h
@@ -67,6 +67,7 @@ struct client_state {
     BOOL refresh_prepped;
     LPMODEL models[MAX_MODELS];
     LPMODEL portraits[MAX_MODELS];
+    LPMODEL minimap_model;
     LPCTEXTURE pics[MAX_IMAGES];
     LPTEXTURE dynamicPics[MAX_DYNAMIC_IMAGES];
     char dynamicPicNames[MAX_DYNAMIC_IMAGES][512];
@@ -183,6 +184,7 @@ LPCRECT SCR_LayoutRect(LPCUIFRAME frame);
 void CL_LayoutDrawMinimap(LPCUIFRAME frame, LPCRECT screen);
 void CL_ClearMinimap(void);
 void CL_ParseMinimapPing(LPSIZEBUF msg);
+void CL_UpdateMinimapModel(void);
 #ifdef BZ_TESTS
 DWORD CL_MinimapPingCount(void);
 DWORD CL_MinimapRecentCount(void);

--- a/common/common.h
+++ b/common/common.h
@@ -58,7 +58,7 @@ enum svc_ops {
 //    svc_disconnect,
 //    svc_reconnect,
     svc_sound,                    // [byte flags] [short sound] [optional volume/attenuation/offset/entity/position]
-    svc_minimap_ping,             // [vec2 position] [float seconds] [rgba] [byte flags] [short optional model]
+    svc_minimap_ping,             // [vec2 position] [float seconds] [rgba] [byte flags]
 //    svc_print,                    // [byte] id [string] null terminated string
 //    svc_stufftext,                // [string] stuffed into client's console buffer, should be \n terminated
 //    svc_serverdata,                // [long] protocol ...

--- a/common/shared.h
+++ b/common/shared.h
@@ -257,6 +257,7 @@ enum {
     CS_HEALTHBAR = 6,
     CS_MANAHBAR = 6,
     CS_WORLD = 7,
+    CS_MINIMAP = 8,            // alert-ping model path; analogous to Quake's CS_SKY
     CS_AIRACCEL = 29,        // air acceleration control
     CS_MAXCLIENTS = 30,
     CS_MAPCHECKSUM = 31,        // for catching cheater maps

--- a/docs/games/warcraft-3/alerts-and-minimap-pings.md
+++ b/docs/games/warcraft-3/alerts-and-minimap-pings.md
@@ -16,13 +16,13 @@ simulation event / JASS native
 
 The server does not move the camera when an alert is emitted, and a ping does not change fog or selection. Recent-alert state is client-local and is not added to `playerState_t`/`entityState_t`.
 
-The wire contract is the generic `svc_minimap_ping` message: world position, lifetime, RGBA color, behavior flags, and an optional registered model index. `server/sv_minimap.c` encodes it and `client/cl_minimap.c` owns parsing, expiry, drawing, click/drag projection, recent history, and Space recall. No minimap state belongs to a game UI library.
+The wire contract is the generic `svc_minimap_ping` message: world position, lifetime, RGBA color, and behavior flags. The authored alert model name is the server-owned `CS_MINIMAP` configstring, following Quake's `CS_SKY` pattern; `client/cl_minimap.c` loads it through the normal configstring lifecycle. No minimap state belongs to a game UI library.
 
 Ordinary minimap unit dots are not pings. They are derived every frame from replicated entities by each game's renderer. A ping is a transient attention event, analogous to `svc_sound`, and therefore does not widen `entityState_t` or survive save/load.
 
 ## Producers
 
-`G_SendMinimapPing()` in `game/g_minimap.c` resolves `MinimapIndicator` from the recipient's active `war3skins.txt` section, registers it through `gi.ModelIndex`, and passes the resulting optional model index to `gi.MinimapPing`. A zero model index is valid for games that want the generic colored client marker.
+`G_SendMinimapPing()` in `game/g_minimap.c` resolves `MinimapIndicator` from the recipient's active `war3skins.txt` section and publishes the model path through `CS_MINIMAP` before sending the generic ping packet. An empty model path leaves the client with its generic colored marker.
 
 The following high-confidence gameplay completions also call `G_SendOwnerMinimapAlert()` and therefore enter recent-alert history:
 

--- a/games/warcraft-3/game/g_minimap.c
+++ b/games/warcraft-3/game/g_minimap.c
@@ -7,15 +7,14 @@
 void G_SendMinimapPing(LPGAMECLIENT client, LPCVECTOR2 position, FLOAT duration, COLOR32 color, DWORD flags) {
     LPEDICT clent;
     LPCSTR model;
-    int model_index;
 
     if (!client || !position || duration <= 0.0f || !client->connected || !gi.MinimapPing) return;
     clent = G_GetPlayerEntityByNumber(client->ps.number);
     if (!clent || !clent->client) return;
 
     model = Theme_PlayerString(client, "MinimapIndicator", WC3_DEFAULT_MINIMAP_INDICATOR);
-    model_index = gi.ModelIndex(model && model[0] ? model : WC3_DEFAULT_MINIMAP_INDICATOR);
-    gi.MinimapPing(clent, position, duration, color.a ? color : COLOR32_WHITE, flags, model_index);
+    gi.configstring(CS_MINIMAP, model && model[0] ? model : WC3_DEFAULT_MINIMAP_INDICATOR);
+    gi.MinimapPing(clent, position, duration, color.a ? color : COLOR32_WHITE, flags);
 }
 
 /* Derive owner alerts from the completed entity so no alert state enters save/load. */

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -98,15 +98,14 @@ static LPEDICT alert_ping_target;
 static VECTOR2 alert_ping_position;
 static FLOAT alert_ping_duration;
 static COLOR32 alert_ping_color;
-static int alert_ping_model;
+static PATHSTR alert_ping_model;
 
-static void alert_test_minimap_ping(LPEDICT ent, LPCVECTOR2 position, FLOAT duration, COLOR32 color, DWORD flags, int model) {
-    alert_ping_count++; alert_ping_target = ent; alert_ping_position = *position; alert_ping_duration = duration;
-    alert_ping_color = color; alert_ping_flags = flags; alert_ping_model = model;
+static void alert_test_configstring(DWORD index, LPCSTR value) {
+    if (index == CS_MINIMAP) snprintf(alert_ping_model, sizeof(alert_ping_model), "%s", value);
 }
-static int alert_test_model_index(LPCSTR model) {
-    T_STREQ(model, "UI\\Minimap\\Minimap-Ping.mdl");
-    return 37;
+static void alert_test_minimap_ping(LPEDICT ent, LPCVECTOR2 position, FLOAT duration, COLOR32 color, DWORD flags) {
+    alert_ping_count++; alert_ping_target = ent; alert_ping_position = *position; alert_ping_duration = duration;
+    alert_ping_color = color; alert_ping_flags = flags;
 }
 
 /* =========================================================================
@@ -122,14 +121,15 @@ TEST(wc3_game, hud_proxy_number_never_moves_backwards) {
 }
 
 TEST(wc3_game, minimap_ping_uses_generic_packet_import) {
-    void (*saved_ping)(edict_t *, LPCVECTOR2, FLOAT, COLOR32, DWORD, int) = gi.MinimapPing;
-    int (*saved_model_index)(LPCSTR) = gi.ModelIndex;
+    void (*saved_ping)(edict_t *, LPCVECTOR2, FLOAT, COLOR32, DWORD) = gi.MinimapPing;
+    void (*saved_configstring)(DWORD, LPCSTR) = gi.configstring;
     VECTOR2 position = { 123.5f, -44.25f };
     COLOR32 color = MAKE(COLOR32, 10, 20, 30, 255);
 
     game.clients[0].connected = true;
     alert_ping_count = 0; alert_ping_target = NULL;
-    gi.MinimapPing = alert_test_minimap_ping; gi.ModelIndex = alert_test_model_index;
+    alert_ping_model[0] = '\0';
+    gi.MinimapPing = alert_test_minimap_ping; gi.configstring = alert_test_configstring;
 
     G_SendMinimapPing(&game.clients[0], &position, 2.5f, color, MINIMAP_PING_REMEMBER);
 
@@ -137,12 +137,13 @@ TEST(wc3_game, minimap_ping_uses_generic_packet_import) {
     T_FEQ(alert_ping_position.x, position.x, 0.001f); T_FEQ(alert_ping_position.y, position.y, 0.001f);
     T_FEQ(alert_ping_duration, 2.5f, 0.001f);
     T_EQ(alert_ping_color.r, 10); T_EQ(alert_ping_color.g, 20); T_EQ(alert_ping_color.b, 30);
-    T_ASSERT(alert_ping_flags & MINIMAP_PING_REMEMBER); T_EQ(alert_ping_model, 37);
+    T_ASSERT(alert_ping_flags & MINIMAP_PING_REMEMBER);
+    T_STREQ(alert_ping_model, "UI\\Minimap\\Minimap-Ping.mdl");
 
     game.clients[0].connected = false;
     G_SendMinimapPing(&game.clients[0], &position, 2.5f, color, 0);
     T_EQ(alert_ping_count, 1);
-    gi.MinimapPing = saved_ping; gi.ModelIndex = saved_model_index;
+    gi.MinimapPing = saved_ping; gi.configstring = saved_configstring;
 }
 
 TEST(wc3_game, hud_authored_window_frame_uses_offset_codec) {

--- a/server/game.h
+++ b/server/game.h
@@ -48,7 +48,7 @@ struct game_import {
     void (*Sound)(LPEDICT ent, int channel, int sound_index, FLOAT volume, FLOAT attenuation, FLOAT timeofs);
     void (*PositionedSound)(LPCVECTOR3 origin, LPEDICT ent, int channel, int sound_index, FLOAT volume,
                             FLOAT attenuation, FLOAT timeofs);
-    void (*MinimapPing)(LPEDICT ent, LPCVECTOR2 position, FLOAT duration, COLOR32 color, DWORD flags, int model);
+    void (*MinimapPing)(LPEDICT ent, LPCVECTOR2 position, FLOAT duration, COLOR32 color, DWORD flags);
     int (*ImageIndex)(LPCSTR imageName);
     int (*FontIndex)(LPCSTR fontName, DWORD fontSize);
     void (*LinkEntity)(LPEDICT ent);

--- a/server/server.h
+++ b/server/server.h
@@ -134,7 +134,7 @@ int SV_ModelIndex(LPCSTR name);
 int SV_SoundIndex(LPCSTR name);
 void SV_StartSound(LPCVECTOR3 origin, LPEDICT ent, int channel, int sound_index, FLOAT volume, FLOAT attenuation,
                    FLOAT timeofs);
-void SV_MinimapPing(LPEDICT ent, LPCVECTOR2 position, FLOAT duration, COLOR32 color, DWORD flags, int model);
+void SV_MinimapPing(LPEDICT ent, LPCVECTOR2 position, FLOAT duration, COLOR32 color, DWORD flags);
 int SV_ImageIndex(LPCSTR name);
 int SV_FontIndex(LPCSTR name, DWORD fontSize);
 //void SV_LoadModels(void); // model animation data is loaded lazily by game modules now

--- a/server/sv_minimap.c
+++ b/server/sv_minimap.c
@@ -1,14 +1,12 @@
 #include "server.h"
 
 /* Send one reliable transient attention marker without adding snapshot or save state. */
-void SV_MinimapPing(LPEDICT ent, LPCVECTOR2 position, FLOAT duration, COLOR32 color, DWORD flags, int model) {
+void SV_MinimapPing(LPEDICT ent, LPCVECTOR2 position, FLOAT duration, COLOR32 color, DWORD flags) {
     LPCLIENT client = NULL;
 
     if (!ent || !position || !isfinite(position->x) || !isfinite(position->y) || !isfinite(duration) ||
-        duration <= 0.0f || duration > MINIMAP_PING_DURATION_MAX ||
-        model < 0 || model >= MAX_MODELS || flags > 0xff) {
-        fprintf(stderr, "SV_MinimapPing: invalid duration=%.3f flags=0x%x model=%d\n",
-                duration, (unsigned)flags, model);
+        duration <= 0.0f || duration > MINIMAP_PING_DURATION_MAX || flags > 0xff) {
+        fprintf(stderr, "SV_MinimapPing: invalid duration=%.3f flags=0x%x\n", duration, (unsigned)flags);
         return;
     }
     FOR_LOOP(i, svs.num_clients)
@@ -30,6 +28,5 @@ void SV_MinimapPing(LPEDICT ent, LPCVECTOR2 position, FLOAT duration, COLOR32 co
     MSG_WriteByte(&client->netchan.message, color.b);
     MSG_WriteByte(&client->netchan.message, color.a);
     MSG_WriteByte(&client->netchan.message, (int)flags);
-    MSG_WriteShort(&client->netchan.message, model);
     Netchan_Transmit(NS_SERVER, &client->netchan);
 }

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -1797,7 +1797,7 @@ TEST(net, minimap_ping_packet_reaches_generic_client_state) {
     MSG_WriteByte(&msg, svc_minimap_ping);
     MSG_WriteFloat(&msg, 123.5f); MSG_WriteFloat(&msg, -44.25f); MSG_WriteFloat(&msg, 2.5f);
     MSG_WriteByte(&msg, 10); MSG_WriteByte(&msg, 20); MSG_WriteByte(&msg, 30); MSG_WriteByte(&msg, 255);
-    MSG_WriteByte(&msg, MINIMAP_PING_REMEMBER); MSG_WriteShort(&msg, 37);
+    MSG_WriteByte(&msg, MINIMAP_PING_REMEMBER);
     msg.readcount = 0; CL_ParseServerMessage(&msg);
 
     T_EQ(CL_MinimapPingCount(), 1);
@@ -1826,7 +1826,7 @@ TEST(net, minimap_ping_packet_rejects_invalid_values) {
     MSG_WriteByte(&msg, svc_minimap_ping);
     MSG_WriteFloat(&msg, NAN); MSG_WriteFloat(&msg, 1.0f); MSG_WriteFloat(&msg, MINIMAP_PING_DURATION_MAX + 1.0f);
     MSG_WriteByte(&msg, 255); MSG_WriteByte(&msg, 255); MSG_WriteByte(&msg, 255); MSG_WriteByte(&msg, 255);
-    MSG_WriteByte(&msg, MINIMAP_PING_REMEMBER); MSG_WriteShort(&msg, 0);
+    MSG_WriteByte(&msg, MINIMAP_PING_REMEMBER);
     msg.readcount = 0; CL_ParseServerMessage(&msg);
 
     T_EQ(CL_MinimapPingCount(), 0);


### PR DESCRIPTION
## Summary

- move minimap drawing, interaction, camera movement, transient ping state, expiry, and recent-position recall into `client/cl_minimap.c`
- add the generic reliable `svc_minimap_ping` packet and server sender, while keeping WC3 producer policy and skin-selected models in the game module
- remove the WC3 UI alert subsystem and obsolete UI callback/state plumbing
- keep minimap pings transient and outside entity snapshots and save/load state
- validate malformed, non-finite, overflowing, and truncated ping payloads
- update minimap architecture documentation and focused tests

## Validation

- `make test`
  - ROC WC3 engine: 3695/3695 assertions in 747 tests
  - TFT WC3 engine: 3695/3695 assertions in 747 tests
- `make build`
- `make openwow opensc2`
- bounded ROC and TFT map loads reached active gameplay
- `git diff --check`
- VS Code diagnostics: no errors in touched minimap and test files

## Save/load

Minimap attention markers are client-local transient presentation. They are cleared by `CL_ClearState` and add no fields to `edict_t`, `entityState_t`, or `playerState_t`, so saved games do not persist stale pings or entity references.