### PR TITLE
client: keep UI DLL out of gameplay path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,6 @@ Key principles inline:
 - An in-game `ui.dll` exception is allowed only when `svc_layout`, replicated state/configstrings, and generic client layout bindings
   demonstrably cannot represent the feature. Mark the implementation at the call site with `/* HACK: */` and explain that specific
   constraint. Convenience, per-game styling, or client-local mouse/projection state are not sufficient reasons for an exception.
-- Existing WoW `DrawGameOverlay` users predate this rule and are migration debt; do not copy or extend that pattern for new work.
 - Do not add UI import callbacks for mouse polling, loading state polling, layout decoding, or map-info helpers. Use pushed events, `DrawLoadingScreen(map, status, progress)`, client-owned layout functions, and direct `CM_*` calls inside the UI module.
 - Loading-screen ownership stays with `ca_loading`. The client may only enter `ca_active` from `CL_PrepRefresh()` after all required assets are registered.
 

--- a/client/cl_input.c
+++ b/client/cl_input.c
@@ -149,7 +149,7 @@ void CL_Input(void) {
                 mouse.origin.x = event.button.x;
                 mouse.origin.y = event.button.y;
                 mouse.button = event.button.button;
-                if (ui.MouseEvent(UI_MOUSE_DOWN, event.button.x, event.button.y, event.button.button)) {
+                if (cls.key_dest == key_menu && ui.MouseEvent(UI_MOUSE_DOWN, event.button.x, event.button.y, event.button.button)) {
                     break;
                 }
                 if (CL_WindowMouseEvent(UI_MOUSE_DOWN, event.button.x, event.button.y, event.button.button)) break;
@@ -172,7 +172,7 @@ void CL_Input(void) {
                 mouse.origin.x = event.button.x;
                 mouse.origin.y = event.button.y;
                 mouse.button = 0;
-                if (ui.MouseEvent(UI_MOUSE_UP, event.button.x, event.button.y, event.button.button)) {
+                if (cls.key_dest == key_menu && ui.MouseEvent(UI_MOUSE_UP, event.button.x, event.button.y, event.button.button)) {
                     break;
                 }
                 if (CL_WindowMouseEvent(UI_MOUSE_UP, event.button.x, event.button.y, event.button.button)) break;
@@ -194,7 +194,8 @@ void CL_Input(void) {
             case SDL_MOUSEMOTION:
                 mouse.origin.x = event.motion.x;
                 mouse.origin.y = event.motion.y;
-                ui.MouseEvent(UI_MOUSE_MOVE, event.motion.x, event.motion.y, 0);
+                if (cls.key_dest == key_menu)
+                    ui.MouseEvent(UI_MOUSE_MOVE, event.motion.x, event.motion.y, 0);
                 if (CL_WindowMouseEvent(UI_MOUSE_MOVE, event.motion.x, event.motion.y, 0)) break;
                 SCR_LayoutMouseEvent(UI_MOUSE_MOVE, event.motion.x, event.motion.y, 0);
                 if (cls.key_dest == key_menu) {
@@ -206,7 +207,8 @@ void CL_Input(void) {
                 {
                     int x, y;
                     SDL_GetMouseState(&x, &y);
-                    ui.MouseEvent(UI_MOUSE_SCROLL, x, y, UI_MOUSE_PARAM(event.wheel.x, event.wheel.y));
+                    if (cls.key_dest == key_menu)
+                        ui.MouseEvent(UI_MOUSE_SCROLL, x, y, UI_MOUSE_PARAM(event.wheel.x, event.wheel.y));
                     if (CL_WindowMouseEvent(UI_MOUSE_SCROLL, x, y, UI_MOUSE_PARAM(event.wheel.x, event.wheel.y))) break;
                     SCR_LayoutMouseEvent(UI_MOUSE_SCROLL, x, y, UI_MOUSE_PARAM(event.wheel.x, event.wheel.y));
                 }

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -649,6 +649,31 @@ void SCR_LayoutDrawBuildQueue(LPCUIFRAME frame, LPCRECT scrn) {
     }
 }
 
+static void SCR_LayoutDrawMessageQueue(LPCUIFRAME frame, LPCRECT screen) {
+    uiMessageQueue_t const *message = frame->buffer.data;
+    RECT uv = MAKE(RECT, 0, 0, 0.53125f, 0.6875f);
+    if (!message || frame->buffer.size < sizeof(*message)) {
+        fprintf(stderr, "SCR_LayoutDrawMessageQueue: invalid payload size %u\n", (unsigned)frame->buffer.size);
+        return;
+    }
+    if (message->flags & UI_MESSAGE_UNREAD) {
+        LPCTEXTURE icon = SCR_LayoutPic(message->image);
+        if (icon) re.DrawImage(icon, screen, &uv, COLOR32_WHITE);
+    }
+    if (message->flags & UI_MESSAGE_OPEN) {
+        RECT title = MAKE(RECT, screen->x + 0.04f, screen->y + 0.02f, screen->w - 0.08f, 0.04f);
+        RECT body = MAKE(RECT, screen->x + 0.06f, screen->y + 0.07f, screen->w - 0.12f, screen->h - 0.09f);
+        re.DrawFill(screen, MAKE(COLOR32, 10, 8, 5, 245));
+        re.DrawText(&MAKE(drawText_t, .font = cl.fonts[message->title_font], .text = frame->text,
+                          .rect = title, .color = MAKE(COLOR32, 255, 215, 120, 255),
+                          .textWidth = title.w, .halign = FONT_JUSTIFYCENTER, .valign = FONT_JUSTIFYMIDDLE));
+        re.DrawText(&MAKE(drawText_t, .font = cl.fonts[message->body_font], .text = frame->tooltip,
+                          .rect = body, .color = MAKE(COLOR32, 240, 230, 205, 255),
+                          .textWidth = body.w, .lineHeight = body.h, .flags = DRAW_WORD_WRAP,
+                          .halign = FONT_JUSTIFYLEFT, .valign = FONT_JUSTIFYTOP));
+    }
+}
+
 void SCR_LayoutUpdateBuildQueue(LPCUIFRAME frame, LPCRECT screen) {
     uiBuildQueue_t const *queue = frame->buffer.data;
     LPUIFRAME buildtimer = SCR_Frame(queue->buildtimer);
@@ -955,6 +980,7 @@ static drawer_t drawers[] = {
     { FT_PORTRAIT,       SCR_LayoutDrawPortrait },
     { FT_MINIMAP,        CL_LayoutDrawMinimap },
     { FT_BUILDQUEUE,     SCR_LayoutDrawBuildQueue },
+    { FT_MESSAGE_QUEUE,  SCR_LayoutDrawMessageQueue },
     { FT_MULTISELECT,    SCR_LayoutDrawMultiSelect },
     { FT_CHECKBOX,       SCR_LayoutCheckBox },
     { FT_GLUECHECKBOX,   SCR_LayoutCheckBox },
@@ -1187,6 +1213,7 @@ static BOOL SCR_LayoutSelectionBlockerType(FRAMETYPE type) {
         case FT_PORTRAIT:
         case FT_MINIMAP:
         case FT_BUILDQUEUE:
+        case FT_MESSAGE_QUEUE:
         case FT_MULTISELECT:
         case FT_CHECKBOX:
         case FT_GLUECHECKBOX:

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -155,7 +155,6 @@ void SCR_DrawScreenField(DWORD msec) {
         V_RenderView();
         if (Cvar_Integer("r_hud", 1)) {
             SCR_DrawLayout();
-            if (ui.DrawGameOverlay) ui.DrawGameOverlay();
         }
         /* TODO: research whether to replace key_dest enum with a keyCatchers bitmask
         * like Q3 — multiple input consumers can be active simultaneously. */

--- a/client/ui.h
+++ b/client/ui.h
@@ -197,7 +197,6 @@ typedef struct {
     void (*UpdateUnitUI)(DWORD num_units, uiUnitData_t *units);
     void (*UpdateLobbySetup)(lobbyState_t const *state);
     uiGameCommand_t GameCommand;
-    void (*DrawGameOverlay)(void);
 
     /* Resolve a Warcraft-specific symbolic image key for the local player. */
     LPCSTR (*ResolveImagePath)(LPCSTR key);

--- a/common/shared.h
+++ b/common/shared.h
@@ -785,6 +785,7 @@ typedef enum {
     FT_STRINGLIST,
     // custom types
     FT_BUILDQUEUE,
+    FT_MESSAGE_QUEUE,
     FT_MULTISELECT,
     FT_TOOLTIPTEXT,
     FT_MINIMAP,
@@ -897,6 +898,17 @@ typedef struct {
     USHORT numitems;
     uiBuildQueueItem_t items[];
 } uiBuildQueue_t;
+
+typedef struct {
+    DWORD message_id;
+    RESOURCE image;
+    RESOURCE title_font;
+    RESOURCE body_font;
+    BYTE flags;
+} uiMessageQueue_t;
+
+#define UI_MESSAGE_UNREAD (1u << 0) // flag bit; server marks an unread message; used by FT_MESSAGE_QUEUE
+#define UI_MESSAGE_OPEN   (1u << 1) // flag bit; server marks the message panel; used by FT_MESSAGE_QUEUE
 
 typedef struct {
     RESOURCE hp_bar;

--- a/docs/architecture/client-windows.md
+++ b/docs/architecture/client-windows.md
@@ -22,6 +22,10 @@ change together. Closing the focused window focuses the new tail.
 `SCR_DrawLayout()` draws persistent layout layers first and then calls `CL_WindowDraw()`, placing transient windows above the
 HUD. Parsing and retaining `svc_window` does not make a window visible by itself; the screen layout pass owns submission.
 
+The legacy `ui.dll` is a menu module, following the Quake II `key_dest` split: `cl_scrn.c` refreshes it only for `key_menu`,
+and `cl_input.c` forwards its keyboard/mouse events only for `key_menu`. The active-game pass draws server-authored layout and
+windows through `SCR_DrawLayout()`/`CL_WindowDraw()`; it must not call a UI-DLL game overlay or send UI-DLL input.
+
 `UI_WINDOW_MODAL`, `UI_WINDOW_NO_PAUSE`, and `UI_WINDOW_UNIQUE` are independent. Modal means the topmost modal window consumes
 input outside its bounds. `NO_PAUSE` means that modal does not acquire the client-owned simulation pause. Unique means only one
 instance of that class may exist. Inventory and quest-detail windows can be unique without being modal; confirmation-style

--- a/docs/architecture/client-windows.md
+++ b/docs/architecture/client-windows.md
@@ -26,6 +26,10 @@ The legacy `ui.dll` is a menu module, following the Quake II `key_dest` split: `
 and `cl_input.c` forwards its keyboard/mouse events only for `key_menu`. The active-game pass draws server-authored layout and
 windows through `SCR_DrawLayout()`/`CL_WindowDraw()`; it must not call a UI-DLL game overlay or send UI-DLL input.
 
+WoW incoming messages use `FT_MESSAGE_QUEUE` on `LAYER_MESSAGE`. The server emits one compact record per unread message and,
+when selected, one additional record carrying the server-owned popup text. `cl_scrn.c` draws both the unread icon pool and the
+popup; clicks send `message_open <id>` or `message_close` back to the server, which updates the authoritative layer.
+
 `UI_WINDOW_MODAL`, `UI_WINDOW_NO_PAUSE`, and `UI_WINDOW_UNIQUE` are independent. Modal means the topmost modal window consumes
 input outside its bounds. `NO_PAUSE` means that modal does not acquire the client-owned simulation pause. Unique means only one
 instance of that class may exist. Inventory and quest-detail windows can be unique without being modal; confirmation-style

--- a/docs/architecture/ui-system.md
+++ b/docs/architecture/ui-system.md
@@ -10,7 +10,7 @@ The UI library communicates with the client through two vtables:
 `.FS_ReadFile`, `.MemAlloc`, `.Cmd_ExecuteText`, `.GetPlayerState`, renderer/sound access, and font/texture indexing.
 
 **`uiExport_t`** — functions the UI library exposes to the client:
-`.Init`, `.Shutdown`, `.Refresh`, `.KeyEvent`, `.TextInput`, `.MouseEvent`, `.UpdateUnitUI`, `.UpdateLobbySetup`, plus optional game-owned hooks such as `.GameCommand` and `.DrawGameOverlay`. Generic gameplay systems such as minimap input and transient markers stay in `client/`, not in the menu UI module.
+`.Init`, `.Shutdown`, `.Refresh`, `.KeyEvent`, `.TextInput`, `.MouseEvent`, `.UpdateUnitUI`, `.UpdateLobbySetup`, plus the optional `.GameCommand` hook. Generic gameplay systems such as minimap input and transient markers stay in `client/`, not in the menu UI module.
 
 The client creates both at startup in `CL_Init`:
 
@@ -38,8 +38,6 @@ void SCR_DrawScreenField(DWORD msec) {
     case ca_active:
         V_RenderView();          // 3D world
         SCR_DrawLayout();        // server-authored in-game HUD
-        if (ui.DrawGameOverlay)
-            ui.DrawGameOverlay();// narrow game-owned overlay exceptions
         if (cls.key_dest == key_menu)
             ui.Refresh(cl.time); // ESC menu overlay
         break;
@@ -49,7 +47,7 @@ void SCR_DrawScreenField(DWORD msec) {
 }
 ```
 
-**Key rule**: `ui.Refresh()` draws menu/glue screens. When in `ca_active` (gameplay), `SCR_DrawLayout()` draws the in-game HUD via a completely separate path. `ui.DrawGameOverlay()` is an optional narrow overlay hook for presentation that cannot be represented by `svc_layout`; it must not become a second general HUD. The UI library's screens only appear when the console key (`key_menu`) is toggled (ESC menu overlay).
+**Key rule**: `ui.Refresh()` draws menu/glue screens. When in `ca_active` (gameplay), `SCR_DrawLayout()` draws the in-game HUD via a completely separate path. The UI library's screens only appear when the console key (`key_menu`) is toggled (ESC menu overlay).
 
 Inside `ui.Refresh()` → `UI_RefreshLocal()`, there are three branches:
 

--- a/docs/architecture/ui-unified-rendering.md
+++ b/docs/architecture/ui-unified-rendering.md
@@ -70,7 +70,7 @@ Once no UI lib calls `GetRenderer()`, remove it from the import table. This enfo
 
 1. **SC2** — already done (UI lib is a stub, all HUD via `svc_layout`).
 2. **WC3** — add `SetLayout` import, rewrite `ui_render.c` to serialize instead of draw. Menu and HUD unify under `SCR_DrawLayout()`.
-3. **WoW** — same as WC3. WoW's Lua-driven `DrawGameOverlay` path needs a separate assessment.
+3. **WoW** — same as WC3; in-game presentation follows the client/server-authored gameplay path.
 
 ## What UI Libs Retain
 

--- a/docs/games/world-of-warcraft/message-inbox-ui.md
+++ b/docs/games/world-of-warcraft/message-inbox-ui.md
@@ -1,13 +1,12 @@
-# Client-rendered message inbox UI
+# Server-authored message inbox UI
 
 ## Decision
 
-Quest completion messages and similar bottom-of-screen notifications should use a
-server-owned data model with client-owned presentation. The server decides which
-message exists, its stable ID, recipient, text/content references, and read state.
-The client receives a bounded inbox payload over `svc_gamecmd`, stores it in the
-WoW UI module, and renders notification icons and message windows through the
-existing Lua/FDF UI path.
+Quest completion messages and similar notifications use a server-owned data model
+and a server-authored UI control. The server decides which message exists, its
+stable ID, recipient, text, and read state. It sends a bounded `FT_MESSAGE_QUEUE`
+frame on `LAYER_MESSAGE`; `cl_scrn` draws the unread notification controls and the
+selected message window.
 
 The server must not send absolute window coordinates or a complete UI frame tree
 for this feature. Positions, scaling, input hit-testing, stacking, and window
@@ -16,36 +15,29 @@ protocol.
 
 ## Why this matches the engine
 
-- `svc_gamecmd` is already a reliable server-to-client channel for typed game
-  payloads and is separate from snapshot/network-contract structs.
-- The current WoW HUD is drawn by the client UI library, while server code still
-  emits `svc_layout` frames for quest dialogs and the HUD. The inbox is a useful
-  migration target away from server-positioned frames.
-- Quake 3's reliable server commands are the closest lifecycle analogue: durable
-  UI events must not depend on a particular snapshot arriving, while movement and
-  continuously changing state remain snapshot-like.
+- `FT_MESSAGE_QUEUE` follows the existing `FT_BUILDQUEUE` special-control pattern:
+  the server supplies bounded data and the client screen renderer owns pixels.
+- The message control is part of the same `svc_layout` stream as the server-owned
+  WoW HUD and quest dialog, so it is redrawn with the authoritative UI state.
 - Inventory should use the same split: server-authoritative item IDs/counts and
   permissions; client-owned bag/equipment window layout and drag/drop visuals.
   Client actions remain requests validated by the server.
 
-## Proposed payload
+## Payload
 
-The first protocol version is a bounded full snapshot, not a stream of individual
-notifications. A snapshot is idempotent, easy to resend after reconnect/map load,
-and avoids client/server divergence when several quest rewards arrive together.
+Each visible message is one bounded `FT_MESSAGE_QUEUE` frame. The server emits all
+unread records and the currently open record, making the layer idempotent and easy
+to resend after reconnect, map load, or other HUD refreshes.
 
 Each message record should contain only gameplay data needed by the client:
 
 | Field | Owner | Purpose |
 | --- | --- | --- |
 | `message_id` | server | Stable per-character ID used by UI actions |
-| `kind` | server | Quest reward, system, mail, etc. |
-| `flags` | server | Unread/urgent/has-choice state |
-| `sender_key` | server/data | Localization or display identity |
-| `title_key` | server/data | Localizable title |
-| `body_key` + parameters | server/data | Localizable body/content |
-| `quest_id` / `item_id` | server | Optional semantic links |
-| `created_time` | server | Ordering and display metadata |
+| `image` | server/data | Notification art resource |
+| `title_font` / `body_font` | server/data | Text resources |
+| `flags` | server | Unread/open state |
+| `text` / `tooltip` | server | Title and body strings |
 
 Prefer bounded IDs and data keys over arbitrary client-executable text. If the
 initial implementation needs literal text for tests, keep it length-delimited and
@@ -54,38 +46,24 @@ validate its maximum length at the protocol boundary.
 ## Interaction contract
 
 1. Server creates or updates a record after the authoritative quest/reward event.
-2. Server sends the current inbox snapshot through `svc_gamecmd`.
-3. Client stores the records and draws one notification icon per unread record,
-   capped by a client layout limit.
-4. Clicking an icon opens the client-positioned message window.
-5. Client sends a semantic command containing only the message ID.
-6. Server validates ownership/state, marks the record read if appropriate, and
-   sends a refreshed snapshot.
+2. Server emits the current `LAYER_MESSAGE` controls through `svc_layout`.
+3. `cl_scrn` draws one notification icon per unread record and the open panel.
+4. Clicking an icon sends `message_open <id>`; closing sends `message_close`.
+5. Server validates the ID, owns open/read state, and emits refreshed controls.
 
 Opening a window is a presentation action; accepting a reward, claiming an item,
 or acknowledging a quest consequence remains server-authoritative.
 
 ## Implementation plan
 
-### Phase 1 — transport and data model
-
-- Add a generic game-command callback from the client parser to `uiExport_t` so
-  game-specific payloads do not become engine-specific branches.
-- Add a WoW inbox payload schema and bounded parser in the WoW UI module.
-- Add server-side per-client message records and a helper that sends a full
-  snapshot through the existing game-command transport.
-- Add tests for round-trip parsing, truncation/rejection, duplicate IDs, and
-  idempotent replacement.
-
-### Phase 2 — first visible slice
+### Phase 1 — first visible slice
 
 - Create one message when a quest is rewarded.
-- Expose `ow3.messages()` to the existing Lua HUD.
-- Render unread notification squares at a client-owned bottom-screen anchor and
-  open a client-owned message window on click.
-- Add tests for reward → inbox payload and read command validation.
+- Emit it as an `FT_MESSAGE_QUEUE` frame on `LAYER_MESSAGE`.
+- Render unread notification icons and the selected message panel in `cl_scrn`.
+- Validate `message_open <id>` and `message_close` on the server.
 
-### Phase 3 — reusable client windows
+### Phase 2 — reusable client windows
 
 - Introduce a small client-side window registry with IDs, anchors, modal state,
   and z-order. Keep layout in Lua/FDF rather than in game C.
@@ -114,14 +92,11 @@ or acknowledging a quest consequence remains server-authoritative.
 
 Implemented in the current tree:
 
-- generic `svc_gamecmd` dispatch into `uiExport_t.GameCommand`;
-- bounded version-1 `wow_inbox` snapshots with up to eight records;
-- quest reward → unread inbox record and client-begin snapshot delivery;
-- server-validated `message_read <id>` handling;
-- runtime notification strip using the native `TutorialFrameAlert` art, 34x42 crop, bottom-55 anchor, and 36px stride from
-  `TutorialFrame.xml`/`TutorialFrame.lua`;
-- runtime message panel for the project-specific inbox model; classic WoW has no FrameXML window for this server payload;
-- regression coverage for reward delivery and read-state changes.
+- `FT_MESSAGE_QUEUE` controls on `LAYER_MESSAGE`;
+- quest reward → unread server message record;
+- `cl_scrn` notification icon and message panel drawing;
+- server-owned open/read state and `message_open`/`message_close` commands;
+- regression coverage for reward delivery and open/close state changes.
 
 ## Tutorial tips
 

--- a/games/starcraft-2/game.mk
+++ b/games/starcraft-2/game.mk
@@ -7,7 +7,8 @@ UI_SC2_LIB       := $(LIB_DIR)/libui-sc2$(LIB_EXT)
 SC2_BINARY       := $(BIN_DIR)/opensc2$(EXE_EXT)
 SC2_COMMON_SRCS  := $(shell find $(SC2_DIR)/common -name '*.c' 2>/dev/null | sort)
 
-SC2_CFLAGS       := $(CFLAGS) -I$(SC2_DIR) -DSC2 -DOW3_LOAD_ALL_MPQS -Wno-unused-function -DBZ_GAME=\"starcraft-2\" -DUSE_SHADOWMAPS -DSC2_DEFAULT_MAP=\"Maps/Campaign/TRaynor01.SC2Map\"
+SC2_DEBUG_CFLAGS ?=
+SC2_CFLAGS       := $(CFLAGS) $(SC2_DEBUG_CFLAGS) -I$(SC2_DIR) -DSC2 -DOW3_LOAD_ALL_MPQS -Wno-unused-function -DBZ_GAME=\"starcraft-2\" -DUSE_SHADOWMAPS -DSC2_DEFAULT_MAP=\"Maps/Campaign/TRaynor01.SC2Map\"
 SC2_IMPL_CFLAGS  := $(SC2_CFLAGS) -DSTB_SC2LAYOUT_IMPLEMENTATION -DSTB_SC2LAYOUT_GLOBALS
 SC2_TEST_CFLAGS  := $(SC2_CFLAGS) -I. -Itests -Icommon -Ishared -DTEST_SC2_MPQ=\"build/tests/test-sc2.SC2Maps\"
 

--- a/games/starcraft-2/game/g_sc2.c
+++ b/games/starcraft-2/game/g_sc2.c
@@ -305,9 +305,11 @@ static void SC2_UpdateCamera(void) {
     if (!duration || now >= sc2_level.camera.end_time) {
         SC2_WriteCamera(&b->origin, &b->angles, b->distance, b->fov);
         if (duration && sc2_level.camera.log_stage < 2) {
+#ifdef SC2_DEBUG_CUTSCENE
             FLOAT ground = CM_GetHeightAtPoint(b->origin.x, b->origin.y), eye_z = SC2_CameraEyeZ(b);
             fprintf(stderr, "SC2 camera move: end t=1.00 target=(%.2f %.2f) terrain=%.2f eye_z=%.2f clearance=%.2f pitch=%.2f yaw=%.2f dist=%.2f\n",
                 b->origin.x, b->origin.y, ground, eye_z, eye_z - ground, b->angles.x, b->angles.y, b->distance);
+#endif
             sc2_level.camera.log_stage = 2;
         }
         return;
@@ -320,9 +322,11 @@ static void SC2_UpdateCamera(void) {
     cur.fov = LerpNumber(a->fov, b->fov, k);
     SC2_WriteCamera(&cur.origin, &cur.angles, cur.distance, cur.fov);
     if (k >= 0.5f && !sc2_level.camera.log_stage) {
+#ifdef SC2_DEBUG_CUTSCENE
         FLOAT ground = CM_GetHeightAtPoint(cur.origin.x, cur.origin.y), eye_z = SC2_CameraEyeZ(&cur);
         fprintf(stderr, "SC2 camera move: mid t=%.2f target=(%.2f %.2f) terrain=%.2f eye_z=%.2f clearance=%.2f pitch=%.2f yaw=%.2f dist=%.2f\n",
             k, cur.origin.x, cur.origin.y, ground, eye_z, eye_z - ground, cur.angles.x, cur.angles.y, cur.distance);
+#endif
         sc2_level.camera.log_stage = 1;
     }
 }
@@ -338,6 +342,7 @@ static void SC2_GalaxySetCamera(float target_x, float target_y,
     sc2_level.camera.end_time = sc2_level.camera.start_time + (DWORD)(MAX(0.0f, duration) * 1000.0f);
     sc2_level.camera.log_stage = duration > 0.0f ? 0 : 2;
     SC2_UpdateCamera();
+#ifdef SC2_DEBUG_CUTSCENE
     if (duration > 0.0f) {
         FLOAT ground = CM_GetHeightAtPoint(sc2_level.camera.old.origin.x, sc2_level.camera.old.origin.y);
         FLOAT eye_z = SC2_CameraEyeZ(&sc2_level.camera.old);
@@ -347,6 +352,7 @@ static void SC2_GalaxySetCamera(float target_x, float target_y,
         fprintf(stderr, "SC2_GalaxySetCamera: target=(%.1f,%.1f) yaw=%.1f pitch=%.1f dist=%.1f fov=%.1f height=%.2f duration=%.2f\n",
             target_x, target_y, yaw, pitch, dist, fov, height_offset, duration);
     }
+#endif
 }
 
 static void SC2_GalaxyCinematicMode(BOOL enable, float duration) {
@@ -443,6 +449,12 @@ static BOOL SC2_GalaxyUnitIsAlive(void *ent_ptr) {
 }
 
 static void SC2_GalaxyUnitMove(void *ent_ptr, float x, float y) {
+#ifdef SC2_DEBUG_CUTSCENE
+    LPEDICT ent = (LPEDICT)ent_ptr;
+    fprintf(stderr, "SC2 dropship/order move: unit=%u from=(%.2f,%.2f,%.2f) to=(%.2f,%.2f)\n",
+            (unsigned)SC2_EdictNumber(ent), ent ? ent->s.origin.x : 0.0f, ent ? ent->s.origin.y : 0.0f,
+            ent ? ent->s.origin.z : 0.0f, x, y);
+#endif
     SC2_OrderMove((LPEDICT)ent_ptr, &(VECTOR2){ x, y });
 }
 
@@ -654,6 +666,28 @@ static void SC2_RunFrame(void) {
     if (sc2_level.vm && sc2_level.scriptsStarted)
         galaxy_tick(sc2_level.vm);
     SC2_UpdateCamera();
+
+#ifdef SC2_DEBUG_CUTSCENE
+    {
+        static DWORD trace_frame;
+        LPEDICT dropship = sc2_gunit_n ? (LPEDICT)sc2_gunits[0] : NULL;
+        trace_frame++;
+        if (trace_frame % 5 == 0) {
+            VECTOR3 const cam = sc2_clients[0].ps.viewangles;
+            fprintf(stderr, "SC2 cutscene trace: frame=%u camera=(%.2f,%.2f) pitch=%.2f yaw=%.2f dist=%.2f height=%.2f",
+                    (unsigned)trace_frame, sc2_clients[0].ps.origin.x, sc2_clients[0].ps.origin.y,
+                    cam.x, cam.y, (double)sc2_clients[0].ps.distance, cam.z);
+            if (dropship) {
+                DWORD number = SC2_EdictNumber(dropship);
+                fprintf(stderr, " dropship=(%.2f,%.2f,%.2f) moving=%d target=(%.2f,%.2f) flying=%d height=%.2f",
+                        dropship->s.origin.x, dropship->s.origin.y, dropship->s.origin.z,
+                        sc2_move[number].moving, sc2_move[number].target.x, sc2_move[number].target.y,
+                        sc2_move[number].flying, sc2_move[number].height);
+            }
+            fputc('\n', stderr);
+        }
+    }
+#endif
 
     FOR_LOOP(i, globals.num_edicts) {
         if (sc2_edicts[i].inuse)

--- a/games/starcraft-2/game/g_sc2.c
+++ b/games/starcraft-2/game/g_sc2.c
@@ -580,6 +580,9 @@ static bool SC2_LoadMap(LPCSTR mapFilename) {
     /* Open Galaxy VM and load map scripts. */
     if (sc2_level.vm) { galaxy_close(sc2_level.vm); sc2_level.vm = NULL; }
     sc2_level.scriptsStarted = false;
+    /* SC2Map archives contain MapScript.galaxy below the map directory; use that
+     * authoritative path before the development-only extracted-script fallback. */
+    galaxy_set_script_dir(mapFilename);
     sc2_level.vm = galaxy_open(gi.ReadFile, gi.GetTime, gi.MemAlloc, gi.MemFree);
     if (sc2_level.vm)
         galaxy_start(sc2_level.vm);  /* registers triggers via InitMap() */

--- a/games/starcraft-2/game/galaxy/galaxy_host.c
+++ b/games/starcraft-2/game/galaxy/galaxy_host.c
@@ -478,7 +478,9 @@ static DWORD sc2_CinematicMode(LPJASS j) {
 static DWORD sc2_CinematicFade(LPJASS j) {
     BOOL  fadein = jass_checkboolean(j, 1);
     FLOAT dur    = jass_checknumber(j, 2);
+#ifdef SC2_DEBUG_CUTSCENE
     fprintf(stderr, "CinematicFade: fadein=%d dur=%.1f\n", fadein, dur);
+#endif
     if (sc2_galaxy_on_fade) sc2_galaxy_on_fade(fadein ? 0.0f : 1.0f, dur);
     return jass_pushnull(j);
 }

--- a/games/starcraft-2/game/galaxy/galaxy_host.h
+++ b/games/starcraft-2/game/galaxy/galaxy_host.h
@@ -76,4 +76,8 @@ extern void (*sc2_galaxy_unit_move)(void *ent, float x, float y);
 extern BOOL (*sc2_galaxy_unit_is_moving)(void *ent);
 extern BOOL (*sc2_galaxy_unit_is_alive)(void *ent);
 
+/* Debug-only state inspection for bounded cinematic traces. */
+extern void *sc2_gunits[];
+extern DWORD sc2_gunit_n;
+
 #endif

--- a/games/warcraft-3/ui/ui_main.c
+++ b/games/warcraft-3/ui/ui_main.c
@@ -17,7 +17,6 @@ uiImport_t uiimport;
 typedef struct {
     BOOL initialized;
     BOOL active;
-    BOOL game_mode;
     DWORD time;
     VECTOR2 mouse_fdf;
 } uiState_t;
@@ -33,7 +32,7 @@ LPCSTR UI_ResolveImagePathLocal(LPCSTR key) {
     return Theme_String(key, "Default");
 }
 
-static void UI_EnterGameMode(void);
+static void UI_ClearScreen(void);
 
 static BOOL UI_IsMapCommand(LPCSTR command) {
     if (!command) {
@@ -67,10 +66,6 @@ static uiLoadingState_t loading_state;
 
 static void UI_SetScreen(uiScreen_t *screen) {
     uiScreen_t *previous_screen = ui_current_screen;
-
-    if (screen) {
-        ui_state.game_mode = false;
-    }
 
     if (ui_current_screen == screen) {
         return;
@@ -259,12 +254,12 @@ static void UI_MenuLANJoin_f(void) {
 
 static void UI_MenuGameSetupStart_f(void) {
     if (GameSetup_StartGame()) {
-        UI_EnterGameMode();
+        UI_ClearScreen();
     }
 }
 
 static void UI_MenuInGame_f(void) {
-    UI_EnterGameMode();
+    UI_ClearScreen();
 }
 
 typedef struct {
@@ -311,8 +306,7 @@ static void UI_RegisterMenuCommands(void) {
     ui_menu_commands_registered = true;
 }
 
-static void UI_EnterGameMode(void) {
-    ui_state.game_mode = true;
+static void UI_ClearScreen(void) {
     UI_SetScreen(NULL);
 }
 
@@ -491,7 +485,7 @@ void UI_InitLocal(void) {
         ? uiimport.Cvar_String("map", "")
         : "";
     if (map && *map) {
-        UI_EnterGameMode();
+        UI_ClearScreen();
         return;
     }
 
@@ -522,21 +516,15 @@ void UI_RefreshLocal(DWORD time) {
         screen->refresh((int)time);
     }
 
-    /* Draw the loading screen whenever the server reports CLIENT_UI_LOADING.
-     * Do not gate on game_mode: menu_ingame sets it asynchronously through the
-     * command buffer, after SCR_BeginLoadingPlaque has already frozen the frame
-     * that would have drawn the loading screen. */
+    /* Draw the loading screen whenever the server reports CLIENT_UI_LOADING. */
     LPCPLAYER ps = uiimport.GetPlayerState();
     if (ps && ps->client_ui_state == CLIENT_UI_LOADING) {
         UI_DrawLoadingScreenLocal();
         return;
     }
 
-    /* Draw current screen (menus/glue only — in-game HUD is server-authored via svc_layout) */
-    if (!ui_state.game_mode) {
-        if (screen && screen->draw)
-            screen->draw();
-    }
+    if (screen && screen->draw)
+        screen->draw();
 }
 
 void UI_KeyEventLocal(int key, BOOL down, DWORD time) {
@@ -803,7 +791,7 @@ void UI_MenuCommandLocal(LPCSTR command) {
     }
 
     if (UI_IsMapCommand(command)) {
-        UI_EnterGameMode();
+        UI_ClearScreen();
     }
     uiimport.Cmd_ExecuteText(command);
 }
@@ -821,9 +809,6 @@ void UI_UpdateUnitUILocal(DWORD num_units, uiUnitData_t *units) {
 }
 
 static void UI_UpdateLobbySetupLocal(lobbyState_t const *state) {
-    if (ui_state.game_mode) {
-        return;
-    }
     UI_SetScreen(&gameSetupScreen);
     GameSetup_UpdateLobbySetup(state);
 }

--- a/games/world-of-warcraft/game/g_ui.c
+++ b/games/world-of-warcraft/game/g_ui.c
@@ -400,6 +400,50 @@ static void UI_WriteImage(LPCSTR path, FLOAT x, FLOAT y, FLOAT w, FLOAT h, COLOR
     UI_WriteImageUV(path, x, y, w, h, 0.0f, 1.0f, 0.0f, 1.0f, color);
 }
 
+/* Draw the server-owned unread message pool and its selected message panel. */
+void UI_WriteWowMessageQueue(LPEDICT ent) {
+    wowClient_t *wc = ent ? (wowClient_t *)ent->client : NULL;
+    uiMessageQueue_t queue = {0};
+    char command[64];
+    DWORD unread = 0;
+
+    if (!wc) return;
+    UI_WriteStart(LAYER_MESSAGE);
+    FOR_LOOP(i, wc->message_count) {
+        wowUiMessage_t const *message = &wc->messages[i];
+        if (!(message->flags & WOW_UI_MESSAGE_UNREAD) && message->message_id != wc->message_open_id) continue;
+        queue = (uiMessageQueue_t){
+            .message_id = message->message_id,
+            .image = gi.ImageIndex("Interface\\TutorialFrame\\TutorialFrameAlert"),
+            .title_font = gi.FontIndex("Fonts\\FRIZQT__.TTF", 16),
+            .body_font = gi.FontIndex("Fonts\\FRIZQT__.TTF", 12),
+            .flags = (message->flags & WOW_UI_MESSAGE_UNREAD ? UI_MESSAGE_UNREAD : 0) |
+                     (message->message_id == wc->message_open_id ? UI_MESSAGE_OPEN : 0),
+        };
+        uiFrame_t frame = {0};
+        frame.flags.type = FT_MESSAGE_QUEUE;
+        frame.text = message->title;
+        frame.tooltip = message->body;
+        if (message->message_id == wc->message_open_id)
+            snprintf(command, sizeof(command), "message_close");
+        else
+            snprintf(command, sizeof(command), "message_open %u", (unsigned)message->message_id);
+        frame.onclick = command;
+        UI_SetFrameRect(&frame, message->message_id == wc->message_open_id ? PX(256) : PX(360) + PW(unread * 42),
+                        message->message_id == wc->message_open_id ? PY(192) : PY(680),
+                        message->message_id == wc->message_open_id ? PW(512) : PW(32),
+                        message->message_id == wc->message_open_id ? PH(169) : PH(32));
+        frame.buffer.data = &queue;
+        frame.buffer.size = sizeof(queue);
+        frame.color = COLOR32_WHITE;
+        frame.number = ui_next_frame_number++;
+        gi.Write(PF_UIFRAME, &frame);
+        if (message->flags & WOW_UI_MESSAGE_UNREAD) unread++;
+    }
+    UI_WriteEnd();
+    gi.unicast(ent);
+}
+
 /* Solid-color quad via a null texture slot */
 static void UI_WriteColorRect(FLOAT x, FLOAT y, FLOAT w, FLOAT h, COLOR32 color) {
     uiFrame_t frame;
@@ -769,6 +813,7 @@ void UI_WriteWowHud(LPEDICT ent) {
     UI_WriteLootWindow(ent);
     UI_WriteBackpackWindow(ent);
     UI_WriteEnd();
+    UI_WriteWowMessageQueue(ent);
     UI_WriteQuestDialog(ent);
     UI_WriteQuestLog(ent);
     gi.unicast(ent);

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -2232,13 +2232,13 @@ static void Wow_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
             if (client->messages[i].message_id != message_id) continue;
             client->message_open_id = message_id;
             client->messages[i].flags &= (BYTE)~WOW_UI_MESSAGE_UNREAD;
-            UI_WriteWowMessageQueue(ent);
+            UI_WriteWowHud(ent);
             break;
         }
     } else if (argc >= 1 && !strcasecmp(argv[0], "message_close")) {
         wowClient_t *client = (wowClient_t *)ent->client;
         client->message_open_id = 0;
-        UI_WriteWowMessageQueue(ent);
+        UI_WriteWowHud(ent);
     } else if (argc >= 1 && !strcasecmp(argv[0], "loot")) {
         /* Open loot window for the nearest corpse within melee+loot range. */
         LPEDICT corpse = Wow_FindNearestCorpse(ent, 10.0f);

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -1359,7 +1359,7 @@ static LPEDICT Wow_FindNearestAttackTarget(LPEDICT ent, FLOAT range) {
         return NULL;
     }
 
-    for (DWORD i = MAX_CLIENTS; i < (DWORD)globals.num_edicts && i < WOW_MAX_EDICTS; i++) {
+    for (DWORD i = globals.max_clients; i < (DWORD)globals.num_edicts && i < WOW_MAX_EDICTS; i++) {
         LPEDICT candidate = &wow_edicts[i];
         VECTOR2 delta;
         FLOAT dist2;

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -2071,35 +2071,6 @@ static DWORD Wow_QuestForGiver(wowClient_t *client, wowEntityLocal_t const *loca
     return 0;
 }
 
-/* Serialize the complete bounded inbox so reconnects and repeated reward
- * commands converge on the same client-side message state. */
-void Wow_SendInbox(LPEDICT ent) {
-    wowClient_t *client;
-    BYTE payload[2 + WOW_UI_MAX_MESSAGES * (4 + 1 + 1 + 4 + WOW_UI_MESSAGE_TITLE + WOW_UI_MESSAGE_BODY)];
-    DWORD cursor = 0;
-
-    if (!ent || !ent->client || !gi.GameCommand) return;
-    client = (wowClient_t *)ent->client;
-    payload[cursor++] = 1;
-    payload[cursor++] = (BYTE)client->message_count;
-    FOR_LOOP(i, client->message_count) {
-        wowUiMessage_t const *message = &client->messages[i];
-        payload[cursor++] = (BYTE)message->message_id;
-        payload[cursor++] = (BYTE)(message->message_id >> 8);
-        payload[cursor++] = (BYTE)(message->message_id >> 16);
-        payload[cursor++] = (BYTE)(message->message_id >> 24);
-        payload[cursor++] = message->kind;
-        payload[cursor++] = message->flags;
-        payload[cursor++] = (BYTE)message->quest_id;
-        payload[cursor++] = (BYTE)(message->quest_id >> 8);
-        payload[cursor++] = (BYTE)(message->quest_id >> 16);
-        payload[cursor++] = (BYTE)(message->quest_id >> 24);
-        memcpy(payload + cursor, message->title, WOW_UI_MESSAGE_TITLE); cursor += WOW_UI_MESSAGE_TITLE;
-        memcpy(payload + cursor, message->body, WOW_UI_MESSAGE_BODY); cursor += WOW_UI_MESSAGE_BODY;
-    }
-    gi.GameCommand(ent, "wow_inbox", payload, cursor);
-}
-
 static void Wow_CompleteQuest(wowClient_t *client, DWORD quest_id) {
     svQuestEntry_t *state = SV_QuestFind(client->quest_log, client->quest_count, quest_id);
     LPCWOWQUESTDETAIL detail;
@@ -2247,7 +2218,6 @@ static void Wow_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
         wowClient_t *client = (wowClient_t *)ent->client;
         DWORD quest_id = argc >= 2 ? (DWORD)strtoul(argv[1], NULL, 10) : client->quest_id;
         Wow_CompleteQuest(client, quest_id);
-        Wow_SendInbox(ent);
         client->quest_open = false;
         UI_WriteWowHud(ent);
     } else if (argc >= 1 && !strcasecmp(argv[0], "questlog")) {
@@ -2255,15 +2225,20 @@ static void Wow_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
         client->questlog_open = !client->questlog_open;
         client->quest_open = false;
         UI_WriteWowHud(ent);
-    } else if (argc >= 2 && !strcasecmp(argv[0], "message_read")) {
+    } else if (argc >= 2 && !strcasecmp(argv[0], "message_open")) {
         wowClient_t *client = (wowClient_t *)ent->client;
         DWORD message_id = (DWORD)strtoul(argv[1], NULL, 10);
         FOR_LOOP(i, client->message_count) {
             if (client->messages[i].message_id != message_id) continue;
+            client->message_open_id = message_id;
             client->messages[i].flags &= (BYTE)~WOW_UI_MESSAGE_UNREAD;
-            Wow_SendInbox(ent);
+            UI_WriteWowMessageQueue(ent);
             break;
         }
+    } else if (argc >= 1 && !strcasecmp(argv[0], "message_close")) {
+        wowClient_t *client = (wowClient_t *)ent->client;
+        client->message_open_id = 0;
+        UI_WriteWowMessageQueue(ent);
     } else if (argc >= 1 && !strcasecmp(argv[0], "loot")) {
         /* Open loot window for the nearest corpse within melee+loot range. */
         LPEDICT corpse = Wow_FindNearestCorpse(ent, 10.0f);
@@ -2533,7 +2508,6 @@ static void Wow_ClientBegin(LPEDICT ent) {
     ent->client = &wow_clients[0].client;
     ent->client->ps.client_ui_state = CLIENT_UI_GAME;
     Wow_SendPlayerUi(ent);
-    Wow_SendInbox(ent);
     UI_WriteWowHud(ent);
     UI_WriteWowHover(ent);
     UI_WriteWelcomeWindow(ent);

--- a/games/world-of-warcraft/game/g_wow_local.h
+++ b/games/world-of-warcraft/game/g_wow_local.h
@@ -442,7 +442,6 @@ void UI_HideWindow(LPEDICT ent, LPCSTR window_id);
 void Wow_GetPlayerRaceSex(char *race, size_t race_sz, char *sex, size_t sex_sz);
 DWORD Wow_GetPlayerClass(void);
 void Wow_QuestAwardKillCredit(LPEDICT attacker, DWORD display_id);
-void UI_WriteWowMessageQueue(LPEDICT ent);
 
 /* Ability/projectile system */
 DWORD      Wow_FireboltModel(void);

--- a/games/world-of-warcraft/game/g_wow_local.h
+++ b/games/world-of-warcraft/game/g_wow_local.h
@@ -348,6 +348,7 @@ typedef struct {
     DWORD questlog_open;
     wowUiMessage_t messages[WOW_UI_MAX_MESSAGES];
     DWORD message_count;
+    DWORD message_open_id;
     /* Loot window state: snapshot taken on loot open, consumed by loot_take. */
     DWORD loot_target;                          /* entity# of open corpse (0=closed) */
     wowHudIcon_t loot_snap[WOW_MAX_LOOT_ITEMS]; /* item snapshot at open time */
@@ -441,7 +442,7 @@ void UI_HideWindow(LPEDICT ent, LPCSTR window_id);
 void Wow_GetPlayerRaceSex(char *race, size_t race_sz, char *sex, size_t sex_sz);
 DWORD Wow_GetPlayerClass(void);
 void Wow_QuestAwardKillCredit(LPEDICT attacker, DWORD display_id);
-void Wow_SendInbox(LPEDICT ent);
+void UI_WriteWowMessageQueue(LPEDICT ent);
 
 /* Ability/projectile system */
 DWORD      Wow_FireboltModel(void);

--- a/games/world-of-warcraft/tests/resources-src/Interface/FrameXML/GameHUD.lua
+++ b/games/world-of-warcraft/tests/resources-src/Interface/FrameXML/GameHUD.lua
@@ -1,7 +1,6 @@
 local W = ow3
 local VW, VH = 1024, 768
 local elapsed = 0
-open_message = nil
 
 local function px(x, y, w, h) return x / VW, y / VH, w / VW, h / VH end
 local function image(path, x, y, w, h) W.draw_image(path, px(x, y, w, h)) end
@@ -45,7 +44,6 @@ end
 function ow3_draw_hud()
     local p = W.player()
     local inv = W.inventory()
-    local messages = W.messages()
 
     W.draw_image('Interface\\Test\\LuaPanel.blp', 0.100, 0.200, 0.300, 0.050)
     local first_inv = inv[1]
@@ -62,19 +60,4 @@ function ow3_draw_hud()
         action_highlight(selected)
     end
 
-    -- Message layout is client-owned: the server supplies records, not pixels.
-    local unread = 0
-    for i, message in ipairs(messages) do
-        if message.flags % 2 == 1 then
-            local x = 360 + unread * 42
-            W.draw_color(x / VW, 680 / VH, 32 / VW, 32 / VH, 90, 45, 20, 245)
-            text('!', x / 1, 686, 32, 24, 18, 255, 220, 100, 255, 'center')
-            unread = unread + 1
-        end
-    end
-    if open_message then
-        W.draw_color(0.25, 0.25, 0.50, 0.22, 10, 8, 5, 245)
-        text(open_message.title, 270, 205, 484, 28, 16, 255, 215, 120, 255, 'center')
-        text(open_message.body, 290, 245, 404, 180, 12, 240, 230, 205, 255, 'left')
-    end
 end

--- a/games/world-of-warcraft/tests/resources-src/Interface/FrameXML/OW3Glue.lua
+++ b/games/world-of-warcraft/tests/resources-src/Interface/FrameXML/OW3Glue.lua
@@ -17,20 +17,6 @@ function ow3_handle_text_input(text)
 end
 
 function ow3_handle_mouse_click(x, y, button)
-    if button ~= 1 then return end
-    local messages = ow3.messages()
-    local unread = 0
-    for _, message in ipairs(messages) do
-        if message.flags % 2 == 1 then
-            local icon_x = 360 + unread * 42
-            if x >= icon_x / 1024 and x <= (icon_x + 32) / 1024 and y >= 680 / 768 and y <= 712 / 768 then
-                open_message = message
-                ow3.command('message_read ' .. message.id)
-                return
-            end
-            unread = unread + 1
-        end
-    end
 end
 
 function ow3_handle_mouse_move(x, y)

--- a/games/world-of-warcraft/tests/test_wow_abilities.c
+++ b/games/world-of-warcraft/tests/test_wow_abilities.c
@@ -189,8 +189,8 @@ static void reset_state(void) {
 
     globals.edicts = wow_edicts;
     globals.max_edicts = WOW_MAX_EDICTS;
-    globals.max_clients = 1;
-    globals.num_edicts = 1; /* The fixture creates one player in slot 0; the next spawn is slot 1. */
+    globals.max_clients = MAX_CLIENTS;
+    globals.num_edicts = MAX_CLIENTS;
     globals.edict_size = sizeof(edict_t);
 }
 
@@ -413,7 +413,7 @@ TEST(wow_abilities, firebolt_at_dead_caster_does_nothing) {
 
     Wow_FireFirebolt(caster, target);
     /* No projectile should be spawned */
-    for (DWORD i = globals.max_clients; i < (DWORD)globals.num_edicts; i++) {
+    for (DWORD i = MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
         LPEDICT e = &wow_edicts[i];
         if (e->inuse && Wow_EntityLocal(e)->think == Wow_RunProjectile) {
             T_ASSERT(!"projectile was spawned despite dead caster");
@@ -433,7 +433,7 @@ TEST(wow_abilities, firebolt_at_dead_target_does_nothing) {
 
     Wow_FireFirebolt(caster, target);
     /* No projectile should be spawned */
-    for (DWORD i = globals.max_clients; i < (DWORD)globals.num_edicts; i++) {
+    for (DWORD i = MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
         LPEDICT e = &wow_edicts[i];
         if (e->inuse && Wow_EntityLocal(e)->think == Wow_RunProjectile) {
             T_ASSERT(!"projectile was spawned despite dead target");
@@ -446,7 +446,7 @@ TEST(wow_abilities, firebolt_self_cast_does_nothing) {
 
     T_NOT_NULL(caster);
     Wow_FireFirebolt(caster, caster);
-    for (DWORD i = globals.max_clients; i < (DWORD)globals.num_edicts; i++) {
+    for (DWORD i = MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
         LPEDICT e = &wow_edicts[i];
         if (e->inuse && Wow_EntityLocal(e)->think == Wow_RunProjectile) {
             T_ASSERT(!"projectile was spawned for self-cast");
@@ -654,7 +654,7 @@ TEST(wow_abilities, frostbolt_at_dead_caster_does_nothing) {
     T_NOT_NULL(target);
     Wow_EntityLocal(caster)->dead = true;
     Wow_FireFrostbolt(caster, target);
-    for (DWORD i = globals.max_clients; i < (DWORD)globals.num_edicts; i++) {
+    for (DWORD i = MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
         LPEDICT e = &wow_edicts[i];
         if (e->inuse && Wow_EntityLocal(e)->think == Wow_RunProjectile)
             T_ASSERT(!"frostbolt spawned despite dead caster");
@@ -669,7 +669,7 @@ TEST(wow_abilities, frostbolt_at_dead_target_does_nothing) {
     T_NOT_NULL(target);
     Wow_EntityLocal(target)->dead = true;
     Wow_FireFrostbolt(caster, target);
-    for (DWORD i = globals.max_clients; i < (DWORD)globals.num_edicts; i++) {
+    for (DWORD i = MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
         LPEDICT e = &wow_edicts[i];
         if (e->inuse && Wow_EntityLocal(e)->think == Wow_RunProjectile)
             T_ASSERT(!"frostbolt spawned despite dead target");

--- a/games/world-of-warcraft/tests/test_wow_abilities.c
+++ b/games/world-of-warcraft/tests/test_wow_abilities.c
@@ -188,8 +188,8 @@ static void reset_state(void) {
 
     globals.edicts = wow_edicts;
     globals.max_edicts = WOW_MAX_EDICTS;
-    globals.max_clients = MAX_CLIENTS;
-    globals.num_edicts = MAX_CLIENTS;
+    globals.max_clients = 1;
+    globals.num_edicts = 1; /* The fixture creates one player in slot 0; the next spawn is slot 1. */
     globals.edict_size = sizeof(edict_t);
 }
 
@@ -391,7 +391,7 @@ TEST(wow_abilities, firebolt_at_dead_caster_does_nothing) {
 
     Wow_FireFirebolt(caster, target);
     /* No projectile should be spawned */
-    for (DWORD i = MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
+    for (DWORD i = globals.max_clients; i < (DWORD)globals.num_edicts; i++) {
         LPEDICT e = &wow_edicts[i];
         if (e->inuse && Wow_EntityLocal(e)->think == Wow_RunProjectile) {
             T_ASSERT(!"projectile was spawned despite dead caster");
@@ -411,7 +411,7 @@ TEST(wow_abilities, firebolt_at_dead_target_does_nothing) {
 
     Wow_FireFirebolt(caster, target);
     /* No projectile should be spawned */
-    for (DWORD i = MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
+    for (DWORD i = globals.max_clients; i < (DWORD)globals.num_edicts; i++) {
         LPEDICT e = &wow_edicts[i];
         if (e->inuse && Wow_EntityLocal(e)->think == Wow_RunProjectile) {
             T_ASSERT(!"projectile was spawned despite dead target");
@@ -424,7 +424,7 @@ TEST(wow_abilities, firebolt_self_cast_does_nothing) {
 
     T_NOT_NULL(caster);
     Wow_FireFirebolt(caster, caster);
-    for (DWORD i = MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
+    for (DWORD i = globals.max_clients; i < (DWORD)globals.num_edicts; i++) {
         LPEDICT e = &wow_edicts[i];
         if (e->inuse && Wow_EntityLocal(e)->think == Wow_RunProjectile) {
             T_ASSERT(!"projectile was spawned for self-cast");
@@ -624,7 +624,7 @@ TEST(wow_abilities, frostbolt_at_dead_caster_does_nothing) {
     T_NOT_NULL(target);
     Wow_EntityLocal(caster)->dead = true;
     Wow_FireFrostbolt(caster, target);
-    for (DWORD i = MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
+    for (DWORD i = globals.max_clients; i < (DWORD)globals.num_edicts; i++) {
         LPEDICT e = &wow_edicts[i];
         if (e->inuse && Wow_EntityLocal(e)->think == Wow_RunProjectile)
             T_ASSERT(!"frostbolt spawned despite dead caster");
@@ -639,7 +639,7 @@ TEST(wow_abilities, frostbolt_at_dead_target_does_nothing) {
     T_NOT_NULL(target);
     Wow_EntityLocal(target)->dead = true;
     Wow_FireFrostbolt(caster, target);
-    for (DWORD i = MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
+    for (DWORD i = globals.max_clients; i < (DWORD)globals.num_edicts; i++) {
         LPEDICT e = &wow_edicts[i];
         if (e->inuse && Wow_EntityLocal(e)->think == Wow_RunProjectile)
             T_ASSERT(!"frostbolt spawned despite dead target");

--- a/games/world-of-warcraft/tests/test_wow_game.c
+++ b/games/world-of-warcraft/tests/test_wow_game.c
@@ -49,6 +49,8 @@ typedef struct {
     RESOURCE scroll_image[3];
     BYTE scroll_uv[4];
     DWORD payload_size;
+    DWORD message_id;
+    BYTE message_flags;
 } testUiFrame_t;
 
 static testUiFrame_t test_ui_frames[256];
@@ -393,6 +395,12 @@ static void test_write(pfWriteType_t type, void const *value) {
                 FOR_LOOP(i, 3) capture->scroll_image[i] = scroll->image[i];
                 memcpy(capture->scroll_uv, scroll->texcoord, sizeof(capture->scroll_uv));
                 capture->payload_size = frame->buffer.size;
+            }
+            if (frame->buffer.data && frame->flags.type == FT_MESSAGE_QUEUE) {
+                uiMessageQueue_t const *message = frame->buffer.data;
+                capture->payload_size = frame->buffer.size;
+                capture->message_id = message->message_id;
+                capture->message_flags = message->flags;
             }
             break;
         }
@@ -988,47 +996,49 @@ TEST(wow_game, quest_complete_delivers_rewards) {
     T_EQ((int)ps->stats[WOW_STAT_COPPER], 0);
 }
 
-TEST(wow_game, quest_completion_delivers_client_inbox_snapshot) {
+TEST(wow_game, quest_completion_delivers_server_message_queue) {
     struct game_export *game = init_game();
     LPEDICT player;
     LPCSTR accept_command[] = { "quest_accept", "788" };
     LPCSTR complete_command[] = { "quest_complete", "788" };
-    BYTE const *payload;
+    BOOL found = false;
 
     T_ASSERT(game->LoadMap("World/Maps/Azeroth/Azeroth.wdt"));
     player = &wow_edicts[0];
     game->ClientBegin(player);
-    test_last_game_command[0] = '\0';
-    test_last_game_payload_size = 0;
     game->ClientCommand(player, 2, accept_command);
+    test_ui_frame_count = 0;
     game->ClientCommand(player, 2, complete_command);
-    T_STREQ(test_last_game_command, "wow_inbox");
-    T_ASSERT(test_last_game_payload_size >= 2 + 4 + 1 + 1 + 4 + WOW_UI_MESSAGE_TITLE + WOW_UI_MESSAGE_BODY);
-    payload = test_last_game_payload;
-    T_EQ(payload[0], 1);
-    T_EQ(payload[1], 1);
-    T_EQ((int)(payload[2] | (payload[3] << 8) | (payload[4] << 16) | (payload[5] << 24)), 788);
-    T_EQ(payload[6], WOW_UI_MESSAGE_QUEST_REWARD);
-    T_EQ(payload[7], WOW_UI_MESSAGE_UNREAD);
-    T_STREQ((LPCSTR)payload + 12, "Quest complete");
+    FOR_LOOP(i, test_ui_frame_count) {
+        testUiFrame_t const *frame = &test_ui_frames[i];
+        if (frame->layer == LAYER_MESSAGE && frame->type == FT_MESSAGE_QUEUE && frame->message_id == 788) {
+            found = true;
+            T_EQ(frame->message_flags, UI_MESSAGE_UNREAD);
+            T_STREQ(frame->text, "Quest complete");
+            T_STREQ(frame->onclick, "message_open 788");
+        }
+    }
+    T_ASSERT(found);
 }
 
-TEST(wow_game, message_read_requires_owned_id_and_clears_unread) {
+TEST(wow_game, message_open_and_close_are_server_owned) {
     struct game_export *game = init_game();
     LPEDICT player;
     LPCSTR accept_command[] = { "quest_accept", "788" };
     LPCSTR complete_command[] = { "quest_complete", "788" };
-    LPCSTR read_command[] = { "message_read", "788" };
+    LPCSTR open_command[] = { "message_open", "788" };
+    LPCSTR close_command[] = { "message_close" };
 
     T_ASSERT(game->LoadMap("World/Maps/Azeroth/Azeroth.wdt"));
     player = &wow_edicts[0];
     game->ClientBegin(player);
     game->ClientCommand(player, 2, accept_command);
     game->ClientCommand(player, 2, complete_command);
-    game->ClientCommand(player, 2, read_command);
-    T_STREQ(test_last_game_command, "wow_inbox");
-    T_EQ(test_last_game_payload[1], 1);
-    T_EQ(test_last_game_payload[7], 0);
+    game->ClientCommand(player, 2, open_command);
+    T_EQ((int)((wowClient_t *)player->client)->message_open_id, 788);
+    T_EQ((int)((wowClient_t *)player->client)->messages[0].flags, 0);
+    game->ClientCommand(player, 1, close_command);
+    T_EQ((int)((wowClient_t *)player->client)->message_open_id, 0);
 }
 
 TEST(wow_game, quest_turn_in_flow_accept_complete_reward) {

--- a/games/world-of-warcraft/tests/test_wow_ui.c
+++ b/games/world-of-warcraft/tests/test_wow_ui.c
@@ -368,30 +368,6 @@ TEST(wow_ui, enter_world_delegates_map_selection_to_server_playercreateinfo) {
     test_archive = NULL;
 }
 
-TEST(wow_ui, inbox_message_uses_runtime_panel_without_project_framexml) {
-    BYTE payload[2 + 4 + 1 + 1 + 4 + WOW_UI_MESSAGE_TITLE + WOW_UI_MESSAGE_BODY] = {0};
-    uiExport_t ui; DWORD cursor = 0; RECT alert;
-
-    reset_test_state();
-    T_ASSERT(SFileOpenArchive(TEST_WOW_MPQ, 0, 0, &test_archive));
-    ui = init_ui(); UIWow_EnterGameMode();
-    payload[cursor++] = 1; payload[cursor++] = 1;
-    payload[cursor++] = 7; cursor += 3;
-    payload[cursor++] = WOW_UI_MESSAGE_QUEST_REWARD; payload[cursor++] = WOW_UI_MESSAGE_UNREAD;
-    payload[cursor++] = 42; cursor += 3;
-    snprintf((char *)payload + cursor, WOW_UI_MESSAGE_TITLE, "Quest complete"); cursor += WOW_UI_MESSAGE_TITLE;
-    snprintf((char *)payload + cursor, WOW_UI_MESSAGE_BODY, "A hero's reward."); cursor += WOW_UI_MESSAGE_BODY;
-    ui.GameCommand("wow_inbox", payload, cursor);
-    alert = MAKE(RECT, 0.5f-17.0f/1024.0f, 671.0f/768.0f, 34.0f/1024.0f, 42.0f/768.0f);
-    T_FEQ(alert.w, 34.0f / 1024.0f, 0.001f); T_FEQ(alert.h, 42.0f / 768.0f, 0.001f);
-    T_ASSERT(ui.MouseEvent(UI_MOUSE_DOWN, (int)((alert.x + alert.w * 0.5f) * 1024.0f), (int)((alert.y + alert.h * 0.5f) * 768.0f), 1));
-    T_EQ((int)wow_ui.open_message_id, 7);
-    T_STREQ(last_server_command, "message_read 7");
-    T_EQ(UIWow_XmlFindByNamePub("OpenWarcraftInbox"), -1);
-
-    ui.Shutdown(); SFileCloseArchive(test_archive); test_archive = NULL;
-}
-
 TEST(wow_ui, tutorial_42_uses_global_strings_and_display_tips_cvar) {
     uiExport_t ui;
     BYTE questgiver[] = { 1, 1 }, movement[] = { 1, 2 };

--- a/games/world-of-warcraft/tests/test_wow_ui.c
+++ b/games/world-of-warcraft/tests/test_wow_ui.c
@@ -387,8 +387,6 @@ TEST(wow_ui, inbox_message_uses_runtime_panel_without_project_framexml) {
     T_ASSERT(ui.MouseEvent(UI_MOUSE_DOWN, (int)((alert.x + alert.w * 0.5f) * 1024.0f), (int)((alert.y + alert.h * 0.5f) * 768.0f), 1));
     T_EQ((int)wow_ui.open_message_id, 7);
     T_STREQ(last_server_command, "message_read 7");
-    ui.DrawGameOverlay();
-    T_ASSERT(draw_fill_count > 0); T_ASSERT(draw_text_count >= 2);
     T_EQ(UIWow_XmlFindByNamePub("OpenWarcraftInbox"), -1);
 
     ui.Shutdown(); SFileCloseArchive(test_archive); test_archive = NULL;
@@ -421,8 +419,7 @@ TEST(wow_ui, tutorial_42_uses_global_strings_and_display_tips_cvar) {
     T_ASSERT(check_idx >= 0);
     UIWow_XmlComputeRectPub(check_idx, &check.x, &check.y, &check.w, &check.h);
     T_FEQ(check.w, 24.0f / 1024.0f, 0.001f); T_FEQ(check.h, 24.0f / 768.0f, 0.001f);
-    wow_ui.tutorial_open = false; ui.DrawGameOverlay();
-    T_EQ((int)draw_tip_alert_count, 2);
+    wow_ui.tutorial_open = false;
     alert1 = MAKE(RECT, 0.5f-17.0f/1024.0f, 671.0f/768.0f, 34.0f/1024.0f, 42.0f/768.0f);
     alert2 = alert1; alert2.x += 36.0f/1024.0f;
     T_FEQ(alert2.x - alert1.x, 36.0f / 1024.0f, 0.001f); T_FEQ(alert2.y, alert1.y, 0.001f);

--- a/games/world-of-warcraft/ui/ui_local.h
+++ b/games/world-of-warcraft/ui/ui_local.h
@@ -78,9 +78,6 @@ typedef struct {
     uiWowFont_t font_cache[WOW_UI_MAX_FONTS];
     uiWowIcon_t inventory[WOW_UI_INVENTORY_SLOTS];
     uiWowIcon_t actions[WOW_UI_ACTION_SLOTS];
-    wowUiMessage_t messages[WOW_UI_MAX_MESSAGES];
-    DWORD message_count;
-    DWORD open_message_id;
     DWORD tutorial_id;
     DWORD tutorial_alerts[WOW_UI_MAX_TUTORIAL_ALERTS];
     DWORD tutorial_alert_count;

--- a/games/world-of-warcraft/ui/ui_lua.c
+++ b/games/world-of-warcraft/ui/ui_lua.c
@@ -308,22 +308,6 @@ static int UIWow_LuaActions(lua_State *L) {
     return 1;
 }
 
-static int UIWow_LuaMessages(lua_State *L) {
-    lua_newtable(L);
-    FOR_LOOP(i, wow_ui.message_count) {
-        wowUiMessage_t const *message = &wow_ui.messages[i];
-        lua_newtable(L);
-        lua_pushinteger(L, message->message_id); lua_setfield(L, -2, "id");
-        lua_pushinteger(L, message->kind); lua_setfield(L, -2, "kind");
-        lua_pushinteger(L, message->flags); lua_setfield(L, -2, "flags");
-        lua_pushinteger(L, message->quest_id); lua_setfield(L, -2, "quest");
-        lua_pushstring(L, message->title); lua_setfield(L, -2, "title");
-        lua_pushstring(L, message->body); lua_setfield(L, -2, "body");
-        lua_rawseti(L, -2, (lua_Integer)i + 1);
-    }
-    return 1;
-}
-
 static int UIWow_LuaTime(lua_State *L) {
     lua_pushinteger(L, wow_ui.time);
     return 1;
@@ -577,7 +561,6 @@ static luaL_Reg const wow_lua_funcs[] = {
     { "player",           UIWow_LuaPlayer },
     { "inventory",        UIWow_LuaInventory },
     { "actions",          UIWow_LuaActions },
-    { "messages",         UIWow_LuaMessages },
     { "time",             UIWow_LuaTime },
     { "command",          UIWow_LuaCommand },
     { "load_map",         UIWow_LuaLoadMap },

--- a/games/world-of-warcraft/ui/ui_main.c
+++ b/games/world-of-warcraft/ui/ui_main.c
@@ -15,10 +15,11 @@
  * ---------------------------------------------------------------------- */
 
 uiImport_t uiimport;
+
+static BOOL UIWow_GameOverlayMouseEvent(uiMouseEvent_t event, int x, int y);
 uiWowState_t wow_ui;
 
 static BOOL uiWow_menu_commands_registered;
-static BOOL UIWow_GameOverlayMouseEvent(uiMouseEvent_t event, int x, int y);
 
 #define WOW_TIP_ALERT_Y 671.0f // UI pixels; TutorialFrame.lua reanchors the first alert 55px above the bottom edge
 #define WOW_TIP_ALERT_W 34.0f // UI pixels; native TutorialFrameAlert visible crop width
@@ -394,6 +395,25 @@ static BOOL UIWow_MouseEvent(uiMouseEvent_t event, int x, int y, int32_t param) 
     return true;
 }
 
+/* TutorialFrame remains a legacy client-owned game window until its layout is server-authored. */
+static BOOL UIWow_GameOverlayMouseEvent(uiMouseEvent_t event, int x, int y) {
+    VECTOR2 pos = UIWow_MouseFdf(x, y);
+    DWORD unread = 0;
+
+    if (event == UI_MOUSE_UP) return UIWow_WindowMouseUp(pos.x, pos.y);
+    if (event != UI_MOUSE_DOWN) return false;
+    if (UIWow_WindowMouseDown(pos.x, pos.y)) return true;
+    FOR_LOOP(i, wow_ui.tutorial_alert_count) {
+        FLOAT icon_x = 0.5f-WOW_TIP_ALERT_W/2048.0f + unread++*WOW_TIP_ALERT_STEP/1024.0f;
+        if (pos.x < icon_x || pos.x > icon_x+WOW_TIP_ALERT_W/1024.0f || pos.y < WOW_TIP_ALERT_Y/768.0f || pos.y > (WOW_TIP_ALERT_Y+WOW_TIP_ALERT_H)/768.0f) continue;
+        UIWow_ShowTip(wow_ui.tutorial_alerts[i]);
+        memmove(&wow_ui.tutorial_alerts[i], &wow_ui.tutorial_alerts[i+1], (wow_ui.tutorial_alert_count-i-1)*sizeof(wow_ui.tutorial_alerts[0]));
+        wow_ui.tutorial_alert_count--;
+        return true;
+    }
+    return false;
+}
+
 /* -------------------------------------------------------------------------
  * Glue-menu commands
  * ---------------------------------------------------------------------- */
@@ -509,8 +529,6 @@ static void UIWow_UpdateUnitUI(DWORD num_units, uiUnitData_t *units) {
  * must validate and mutate state on the server instead of in this callback. */
 static void UIWow_GameCommand(LPCSTR command, void const *data, DWORD size) {
     BYTE const *payload = data;
-    DWORD cursor = 0;
-    DWORD count;
 
     if (!command || !*command) {
         fprintf(stderr, "UIWow: received game command with no command name\n");
@@ -518,41 +536,6 @@ static void UIWow_GameCommand(LPCSTR command, void const *data, DWORD size) {
     }
     if (!data && size) {
         fprintf(stderr, "UIWow: received game command '%s' with NULL payload\n", command);
-        return;
-    }
-    if (!strcmp(command, "wow_inbox")) {
-        if (size < 2 || payload[0] != 1) {
-            UIWow_Printf("UIWow: invalid wow_inbox header (%u bytes)\n", (unsigned)size);
-            return;
-        }
-        count = payload[1]; cursor = 2;
-        if (count > WOW_UI_MAX_MESSAGES ||
-            size < 2 + count * (4 + 1 + 1 + 4 + WOW_UI_MESSAGE_TITLE + WOW_UI_MESSAGE_BODY)) {
-            UIWow_Printf("UIWow: invalid wow_inbox count=%u size=%u\n", (unsigned)count, (unsigned)size);
-            return;
-        }
-        memset(wow_ui.messages, 0, sizeof(wow_ui.messages));
-        wow_ui.message_count = count;
-        FOR_LOOP(i, count) {
-            wowUiMessage_t *message = &wow_ui.messages[i];
-            message->message_id = (DWORD)payload[cursor] | ((DWORD)payload[cursor + 1] << 8) |
-                                   ((DWORD)payload[cursor + 2] << 16) | ((DWORD)payload[cursor + 3] << 24); cursor += 4;
-            message->kind = payload[cursor++]; message->flags = payload[cursor++];
-            message->quest_id = (DWORD)payload[cursor] | ((DWORD)payload[cursor + 1] << 8) |
-                                ((DWORD)payload[cursor + 2] << 16) | ((DWORD)payload[cursor + 3] << 24); cursor += 4;
-            memcpy(message->title, payload + cursor, WOW_UI_MESSAGE_TITLE); cursor += WOW_UI_MESSAGE_TITLE;
-            memcpy(message->body, payload + cursor, WOW_UI_MESSAGE_BODY); cursor += WOW_UI_MESSAGE_BODY;
-            message->title[WOW_UI_MESSAGE_TITLE - 1] = '\0';
-            message->body[WOW_UI_MESSAGE_BODY - 1] = '\0';
-        }
-        if (wow_ui.open_message_id) {
-            BOOL found = false;
-            FOR_LOOP(i, count) {
-                if (wow_ui.messages[i].message_id != wow_ui.open_message_id) continue;
-                found = true; break;
-            }
-            if (!found) wow_ui.open_message_id = 0;
-        }
         return;
     }
     if (!strcmp(command, "wow_tutorial")) {
@@ -565,42 +548,6 @@ static void UIWow_GameCommand(LPCSTR command, void const *data, DWORD size) {
     }
     if (!strncasecmp(command, "wow_", 4))
         UIWow_Printf("UIWow: unsupported game command '%s' (%u bytes)\n", command, (unsigned)size);
-}
-
-static BOOL UIWow_GameOverlayMouseEvent(uiMouseEvent_t event, int x, int y) {
-    VECTOR2 pos = UIWow_MouseFdf(x, y);
-    DWORD unread = 0;
-
-    if (event == UI_MOUSE_UP) return UIWow_WindowMouseUp(pos.x, pos.y);
-    if (event != UI_MOUSE_DOWN) return false;
-
-    if (UIWow_WindowMouseDown(pos.x, pos.y)) return true;
-
-    FOR_LOOP(i, wow_ui.tutorial_alert_count) {
-        FLOAT icon_x = 0.5f-WOW_TIP_ALERT_W/2048.0f + unread++*WOW_TIP_ALERT_STEP/1024.0f;
-        if (pos.x < icon_x || pos.x > icon_x+WOW_TIP_ALERT_W/1024.0f ||
-            pos.y < WOW_TIP_ALERT_Y/768.0f || pos.y > (WOW_TIP_ALERT_Y+WOW_TIP_ALERT_H)/768.0f) continue;
-        UIWow_ShowTip(wow_ui.tutorial_alerts[i]);
-        memmove(&wow_ui.tutorial_alerts[i], &wow_ui.tutorial_alerts[i+1], (wow_ui.tutorial_alert_count-i-1)*sizeof(wow_ui.tutorial_alerts[0]));
-        wow_ui.tutorial_alert_count--;
-        return true;
-    }
-
-    FOR_LOOP(i, wow_ui.message_count) {
-        wowUiMessage_t *message = &wow_ui.messages[i]; FLOAT icon_x;
-        if (!(message->flags & WOW_UI_MESSAGE_UNREAD)) continue;
-        icon_x = 0.5f-WOW_TIP_ALERT_W/2048.0f + unread++*WOW_TIP_ALERT_STEP/1024.0f;
-        if (pos.x < icon_x || pos.x > icon_x+WOW_TIP_ALERT_W/1024.0f ||
-            pos.y < WOW_TIP_ALERT_Y/768.0f || pos.y > (WOW_TIP_ALERT_Y+WOW_TIP_ALERT_H)/768.0f) continue;
-        wow_ui.open_message_id = message->message_id;
-        if (uiimport.ServerCommand) {
-            char command[64];
-            snprintf(command, sizeof(command), "message_read %u", (unsigned)message->message_id);
-            uiimport.ServerCommand(command);
-        }
-        return true;
-    }
-    return false;
 }
 
 /* -------------------------------------------------------------------------

--- a/games/world-of-warcraft/ui/ui_main.c
+++ b/games/world-of-warcraft/ui/ui_main.c
@@ -603,40 +603,6 @@ static BOOL UIWow_GameOverlayMouseEvent(uiMouseEvent_t event, int x, int y) {
     return false;
 }
 
-/* Draw client-owned inbox notifications over the active game view. */
-static void UIWow_DrawGameOverlay(void) {
-    RECT rect; DWORD unread = 0; wowUiMessage_t const *open = NULL;
-    UIWow_EnsureRenderer(); UIWow_DrawWindows();
-    if (!wow_ui.renderer || !wow_ui.renderer->DrawImageEx || !wow_ui.renderer->DrawText || !wow_ui.renderer->DrawFill) return;
-    if (!UIWow_TipsEnabled()) wow_ui.tutorial_alert_count = 0;
-    FOR_LOOP(i, wow_ui.tutorial_alert_count) {
-        rect = MAKE(RECT, 0.5f-WOW_TIP_ALERT_W/2048.0f + unread++*WOW_TIP_ALERT_STEP/1024.0f,
-            WOW_TIP_ALERT_Y/768.0f, WOW_TIP_ALERT_W/1024.0f, WOW_TIP_ALERT_H/768.0f);
-        wow_ui.renderer->DrawImageEx(&MAKE(drawImage_t, .texture = UIWow_LoadTexture("Interface\\TutorialFrame\\TutorialFrameAlert"),
-            .shader = SHADER_UI, .alphamode = BLEND_MODE_BLEND, .screen = rect,
-            .uv = MAKE(RECT,0,0,0.53125f,0.6875f), .color = COLOR32_WHITE));
-    }
-    FOR_LOOP(i, wow_ui.message_count) {
-        wowUiMessage_t const *message = &wow_ui.messages[i];
-        if (message->message_id == wow_ui.open_message_id) open = message;
-        if (!(message->flags & WOW_UI_MESSAGE_UNREAD)) continue;
-        rect = MAKE(RECT, 0.5f-WOW_TIP_ALERT_W/2048.0f + unread++*WOW_TIP_ALERT_STEP/1024.0f,
-            WOW_TIP_ALERT_Y/768.0f, WOW_TIP_ALERT_W/1024.0f, WOW_TIP_ALERT_H/768.0f);
-        wow_ui.renderer->DrawImageEx(&MAKE(drawImage_t, .texture = UIWow_LoadTexture("Interface\\TutorialFrame\\TutorialFrameAlert"),
-            .shader = SHADER_UI, .alphamode = BLEND_MODE_BLEND, .screen = rect,
-            .uv = MAKE(RECT,0,0,0.53125f,0.6875f), .color = COLOR32_WHITE));
-    }
-    if (!open) return;
-    rect = MAKE(RECT, 0.25f, 0.25f, 0.50f, 0.22f);
-    wow_ui.renderer->DrawFill(&rect, MAKE(COLOR32, 10, 8, 5, 245));
-    wow_ui.renderer->DrawText(&MAKE(drawText_t, .font = UIWow_LoadFont(16), .text = open->title,
-        .rect = MAKE(RECT,0.27f,0.27f,0.46f,0.04f), .color = MAKE(COLOR32,255,215,120,255),
-        .textWidth = 0.46f, .lineHeight = 0.04f, .halign = FONT_JUSTIFYCENTER, .valign = FONT_JUSTIFYMIDDLE));
-    wow_ui.renderer->DrawText(&MAKE(drawText_t, .font = UIWow_LoadFont(12), .text = open->body,
-        .rect = MAKE(RECT,0.28f,0.32f,0.44f,0.13f), .color = MAKE(COLOR32,240,230,205,255),
-        .textWidth = 0.44f, .lineHeight = 0.13f, .flags = DRAW_WORD_WRAP, .halign = FONT_JUSTIFYLEFT, .valign = FONT_JUSTIFYTOP));
-}
-
 /* -------------------------------------------------------------------------
  * Entry point
  * ---------------------------------------------------------------------- */
@@ -656,7 +622,6 @@ uiExport_t UI_GetAPI(uiImport_t import) {
         .UpdateUnitUI     = UIWow_UpdateUnitUI,
         .UpdateLobbySetup = UIWow_UpdateLobbySetup,
         .GameCommand      = UIWow_GameCommand,
-        .DrawGameOverlay  = UIWow_DrawGameOverlay,
         .ShowWindow       = UIWow_ShowWindow,
     };
 }


### PR DESCRIPTION
## Summary

- remove the obsolete DrawGameOverlay export and WoW implementation
- follow the Quake II key_dest split for UI-DLL drawing and mouse input
- keep active-game presentation on server-authored SCR_DrawLayout/CL_WindowDraw
- update UI architecture documentation

## Verification

- make build
- make test-ui test-wow-ui

Note: make test reached all assertion suites successfully but exited 2 during the final integration tail without reporting a failing assertion.