### PR TITLE
wc3: stop stale menu UI from swallowing gameplay clicks

### DIFF
--- a/docs/architecture/ui-system.md
+++ b/docs/architecture/ui-system.md
@@ -49,11 +49,13 @@ void SCR_DrawScreenField(DWORD msec) {
 
 **Key rule**: `ui.Refresh()` draws menu/glue screens. When in `ca_active` (gameplay), `SCR_DrawLayout()` draws the in-game HUD via a completely separate path. The UI library's screens only appear when the console key (`key_menu`) is toggled (ESC menu overlay).
 
-Inside `ui.Refresh()` → `UI_RefreshLocal()`, there are three branches:
+Inside `ui.Refresh()` → `UI_RefreshLocal()`, presentation ownership has two independent signals:
 
-1. **Loading** (`playerState_t.client_ui_state == CLIENT_UI_LOADING`): Draws the loading screen. This is checked first and is **not** gated on `game_mode` — `menu_ingame` sets `game_mode` asynchronously through the command buffer, after `SCR_BeginLoadingPlaque` has already frozen the frame that would have drawn the loading screen.
-2. **Menu/glue mode** (`game_mode == false`): Calls current `uiScreen_t->draw()` — main menu, single player, options, LAN lobby, etc.
-3. **Game mode + active** (`game_mode == true` + `CLIENT_UI_GAME`): Does nothing — the in-game HUD is handled entirely by `SCR_DrawLayout()`.
+1. **Loading** (`playerState_t.client_ui_state == CLIENT_UI_LOADING`): Draws the loading screen first. This remains authoritative even if `menu_ingame` has already been queued through the command buffer.
+2. **Standalone menu/glue screen** (`UI_GetCurrentScreen() != NULL`): Calls the current `uiScreen_t->draw()` — main menu, single player, options, LAN lobby, etc.
+3. **No standalone screen** (`UI_GetCurrentScreen() == NULL`): The UI module draws no glue screen. During gameplay the in-game HUD is handled by `SCR_DrawLayout()`.
+
+`ui_current_screen` is the WC3 UI module's ownership token; do not add a parallel `game_mode` boolean. `UI_SetScreen(NULL)` is the handoff from standalone glue/menu presentation to loading/gameplay presentation.
 
 ## Screen Controllers
 
@@ -98,7 +100,7 @@ Navigation is command-driven — buttons in FDF files have `OnClick = "menu_game
 | `menu_game` | Single-player menu |
 | `menu_lan_refresh` | Refresh LAN game list |
 | `menu_startserver` | Create LAN game |
-| `menu_ingame` | Enter game mode (sets `game_mode = true`) |
+| `menu_ingame` | Release the standalone menu screen with `UI_SetScreen(NULL)` |
 
 The startup command is hardcoded: `menu_main` for Warcraft III, `menu_login` for World of Warcraft.
 
@@ -256,11 +258,14 @@ ui.MouseEvent(x, y, button, down);
 ```
 
 `UI_MouseEventLocal()`:
-1. Converts pixel coords to FDF space
-2. Hit tests all interactive frames back-to-front
-3. Updates frame flags (`UIFLAG_HOVERED`, `UIFLAG_PRESSED`)
-4. Dispatches to per-frame `event_handler` (e.g., `UI_ButtonEventHandler`)
-5. Handles globals: editbox focus loss, slider drag, popup close on outside click
+1. In an initialized runtime, returns immediately when there is no current standalone screen
+2. Converts pixel coords to FDF space
+3. Hit tests all interactive frames back-to-front
+4. Updates frame flags (`UIFLAG_HOVERED`, `UIFLAG_PRESSED`)
+5. Dispatches to per-frame `event_handler` (e.g., `UI_ButtonEventHandler`)
+6. Handles globals: editbox focus loss, slider drag, popup close on outside click
+
+The no-screen guard matters because `UI_SetScreen(NULL)` stops drawing the menu but does not clear `ui_render.c`'s last layout cache. Without the ownership check, an invisible stale glue button can consume a gameplay click before `CL_WindowMouseEvent()` and `SCR_LayoutMouseEvent()` see it.
 
 Button clicks execute `UI_MenuCommandLocal(frame->OnClick)`, which routes through the registered menu command table.
 
@@ -268,7 +273,7 @@ Game-mode mouse behavior lives in per-game `cl_input_<game>.c` files. Never crea
 
 ## Loading Screen
 
-The loading screen is owned by the UI library and drawn when `playerState_t.client_ui_state == CLIENT_UI_LOADING` (regardless of `game_mode`). It:
+The loading screen is owned by the UI library and drawn when `playerState_t.client_ui_state == CLIENT_UI_LOADING`, before standalone-screen dispatch. It:
 
 1. Loads `Loading.fdf` frames
 2. Reads map info from `.w3m`/`.w3x` (title, subtitle, custom loading screen model)

--- a/docs/games/warcraft-3/loading-and-assets.md
+++ b/docs/games/warcraft-3/loading-and-assets.md
@@ -27,7 +27,7 @@ TFT has an additional independent schema difference: ROC `LoadingScreens` rows a
 under TFT archives. Fixed ROC indices interpreted HumanX01's sequence `6` as a filename. `UI_ParseLoadingRow`
 consumes the optional numeric category and validates the sequence/model fields; malformed rows log their key.
 
-Preserve the loading-state draw check before `game_mode` dispatch: menu commands are queued asynchronously.
+Preserve the loading-state draw check before standalone-screen dispatch: `menu_ingame` is queued asynchronously, so loading must remain authoritative even after the glue screen is released.
 
 ## Asset names are data
 

--- a/games/warcraft-3/tests/test_ui_fdf.c
+++ b/games/warcraft-3/tests/test_ui_fdf.c
@@ -127,6 +127,12 @@ static int test_fs_read_file(LPCSTR file_name, void **buf) {
     return (int)size;
 }
 
+static int test_missing_fs_read(LPCSTR file_name, void **buf) {
+    (void)file_name;
+    if (buf) *buf = NULL;
+    return -1;
+}
+
 static void test_fs_free_file(void *buf) {
     free(buf);
 }
@@ -1321,6 +1327,53 @@ TEST(ui_fdf, single_line_text_auto_height_uses_fdf_font_size) {
     T_EQ(captured_text_draws, 2);
     T_FEQ(captured_text_rects[0].h, 0.013f, 0.0001f);
     T_FEQ(captured_text_rects[1].h, 0.016f, 0.0001f);
+}
+
+TEST(ui_fdf, gameplay_ignores_stale_glue_hit_test_cache) {
+    uiImport_t saved = uiimport;
+    LPFRAMEDEF root;
+    LPFRAMEDEF button;
+
+    reset_ui_state();
+    uiimport.FS_ReadFile = test_missing_fs_read;
+    uiimport.FS_FreeFile = test_fs_free_file;
+    uiimport.Cvar_String = test_cvar_string;
+    uiimport.Cmd_ExecuteText = test_cmd_execute_text;
+
+    /* A startup map enters the initialized runtime with no standalone screen. */
+    test_map = "Maps\\Campaign\\Human02.w3m";
+    UI_InitLocal();
+
+    parse_fdf("gameplay_input_ownership.fdf",
+              "Frame \"FRAME\" \"InputOwnershipRoot\" {"
+              " Width 0.8, Height 0.6,"
+              " Frame \"GLUETEXTBUTTON\" \"StaleMenuButton\" {"
+              "  Width 0.2, Height 0.1,"
+              "  SetPoint TOPLEFT, \"InputOwnershipRoot\", TOPLEFT, 0.1, -0.1,"
+              " }"
+              "}");
+
+    root = UI_FindFrame("InputOwnershipRoot");
+    button = UI_FindFrame("StaleMenuButton");
+    if (!require_not_null(root) || !require_not_null(button)) {
+        UI_ShutdownLocal();
+        test_map = "";
+        uiimport = saved;
+        return;
+    }
+    UI_SetOnClick(button, "test_stale_menu_click");
+
+    /* Simulate the retained rectangle from the last glue draw. The cache is
+     * still hit-testable internally, but gameplay must not dispatch through it. */
+    UI_DrawFrame(root);
+    T_ASSERT(UI_HitTest(0.15f, 0.15f) != NULL);
+    captured_command[0] = '\0';
+    T_ASSERT(!UI_MouseEventLocal(UI_MOUSE_UP, 188, 144, 1));
+    T_STREQ(captured_command, "");
+
+    UI_ShutdownLocal();
+    test_map = "";
+    uiimport = saved;
 }
 
 TEST(ui_fdf, glue_checkbox_toggles_and_draws_check_highlight) {

--- a/games/warcraft-3/ui/ui_main.c
+++ b/games/warcraft-3/ui/ui_main.c
@@ -565,7 +565,12 @@ BOOL UI_MouseEventLocal(uiMouseEvent_t event, int x, int y, int32_t param) {
     BOOL const up = event == UI_MOUSE_UP;
     BOOL const left = param == 1;
     int const wheel_y = event == UI_MOUSE_SCROLL ? UI_MOUSE_PARAM_Y(param) : 0;
-    if (!ui_state.active) {
+    /* In the initialized runtime, a current screen is the ownership token for
+     * standalone FDF input. Gameplay clears the screen, but ui_render.c keeps
+     * the previous layout cache; never hit-test those stale invisible frames.
+     * Uninitialized unit tests may exercise the low-level FDF event path
+     * directly without installing a screen controller. */
+    if (!ui_state.active || (ui_state.initialized && !UI_GetCurrentScreen())) {
         return false;
     }
 
@@ -809,6 +814,11 @@ void UI_UpdateUnitUILocal(DWORD num_units, uiUnitData_t *units) {
 }
 
 static void UI_UpdateLobbySetupLocal(lobbyState_t const *state) {
+    /* No current standalone screen means loading/gameplay owns presentation;
+     * late lobby packets must not resurrect the game-setup glue screen. */
+    if (!UI_GetCurrentScreen()) {
+        return;
+    }
     UI_SetScreen(&gameSetupScreen);
     GameSetup_UpdateLobbySetup(state);
 }


### PR DESCRIPTION
Ignore standalone FDF mouse hit-testing while game mode is active so server-authored Warcraft HUD and window controls receive mouse events.

Add regression coverage for stale menu layout state and document the gameplay input-routing boundary.