### PR TITLE
Big ability effects fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 pathfinding, flow fields, collision-sized routing, unreachable lumber targets | [docs/games/warcraft-3/pathfinding.md](docs/games/warcraft-3/pathfinding.md) |
 | WC3 resource-worker crowd routing and Human02 30-Peasant simulation | [docs/games/warcraft-3/worker-crowd-routing.md](docs/games/warcraft-3/worker-crowd-routing.md) |
 | WC3 inventory, world-item lifecycle, item UI presentation | [docs/games/warcraft-3/inventory-and-items.md](docs/games/warcraft-3/inventory-and-items.md) |
+| WC3 ability/item presentation art, effect edict lifetimes, JASS effect handles, consumable charge semantics | [docs/games/warcraft-3/ability-and-item-effects.md](docs/games/warcraft-3/ability-and-item-effects.md) |
 | WC3 player AI, Blizzard AI script contract, Human02 implementation plan | [docs/games/warcraft-3/player-ai.md](docs/games/warcraft-3/player-ai.md) |
 | WC3 player AI architecture and implementation postmortem | [docs/games/warcraft-3/player-ai-postmortem.md](docs/games/warcraft-3/player-ai-postmortem.md) |
 | WC3 client UI lifecycle, single-player campaign/mission/custom-game flow | [docs/games/warcraft-3/architecture/ui-flow.md](docs/games/warcraft-3/architecture/ui-flow.md) |

--- a/docs/architecture/server-selected-effects.md
+++ b/docs/architecture/server-selected-effects.md
@@ -35,7 +35,7 @@ the new `games/warcraft-3/game/skills/s_onfire.c`.
 - `games/warcraft-3/renderer/r_game.c` `R_RenderModel()` — generic consumer, no
   per-race branching.
 
-See also: [Building Damage Rendering](../games/warcraft-3/building-damage-rendering.md)
+See also: [Building Damage Rendering](../games/warcraft-3/building-damage-rendering.md) and [WC3 Ability, Buff, And Item Presentation Effects](../games/warcraft-3/ability-and-item-effects.md).
 
 ## Anti-pattern #2: `#ifdef` branch in a shared dispatcher (do not repeat)
 

--- a/docs/games/warcraft-3/ability-and-item-effects.md
+++ b/docs/games/warcraft-3/ability-and-item-effects.md
@@ -1,0 +1,161 @@
+# WC3 Ability, Buff, And Item Presentation Effects
+
+## Contract
+
+Warcraft III gameplay owns effect timing and semantics. The renderer never decides that an art model deals damage, heals a unit, applies a buff, or consumes an item. Game code first performs or validates the simulation action and then requests presentation by Warcraft rawcode and effect slot.
+
+The game-side effect selector is `wc3EffectType_t` in `games/warcraft-3/game/g_local.h`:
+
+| Effect type | Warcraft presentation field |
+|---|---|
+| `WC3_EFFECT_EFFECT` | `EffectArt` / `Effectart` |
+| `WC3_EFFECT_TARGET` | `TargetArt` / `Targetart` |
+| `WC3_EFFECT_CASTER` | `CasterArt` / `Casterart` |
+| `WC3_EFFECT_SPECIAL` | `SpecialArt` / `Specialart` |
+| `WC3_EFFECT_AREA_EFFECT` | `AreaEffectArt` / `Areaeffectart` |
+| `WC3_EFFECT_MISSILE` | `MissileArt` / `Missileart` |
+| `WC3_EFFECT_LIGHTNING` | reserved; dedicated lightning rendering is not implemented |
+
+`games/warcraft-3/game/g_effects.c` is the common WC3 presentation entry point. It keeps content selection in the game module: it resolves an art path, registers that model, and exposes the result as an ordinary game edict. No spell rawcode or WC3 effect category is added to shared engine state.
+
+This is adjacent to, but intentionally different from, `entityState_t.effect/effect_flags`: that compact server-selected effect channel is useful when presentation is an attribute of another entity, such as building damage fire. Spell/JASS effects need independent handles and lifetimes, so they are represented by independent edicts instead.
+
+See also [Server-Selected Presentation Effects](../../architecture/server-selected-effects.md) and [Inventory And Items](inventory-and-items.md).
+
+## Data Flow
+
+Ability-authored presentation follows:
+
+```text
+ability/rawcode + wc3EffectType_t + index
+    -> G_AbilityEffectArt
+    -> Ability Func configuration lookup
+    -> alias field, then base AbilityData.code field as fallback
+    -> comma-separated art selection
+    -> G_RegisterModel
+    -> independent effect edict
+```
+
+`G_AbilityEffectArt` first checks the requested ability alias. Custom ability aliases can therefore override their base ability's art. If the alias has no value, `AbilityData.code` is used as a fallback. If an art list contains multiple comma-separated paths, `index` selects the requested element; an out-of-range index falls back to the final configured element. Empty/`-`/`_` entries do not create effects.
+
+Typed `AbilityBuffData` now retains the buff `TargetArt`, `SpecialArt`, `EffectArt`, and `Missileart` columns in addition to the existing icon/tooltip fields. If no ability Func value is found, the resolver checks the requested buff rawcode (and its buff `code` base row where present). This enables generic JASS/buff rawcode art lookup without making a buff model authoritative for gameplay lifetime. Attachment metadata and effect sounds are not normalized by this slice.
+
+## Effect Edict Lifecycle
+
+`G_SpawnModelEffect` creates an independent edict for a model path. `G_SpawnAbilityEffectAtPoint` and `G_SpawnAbilityEffectTarget` add the Warcraft ability-data lookup above it.
+
+A target effect:
+
+- copies the target's position/facing;
+- uses `MOVETYPE_LINK` to follow the target;
+- keeps the target's `spawn_time` as a generation guard so a recycled edict slot cannot become the new attachment target;
+- frees itself if that target ceases to be the same live edict.
+
+A point effect uses the supplied world X/Y and `CM_GetHeightAtPoint` for Z.
+
+Temporary effects try `birth`, then `stand`, and free when that sequence completes. If neither sequence exists, the temporary edict is freed rather than leaked indefinitely.
+
+Persistent effects try `birth`, transition to looping `stand`, and remain until `G_DestroyEffect`. Destruction detaches the effect and attempts `death`; if no death sequence exists, the edict is freed immediately.
+
+The generic game-side attachment implementation currently recognizes only `"overhead"`, represented as a vertical offset while following the target. Other attachment strings are accepted by JASS but currently fall back to the target origin. Full MDX attachment-token matching (`origin`, `chest`, `hand,left`, and similar) is intentionally deferred until the renderer/model attachment contract is implemented generically.
+
+## Production Callers
+
+The following existing abilities now use the common resolver rather than owning separate art-path lookup code:
+
+- Holy Light: `WC3_EFFECT_TARGET` on the affected unit.
+- Blink: `WC3_EFFECT_SPECIAL` before relocation and `WC3_EFFECT_AREA_EFFECT` after relocation.
+- Devotion Aura: persistent `WC3_EFFECT_TARGET` on the caster.
+- Thunder Bolt / Fire Bolt: `WC3_EFFECT_MISSILE` supplies the existing projectile edict's model; projectile speed, tracking, damage, stun, and impact lifecycle remain in `s_thunderbolt.c`.
+- supported immediate item abilities in `s_item.c`: `WC3_EFFECT_TARGET` after a successful gameplay effect.
+- Scroll of Protection (`spro` / `AIda`): the item ability applies its authored
+  area/duration `Bdef` status to allowed friendly targets and uses the same
+  `TARGET` art resolver. Combat and the HUD derive the temporary armor bonus
+  from the live status, so expiry needs no extra callback/save field.
+
+These migrations are deliberately presentation-only. They do not change damage/healing calculations, target validation, projectile movement, or spell cooldown/mana behavior.
+
+## JASS Effect Handles
+
+`games/warcraft-3/game/api/api_effect.h` now routes the following natives through independent effect edicts:
+
+- `AddSpecialEffect`
+- `AddSpecialEffectLoc`
+- `AddSpecialEffectTarget`
+- `DestroyEffect`
+- `AddSpellEffect`
+- `AddSpellEffectLoc`
+- `AddSpellEffectById`
+- `AddSpellEffectByIdLoc`
+- `AddSpellEffectTarget`
+- `AddSpellEffectTargetById`
+
+`AddSpecialEffect*` takes an explicit model path and does not consult ability data. `AddSpellEffect*` takes an ability rawcode/string plus a converted effect type and resolves the corresponding ability presentation field. A returned JASS `effect` handle points at the independent effect edict, not at the target unit. Destroying the effect therefore cannot overwrite or clear the target unit's `model2` state.
+
+The three weather-effect natives remain placeholders. `LIGHTNING` also remains unsupported by the model-effect resolver because Warcraft lightning requires a dedicated endpoint/colour/movement lifecycle rather than an MDX model path.
+
+## Item Use And Charges
+
+Item object data remains authoritative for item properties. `abilList` is an
+`ItemData.slk` column, so active command dispatch resolves it through the typed
+`ItemData_t.abilList` row first. `FindConfigValue(itemRawcode, "abilList")` is
+retained only as a compatibility fallback for custom/legacy data; that helper
+searches TXT/INI configuration and is not an authoritative ItemData SLK lookup.
+Immediate item abilities use the `ability_t.item_use` callback when they can
+synchronously report whether the gameplay effect actually happened. The
+callback is append-only at the end of `ability_t`; existing dispatch-field
+offsets must not be changed.
+
+The inventory command walks `abilList` in authored order and uses the first registered ability it can handle. For a synchronous `item_use` callback:
+
+```text
+inventory click
+    -> item ability validates carrier/state
+    -> gameplay effect succeeds
+    -> optional ability TARGET art
+    -> EVENT_PLAYER_UNIT_USE_ITEM / EVENT_UNIT_USE_ITEM
+    -> G_ConsumeItemCharge
+```
+
+Failed uses do not publish use-item events and do not consume a charge. For example, a healing item at full health returns failure.
+
+`G_ConsumeItemCharge` decrements a positive runtime charge count after successful use. When the final charge belongs to a `perishable` item, the item is removed through `G_RemoveItem`, which also reverses passive item-stat hooks and clears the inventory slot. A non-perishable item also decrements to zero but remains present.
+
+Legacy/asynchronous item abilities that enter a targeting command through `ability_t.cmd` are still dispatched, but their eventual success cannot be known by the inventory click handler. This slice intentionally does not consume their charges or publish success events at click time. The eventual targeted-item completion path needs to own those operations.
+
+Spell command dispatch has a similar rawcode boundary: a WC3 FourCC held in a
+`DWORD` is not a C string. Runtime lookup must convert it through
+`GetClassName(code)` and `FindAbilityForCommand`, rather than casting `&code` to
+`LPCSTR`. The latter reads beyond the four rawcode bytes and made a command such
+as Holy Light (`AHhb`) fail or succeed depending on unrelated stack contents.
+
+## Known Gaps
+
+The following are deliberately outside this implementation slice:
+
+- arbitrary MDX attachment-token resolution and team-coloured spell-effect attachment;
+- generic binding of buff lifetime to persistent world-art ownership and non-stacking FX;
+- ability/buff `EffectSound` and `EffectSoundLooped`;
+- Warcraft lightning effects;
+- item `cooldownID` / `ignoreCD` shared cooldown behavior;
+- automatic `powerup` acquisition/use;
+- asynchronous targeted-item success/charge completion;
+- spell cast-point/backswing timing changes;
+- a fully generalized missile-art/arc object separate from existing projectile simulation.
+- save/load rebinding for independent effect-edict animation callbacks and persistent effect ownership.
+
+Do not work around these by adding spell-specific asset paths to the renderer or new WC3-specific flags to shared engine structs. Extend the game-side effect resolver/lifecycle instead.
+
+## Verification
+
+Relevant in-engine tests are:
+
+- `wc3_slk.ability_buff_ui_columns_decode`
+- `wc3_effects.ability_effect_art_selects_requested_entry_and_last_fallback`
+- `wc3_api.effect_natives_return_independent_handles`
+- `wc3_items.perishable_success_consumes_charge_and_removes_at_zero`
+- `wc3_items.nonperishable_use_decrements_charges_but_keeps_item_at_zero`
+- `wc3_items.inventory_click_uses_itemdata_ability_list_and_applies_scroll`
+- `wc3_spell.holy_light_rawcode_lookup_is_nul_safe`
+
+The requested workflow for this patch deliberately did not compile or execute tests. When validating manually, cover at least Holy Light, Blink, Thunder Bolt, a healing consumable with more than one charge, its final-charge removal, and a JASS map that creates/destroys point and target special effects.

--- a/docs/games/warcraft-3/architecture/ability-coverage.md
+++ b/docs/games/warcraft-3/architecture/ability-coverage.md
@@ -59,7 +59,8 @@ machines, existing edict fields, and data loaded from SLK/config tables.
 | `AHwe`, `AOsf` | `s_summon.c` | Partial no-target summon; reads unit id/count/duration, spawns owned timed-life units. |
 | `AHbz`, `AUcs`, `ANcl` | `s_area_spell.c` | Partial point/channel spell family; Blizzard ticks area damage, Carrion Swarm applies a simple point blast, Channel opens cancel mode. |
 | `ANch`, `AIco`, `Aeat`, `Ambt`, `Aroo` | `s_utility_abilities.c` | Partial utility behaviors: Charm ownership transfer, Eat Tree heal/remove, Moon Well transfer, Root toggle. |
-| `AIhe`, `AIma`, `AImi` | `s_item.c` | Partial item use for heal, mana restore, and permanent life gain; item consumption is not yet wired. |
+| `AIhe`, `AIma`, `AImi` | `s_item.c` | Synchronous item use for heal, mana restore, and permanent life gain; successful charged uses decrement charges and zero-charge perishables are removed. |
+| `AIda` | `s_item.c` | Scroll of Protection item-defense AOE: applies authored `Bdef` duration/area/armor bonus to allowed friendly targets and consumes the successful charged use. |
 | Heavy/system abilities | `s_ability_stubs.c` | Registered explicit stubs for passive autocast, cargo, mine, shop, harvest variants, item passives, and stat/XP item families. |
 
 `a_train` exists in `s_train.c`, but training is currently handled by the
@@ -107,8 +108,9 @@ generic `Button` command path rather than by a registered ability code.
 | `Aneu` | Neutral Building | TODO | Needs neutral interaction and command card behavior. |
 | `Aall` | Shop Sharing | TODO | Depends on shop/neutral building systems. |
 | `Acoi` | Couple Instant | TODO | Test/special ability; low priority unless map data requires it. |
-| `AIhe` | Item Heal | Partial | Inventory alias dispatch and selected-unit heal exist. Needs item charge/consume rules. |
-| `AIma` | Item Mana Regain | Partial | Inventory alias dispatch and selected-unit mana restore exist. Needs item charge/consume rules. |
+| `AIhe` | Item Heal | Partial | Inventory dispatch, selected-unit heal, target art and synchronous charge/consume rules exist. Shared item cooldown groups remain. |
+| `AIma` | Item Mana Regain | Partial | Inventory dispatch, selected-unit mana restore, target art and synchronous charge/consume rules exist. Shared item cooldown groups remain. |
+| `AIda` | Item Defense AOE | Partial | Authored area/duration/target mask applies `Bdef`; live status contributes its authored armor bonus to combat/HUD. Persistent buff-world-art ownership and shared item cooldown groups remain. |
 | `AIat` | Item Attack Bonus | TODO | Needs item stat modifier system. |
 | `AIab` | Item Stat Bonus | TODO | Needs hero stat modifier system. |
 | `AIim` | Permanent Intelligence Gain | TODO | Needs permanent hero stat updates. |
@@ -119,7 +121,7 @@ generic `Button` command path rather than by a registered ability code.
 | `AIml` | Item Life Bonus | TODO | Needs max-health modifier system. |
 | `AImm` | Item Mana Bonus | TODO | Needs max-mana modifier system. |
 | `AIfs` | Figurine Summon | TODO | Needs item summon behavior. |
-| `AImi` | Permanent Life Gain | Partial | Selected-unit max-health and current-health gain exist. Needs item charge/consume rules. |
+| `AImi` | Permanent Life Gain | Partial | Selected-unit max-health/current-health gain plus synchronous charge/consume rules exist. Shared item cooldown groups remain. |
 | `AIem` | Experience Gain | TODO | Needs hero XP/level flow. |
 | `AIlm` | Level Gain | TODO | Needs hero level-up flow. |
 | `Acar` | Cargo Hold | TODO | Needs cargo slots and load/unload state. |

--- a/docs/games/warcraft-3/inventory-and-items.md
+++ b/docs/games/warcraft-3/inventory-and-items.md
@@ -70,6 +70,41 @@ When every slot exposed by the inventory ability is occupied, the transition
 does not modify either entity. The world item stays linked and visible, and
 contextual pickup displays an `Inventory is full.` message to the owning player.
 
+## Active Item Use
+
+The focused-unit `inventory <slot>` command resolves the carried item's
+`abilList` from the normalized `ItemData_t` row in authored order and dispatches
+the first registered item ability it can handle. This matters because
+`abilList` is an `ItemData.slk` field; `FindConfigValue` searches TXT/INI
+configuration and therefore cannot be the primary lookup for a real carried
+item. A TXT/INI lookup remains only as a fallback when the typed field is
+absent. Immediate effects use `ability_t.item_use`, which returns
+true only when the gameplay effect actually applies. Current handlers cover the
+existing heal, mana, permanent-life/stat, experience/level, and figurine item
+abilities, plus stock item-defense AOE (`AIda`, used by Scroll of Protection).
+Their successful presentation uses the same ability `TargetArt`
+resolver documented in [Ability, Buff, And Item Presentation Effects](ability-and-item-effects.md).
+
+For `AIda`, OpenRealm reads the authored defense amount, area, normal/hero
+duration, target mask and BuffID. Eligible friendly units receive the timed
+`Bdef` status. Combat armor calculation and the displayed armor value both
+include the status bonus while it is live, so normal status expiration removes
+the bonus automatically.
+
+For a synchronous successful use, the server publishes
+`EVENT_PLAYER_UNIT_USE_ITEM` and `EVENT_UNIT_USE_ITEM` and then calls
+`G_ConsumeItemCharge`. Failed uses (for example, healing an already full-health
+unit) publish neither event and consume no charge. Every successful synchronous charged-item use decrements a positive runtime
+charge count. If that reaches zero on a perishable item, `G_RemoveItem` destroys
+it, clearing the slot and reversing passive item-stat hooks. A non-perishable
+item also decrements to zero but remains present.
+
+Existing item abilities that enter an asynchronous targeting command through
+`ability_t.cmd` are still dispatched, but the click handler cannot yet know
+whether that later target operation succeeds. It therefore does not consume
+their charge or publish a success event at click time. That completion path is
+explicitly future work rather than speculative charge consumption.
+
 ## Inventory Presentation
 
 The HUD has no item-specific branches. `G_GetInventory` walks only the selected
@@ -91,9 +126,10 @@ state, so no second item-UI cache is maintained.
 
 The runtime charge count is copied into `gameInventoryItem_t`. `WriteInventory`
 draws a bottom-right number overlay whenever `charges > 0`, including a
-single-charge item. A zero-charge item therefore keeps its icon but has no
-number overlay. Cooldown/disabled-state presentation and charge consumption are
-separate active-item work.
+single-charge item. A zero-charge non-perishable item therefore keeps its icon
+but has no number overlay. Successful synchronous use of a perishable item now
+consumes its runtime charge and removes the item at zero; cooldown/disabled-state
+presentation remains separate active-item work.
 
 For Human02 this means a carried Scroll of Protection is handled generically:
 rawcode `spro` resolves its item UI data, appears in the first free slot, and
@@ -200,11 +236,15 @@ flight.
 
 ## Phase Boundary
 
-This slice includes generic item icon/tooltips, ability-defined capacity, and
-runtime/displayed charges. It deliberately does not consume charges, destroy a
-perishable item at zero, implement automatic use, active target modes, item-use
-cooldowns/disabled icons, slot swapping, giving, or death-drop rules. Existing
-passive-effect hooks remain attached to inventory entry and exit.
+This slice includes generic item icon/tooltips, ability-defined capacity,
+runtime/displayed charges, and successful synchronous use of the existing
+immediate item ability handlers. Perishable synchronous uses consume one charge
+and destroy the item at zero. Existing passive-effect hooks remain attached to
+inventory entry and exit.
+
+Still missing are automatic `powerup` acquisition/use, asynchronous targeted
+item completion and its charge/event semantics, `cooldownID`/`ignoreCD` item
+cooldowns and disabled icons, slot swapping, giving, and death-drop rules.
 
 The implementation is derived from observable behavior and Warcraft III data
 formats described by the clean-room specification. It does not depend on
@@ -218,8 +258,9 @@ capacity (including reduced, zero, above-storage-limit, and implicit ROC Hero
 first-empty-slot insertion,
 full-inventory failure, pickup range and revalidation, drop identity, renderer
 visibility flags, carried-item removal, connection-state refresh gating, charge
-initialization/preservation, carried-charge refresh/no-op behavior, JASS charge
-access, and generic `spro` Art/Tip/Ubertip/charge presentation.
+initialization/preservation, carried-charge refresh/no-op behavior, perishable
+use decrement/removal, non-perishable decrement-without-removal behavior, JASS charge access,
+and generic `spro` Art/Tip/Ubertip/charge presentation.
 They also cover mixed-selection Smart pickup where a non-inventory unit is the
 first selected entity and a later ROC Hero must still receive the item order.
 Minimal `AbilityData.slk`, `UnitAbilities.slk`, `ItemData.slk`, `ItemFunc.txt`,

--- a/docs/games/warcraft-3/jass-native-coverage.md
+++ b/docs/games/warcraft-3/jass-native-coverage.md
@@ -15,8 +15,8 @@ native behavior, commonly followed by `PauseTimer` when resetting getter state.
 ## Baseline
 
 The registry currently contains 917 callbacks. The last conservative source
-audit snapshot classified 487 as implemented and 349 as clear placeholders
-across 836 callbacks (58.3% overall at that snapshot). Newer registrations,
+audit snapshot now classifies 495 as implemented and 341 as clear placeholders
+across 836 callbacks (59.2% overall at that snapshot). Newer registrations,
 including `GetUnitAbilityLevel`, are not folded into the implementation split
 below yet. This count treats a callback as a placeholder only when it ignores its
 arguments and unconditionally returns no value, zero, false, or a null handle.
@@ -37,7 +37,7 @@ raw `return 0` counts are not meaningful.
 | `api_quest.h` | 24 | 22 | 2 |
 | `api_destructable.h` | 22 | 17 | 5 |
 | `api_item.h` | 16 | 10 | 6 |
-| `api_effect.h` | 13 | 2 | 11 |
+| `api_effect.h` | 13 | 10 | 3 |
 | `api_cinefilter.h` | 10 | 10 | 0 |
 | `api_test.h` | 1 | 1 | 0 |
 
@@ -48,7 +48,14 @@ to the registry or a placeholder begins consuming authoritative state.
 
 Coverage is not conformance. Several callbacks consume state but still violate
 their JASS contract and therefore need a `partial` status in any future generated
-ledger. Known examples include:
+ledger. The effect module now has functional independent handles for
+`AddSpecialEffect*`, `AddSpellEffect*`, and `DestroyEffect`; its three weather
+effect callbacks remain placeholders. Target effects currently implement only
+the `overhead` attachment specially, and `LIGHTNING` spell effects remain
+unsupported, so those paths are partial rather than proof of full retail
+conformance. See [Ability, Buff, And Item Presentation Effects](ability-and-item-effects.md).
+
+Known examples include:
 
 - `GroupAddUnit` and `GroupRemoveUnit` are declared to return `boolean`, but the
   current callbacks push no return value.

--- a/docs/games/warcraft-3/readme.md
+++ b/docs/games/warcraft-3/readme.md
@@ -103,6 +103,7 @@ File formats, renderer notes, UI/FDF behavior, and gameplay coverage work used b
 - [Persistent Hero And Idle-Worker Shortcuts](unit-shortcuts.md)
 - [Pathfinding And Harvest Reachability](pathfinding.md)
 - [Inventory And World Items](inventory-and-items.md)
+- [Ability And Item Effects](ability-and-item-effects.md)
 - [Breakable Destructables](breakable-destructables.md)
 - [Warcraft III UI System](architecture/ui.md)
 - [UI Flow](architecture/ui-flow.md)

--- a/games/warcraft-3/game/api/api_effect.h
+++ b/games/warcraft-3/game/api/api_effect.h
@@ -12,69 +12,91 @@ DWORD EnableWeatherEffect(LPJASS j) {
     //BOOL enable = jass_checkboolean(j, 2);
     return 0;
 }
+
+static BOOL JassEffectType(LPJASS j, LONG arg, wc3EffectType_t *out) {
+    LPDWORD type = jass_checkhandle(j, arg, "effecttype");
+    if (!type || *type > WC3_EFFECT_LIGHTNING) return false;
+    *out = (wc3EffectType_t)*type;
+    return true;
+}
+
+static DWORD JassPushEffect(LPJASS j, LPEDICT effect) {
+    return effect ? jass_pushlighthandle(j, effect, "effect") : jass_pushnullhandle(j, "effect");
+}
+
+static DWORD JassAbilityStringId(LPCSTR ability) {
+    DWORD id = 0;
+    if (ability && strlen(ability) >= 4) memcpy(&id, ability, 4);
+    return id;
+}
+
 DWORD AddSpecialEffect(LPJASS j) {
-    //LPCSTR modelName = jass_checkstring(j, 1);
-    //FLOAT x = jass_checknumber(j, 2);
-    //FLOAT y = jass_checknumber(j, 3);
-    return jass_pushnullhandle(j, "effect");
+    LPCSTR modelName = jass_checkstring(j, 1);
+    VECTOR2 where = { jass_checknumber(j, 2), jass_checknumber(j, 3) };
+    return JassPushEffect(j, G_SpawnModelEffect(modelName, &where, NULL, NULL, false));
 }
 DWORD AddSpecialEffectLoc(LPJASS j) {
-    //LPCSTR modelName = jass_checkstring(j, 1);
-    //HANDLE where = jass_checkhandle(j, 2, "location");
-    return jass_pushnullhandle(j, "effect");
+    LPCSTR modelName = jass_checkstring(j, 1);
+    LPCVECTOR2 where = jass_checkhandle(j, 2, "location");
+    return JassPushEffect(j, where ? G_SpawnModelEffect(modelName, where, NULL, NULL, false) : NULL);
 }
 DWORD AddSpecialEffectTarget(LPJASS j) {
     LPCSTR modelName = jass_checkstring(j, 1);
     LPEDICT targetWidget = jass_checkhandle(j, 2, "widget");
     LPCSTR attachPointName = jass_checkstring(j, 3);
-    targetWidget->s.model2 = G_RegisterModel(modelName);
-    if (!strcmp(attachPointName, "overhead")) {
-        targetWidget->s.renderfx |= RF_ATTACH_OVERHEAD;
-    }
-    return jass_pushlighthandle(j, targetWidget, "effect");
+    return JassPushEffect(j, targetWidget
+        ? G_SpawnModelEffect(modelName, NULL, targetWidget, attachPointName, false)
+        : NULL);
 }
 DWORD DestroyEffect(LPJASS j) {
     LPEDICT whichEffect = jass_checkhandle(j, 1, "effect");
-    if (whichEffect) whichEffect->s.model2 = 0;
+    G_DestroyEffect(whichEffect);
     return 0;
 }
 DWORD AddSpellEffect(LPJASS j) {
-    //LPCSTR abilityString = jass_checkstring(j, 1);
-    //HANDLE t = jass_checkhandle(j, 2, "effecttype");
-    //FLOAT x = jass_checknumber(j, 3);
-    //FLOAT y = jass_checknumber(j, 4);
-    return jass_pushnullhandle(j, "effect");
+    LPCSTR abilityString = jass_checkstring(j, 1);
+    wc3EffectType_t type;
+    VECTOR2 where = { jass_checknumber(j, 3), jass_checknumber(j, 4) };
+    DWORD abilityId = JassAbilityStringId(abilityString);
+    if (!abilityId || !JassEffectType(j, 2, &type)) return jass_pushnullhandle(j, "effect");
+    return JassPushEffect(j, G_SpawnAbilityEffectAtPoint(abilityId, type, 0, &where, false));
 }
 DWORD AddSpellEffectLoc(LPJASS j) {
-    //LPCSTR abilityString = jass_checkstring(j, 1);
-    //HANDLE t = jass_checkhandle(j, 2, "effecttype");
-    //HANDLE where = jass_checkhandle(j, 3, "location");
-    return jass_pushnullhandle(j, "effect");
+    LPCSTR abilityString = jass_checkstring(j, 1);
+    wc3EffectType_t type;
+    LPCVECTOR2 where = jass_checkhandle(j, 3, "location");
+    DWORD abilityId = JassAbilityStringId(abilityString);
+    if (!abilityId || !where || !JassEffectType(j, 2, &type)) return jass_pushnullhandle(j, "effect");
+    return JassPushEffect(j, G_SpawnAbilityEffectAtPoint(abilityId, type, 0, where, false));
 }
 DWORD AddSpellEffectById(LPJASS j) {
-    //LONG abilityId = jass_checkinteger(j, 1);
-    //HANDLE t = jass_checkhandle(j, 2, "effecttype");
-    //FLOAT x = jass_checknumber(j, 3);
-    //FLOAT y = jass_checknumber(j, 4);
-    return jass_pushnullhandle(j, "effect");
+    DWORD abilityId = (DWORD)jass_checkinteger(j, 1);
+    wc3EffectType_t type;
+    VECTOR2 where = { jass_checknumber(j, 3), jass_checknumber(j, 4) };
+    if (!abilityId || !JassEffectType(j, 2, &type)) return jass_pushnullhandle(j, "effect");
+    return JassPushEffect(j, G_SpawnAbilityEffectAtPoint(abilityId, type, 0, &where, false));
 }
 DWORD AddSpellEffectByIdLoc(LPJASS j) {
-    //LONG abilityId = jass_checkinteger(j, 1);
-    //HANDLE t = jass_checkhandle(j, 2, "effecttype");
-    //HANDLE where = jass_checkhandle(j, 3, "location");
-    return jass_pushnullhandle(j, "effect");
+    DWORD abilityId = (DWORD)jass_checkinteger(j, 1);
+    wc3EffectType_t type;
+    LPCVECTOR2 where = jass_checkhandle(j, 3, "location");
+    if (!abilityId || !where || !JassEffectType(j, 2, &type)) return jass_pushnullhandle(j, "effect");
+    return JassPushEffect(j, G_SpawnAbilityEffectAtPoint(abilityId, type, 0, where, false));
 }
 DWORD AddSpellEffectTarget(LPJASS j) {
-    //LPCSTR modelName = jass_checkstring(j, 1);
-    //HANDLE t = jass_checkhandle(j, 2, "effecttype");
-    //HANDLE targetWidget = jass_checkhandle(j, 3, "widget");
-    //LPCSTR attachPoint = jass_checkstring(j, 4);
-    return jass_pushnullhandle(j, "effect");
+    LPCSTR abilityString = jass_checkstring(j, 1);
+    wc3EffectType_t type;
+    LPEDICT targetWidget = jass_checkhandle(j, 3, "widget");
+    LPCSTR attachPoint = jass_checkstring(j, 4);
+    DWORD abilityId = JassAbilityStringId(abilityString);
+    if (!abilityId || !targetWidget || !JassEffectType(j, 2, &type)) return jass_pushnullhandle(j, "effect");
+    return JassPushEffect(j, G_SpawnAbilityEffectTarget(abilityId, type, 0, targetWidget, attachPoint, false));
 }
 DWORD AddSpellEffectTargetById(LPJASS j) {
-    //LONG abilityId = jass_checkinteger(j, 1);
-    //HANDLE t = jass_checkhandle(j, 2, "effecttype");
-    //HANDLE targetWidget = jass_checkhandle(j, 3, "widget");
-    //LPCSTR attachPoint = jass_checkstring(j, 4);
-    return jass_pushnullhandle(j, "effect");
+    DWORD abilityId = (DWORD)jass_checkinteger(j, 1);
+    wc3EffectType_t type;
+    LPEDICT targetWidget = jass_checkhandle(j, 3, "widget");
+    LPCSTR attachPoint = jass_checkstring(j, 4);
+    if (!abilityId || !targetWidget || !JassEffectType(j, 2, &type)) return jass_pushnullhandle(j, "effect");
+    return JassPushEffect(j, G_SpawnAbilityEffectTarget(abilityId, type, 0, targetWidget, attachPoint, false));
 }

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -657,9 +657,12 @@ CLIENTCOMMAND(Inventory) {
         }
     }
 
-    Get_Portrait_f(clent);
-    if (!handled) {
-        Get_Commands_f(clent);
+    /* HUD serialization is only valid after ClientBegin; disconnected slots retain authoritative state only. */
+    if (client->connected) {
+        Get_Portrait_f(clent);
+        if (!handled) Get_Commands_f(clent);
+    } else if (!handled) {
+        G_InvalidateCommands(client);
     }
 }
 

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -624,19 +624,36 @@ CLIENTCOMMAND(Inventory) {
         return;
     }
 
-    G_PublishEvent(ent, EVENT_PLAYER_UNIT_USE_ITEM);
-    G_PublishEvent(ent, EVENT_UNIT_USE_ITEM);
-
-    abilities = FindConfigValue(GetClassName(item->class_id), "abilList");
+    /* Item ability lists are authored in ItemData.slk. Resolve through the
+     * typed row first; FindConfigValue() is only a compatibility fallback in
+     * G_ItemAbilityList() because it searches TXT/INI tables rather than the
+     * ItemData SLK. */
+    abilities = G_ItemAbilityList(item);
     if (abilities && *abilities) {
         PARSE_LIST(abilities, ability_name, parse_segment) {
             ability_t const *ability = FindAbilityForCommand(ability_name);
-            if (ability && ability->cmd) {
-                client->menu.ability_code = *((DWORD const *)ability_name);
+            BOOL succeeded = false;
+
+            if (!ability) continue;
+            client->menu.ability_code = *((DWORD const *)ability_name);
+            if (ability->item_use) {
+                succeeded = ability->item_use(clent);
+                handled = true;
+            } else if (ability->cmd) {
+                /* Preserve existing support for item-authored command abilities
+                 * that enter an asynchronous targeting mode. Their eventual
+                 * success is not known here, so charge consumption remains the
+                 * responsibility of a future targeted-item completion path. */
                 ability->cmd(clent);
                 handled = true;
-                break;
             }
+
+            if (succeeded) {
+                G_PublishEvent(ent, EVENT_PLAYER_UNIT_USE_ITEM);
+                G_PublishEvent(ent, EVENT_UNIT_USE_ITEM);
+                G_ConsumeItemCharge(item);
+            }
+            if (handled) break;
         }
     }
 

--- a/games/warcraft-3/game/g_effects.c
+++ b/games/warcraft-3/game/g_effects.c
@@ -1,0 +1,224 @@
+#include "g_local.h"
+
+/* Warcraft III ability presentation art is selected by an effect-type enum.
+ * Keep the renderer/content boundary on the game side: gameplay chooses an
+ * ability/buff rawcode and effect slot, this module resolves the model path,
+ * and the shared engine only sees a registered model index on an ordinary
+ * game edict. */
+
+static umove_t wc3_effect_temp_birth;
+static umove_t wc3_effect_temp_stand;
+static umove_t wc3_effect_birth;
+static umove_t wc3_effect_stand;
+static umove_t wc3_effect_death;
+
+static void G_EffectEnterStand(LPEDICT effect);
+static void G_EffectLoopStand(LPEDICT effect);
+
+static umove_t wc3_effect_temp_birth = { "birth", NULL, G_FreeEdict };
+static umove_t wc3_effect_temp_stand = { "stand", NULL, G_FreeEdict };
+static umove_t wc3_effect_birth = { "birth", NULL, G_EffectEnterStand };
+static umove_t wc3_effect_stand = { "stand", NULL, G_EffectLoopStand };
+static umove_t wc3_effect_death = { "death", NULL, G_FreeEdict };
+
+static LPCSTR G_EffectFieldName(wc3EffectType_t type, BOOL alternate) {
+    switch (type) {
+        case WC3_EFFECT_EFFECT:      return alternate ? "Effectart"     : "EffectArt";
+        case WC3_EFFECT_TARGET:      return alternate ? "Targetart"     : "TargetArt";
+        case WC3_EFFECT_CASTER:      return alternate ? "Casterart"     : "CasterArt";
+        case WC3_EFFECT_SPECIAL:     return alternate ? "Specialart"    : "SpecialArt";
+        case WC3_EFFECT_AREA_EFFECT: return alternate ? "Areaeffectart" : "AreaEffectArt";
+        case WC3_EFFECT_MISSILE:     return alternate ? "Missileart"    : "MissileArt";
+        default:                     return NULL;
+    }
+}
+
+
+static LPCSTR G_BuffEffectValue(DWORD buff_id, wc3EffectType_t type) {
+    AbilityBuffData_t const *row = G_AbilityBuffData(buff_id);
+    LPCSTR value = NULL;
+
+    if (row->id != buff_id) return NULL;
+    switch (type) {
+        case WC3_EFFECT_EFFECT:  value = row->effectArt; break;
+        case WC3_EFFECT_TARGET:  value = row->targetArt; break;
+        case WC3_EFFECT_SPECIAL: value = row->specialArt; break;
+        case WC3_EFFECT_MISSILE: value = row->missileArt; break;
+        default: break;
+    }
+    if (value && *value && strcmp(value, "-") && strcmp(value, "_")) return value;
+
+    if (row->code && row->code != buff_id) {
+        AbilityBuffData_t const *base = G_AbilityBuffData(row->code);
+        if (base->id == row->code) {
+            switch (type) {
+                case WC3_EFFECT_EFFECT:  return base->effectArt;
+                case WC3_EFFECT_TARGET:  return base->targetArt;
+                case WC3_EFFECT_SPECIAL: return base->specialArt;
+                case WC3_EFFECT_MISSILE: return base->missileArt;
+                default: break;
+            }
+        }
+    }
+    return NULL;
+}
+
+static LPCSTR G_EffectConfigValue(DWORD ability_id, wc3EffectType_t type) {
+    char classname[5];
+    LPCSTR field;
+    LPCSTR value;
+    AbilityData_t const *row;
+
+    memcpy(classname, &ability_id, 4);
+    classname[4] = '\0';
+    field = G_EffectFieldName(type, false);
+    value = field ? FindConfigValue(classname, field) : NULL;
+    if (!value) {
+        field = G_EffectFieldName(type, true);
+        value = field ? FindConfigValue(classname, field) : NULL;
+    }
+    if (value) return value;
+
+    /* Custom aliases may inherit presentation from their base code. The SLK
+     * resolver already exposes that base rawcode, so use it only as a fallback
+     * after the alias's own Func entry has been checked. */
+    row = G_AbilityData(ability_id);
+    if (row->code && row->code != ability_id) {
+        memcpy(classname, &row->code, 4);
+        classname[4] = '\0';
+        field = G_EffectFieldName(type, false);
+        value = field ? FindConfigValue(classname, field) : NULL;
+        if (!value) {
+            field = G_EffectFieldName(type, true);
+            value = field ? FindConfigValue(classname, field) : NULL;
+        }
+        if (value) return value;
+    }
+    return G_BuffEffectValue(ability_id, type);
+}
+
+LPCSTR G_AbilityEffectArt(DWORD ability_id, wc3EffectType_t type, DWORD index) {
+    static char selected[4][MAX_PATHLEN];
+    static DWORD cursor;
+    char *out = selected[cursor++ & 3];
+    LPCSTR list = G_EffectConfigValue(ability_id, type);
+    DWORD count = 0;
+
+    out[0] = '\0';
+    if (!list || !*list || type == WC3_EFFECT_LIGHTNING) return NULL;
+
+    PARSE_LIST(list, art, parse_segment) {
+        if (!art || !*art || !strcmp(art, "-") || !strcmp(art, "_")) continue;
+        strlcpy(out, art, MAX_PATHLEN);
+        if (count++ == index) return out;
+    }
+
+    /* Warsmash's AbilityUI selection falls back to the last configured art
+     * entry when an index exceeds the list. Preserve that useful data-driven
+     * behavior rather than turning an otherwise valid spell invisible. */
+    return count ? out : NULL;
+}
+
+static void G_EffectValidateTarget(LPEDICT effect) {
+    if (!effect->goalentity || !effect->goalentity->inuse ||
+        effect->goalentity->spawn_time != effect->damage) {
+        effect->goalentity = NULL;
+        effect->movetype = MOVETYPE_NONE;
+        effect->think = G_FreeEdict;
+    }
+}
+
+static void G_EffectThink(LPEDICT effect) {
+    if (effect->goalentity && effect->wait != 0.0f) {
+        effect->s.origin.z += effect->wait;
+    }
+    M_MoveFrame(effect);
+}
+
+static void G_EffectLoopStand(LPEDICT effect) {
+    unit_setmove(effect, &wc3_effect_stand);
+}
+
+static void G_EffectEnterStand(LPEDICT effect) {
+    unit_setmove(effect, &wc3_effect_stand);
+    if (!effect->animation) {
+        effect->think = NULL;
+        effect->currentmove = NULL;
+    }
+}
+
+static void G_EffectStartAnimation(LPEDICT effect, BOOL temporary) {
+    unit_setmove(effect, temporary ? &wc3_effect_temp_birth : &wc3_effect_birth);
+    if (effect->animation) return;
+
+    unit_setmove(effect, temporary ? &wc3_effect_temp_stand : &wc3_effect_stand);
+    if (!effect->animation) {
+        if (temporary) {
+            /* No usable animation sequence means there is no deterministic
+             * lifetime to drive. A one-shot art with no animation should not
+             * leak an edict indefinitely. */
+            G_FreeEdict(effect);
+        } else {
+            effect->think = NULL;
+            effect->currentmove = NULL;
+        }
+    }
+}
+
+LPEDICT G_SpawnModelEffect(LPCSTR model, LPCVECTOR2 point, LPEDICT target,
+                           LPCSTR attach_point, BOOL temporary) {
+    LPEDICT effect;
+
+    if (!model || !*model || (!point && !target)) return NULL;
+    effect = G_Spawn();
+    effect->s.model = G_RegisterModel(model);
+    if (!effect->s.model) {
+        G_FreeEdict(effect);
+        return NULL;
+    }
+
+    if (target) {
+        effect->s.origin = target->s.origin;
+        effect->s.origin2 = target->s.origin2;
+        effect->s.angle = target->s.angle;
+        effect->goalentity = target;
+        effect->damage = target->spawn_time; /* target generation guard */
+        effect->movetype = MOVETYPE_LINK;
+        effect->prethink = G_EffectValidateTarget;
+        if (attach_point && !strcasecmp(attach_point, "overhead")) {
+            effect->wait = target->s.radius * 2.5f;
+            effect->s.origin.z += effect->wait;
+        }
+    } else {
+        effect->s.origin2 = *point;
+        effect->s.origin.x = point->x;
+        effect->s.origin.y = point->y;
+        effect->s.origin.z = CM_GetHeightAtPoint(point->x, point->y);
+        effect->movetype = MOVETYPE_NONE;
+    }
+
+    effect->think = G_EffectThink;
+    G_EffectStartAnimation(effect, temporary);
+    return effect->inuse ? effect : NULL;
+}
+
+LPEDICT G_SpawnAbilityEffectAtPoint(DWORD ability_id, wc3EffectType_t type, DWORD index,
+                                    LPCVECTOR2 point, BOOL temporary) {
+    return G_SpawnModelEffect(G_AbilityEffectArt(ability_id, type, index), point, NULL, NULL, temporary);
+}
+
+LPEDICT G_SpawnAbilityEffectTarget(DWORD ability_id, wc3EffectType_t type, DWORD index,
+                                   LPEDICT target, LPCSTR attach_point, BOOL temporary) {
+    return G_SpawnModelEffect(G_AbilityEffectArt(ability_id, type, index), NULL, target, attach_point, temporary);
+}
+
+void G_DestroyEffect(LPEDICT effect) {
+    if (!effect || !effect->inuse) return;
+    effect->prethink = NULL;
+    effect->goalentity = NULL;
+    effect->movetype = MOVETYPE_NONE;
+    effect->wait = 0.0f;
+    effect->think = G_EffectThink;
+    unit_setmove(effect, &wc3_effect_death);
+    if (!effect->animation) G_FreeEdict(effect);
+}

--- a/games/warcraft-3/game/g_items.c
+++ b/games/warcraft-3/game/g_items.c
@@ -65,10 +65,27 @@ static void G_ShowInventoryFull(LPEDICT unit) {
     }
 }
 
+LPCSTR G_ItemAbilityList(LPCEDICT item) {
+    LPCSTR abilities;
+
+    if (!item || !item->class_id) return NULL;
+
+    /* abilList is authored on ItemData.slk. Prefer the normalized typed row:
+     * FindConfigValue() searches the TXT/INI configuration tables and cannot
+     * be relied on to find this SLK field. Keep the config lookup only as a
+     * compatibility fallback for hand-authored/custom data that did not make
+     * it into the typed item row. */
+    if (item->ItemData && item->ItemData->abilList && *item->ItemData->abilList)
+        return item->ItemData->abilList;
+
+    abilities = FindConfigValue(GetClassName(item->class_id), "abilList");
+    return abilities && *abilities ? abilities : NULL;
+}
+
 /* ItemData stores passive effects as an ability list; the item rawcode itself
  * is not an ability code. */
 static void G_ApplyItemStats(LPEDICT unit, LPCEDICT item, BOOL apply) {
-    LPCSTR abilities = FindConfigValue(GetClassName(item->class_id), "abilList");
+    LPCSTR abilities = G_ItemAbilityList(item);
     if (!abilities || !*abilities) return;
     PARSE_LIST(abilities, ability, parse_segment) {
         DWORD code = *((DWORD const *)ability);
@@ -197,6 +214,21 @@ void G_SetItemCharges(LPEDICT item, DWORD charges) {
     if (!G_IsItem(item) || item->item.charges == charges) return;
     item->item.charges = charges;
     if (item->item.carrier) G_RefreshInventoryUI(item->item.carrier);
+}
+
+void G_ConsumeItemCharge(LPEDICT item) {
+    if (!G_IsItem(item) || !item->ItemData || item->item.charges == 0) return;
+
+    /* All charged item uses decrement charges. Perishable only controls the
+     * zero-charge lifetime: Warsmash removes perishables, while reusable
+     * zero-charge items remain held. Avoid publishing a transient zero-charge
+     * copy immediately before final perishable removal. */
+    if (item->item.charges == 1 && item->ItemData->perishable) {
+        item->item.charges = 0;
+        G_RemoveItem(item);
+        return;
+    }
+    G_SetItemCharges(item, item->item.charges - 1);
 }
 
 LONG G_FindFreeInventorySlot(LPCEDICT unit) {
@@ -372,20 +404,42 @@ void G_RemoveItem(LPEDICT item) {
 /* Use an item in inventory by slot index. Calls the item's ability cmd handler. */
 void G_UseItem(LPEDICT unit, DWORD slot) {
     LPEDICT item;
-    ability_t const *abil;
+    LPEDICT clent;
+    LPCSTR abilities;
 
-    if (!unit || !unit->client || slot >= G_InventoryCapacity(unit)) {
+    if (!unit || slot >= G_InventoryCapacity(unit) || unit->s.player >= MAX_PLAYERS) {
         return;
     }
     item = unit->inventory[slot];
     if (!item) {
         return;
     }
-    /* Look up the item's ability code in the ability registry.
-     * Item abilities use the item's class_id as their ability code. */
-    abil = FindAbilityByClassname((LPCSTR)&item->class_id);
-    if (abil && abil->cmd) {
-        unit->client->menu.ability_code = item->class_id;
-        abil->cmd(unit);
+
+    clent = G_GetPlayerEntityByNumber(unit->s.player);
+    if (!clent || !clent->client) return;
+    abilities = G_ItemAbilityList(item);
+    if (!abilities) return;
+
+    PARSE_LIST(abilities, ability_name, parse_segment) {
+        ability_t const *ability = FindAbilityForCommand(ability_name);
+        BOOL succeeded = false;
+
+        if (!ability) continue;
+        clent->client->menu.ability_code = *((DWORD const *)ability_name);
+        if (ability->item_use) {
+            succeeded = ability->item_use(clent);
+        } else if (ability->cmd) {
+            ability->cmd(clent);
+            return;
+        } else {
+            continue;
+        }
+
+        if (succeeded) {
+            G_PublishEvent(unit, EVENT_PLAYER_UNIT_USE_ITEM);
+            G_PublishEvent(unit, EVENT_UNIT_USE_ITEM);
+            G_ConsumeItemCharge(item);
+        }
+        return;
     }
 }

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -504,12 +504,29 @@ typedef struct spell_info_s {
     void (*execute)(LPEDICT caster, spellTarget_t target, struct spell_info_s const *spell);
 } spell_info_t;
 
+
+typedef enum {
+    WC3_EFFECT_EFFECT = 0,
+    WC3_EFFECT_TARGET = 1,
+    WC3_EFFECT_CASTER = 2,
+    WC3_EFFECT_SPECIAL = 3,
+    WC3_EFFECT_AREA_EFFECT = 4,
+    WC3_EFFECT_MISSILE = 5,
+    WC3_EFFECT_LIGHTNING = 6,
+} wc3EffectType_t;
+
 typedef struct ability_s {
     void (*init)(LPCSTR, struct ability_s *);
     void (*cmd)(LPEDICT);
     BOOL (*is_toggle_on)(LPEDICT); /* selects Un* command-card fields when true */
     DWORD flags;
     struct spell_info_s *spell;    /* non-NULL for spells using the unified pipeline */
+
+    /* Keep new dispatch hooks append-only. ability_t is defined in a widely
+     * included game header and incremental builds may retain objects compiled
+     * against the previous layout; inserting a field above spell changes the
+     * offsets of every existing dispatch member. */
+    BOOL (*item_use)(LPEDICT); /* synchronous inventory activation; true only when gameplay effect applies */
 } ability_t;
 
 typedef struct {
@@ -1392,6 +1409,13 @@ void SetAbilityNames(void);
 LPCSTR FindConfigValue(LPCSTR, LPCSTR);
 LPCSTR GetClassName(DWORD);
 
+// g_effects.c
+LPCSTR G_AbilityEffectArt(DWORD ability_id, wc3EffectType_t type, DWORD index);
+LPEDICT G_SpawnModelEffect(LPCSTR model, LPCVECTOR2 point, LPEDICT target, LPCSTR attach_point, BOOL temporary);
+LPEDICT G_SpawnAbilityEffectAtPoint(DWORD ability_id, wc3EffectType_t type, DWORD index, LPCVECTOR2 point, BOOL temporary);
+LPEDICT G_SpawnAbilityEffectTarget(DWORD ability_id, wc3EffectType_t type, DWORD index, LPEDICT target, LPCSTR attach_point, BOOL temporary);
+void G_DestroyEffect(LPEDICT effect);
+
 // g_unit_ui.c (Phase 8)
 BYTE G_GetCommandButtons(LPEDICT ent, gameCommandButton_t *buttons, BYTE max_buttons);
 BOOL G_BuildCommandButton(LPEDICT ent, LPCSTR code, BOOL research, DWORD level, gameCommandButton_t *button);
@@ -1657,6 +1681,7 @@ void G_HeroSetXP(LPEDICT, DWORD xp);
 void G_GrantKillXP(LPEDICT victim, LPEDICT killer);
 void G_ReviveHero(LPEDICT, FLOAT x, FLOAT y);
 BOOL G_UnitIsHero(LPCEDICT ent);
+FLOAT G_UnitArmorValue(LPCEDICT ent);
 BOOL S_SpellCooldownReady(LPEDICT caster, DWORD code);
 LPCSTR S_SpellString(DWORD code, LPCSTR field, DWORD level);
 
@@ -1722,6 +1747,8 @@ DWORD G_InventoryCapacity(LPCEDICT unit);
 BOOL G_UnitHasInventory(LPEDICT unit);
 DWORD G_ItemCharges(LPCEDICT item);
 void G_SetItemCharges(LPEDICT item, DWORD charges);
+void G_ConsumeItemCharge(LPEDICT item);
+LPCSTR G_ItemAbilityList(LPCEDICT item);
 LONG G_FindFreeInventorySlot(LPCEDICT unit);
 BOOL G_CanPickupItem(LPEDICT unit, LPEDICT item);
 BOOL G_AddItemToSlot(LPEDICT unit, LPEDICT item, DWORD slot);

--- a/games/warcraft-3/game/g_metadata.c
+++ b/games/warcraft-3/game/g_metadata.c
@@ -501,6 +501,10 @@ static slkField_t const ability_buff_schema[] = {
     { "Buffart",     offsetof(AbilityBuffData_t, buffArt),     STB_SLK_STR    },
     { "Bufftip",     offsetof(AbilityBuffData_t, buffTip),     STB_SLK_STR    },
     { "Buffubertip", offsetof(AbilityBuffData_t, buffUberTip), STB_SLK_STR    },
+    { "TargetArt",   offsetof(AbilityBuffData_t, targetArt),   STB_SLK_STR    },
+    { "SpecialArt",  offsetof(AbilityBuffData_t, specialArt),  STB_SLK_STR    },
+    { "EffectArt",   offsetof(AbilityBuffData_t, effectArt),   STB_SLK_STR    },
+    { "Missileart",  offsetof(AbilityBuffData_t, missileArt),  STB_SLK_STR    },
     { NULL, 0, 0 }
 };
 

--- a/games/warcraft-3/game/g_unitrow.h
+++ b/games/warcraft-3/game/g_unitrow.h
@@ -288,6 +288,7 @@ typedef struct {
     LONG version;
     BOOL isEffect, useInEditor, InBeta;
     LPCSTR buffArt, buffTip, buffUberTip;
+    LPCSTR targetArt, specialArt, effectArt, missileArt;
 } AbilityBuffData_t;
 
 /* =========================================================================

--- a/games/warcraft-3/game/hud/hud_infopanel.c
+++ b/games/warcraft-3/game/hud/hud_infopanel.c
@@ -172,7 +172,7 @@ static void WriteLegacyUnitStats(LPEDICT ent, UnitWeapons_t const *weapons,
     UI_SetHidden(hud.unit.AttackLabel2, !has_attack2);
     UI_SetHidden(hud.unit.AttackValue2, !has_attack2);
     UI_SetText(hud.unit.DefenseLabel, "Armor:");
-    UI_SetText(hud.unit.DefenseValue, "%d", (int)(ent->armor_value + 0.5f));
+    UI_SetText(hud.unit.DefenseValue, "%d", (int)(G_UnitArmorValue(ent) + 0.5f));
     UI_SetText(hud.unit.SpeedTitle, "Speed:");
     UI_SetText(hud.unit.SpeedValue, "%d", (int)(ent->unitinfo.MoveSpeed + 0.5f));
     UI_SetText(hud.unit.RangeTitle1, "Range:");
@@ -536,7 +536,7 @@ static void WriteSelectedUnitStatusFrames(LPEDICT ent, UnitWeapons_t const *weap
 
     SetTypedInfoPanelIcon(hud.simple.InfoPanelIconBackdrop_2, "Armor", ent->UnitBalance->defenseType,
                           armor_upgrade != 0);
-    UI_SetText(hud.simple.InfoPanelIconValue_2, "%d", (int)(ent->armor_value + 0.5f));
+    UI_SetText(hud.simple.InfoPanelIconValue_2, "%d", (int)(G_UnitArmorValue(ent) + 0.5f));
     SetUpgradeLevel(hud.simple.InfoPanelIconLevel_2, armor_upgrade, ent);
     UI_WriteFrame(&hud.armor);
     UI_WriteFrameWithChildren(hud.simple.SimpleInfoPanelIconArmor, &hud.armor);

--- a/games/warcraft-3/game/m_unit.c
+++ b/games/warcraft-3/game/m_unit.c
@@ -460,6 +460,27 @@ static BOOL unit_status_timedlife(DWORD code) {
     return code == MAKEFOURCC('B', 'T', 'L', 'F');
 }
 
+FLOAT G_UnitArmorValue(LPCEDICT ent) {
+    FLOAT armor;
+
+    if (!ent) return 0.0f;
+    armor = ent->armor_value;
+
+    /* Bdef is the stock Scroll of Protection status. Keep the authored armor
+     * amount in AbilityData (AIda/DataA) rather than baking it into the unit or
+     * status record; status expiry then removes the bonus automatically from
+     * both combat and HUD calculations without adding save-state fields. */
+    FOR_LOOP(i, MAX_UNIT_STATUSES) {
+        heroabilitystatus_t const *status = ent->abilstatus + i;
+        if (status->level && status->code == MAKEFOURCC('B', 'd', 'e', 'f')) {
+            DWORD level = MAX(1, MIN(status->level, 4));
+            AbilityData_t const *ability = G_AbilityData(MAKEFOURCC('A', 'I', 'd', 'a'));
+            armor += ability->data[level - 1][0];
+        }
+    }
+    return armor;
+}
+
 static void unit_refreshstatusflags(LPEDICT ent) {
     ent->stunned = false;
     FOR_LOOP(i, MAX_UNIT_STATUSES) {

--- a/games/warcraft-3/game/skills/s_attack.c
+++ b/games/warcraft-3/game/skills/s_attack.c
@@ -158,7 +158,7 @@ int G_AttackDamage(LPEDICT attacker, LPEDICT target, int base) {
     if (def >= 8) def = 7;
     FLOAT mult = (atk == ATK_CHAOS) ? 1.0f : g_damage_table[atk][def];
     FLOAT dmg = (FLOAT)base * mult;
-    FLOAT armor = target->armor_value;
+    FLOAT armor = G_UnitArmorValue(target);
     if (armor >= 0.0f)
         dmg = dmg / (1.0f + armor * 0.06f);
     else

--- a/games/warcraft-3/game/skills/s_devotionaura.c
+++ b/games/warcraft-3/game/skills/s_devotionaura.c
@@ -2,27 +2,11 @@
 
 #define ID_DEVOTION_AURA "AHad"
 
-static LPCSTR devotionaura_target_art;
-
-static umove_t aura_move_stand = { "stand", ai_idle, NULL };
-
 static void devotionaura_execute(LPEDICT caster, spellTarget_t st, spell_info_t const *spell) {
     (void)st;
-    (void)spell;
     unit_addstatus(caster, ID_DEVOTION_AURA, 1);
 
-    LPEDICT effect = G_Spawn();
-    effect->s.origin = caster->s.origin;
-    effect->s.angle = caster->s.angle;
-    effect->s.model = G_RegisterModel(devotionaura_target_art);
-    effect->goalentity = caster;
-    effect->movetype = MOVETYPE_LINK;
-    effect->think = M_MoveFrame;
-    unit_setmove(effect, &aura_move_stand);
-}
-
-static void SP_ability_devotionaura(LPCSTR classname, ability_t *self) {
-    devotionaura_target_art = FindConfigValue(classname, STR_TARGET_ART);
+    G_SpawnAbilityEffectTarget(spell->code, WC3_EFFECT_TARGET, 0, caster, NULL, false);
 }
 
 static spell_info_t spell_devotionaura = {
@@ -33,7 +17,6 @@ static spell_info_t spell_devotionaura = {
 };
 
 ability_t a_devotionaura = {
-    .init = SP_ability_devotionaura,
     .cmd = spell_cmd,
     .spell = &spell_devotionaura,
 };

--- a/games/warcraft-3/game/skills/s_holylight.c
+++ b/games/warcraft-3/game/skills/s_holylight.c
@@ -1,7 +1,5 @@
 #include "s_skills.h"
 
-static LPCSTR holylight_target_art;
-
 void holylight_done(LPEDICT self);
 
 static umove_t move_heal = { "stand channel", ai_idle, holylight_done, &a_holylight };
@@ -29,16 +27,12 @@ static void holylight_execute(LPEDICT caster, spellTarget_t st, spell_info_t con
     DWORD level = S_SpellLevel(caster, spell->code);
     FLOAT amount = S_SpellData(spell->code, level, 1);
 
-    S_SpellSpawnTargetArt(target, holylight_target_art);
+    G_SpawnAbilityEffectTarget(spell->code, WC3_EFFECT_TARGET, 0, target, NULL, true);
     unit_setmove(caster, &move_heal);
     if (S_SpellIsFriend(caster, target))
         S_SpellHeal(target, amount);
     else
         T_Damage(target, caster, (int)(amount * 0.5f));
-}
-
-static void SP_ability_holylight(LPCSTR classname, ability_t *self) {
-    holylight_target_art = FindConfigValue(classname, STR_TARGET_ART);
 }
 
 static spell_info_t spell_holylight = {
@@ -50,7 +44,6 @@ static spell_info_t spell_holylight = {
 };
 
 ability_t a_holylight = {
-    .init = SP_ability_holylight,
     .cmd = spell_cmd,
     .spell = &spell_holylight,
 };

--- a/games/warcraft-3/game/skills/s_item.c
+++ b/games/warcraft-3/game/skills/s_item.c
@@ -10,46 +10,53 @@
 #define ID_ITEM_XP_GAIN        MAKEFOURCC('A', 'I', 'e', 'm')
 #define ID_ITEM_LEVEL_GAIN     MAKEFOURCC('A', 'I', 'l', 'm')
 #define ID_ITEM_FIGURINE       MAKEFOURCC('A', 'I', 'f', 's')
+#define ID_ITEM_DEFENSE_AOE     MAKEFOURCC('A', 'I', 'd', 'a')
 
 /* ---- Active items (consume on use) -------------------------------------- */
 
-static void item_heal_command(LPEDICT clent) {
+static BOOL item_heal_command(LPEDICT clent) {
     LPEDICT target = G_GetMainSelectedUnit(clent->client);
     DWORD code = S_SpellCurrentCode(clent, ID_ITEM_HEAL);
     FLOAT amount = S_SpellData(code, 1, 1);
 
-    if (!S_SpellIsAliveTarget(target)) {
-        return;
+    if (!S_SpellIsAliveTarget(target) || amount <= 0 || target->health.value >= target->health.max_value) {
+        return false;
     }
     S_SpellHeal(target, amount);
+    G_SpawnAbilityEffectTarget(code, WC3_EFFECT_TARGET, 0, target, NULL, true);
+    return true;
 }
 
-static void item_mana_command(LPEDICT clent) {
+static BOOL item_mana_command(LPEDICT clent) {
     LPEDICT target = G_GetMainSelectedUnit(clent->client);
     DWORD code = S_SpellCurrentCode(clent, ID_ITEM_MANA);
     FLOAT amount = S_SpellData(code, 1, 1);
 
-    if (!target || amount <= 0) {
-        return;
+    if (!target || amount <= 0 || target->mana.value >= target->mana.max_value) {
+        return false;
     }
     target->mana.value = MIN(target->mana.max_value, target->mana.value + amount);
+    G_SpawnAbilityEffectTarget(code, WC3_EFFECT_TARGET, 0, target, NULL, true);
+    return true;
 }
 
-static void item_permanent_life_command(LPEDICT clent) {
+static BOOL item_permanent_life_command(LPEDICT clent) {
     LPEDICT target = G_GetMainSelectedUnit(clent->client);
     DWORD code = S_SpellCurrentCode(clent, ID_ITEM_LIFE_GAIN);
     FLOAT amount = S_SpellData(code, 1, 1);
 
     if (!target || amount <= 0) {
-        return;
+        return false;
     }
     target->health.max_value += amount;
     target->health.value += amount;
+    G_SpawnAbilityEffectTarget(code, WC3_EFFECT_TARGET, 0, target, NULL, true);
+    return true;
 }
 
 /* WarSmash: CAbilityItemPermanentStatGain.checkBeforeQueue
  * Permanently adds to hero base stats, consumes the item. */
-static void item_permanent_stat_command(LPEDICT clent) {
+static BOOL item_permanent_stat_command(LPEDICT clent) {
     LPEDICT target = G_GetMainSelectedUnit(clent->client);
     DWORD code = S_SpellCurrentCode(clent, 0);
     FLOAT str = S_SpellData(code, 1, 1);
@@ -57,67 +64,113 @@ static void item_permanent_stat_command(LPEDICT clent) {
     FLOAT intel = S_SpellData(code, 1, 3);
 
     if (!target || !G_UnitIsHero(target)) {
-        return;
+        return false;
     }
     target->hero.str += (DWORD)str;
     target->hero.agi += (DWORD)agi;
     target->hero.intel += (DWORD)intel;
     G_RecomputeHeroStats(target);
+    G_SpawnAbilityEffectTarget(code, WC3_EFFECT_TARGET, 0, target, NULL, true);
+    return true;
 }
 
 /* WarSmash: CAbilityItemExperienceGain — grants XP. */
-static void item_experience_command(LPEDICT clent) {
+static BOOL item_experience_command(LPEDICT clent) {
     LPEDICT target = G_GetMainSelectedUnit(clent->client);
     DWORD code = S_SpellCurrentCode(clent, ID_ITEM_XP_GAIN);
     DWORD amount = (DWORD)S_SpellData(code, 1, 1);
 
     if (!target || !G_UnitIsHero(target) || amount == 0) {
-        return;
+        return false;
     }
     G_HeroSetXP(target, target->hero.xp + amount);
+    G_SpawnAbilityEffectTarget(code, WC3_EFFECT_TARGET, 0, target, NULL, true);
+    return true;
 }
 
 /* WarSmash: CAbilityItemLevelGain — grants hero level. */
-static void item_level_command(LPEDICT clent) {
+static BOOL item_level_command(LPEDICT clent) {
     LPEDICT target = G_GetMainSelectedUnit(clent->client);
     DWORD code = S_SpellCurrentCode(clent, ID_ITEM_LEVEL_GAIN);
     DWORD levels = (DWORD)S_SpellData(code, 1, 1);
 
     if (!target || !G_UnitIsHero(target) || levels == 0) {
-        return;
+        return false;
     }
     DWORD target_level = MIN(target->hero.level + levels, G_MaxHeroLevel());
     DWORD target_xp = G_HeroXPForLevel(target_level);
-    if (target_xp > target->hero.xp) {
-        G_HeroSetXP(target, target_xp);
+    if (target_xp <= target->hero.xp) {
+        return false;
     }
+    G_HeroSetXP(target, target_xp);
+    G_SpawnAbilityEffectTarget(code, WC3_EFFECT_TARGET, 0, target, NULL, true);
+    return true;
 }
 
 /* WarSmash: CAbilityItemFigurineSummon — summons a unit. */
-static void item_figurine_command(LPEDICT clent) {
+static BOOL item_figurine_command(LPEDICT clent) {
     LPEDICT target = G_GetMainSelectedUnit(clent->client);
     DWORD code = S_SpellCurrentCode(clent, ID_ITEM_FIGURINE);
     DWORD unit_id = S_SpellUnitId(code, 1);
 
     if (!target || !unit_id) {
-        return;
+        return false;
     }
     LPEDICT summon = SP_SpawnAtLocation(unit_id, target->s.player, &target->s.origin2);
+    if (!summon) {
+        return false;
+    }
     G_ActivateUnitFood(summon);
+    G_SpawnAbilityEffectTarget(code, WC3_EFFECT_TARGET, 0, summon, NULL, true);
+    return true;
+}
+
+/* Scroll of Protection / item defense AOE (AIda). Warcraft data carries the
+ * defense amount in DataA, radius in Area, duration in Dur/HeroDur and the
+ * visible status rawcode in BuffID. Keep the item itself as a thin ability
+ * carrier: the ability data decides the actual numbers. */
+static BOOL item_defense_aoe_command(LPEDICT clent) {
+    LPEDICT caster = clent && clent->client ? G_GetMainSelectedUnit(clent->client) : NULL;
+    DWORD code = S_SpellCurrentCode(clent, ID_ITEM_DEFENSE_AOE);
+    DWORD level = 1;
+    AbilityData_t const *data = G_AbilityData(code);
+    FLOAT bonus = S_SpellData(code, level, 1);
+    FLOAT area = S_SpellNumber(code, ABILITY_NUMBER_AREA, level);
+    LPCSTR buff = data->buffID[level - 1];
+    DWORD affected = 0;
+
+    if (!caster || bonus <= 0.0f || area < 0.0f || !buff || strlen(buff) < 4) {
+        return false;
+    }
+
+#define ITEM_DEFENSE_AOE_TARGET(t) \
+    ((t)->inuse && S_SpellIsAliveTarget(t) && S_SpellIsFriend(caster, (t)) && \
+     S_SpellAllowsTarget(code, caster, (t)) && \
+     Vector2_distance(&(t)->s.origin2, &caster->s.origin2) <= area)
+
+    FILTER_EDICTS(target, ITEM_DEFENSE_AOE_TARGET(target)) {
+        FLOAT duration = S_SpellDuration(code, level, G_UnitIsHero(target));
+        unit_addtimedstatus(target, buff, level, duration);
+        G_SpawnAbilityEffectTarget(code, WC3_EFFECT_TARGET, 0, target, NULL, true);
+        affected++;
+    }
+#undef ITEM_DEFENSE_AOE_TARGET
+
+    return affected != 0;
 }
 
 /* ---- Ability definitions ------------------------------------------------ */
 
 ability_t a_item_heal = {
-    .cmd = item_heal_command,
+    .item_use = item_heal_command,
 };
 
 ability_t a_item_mana_regain = {
-    .cmd = item_mana_command,
+    .item_use = item_mana_command,
 };
 
 ability_t a_item_permanent_life_gain = {
-    .cmd = item_permanent_life_command,
+    .item_use = item_permanent_life_command,
 };
 
 /* Passive items: init reads bonus value from SLK, actual apply/remove
@@ -144,17 +197,21 @@ ability_t a_item_mana_bonus = {
 
 /* Consume-on-use items. */
 ability_t a_item_permanent_stat_gain = {
-    .cmd = item_permanent_stat_command,
+    .item_use = item_permanent_stat_command,
 };
 
 ability_t a_item_figurine_summon = {
-    .cmd = item_figurine_command,
+    .item_use = item_figurine_command,
 };
 
 ability_t a_item_experience_gain = {
-    .cmd = item_experience_command,
+    .item_use = item_experience_command,
 };
 
 ability_t a_item_level_gain = {
-    .cmd = item_level_command,
+    .item_use = item_level_command,
+};
+
+ability_t a_item_defense_aoe = {
+    .item_use = item_defense_aoe_command,
 };

--- a/games/warcraft-3/game/skills/s_skills.c
+++ b/games/warcraft-3/game/skills/s_skills.c
@@ -78,6 +78,7 @@ static abilityitem_t abilitylist[] = {
     { "AImi", &a_item_permanent_life_gain },
     { "AIem", &a_item_experience_gain },
     { "AIlm", &a_item_level_gain },
+    { "AIda", &a_item_defense_aoe },
     { "Acar", &a_cargo_hold },
     { "Aloa", &a_load },
     { "Adro", &a_drop },

--- a/games/warcraft-3/game/skills/s_skills.h
+++ b/games/warcraft-3/game/skills/s_skills.h
@@ -71,6 +71,7 @@ extern ability_t a_item_figurine_summon;
 extern ability_t a_item_permanent_life_gain;
 extern ability_t a_item_experience_gain;
 extern ability_t a_item_level_gain;
+extern ability_t a_item_defense_aoe;
 extern ability_t a_flame_strike;
 extern ability_t a_siphon_mana;
 
@@ -95,6 +96,7 @@ typedef enum {
 	ABILITY_NUMBER_RANGE
 } abilityNumber_t;
 DWORD S_SpellCurrentCode(LPEDICT clent, DWORD fallback);
+spell_info_t const *S_SpellInfoForCode(DWORD code);
 DWORD S_SpellLevel(LPEDICT caster, DWORD code);
 FLOAT S_SpellNumber(DWORD code, abilityNumber_t field, DWORD level);
 LPCSTR S_SpellString(DWORD code, LPCSTR field, DWORD level);
@@ -113,7 +115,6 @@ BOOL S_SpellIsEnemy(LPEDICT caster, LPEDICT target);
 BOOL S_SpellIsFriend(LPEDICT caster, LPEDICT target);
 BOOL S_SpellAllowsTarget(DWORD code, LPEDICT caster, LPEDICT target);
 void S_SpellHeal(LPEDICT target, FLOAT amount);
-void S_SpellSpawnTargetArt(LPEDICT target, LPCSTR art);
 void S_SpellCursorSplat(LPEDICT clent, FLOAT radius);
 void S_SpellCodeString(DWORD code, LPSTR out);
 BOOL S_SpellIsChanneling(LPEDICT caster);

--- a/games/warcraft-3/game/skills/s_spell.c
+++ b/games/warcraft-3/game/skills/s_spell.c
@@ -2,8 +2,6 @@
 
 #include <ctype.h>
 
-static umove_t spell_effect_birth = { "birth", NULL, G_FreeEdict };
-
 #define DEFAULT_SPELL_AREA_CURSOR "ReplaceableTextures\\Selection\\SpellAreaOfEffect.blp"
 
 /* ---- Unified Spell Pipeline ----
@@ -36,6 +34,21 @@ void S_SpellCodeString(DWORD code, LPSTR out) {
 DWORD S_SpellCurrentCode(LPEDICT clent, DWORD fallback) {
     DWORD code = clent && clent->client ? clent->client->menu.ability_code : 0;
     return code ? code : fallback;
+}
+
+spell_info_t const *S_SpellInfoForCode(DWORD code) {
+    ability_t const *ability;
+
+    if (!code) return NULL;
+
+    /* A rawcode stored in a DWORD is four bytes, not a C string. The old
+     * spell path cast &code to LPCSTR and handed it to strcmp(), so lookup
+     * depended on the unrelated byte immediately after the DWORD being zero.
+     * Convert through GetClassName(), which supplies the required terminator,
+     * and use the normal alias-aware command resolver so custom abilities
+     * inherit their registered base handler as well. */
+    ability = FindAbilityForCommand(GetClassName(code));
+    return ability ? ability->spell : NULL;
 }
 
 DWORD S_SpellLevel(LPEDICT caster, DWORD code) {
@@ -272,23 +285,6 @@ void S_SpellHeal(LPEDICT target, FLOAT amount) {
     target->health.value = MIN(target->health.max_value, target->health.value + amount);
 }
 
-void S_SpellSpawnTargetArt(LPEDICT target, LPCSTR art) {
-    LPEDICT effect;
-
-    if (!target || !art || !*art) {
-        return;
-    }
-
-    effect = G_Spawn();
-    effect->s.origin = target->s.origin;
-    effect->s.angle = target->s.angle;
-    effect->s.model = G_RegisterModel(art);
-    effect->goalentity = target;
-    effect->movetype = MOVETYPE_LINK;
-    effect->think = M_MoveFrame;
-    unit_setmove(effect, &spell_effect_birth);
-}
-
 void S_SpellCursorSplat(LPEDICT clent, FLOAT radius) {
     LONG image = 0;
 
@@ -396,8 +392,7 @@ static BOOL spell_unit_target_selected(LPEDICT clent, LPEDICT target) {
     DWORD code = S_SpellCurrentCode(clent, 0);
     DWORD level = S_SpellLevel(caster, code);
     FLOAT range = S_SpellRange(code, level);
-    ability_t const *abil = FindAbilityByClassname((LPCSTR)&code);
-    spell_info_t const *spell = abil ? abil->spell : NULL;
+    spell_info_t const *spell = S_SpellInfoForCode(code);
 
     if (!spell) return false;
     if (!spell_validate(clent, caster, code, level, target, range)) return false;
@@ -419,8 +414,7 @@ static BOOL spell_point_target_selected(LPEDICT clent, LPCVECTOR2 point) {
     DWORD code = S_SpellCurrentCode(clent, 0);
     DWORD level = S_SpellLevel(caster, code);
     FLOAT range = S_SpellRange(code, level);
-    ability_t const *abil = FindAbilityByClassname((LPCSTR)&code);
-    spell_info_t const *spell = abil ? abil->spell : NULL;
+    spell_info_t const *spell = S_SpellInfoForCode(code);
 
     if (!spell) return false;
     if (!spell_validate_point(clent, caster, code, level, point, range))
@@ -442,8 +436,7 @@ static void spell_no_target_execute(LPEDICT clent) {
     LPEDICT caster = G_GetMainSelectedUnit(clent->client);
     DWORD code = S_SpellCurrentCode(clent, 0);
     DWORD level = S_SpellLevel(caster, code);
-    ability_t const *abil = FindAbilityByClassname((LPCSTR)&code);
-    spell_info_t const *spell = abil ? abil->spell : NULL;
+    spell_info_t const *spell = S_SpellInfoForCode(code);
 
     if (!spell) return;
     if (!spell_validate(clent, caster, code, level, NULL, 0.0f)) return;
@@ -460,8 +453,7 @@ static void spell_no_target_execute(LPEDICT clent) {
 void spell_cmd(LPEDICT clent) {
     LPEDICT caster = G_GetMainSelectedUnit(clent->client);
     DWORD code = S_SpellCurrentCode(clent, 0);
-    ability_t const *abil = FindAbilityByClassname((LPCSTR)&code);
-    spell_info_t const *spell = abil ? abil->spell : NULL;
+    spell_info_t const *spell = S_SpellInfoForCode(code);
 
     if (!spell) {
         fprintf(stderr, "spell_cmd: no spell_info for code '%.4s'\n", (LPCSTR)&code);

--- a/games/warcraft-3/game/skills/s_thunderbolt.c
+++ b/games/warcraft-3/game/skills/s_thunderbolt.c
@@ -4,8 +4,6 @@
 #define ID_FIRE_BOLT MAKEFOURCC('A', 'N', 'f', 'b')
 #define ID_STUN_BUFF "Bstu"
 
-static LPCSTR thunderbolt_missile_art;
-static LPCSTR firebolt_missile_art;
 static FLOAT thunderbolt_missile_speed;
 static FLOAT firebolt_missile_speed;
 
@@ -16,10 +14,6 @@ static void thunderbolt_projectile_hit(LPEDICT missile);
 static umove_t thunderbolt_projectile_move = { "stand", NULL, thunderbolt_projectile_hit, &a_thunderbolt };
 static umove_t firebolt_projectile_move = { "stand", NULL, thunderbolt_projectile_hit, &a_firebolt };
 static umove_t spell_cast_move = { "spell", ai_idle, NULL, &a_thunderbolt };
-
-static LPCSTR bolt_missile_art(DWORD code) {
-    return code == ID_FIRE_BOLT ? firebolt_missile_art : thunderbolt_missile_art;
-}
 
 static FLOAT bolt_missile_speed(DWORD code) {
     FLOAT speed = code == ID_FIRE_BOLT ? firebolt_missile_speed : thunderbolt_missile_speed;
@@ -43,7 +37,7 @@ static void thunderbolt_execute(LPEDICT caster, spellTarget_t st, spell_info_t c
     LPEDICT target = st.entity;
     DWORD code = spell->code;
     DWORD level = S_SpellLevel(caster, code);
-    LPCSTR art = bolt_missile_art(code);
+    LPCSTR art = G_AbilityEffectArt(code, WC3_EFFECT_MISSILE, 0);
     FLOAT speed = bolt_missile_speed(code);
     FLOAT duration = S_SpellDuration(code, level, target->UnitBalance->level >= 5);
     LPEDICT missile;
@@ -64,13 +58,11 @@ static void thunderbolt_execute(LPEDICT caster, spellTarget_t st, spell_info_t c
 
 static void SP_ability_thunderbolt(LPCSTR classname, ability_t *self) {
     (void)self;
-    thunderbolt_missile_art = FindConfigValue(classname, "Missileart");
     thunderbolt_missile_speed = ConfigNumber(classname, "Missilespeed");
 }
 
 static void SP_ability_firebolt(LPCSTR classname, ability_t *self) {
     (void)self;
-    firebolt_missile_art = FindConfigValue(classname, "Missileart");
     firebolt_missile_speed = ConfigNumber(classname, "Missilespeed");
 }
 

--- a/games/warcraft-3/game/skills/s_warden_abilities.c
+++ b/games/warcraft-3/game/skills/s_warden_abilities.c
@@ -20,16 +20,14 @@ static BOOL blink_validate(LPEDICT caster, spellTarget_t st) {
 }
 
 static void blink_execute(LPEDICT caster, spellTarget_t st, spell_info_t const *spell) {
-    DWORD level = S_SpellLevel(caster, spell->code);
-
-    S_SpellSpawnTargetArt(caster, S_SpellString(spell->code, "Specialart", level));
+    G_SpawnAbilityEffectTarget(spell->code, WC3_EFFECT_SPECIAL, 0, caster, NULL, true);
     VECTOR2 dest = st.point;
     CM_ClosestPathablePointForRadius(&st.point, caster->collision, &dest);
     caster->s.origin2 = dest;
     caster->s.origin.x = dest.x;
     caster->s.origin.y = dest.y;
     gi.LinkEntity(caster);
-    S_SpellSpawnTargetArt(caster, S_SpellString(spell->code, "Areaeffectart", level));
+    G_SpawnAbilityEffectTarget(spell->code, WC3_EFFECT_AREA_EFFECT, 0, caster, NULL, true);
 }
 
 static spell_info_t spell_blink = {

--- a/games/warcraft-3/game/tests/t_api.c
+++ b/games/warcraft-3/game/tests/t_api.c
@@ -764,6 +764,20 @@ static LPEDICT make_unit_hero(void) {
     return ent;
 }
 
+TEST(wc3_api, effect_natives_return_independent_handles) {
+    setup_test_world();
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  local effect direct = AddSpecialEffect(\"TestUI\\\\Models\\\\anim_pulse.mdx\", 64.0, 64.0)\n"
+        "  local effect spell = AddSpellEffectById('AHhb', EFFECT_TYPE_TARGET, 96.0, 96.0)\n"
+        "  call BJassAssert(direct != null, \"AddSpecialEffect returned null\")\n"
+        "  call BJassAssert(spell != null, \"AddSpellEffectById returned null\")\n"
+        "  call BJassAssert(direct != spell, \"effect handles aliased\")\n"
+        "  call DestroyEffect(direct)\n"
+        "  call DestroyEffect(spell)\n"
+        "endfunction\n"));
+}
+
 TEST(wc3_api, ui_sound_transport_waits_for_connected_client) {
     GAMECLIENT client = { 0 };
     edict_t ent = { .client = &client };

--- a/games/warcraft-3/game/tests/t_combat.c
+++ b/games/warcraft-3/game/tests/t_combat.c
@@ -1,4 +1,5 @@
 #ifdef BZ_TESTS
+#include <stddef.h>
 /* Forward declarations — defined in t_slk.c, compiled together in unity build. */
 slkTestData_t *parse_slk_string(const char *slk_text);
 void free_slk_rows(slkTestData_t *rows);
@@ -87,6 +88,34 @@ static animation_t _stub_anim = {
 /* Wire a real animation into an entity so M_MoveFrame has something to work with. */
 static void attach_stub_anim(LPEDICT ent) {
     ent->animation = &_stub_anim;
+}
+
+/* ==========================================================================
+ * Ability presentation effects
+ * ========================================================================== */
+
+TEST(wc3_effects, ability_effect_art_selects_requested_entry_and_last_fallback) {
+    DWORD const holy_light = MAKEFOURCC('A','H','h','b');
+
+    setup_test_world();
+    T_STREQ(G_AbilityEffectArt(holy_light, WC3_EFFECT_TARGET, 0),
+            "TestUI\\Models\\anim_pulse.mdx");
+    T_STREQ(G_AbilityEffectArt(holy_light, WC3_EFFECT_TARGET, 1),
+            "TestUI\\Models\\quad_sprite.mdx");
+    T_STREQ(G_AbilityEffectArt(holy_light, WC3_EFFECT_TARGET, 99),
+            "TestUI\\Models\\quad_sprite.mdx");
+    T_STREQ(G_AbilityEffectArt(holy_light, WC3_EFFECT_SPECIAL, 0),
+            "TestUI\\Models\\panel_sprite.mdx");
+    T_STREQ(G_AbilityEffectArt(holy_light, WC3_EFFECT_AREA_EFFECT, 0),
+            "TestUI\\Models\\ui_panel.mdx");
+    T_NULL(G_AbilityEffectArt(holy_light, WC3_EFFECT_LIGHTNING, 0));
+
+    T_STREQ(G_AbilityEffectArt(MAKEFOURCC('B','i','m','l'), WC3_EFFECT_TARGET, 0),
+            "TestUI\\Models\\anim_pulse.mdx");
+    T_STREQ(G_AbilityEffectArt(MAKEFOURCC('B','i','m','l'), WC3_EFFECT_SPECIAL, 0),
+            "TestUI\\Models\\panel_sprite.mdx");
+    T_STREQ(G_AbilityEffectArt(MAKEFOURCC('B','i','m','l'), WC3_EFFECT_EFFECT, 0),
+            "TestUI\\Models\\quad_sprite.mdx");
 }
 
 /* ==========================================================================
@@ -993,6 +1022,10 @@ static const char slk_ability_helpers[] =
     "C;Y4;X1;K\"Ahrp\"\n"
     "C;Y4;X2;K\"Arep\"\n"
     "E\n";
+
+TEST(wc3_combat, ability_dispatch_extension_is_append_only) {
+    T_ASSERT(offsetof(ability_t, item_use) > offsetof(ability_t, spell));
+}
 
 TEST(wc3_combat, command_lookup_resolves_fourcc_ability_alias) {
     slkTestData_t *rows = parse_slk_string(slk_ability_helpers);

--- a/games/warcraft-3/game/tests/t_items.c
+++ b/games/warcraft-3/game/tests/t_items.c
@@ -574,6 +574,89 @@ TEST(wc3_items, carried_charge_change_refreshes_inventory_and_same_value_is_noop
     T_ASSERT(!inventory_refresh_saw_inventory_layer);
 }
 
+TEST(wc3_items, perishable_success_consumes_charge_and_removes_at_zero) {
+    ItemData_t perishable = { .perishable = true };
+    LPEDICT item;
+
+    setup_test_world();
+    item = make_item_test_world_item(MAKEFOURCC('r','a','t','f'), 64, 0);
+    item->ItemData = &perishable;
+    item->item.charges = 2;
+
+    G_ConsumeItemCharge(item);
+    T_ASSERT(item->inuse);
+    T_EQ(item->item.charges, 1);
+
+    G_ConsumeItemCharge(item);
+    T_ASSERT(!item->inuse);
+}
+
+TEST(wc3_items, nonperishable_use_decrements_charges_but_keeps_item_at_zero) {
+    ItemData_t reusable = { .perishable = false };
+    LPEDICT item;
+
+    setup_test_world();
+    item = make_item_test_world_item(MAKEFOURCC('r','a','t','f'), 64, 0);
+    item->ItemData = &reusable;
+    item->item.charges = 2;
+
+    G_ConsumeItemCharge(item);
+    T_ASSERT(item->inuse);
+    T_EQ(item->item.charges, 1);
+
+    G_ConsumeItemCharge(item);
+    T_ASSERT(item->inuse);
+    T_EQ(item->item.charges, 0);
+}
+
+TEST(wc3_items, inventory_click_uses_itemdata_ability_list_and_applies_scroll) {
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(LPEDICT) = gi.unicast;
+    LPEDICT clent;
+    LPGAMECLIENT client;
+    LPEDICT unit;
+    LPEDICT item;
+    FLOAT base_armor;
+    BOOL found_buff = false;
+    LPCSTR command[] = { "inventory", "0" };
+
+    setup_test_world();
+    clent = &g_edicts[0];
+    client = clent->client;
+    gi.Write = item_noop_write;
+    gi.unicast = item_noop_unicast;
+
+    unit = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 0, 0);
+    unit->s.player = client->ps.number;
+    unit->svflags |= SVF_MONSTER;
+    unit->targtype = TARG_GROUND;
+    unit->armor_value = 3.0f;
+    base_armor = G_UnitArmorValue(unit);
+    G_SelectEntity(client, unit);
+
+    item = alloc_test_unit(MAKEFOURCC('s','p','r','o'), 32, 0);
+    SP_SpawnItem(item);
+    gi.LinkEntity(item);
+    T_STREQ(G_ItemAbilityList(item), "AIda");
+    T_ASSERT(G_AddItemToSlot(unit, item, 0));
+
+    G_ClientCommand(clent, 2, command);
+
+    T_FEQ(G_UnitArmorValue(unit), base_armor + 2.0f, 0.01f);
+    FOR_LOOP(i, MAX_UNIT_STATUSES) {
+        if (unit->abilstatus[i].level && unit->abilstatus[i].code == MAKEFOURCC('B','d','e','f')) {
+            found_buff = true;
+            break;
+        }
+    }
+    T_ASSERT(found_buff);
+    T_NULL(unit->inventory[0]);
+    T_ASSERT(!item->inuse);
+
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+}
+
 TEST(wc3_items, drop_preserves_item_charges) {
     setup_test_world();
     LPEDICT unit = make_item_test_inventory_unit(128, 256);

--- a/games/warcraft-3/game/tests/t_slk.c
+++ b/games/warcraft-3/game/tests/t_slk.c
@@ -285,6 +285,10 @@ TEST(wc3_slk, ability_buff_ui_columns_decode) {
     T_EQ(buff->id, MAKEFOURCC('B','i','m','l'));
     T_STREQ(buff->buffArt, "ReplaceableTextures\\CommandButtons\\BTNImmolationOn.blp");
     T_STREQ(buff->buffTip, "Immolation");
+    T_STREQ(buff->targetArt, "TestUI\\Models\\anim_pulse.mdx");
+    T_STREQ(buff->specialArt, "TestUI\\Models\\panel_sprite.mdx");
+    T_STREQ(buff->effectArt, "TestUI\\Models\\quad_sprite.mdx");
+    T_STREQ(buff->missileArt, "TestUI\\Models\\ui_panel.mdx");
 }
 
 TEST(wc3_slk, upgrade_class_column_decodes) {

--- a/games/warcraft-3/game/tests/t_spell.c
+++ b/games/warcraft-3/game/tests/t_spell.c
@@ -177,6 +177,21 @@ TEST(wc3_spell, spell_info_attached_to_ability) {
 	T_EQ((int)abil->spell->target_type, (int)SPELL_TARGET_UNIT);
 }
 
+TEST(wc3_spell, holy_light_rawcode_lookup_is_nul_safe) {
+	DWORD code = MAKEFOURCC('A','H','h','b');
+	spell_info_t const *spell = S_SpellInfoForCode(code);
+	ability_t const *abil = FindAbilityForCommand(GetClassName(code));
+
+	/* Runtime spell dispatch starts from a DWORD rawcode. This specifically
+	 * guards against treating &code as a C string: that only worked when the
+	 * unrelated byte after the four rawcode bytes happened to be zero. */
+	T_NOT_NULL(abil);
+	T_ASSERT(abil->cmd == spell_cmd);
+	T_NOT_NULL(spell);
+	T_EQ((int)spell->code, (int)code);
+	T_EQ((int)spell->target_type, (int)SPELL_TARGET_UNIT);
+}
+
 TEST(wc3_spell, blizzard_is_channel) {
 	ability_t const *abil = FindAbilityByClassname("AHbz");
 	T_NOT_NULL(abil);

--- a/games/warcraft-3/tests/resources-src/Scripts/common.j
+++ b/games/warcraft-3/tests/resources-src/Scripts/common.j
@@ -10,6 +10,8 @@ type widget           extends agent
 type unit             extends widget
 type destructable     extends widget
 type item             extends widget
+type effect           extends agent
+type effecttype       extends handle
 type player           extends agent
 type quest            extends handle
 type questitem        extends handle
@@ -78,6 +80,12 @@ native ConvertGameSpeed      takes integer i returns gamespeed
 native ConvertPlayerState    takes integer i returns playerstate
 native ConvertFogState       takes integer i returns fogstate
 native ConvertUnitType       takes integer i returns unittype
+native ConvertEffectType     takes integer i returns effecttype
+
+// Effect natives used by the independent-handle lifecycle regression.
+native AddSpecialEffect      takes string modelName, real x, real y returns effect
+native AddSpellEffectById    takes integer abilityId, effecttype t, real x, real y returns effect
+native DestroyEffect         takes effect whichEffect returns nothing
 native IsUnitType             takes unit whichUnit, unittype whichUnitType returns boolean
 native SetMapName            takes string name returns nothing
 native SetMapDescription     takes string description returns nothing
@@ -245,4 +253,5 @@ globals
     constant gamespeed MAP_SPEED_FAST = ConvertGameSpeed(3)
     constant playerstate PLAYER_STATE_RESOURCE_GOLD = ConvertPlayerState(1)
     constant unittype UNIT_TYPE_STRUCTURE = ConvertUnitType(2)
+    constant effecttype EFFECT_TYPE_TARGET = ConvertEffectType(1)
 endglobals

--- a/games/warcraft-3/tests/resources-src/Units/AbilityBuffData.slk
+++ b/games/warcraft-3/tests/resources-src/Units/AbilityBuffData.slk
@@ -1,11 +1,24 @@
 ID;PWXL;N;E
-B;X4;Y2;D0
+B;X8;Y3;D0
 C;X1;Y1;K"alias"
 C;X2;K"Buffart"
 C;X3;K"Bufftip"
 C;X4;K"Buffubertip"
+C;X5;K"TargetArt"
+C;X6;K"SpecialArt"
+C;X7;K"EffectArt"
+C;X8;K"Missileart"
 C;X1;Y2;K"Biml"
 C;X2;K"ReplaceableTextures\CommandButtons\BTNImmolationOn.blp"
 C;X3;K"Immolation"
 C;X4;K"Deals damage to nearby enemy units."
+C;X5;K"TestUI\Models\anim_pulse.mdx"
+C;X6;K"TestUI\Models\panel_sprite.mdx"
+C;X7;K"TestUI\Models\quad_sprite.mdx"
+C;X8;K"TestUI\Models\ui_panel.mdx"
+C;X1;Y3;K"Bdef"
+C;X2;K"TestUI\Textures\solid_white.blp"
+C;X3;K"Scroll of Protection"
+C;X4;K"Increases armor temporarily."
+C;X5;K"TestUI\Models\anim_pulse.mdx"
 E

--- a/games/warcraft-3/tests/resources-src/Units/AbilityData.slk
+++ b/games/warcraft-3/tests/resources-src/Units/AbilityData.slk
@@ -1,5 +1,5 @@
 ID;PWXL;N;E
-B;X9;Y8;D0
+B;X14;Y9;D0
 C;X1;Y1;K"alias"
 C;X2;K"code"
 C;X3;K"Data11"
@@ -9,6 +9,11 @@ C;X6;K"Data13"
 C;X7;K"levels"
 C;X8;K"reqLevel"
 C;X9;K"levelSkip"
+C;X10;K"targs"
+C;X11;K"Dur1"
+C;X12;K"HeroDur1"
+C;X13;K"Area1"
+C;X14;K"BuffID1"
 C;X1;Y2;K"AInv"
 C;X2;K"AInv"
 C;X3;K"6"
@@ -39,4 +44,12 @@ C;X2;K"AHhb"
 C;X7;K3
 C;X8;K1
 C;X9;K2
+C;X1;Y9;K"AIda"
+C;X2;K"AIda"
+C;X4;K"2"
+C;X10;K"air,ground,friend,self"
+C;X11;K"30"
+C;X12;K"30"
+C;X13;K"600"
+C;X14;K"Bdef"
 E

--- a/games/warcraft-3/tests/resources-src/Units/HumanAbilityFunc.txt
+++ b/games/warcraft-3/tests/resources-src/Units/HumanAbilityFunc.txt
@@ -5,3 +5,11 @@ Hotkey=G
 Unart=TestUI\Textures\return-resources.blp
 UnButtonpos=3,2
 Unhotkey=R
+
+[AHhb]
+TargetArt=TestUI\Models\anim_pulse.mdx,TestUI\Models\quad_sprite.mdx
+SpecialArt=TestUI\Models\panel_sprite.mdx
+AreaEffectArt=TestUI\Models\ui_panel.mdx
+
+[AIda]
+TargetArt=TestUI\Models\anim_pulse.mdx

--- a/games/warcraft-3/tests/resources-src/Units/ItemData.slk
+++ b/games/warcraft-3/tests/resources-src/Units/ItemData.slk
@@ -1,5 +1,5 @@
 ID;PWXL;N;E
-B;X10;Y4;D0
+B;X12;Y4;D0
 C;X1;Y1;K"itemID"
 C;X2;K"comment"
 C;X3;K"itemClass"
@@ -10,6 +10,8 @@ C;X7;K"abilList"
 C;X8;K"pickRandom"
 C;X9;K"Level"
 C;X10;K"uses"
+C;X11;K"perishable"
+C;X12;K"usable"
 C;X1;Y2;K"ratf"
 C;X2;K"Test Attack Item"
 C;X3;K"Permanent"
@@ -36,7 +38,10 @@ C;X3;K"Charged"
 C;X4;K"TestUI\Models\anim_pulse.mdx"
 C;X5;K"1"
 C;X6;K"32"
+C;X7;K"AIda"
 C;X8;K"FALSE"
 C;X9;K"1"
 C;X10;K"1"
+C;X11;K"TRUE"
+C;X12;K"TRUE"
 E


### PR DESCRIPTION
wc3: implement ability and item effect lifecycle

Add data-driven ability and buff presentation effects with independent
temporary and persistent effect entities and JASS effect handles.

Fix raw FourCC spell dispatch so Holy Light and other unified spells
resolve their spell metadata reliably.

Resolve item abilities from typed ItemData, consume successful charged
uses, remove depleted perishables, and implement Scroll of Protection
area armor behavior using timed statuses.

Migrate existing spell visuals to the common effect resolver, add
coverage for effect lookup and item activation, and document the
remaining Warcraft III effect-system gaps.