### PR TITLE
wc3: align attack damage math with Warsmash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WoW gameplay features: implemented vs missing (WoWee gap analysis), loot system details | [docs/games/world-of-warcraft/gameplay-features.md](docs/games/world-of-warcraft/gameplay-features.md) |
 | Entity sound architecture | [docs/architecture/sound.md](docs/architecture/sound.md) |
 | WC3 data model (SLK, unit stats, combat) | [docs/wc3-data-model.md](docs/wc3-data-model.md) |
+| WC3 attack damage math, runtime modifiers, armor/type multipliers, projectile impact timing | [docs/games/warcraft-3/attack-damage.md](docs/games/warcraft-3/attack-damage.md) |
 | WC3 JASS native coverage, callback contracts, state ownership | [docs/games/warcraft-3/jass-native-coverage.md](docs/games/warcraft-3/jass-native-coverage.md) |
 | WC3 campaign game cache, persisted Hero progression, `StoreUnit`/`RestoreUnit` | [docs/games/warcraft-3/campaign-game-cache.md](docs/games/warcraft-3/campaign-game-cache.md) |
 | WC3 game save/load format, entity pointer fixups, and `field_t` synchronization | [docs/games/warcraft-3/save-load.md](docs/games/warcraft-3/save-load.md) |

--- a/docs/games/warcraft-3/architecture/ability-coverage.md
+++ b/docs/games/warcraft-3/architecture/ability-coverage.md
@@ -111,13 +111,13 @@ generic `Button` command path rather than by a registered ability code.
 | `AIhe` | Item Heal | Partial | Inventory dispatch, selected-unit heal, target art and synchronous charge/consume rules exist. Shared item cooldown groups remain. |
 | `AIma` | Item Mana Regain | Partial | Inventory dispatch, selected-unit mana restore, target art and synchronous charge/consume rules exist. Shared item cooldown groups remain. |
 | `AIda` | Item Defense AOE | Partial | Authored area/duration/target mask applies `Bdef`; live status contributes its authored armor bonus to combat/HUD. Persistent buff-world-art ownership and shared item cooldown groups remain. |
-| `AIat` | Item Attack Bonus | TODO | Needs item stat modifier system. |
+| `AIat` | Item Attack Bonus | Partial | Passive item bonus updates temporary Attack 1/2 damage and HUD modifier; broader stacking/modifier framework remains. |
 | `AIab` | Item Stat Bonus | TODO | Needs hero stat modifier system. |
 | `AIim` | Permanent Intelligence Gain | TODO | Needs permanent hero stat updates. |
 | `AIsm` | Permanent Strength Gain | TODO | Needs permanent hero stat updates. |
 | `AIam` | Permanent Agility Gain | TODO | Needs permanent hero stat updates. |
 | `AIxm` | Permanent Multi-stat Gain | TODO | Needs permanent hero stat updates. |
-| `AIde` | Item Defense Bonus | TODO | Needs armor/stat modifier system. |
+| `AIde` | Item Defense Bonus | Partial | Passive item armor modifier is preserved across Hero Agility recomputation; broader armor modifier framework remains. |
 | `AIml` | Item Life Bonus | TODO | Needs max-health modifier system. |
 | `AImm` | Item Mana Bonus | TODO | Needs max-mana modifier system. |
 | `AIfs` | Figurine Summon | TODO | Needs item summon behavior. |

--- a/docs/games/warcraft-3/attack-damage.md
+++ b/docs/games/warcraft-3/attack-damage.md
@@ -1,0 +1,170 @@
+# Warcraft III Attack Damage
+
+## Contract
+
+OpenRealm keeps normal WC3 attack damage in three layers:
+
+1. `unitAttack_t.damageBase` + dice describe the permanent displayed range.
+2. `unitAttack_t.temporaryDamageBonus` is added after the dice roll and is shown as a green/red `+N/-N` suffix.
+3. `G_AttackDamage()` applies the target-facing attack-type/defense-type multiplier and numeric armor.
+
+The ordinary Attack 1 path is:
+
+```text
+unit object data
+  -> permanent runtime attack mutations (`ratx`, `ratd`, Hero primary attribute)
+  -> roll `damageBase + NdS + temporaryDamageBonus`
+  -> attack-type x defense-type multiplier
+  -> numeric armor
+  -> `T_Damage`
+```
+
+Melee resolves the target-facing stages at the damage point. Missile attacks roll at launch but defer `G_AttackDamage()` until projectile impact, so armor/defense changes while the missile is in flight affect the hit. Spell missiles provide their own `currentmove/endfunc` and do not enter this physical-attack mitigation branch.
+
+## Runtime Attack Fields
+
+`edict_t.attack1` and `attack2` are mutable copies of `UnitWeapons.slk` data. Both are initialized at spawn even though combat order selection still uses Attack 1.
+
+For each `unitAttack_t`:
+
+- `damageBase`: permanent base used by the HUD range and roll.
+- `numberOfDice`, `sidesPerDie`: `NdS` random component.
+- `permanentDamageBonus`: permanent modifier ledger used to survive Hero stat recomputation (for example `ratx`).
+- `temporaryDamageBonus`: item/temporary modifier added to each roll but not folded into the base range.
+- `cooldown`, `damagePoint`, `range`: attack timing/range.
+- splash/bounce metadata is parsed but the special weapon behaviors are not yet implemented.
+
+The displayed permanent range is:
+
+```text
+min = max(0, damageBase + numberOfDice)
+max = max(0, damageBase + numberOfDice * sidesPerDie)
+```
+
+A temporary bonus is rendered separately, for example `12 - 18 +3`.
+
+## Damage Roll
+
+`skills/s_attack.c:ai_rolldamage1()` performs one RNG draw per die:
+
+```text
+raw = damageBase
+    + sum(random(1..sidesPerDie))
+    + temporaryDamageBonus
+```
+
+Malformed zero-sided dice contribute `+1` rather than taking modulo zero, matching the current Warsmash edge behavior.
+
+OpenRealm still uses the process C `rand()` stream. It does not yet have Warsmash's dedicated seeded simulation RNG contract for attack rolls.
+
+## Gameplay Constants
+
+`InitConstants()` loads combat values from the active Misc data cache. `war3mapMisc.txt` is loaded after stock Misc files and can override them.
+
+Relevant fields:
+
+- `DamageBonusNormal`
+- `DamageBonusPierce`
+- `DamageBonusSiege`
+- `DamageBonusChaos`
+- `DamageBonusMagic`
+- `DamageBonusHero`
+- `DamageBonusSpells` (if absent, copy the active Magic row as Warsmash does)
+- `DefenseArmor`
+- `StrAttackBonus`
+- `AgiDefenseBonus`
+- `AgiAttackSpeedBonus`
+
+The defense-column order is:
+
+```text
+small, medium, large, fort, normal, hero, divine, none
+```
+
+Stock fallback values are retained only for missing data/bootstrap tests. In particular, ordinary attack classes deal `0.05x` to Divine while Chaos deals `1.00x`.
+
+## Numeric Armor
+
+Let `A` be `G_UnitArmorValue(target)` and `K` be `Misc.DefenseArmor` (stock fallback `0.06`).
+
+For `A >= 0`:
+
+```text
+multiplier = 1 / (1 + K*A)
+```
+
+For `A < 0`:
+
+```text
+multiplier = 2 - (1 - K)^(-A)
+```
+
+`G_AttackDamage()` applies:
+
+```text
+final = raw * DamageBonus[attackType][defenseType] * armorMultiplier
+```
+
+and preserves OpenRealm's existing minimum-one physical-hit rule.
+
+`armor_value` is the derived/base armor plus tracked persistent modifiers. `permanent_armor_bonus` (research) and `temporary_armor_bonus` (items) are kept separately so `G_RecomputeHeroStats()` cannot erase them when Agility changes. `G_UnitArmorValue()` then layers timed status armor such as `Bdef` on top.
+
+## Hero Attack Math
+
+For heroes, `G_RecomputeHeroStats()` applies the active `Misc.StrAttackBonus` to the current primary attribute (`STR`, `AGI`, or `INT`) and adds `permanentDamageBonus` when rebuilding each runtime attack.
+
+Current limitation: OpenRealm's `doodadHero_t` stores only total STR/AGI/INT, not Warsmash's separate base and bonus attributes. Therefore primary-attribute item/stat bonuses are still folded into the permanent damage range rather than displayed as a separate green primary-attribute damage bonus. `AIat` attack bonuses are separated correctly.
+
+Agility attack timing uses:
+
+```text
+totalBonus = agility * Misc.AgiAttackSpeedBonus
+clampedBonus = clamp(totalBonus, -0.90, +4.00)
+divisor = 1 + clampedBonus
+```
+
+Both damage point and cooldown recovery are divided by that divisor. OpenRealm does not yet have the other Warsmash attack-speed modifier sources, so only the Agility contribution is currently present.
+
+## Upgrade Effects
+
+The generic research dispatcher implements:
+
+- `ratx`: permanent flat attack damage using `base + mod*(level-1)` and applying only the old/new delta.
+- `ratd`: attack dice using the same level-value/delta rule.
+- `rarm`: armor using the unit type's `armorPerUpgrade`, tracked in `permanent_armor_bonus`.
+
+These affect existing owned units and newly spawned units that inherit already-researched player tech.
+
+## Item Attack/Armor Modifiers
+
+`AIat` changes `temporaryDamageBonus` rather than `damageBase`. This prevents later Hero stat recomputation from erasing the item bonus and makes the HUD show the modifier separately.
+
+`AIde` changes both `temporary_armor_bonus` and the current `armor_value`, so later Hero Agility recomputation preserves the item armor modifier.
+
+## Known Gaps
+
+The current implementation intentionally does not invent the larger Warsmash combat-listener architecture. Remaining work includes:
+
+- attacker pre-damage listeners (critical strike, bash, Wind Walk, attack replacement/orbs);
+- low-ground miss and target evasion;
+- target damage-taken and final-damage listeners;
+- generic distinction between attack type and damage type / numeric-armor bypass;
+- `MSPLASH`, `ARTILLERY`, `MBOUNCE`, `MLINE`/`ALINE` damage behavior;
+- combat selection between Attack 1 and Attack 2;
+- separate Hero base-vs-bonus attributes for Warsmash-exact green primary-stat damage;
+- seeded combat RNG independent from unrelated `rand()` consumers;
+- non-Agility attack-speed buffs/debuffs.
+
+## Verification
+
+Relevant source/tests:
+
+- `games/warcraft-3/game/skills/s_attack.c`
+- `games/warcraft-3/game/g_phys.c`
+- `games/warcraft-3/game/m_unit.c`
+- `games/warcraft-3/game/g_building.c`
+- `games/warcraft-3/game/skills/s_item_stats.c`
+- `games/warcraft-3/game/tests/t_combat.c`
+- `games/warcraft-3/game/tests/t_building.c`
+
+The combat tests cover representative type multipliers, Divine, data-driven constants, positive/negative armor, Hero modifier preservation, and the attack-speed cap. Research tests cover `ratx` level-delta semantics.

--- a/docs/games/warcraft-3/inventory-and-items.md
+++ b/docs/games/warcraft-3/inventory-and-items.md
@@ -178,7 +178,7 @@ Undead unit-inventory variants. Plain `AInv` and custom `AInv`-derived inventory
 abilities are not implicitly gated.
 
 `UpgradeData.slk` is now normalized for research costs/times and its four
-effect slots, with `ratd` and `rarm` implemented generically for Blacksmith-style
+effect slots, with `ratx`, `ratd`, and `rarm` implemented generically for Blacksmith-style
 stat research. The stock inventory-ability-to-Backpack relationships remain a
 small explicit table in `g_items.c` because that Backpack effect has not yet been
 moved onto the generic upgrade-effect dispatcher.
@@ -271,3 +271,5 @@ race-skin selection, and the native cover frame's crop/geometry. Synthetic
 ability-only unit IDs such as `H001` have no `UnitBalance` life value, so the
 shared test-unit allocator initializes a minimum positive life value without
 weakening the runtime rule that zero-life units are corpses and cannot be selected.
+
+`AIat` is represented as `unitAttack_t.temporaryDamageBonus`, so it survives Hero stat recomputation and is rendered as a separate green/red attack modifier. `AIde` uses `temporary_armor_bonus` so Hero Agility recomputation likewise preserves item armor. See [Attack Damage](attack-damage.md).

--- a/docs/games/warcraft-3/research-and-upgrades.md
+++ b/docs/games/warcraft-3/research-and-upgrades.md
@@ -121,6 +121,16 @@ stats rather than only changing the integer queried by JASS/AI.
 This implementation intentionally enables only the upgrade effect codes whose
 current Warsmash behavior is sufficiently unambiguous for the stock Blacksmith:
 
+### `ratx` — flat attack damage
+
+For an affected runtime attack, each level's effect value is:
+
+```text
+base + mod * (level - 1)
+```
+
+Changing level applies only the old/new delta to `damageBase` and records the same delta in `permanentDamageBonus`. The ledger keeps the research bonus intact when Hero primary-attribute recomputation rebuilds the base attack range.
+
 ### `ratd` — attack dice
 
 For an affected unit, each level's effect value is:
@@ -141,8 +151,8 @@ Armor follows the Warcraft unit type's `defUp` / `armorPerUpgrade` value:
 upgrade armor = armorPerUpgrade * researched level
 ```
 
-Changing level applies the delta between old and new levels to
-`edict_t.armor_value`, preserving unrelated armor modifiers.
+Changing level applies the delta between old and new levels to both
+`edict_t.permanent_armor_bonus` and `edict_t.armor_value`. Hero Agility recomputation rebuilds base armor plus this persistent ledger, so researched armor is not lost when attributes change.
 
 Existing owned units whose `Upgrades Used` list contains the upgrade are updated
 when player tech changes. Newly spawned/trained units run the same application
@@ -183,9 +193,9 @@ The following compatibility work also remains:
 - `EVENT_*_RESEARCH_START/CANCEL/FINISH` are declared but the JASS event context
   still lacks the researched rawcode needed for a correct `GetResearched()`
   implementation, so this patch does not publish incomplete research events;
-- second-attack runtime initialization is still incomplete elsewhere in the
-  unit combat path, so `ratd` updates attack 2 only when that runtime attack is
-  already present;
+- Attack 2 runtime stats are initialized and receive `ratx`/`ratd`, but combat
+  order selection still attacks through Attack 1; full WC3 Attack 1/Attack 2
+  selection remains unresolved;
 - ownership-transfer semantics for upgrades whose `inherit` flag controls
   transfer are not changed here;
 - UpgradeData `global` semantics and any timing/game-speed adjustment beyond the
@@ -193,3 +203,5 @@ The following compatibility work also remains:
 
 These gaps should be completed from authoritative Warcraft/Warsmash behavior
 rather than by adding Blacksmith-specific rawcode tables.
+
+See also [Attack Damage](attack-damage.md) for the runtime damage/armor formula and modifier ownership.

--- a/docs/wc3-data-model.md
+++ b/docs/wc3-data-model.md
@@ -159,9 +159,21 @@ hero          1.00   1.00   1.00  0.50    1.00  1.00    0.05  1.00
 ```
 
 ### Armor Reduction
-`dmg /= (1 + armor * 0.06)` for positive armor.
-`dmg *= (2 - 1 / (1 + (-armor) * 0.06))` for negative armor.
-Minimum final damage: 1.
+`DefenseArmor` is loaded from the active Misc data (`Units\MiscGame.txt` plus `war3mapMisc.txt` overrides; stock fallback `0.06`).
+
+For non-negative armor `A` and coefficient `K`:
+
+`dmg *= 1 / (1 + K * A)`
+
+For negative armor:
+
+`dmg *= 2 - (1 - K)^(-A)`
+
+This is the Warsmash/WC3 exponential negative-armor curve. Minimum final physical-attack damage remains 1 in the current OpenRealm path.
+
+Attack-type/defense-type rows are also loaded from the active `DamageBonus*` Misc fields rather than being fixed in `s_attack.c`; if `DamageBonusSpells` is absent, the active Magic row is used as Warsmash's fallback. Basic missile attacks roll at launch and apply type/armor mitigation at impact.
+
+See [Attack Damage](games/warcraft-3/attack-damage.md) for the runtime modifier and timing contract.
 
 ### Defense Type Is a String
 `defType` in `UnitBalance.slk` is a string column (`"large"`, `"medium"`, etc.), not an integer. `atoi` returns 0 for every unit. Use `FindEnumValue` against the `defense_type[]` enum table. Base armor is `udef`; load `udfc` (realdef) at spawn.
@@ -171,8 +183,8 @@ Minimum final damage: 1.
 ### Attribute → Derived Stats (per-point constants from UnitBalance.slk)
 - **Strength**: +25 max HP per point
 - **Intelligence**: +15 max mana per point
-- **Agility**: +0.3 armor per point; scales attack speed
-- **Primary attribute**: +1 attack damage per point (`upra` column: `"STR"/"AGI"/"INT"`)
+- **Agility**: armor contribution uses `Misc.AgiDefenseBonus` (stock 0.3); attack speed uses `Misc.AgiAttackSpeedBonus` (stock 0.02)
+- **Primary attribute**: attack damage uses `Misc.StrAttackBonus` (stock 1.0) for whichever `upra` primary attribute is active
 
 Stats are precomputed at base attributes; deltas are applied live on attribute change. Gaining STR heals by the HP gained; losing attributes cannot drop a living hero below 1 HP. Call `G_RecomputeHeroStats` whenever `hero.str/agi/intel` change.
 

--- a/games/warcraft-3/game/g_building.c
+++ b/games/warcraft-3/game/g_building.c
@@ -6,8 +6,9 @@
 #define WC3_PATH_UNWALKABLE 0x02
 #define WC3_PATH_UNBUILDABLE 0x08
 #define WC3_PATH_BLIGHTED 0x20
-#define ID_UPGRADE_EFFECT_ATTACK_DICE MAKEFOURCC('r', 'a', 't', 'd')
-#define ID_UPGRADE_EFFECT_ARMOR       MAKEFOURCC('r', 'a', 'r', 'm')
+#define ID_UPGRADE_EFFECT_ATTACK_DAMAGE MAKEFOURCC('r', 'a', 't', 'x')
+#define ID_UPGRADE_EFFECT_ATTACK_DICE   MAKEFOURCC('r', 'a', 't', 'd')
+#define ID_UPGRADE_EFFECT_ARMOR         MAKEFOURCC('r', 'a', 'r', 'm')
 
 static BYTE G_PlacementFlags(LPCSTR list) {
     BYTE flags = 0;
@@ -139,7 +140,22 @@ static void G_ApplyUpgradeLevelDelta(LPEDICT unit, UpgradeData_t const *upgrade,
     FOR_LOOP(i, 4) {
         DWORD const effect = upgrade->effect[i];
         if (!effect) continue;
-        if (effect == ID_UPGRADE_EFFECT_ATTACK_DICE) {
+        if (effect == ID_UPGRADE_EFFECT_ATTACK_DAMAGE) {
+            LONG const old_value = (LONG)G_UpgradeEffectValue(upgrade, i, old_level);
+            LONG const new_value = (LONG)G_UpgradeEffectValue(upgrade, i, new_level);
+            LONG const delta = new_value - old_value;
+
+            if (delta && unit->attack1.numberOfDice) {
+                unit->attack1.permanentDamageBonus += (FLOAT)delta;
+                unit->attack1.damageBase = (DWORD)MAX(0, (LONG)unit->attack1.damageBase + delta);
+                changed = true;
+            }
+            if (delta && unit->attack2.numberOfDice) {
+                unit->attack2.permanentDamageBonus += (FLOAT)delta;
+                unit->attack2.damageBase = (DWORD)MAX(0, (LONG)unit->attack2.damageBase + delta);
+                changed = true;
+            }
+        } else if (effect == ID_UPGRADE_EFFECT_ATTACK_DICE) {
             LONG const old_value = (LONG)G_UpgradeEffectValue(upgrade, i, old_level);
             LONG const new_value = (LONG)G_UpgradeEffectValue(upgrade, i, new_level);
             LONG const delta = new_value - old_value;
@@ -155,6 +171,7 @@ static void G_ApplyUpgradeLevelDelta(LPEDICT unit, UpgradeData_t const *upgrade,
         } else if (effect == ID_UPGRADE_EFFECT_ARMOR) {
             FLOAT const delta = unit->UnitBalance->armorPerUpgrade * (FLOAT)(new_level - old_level);
             if (delta != 0.0f) {
+                unit->permanent_armor_bonus += delta;
                 unit->armor_value += delta;
                 changed = true;
             }

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -549,6 +549,11 @@ typedef struct {
     DWORD damageBase;
     DWORD numberOfDice;
     DWORD sidesPerDie;
+    /* Warsmash keeps permanent range changes separate from temporary green/red
+     * attack bonuses. damageBase includes permanentDamageBonus; rolls add
+     * temporaryDamageBonus after the dice. */
+    FLOAT permanentDamageBonus;
+    FLOAT temporaryDamageBonus;
     FLOAT damagePoint;
     FLOAT cooldown;
     FLOAT range;
@@ -915,7 +920,9 @@ struct edict_s {
     unitAttack_t attack1;
     unitAttack_t attack2;
     DWORD defense_type;   /* WC3 defType index: small/medium/large/fort/normal/hero/divine/none */
-    FLOAT armor_value;    /* computed armor ('realdef', incl. hero AGI) for damage reduction */
+    FLOAT armor_value;    /* computed armor ('realdef', incl. hero AGI/modifiers) */
+    FLOAT permanent_armor_bonus; /* research/permanent modifiers preserved across hero recompute */
+    FLOAT temporary_armor_bonus; /* item/temporary modifiers preserved across hero recompute */
     struct {
         BYTE select[MAX_UNIT_SELECT_SOUNDS];
         BYTE num_select;
@@ -982,6 +989,14 @@ struct game_locals {
         FLOAT gameDayLength;
         FLOAT buildingAngle;
         FLOAT rootAngle;
+        /* Combat constants are sourced from Units\MiscGame.txt (and
+         * war3mapMisc.txt overrides) rather than baked into attack code. */
+        FLOAT defenseArmor;
+        FLOAT strAttackBonus;
+        FLOAT agiDefenseBonus;
+        FLOAT agiAttackSpeedBonus;
+        FLOAT damageBonus[8][8];
+        BOOL combatConstantsLoaded;
         LONG foodCeiling;
         DWORD upkeepUsageCount;
         DWORD upkeepGoldTaxCount;
@@ -1651,6 +1666,7 @@ FLOAT AB_Data(LPCSTR, DWORD, DWORD);
 DWORD GetAbilityIndex(ability_t const *);
 
 // g_combat.c
+int G_AttackDamage(LPEDICT, LPEDICT, int);
 void T_Damage(LPEDICT, LPEDICT, int);
 
 // g_utils.c

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -139,6 +139,13 @@ static void InitMiscValue(LPCSTR name, FLOAT *dest) {
     *dest = strvalue ? atof(strvalue) : 0;
 }
 
+static void InitMiscValueDefault(LPCSTR name, FLOAT *dest, FLOAT fallback) {
+    LPCSTR strvalue = Stb_IniCacheFind(&game.config.misc, "Misc", name);
+    /* BZ_HARDCODED_DATA_FALLBACK: stock WC3 1.29 defaults are used only when
+     * the authoritative MiscGame field is absent from the active data set. */
+    *dest = strvalue && *strvalue ? (FLOAT)atof(strvalue) : fallback;
+}
+
 static DWORD InitMiscList(LPCSTR name, FLOAT *dest, DWORD capacity) {
     LPCSTR value = Stb_IniCacheFind(&game.config.misc, "Misc", name);
     DWORD count = 0;
@@ -166,6 +173,25 @@ static DWORD InitMiscList(LPCSTR name, FLOAT *dest, DWORD capacity) {
 }
 
 static void InitConstants(void) {
+    static FLOAT const default_damage_bonus[8][8] = {
+        /* BZ_HARDCODED_DATA_FALLBACK: WC3 1.29 MiscGame defaults. */
+        { 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f }, /* unknown */
+        { 1.00f, 1.50f, 1.00f, 0.70f, 1.00f, 1.00f, 0.05f, 1.00f }, /* normal  */
+        { 2.00f, 0.75f, 1.00f, 0.35f, 1.00f, 0.50f, 0.05f, 1.50f }, /* pierce  */
+        { 1.00f, 0.50f, 1.00f, 1.50f, 1.00f, 0.50f, 0.05f, 1.50f }, /* siege   */
+        { 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 0.70f, 0.05f, 1.00f }, /* spells  */
+        { 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f }, /* chaos   */
+        { 1.25f, 0.75f, 2.00f, 0.35f, 1.00f, 0.50f, 0.05f, 1.00f }, /* magic   */
+        { 1.00f, 1.00f, 1.00f, 0.50f, 1.00f, 1.00f, 0.05f, 1.00f }, /* hero    */
+    };
+    static struct { DWORD type; LPCSTR key; } const damage_rows[] = {
+        { ATK_NORMAL, "DamageBonusNormal" },
+        { ATK_PIERCE, "DamageBonusPierce" },
+        { ATK_SIEGE,  "DamageBonusSiege"  },
+        { ATK_CHAOS,  "DamageBonusChaos"  },
+        { ATK_MAGIC,  "DamageBonusMagic"  },
+        { ATK_HERO,   "DamageBonusHero"   },
+    };
     FLOAT food_ceiling;
     Stb_IniCacheLoadFiles(&game.config.misc, miscdata_files);
     InitMiscValue("AttackHalfAngle", &game.constants.attackHalfAngle);
@@ -182,6 +208,24 @@ static void InitConstants(void) {
     InitMiscValue("DayLength", &game.constants.gameDayLength);
     InitMiscValue("BuildingAngle", &game.constants.buildingAngle);
     InitMiscValue("RootAngle", &game.constants.rootAngle);
+
+    memcpy(game.constants.damageBonus, default_damage_bonus, sizeof(default_damage_bonus));
+    FOR_LOOP(i, sizeof(damage_rows) / sizeof(damage_rows[0])) {
+        DWORD const row = damage_rows[i].type;
+        InitMiscList(damage_rows[i].key, game.constants.damageBonus[row], 8);
+    }
+    /* Warsmash falls SPELLS back to the active Magic row when a dedicated
+     * DamageBonusSpells field is absent. */
+    if (!InitMiscList("DamageBonusSpells", game.constants.damageBonus[ATK_SPELLS], 8)) {
+        memcpy(game.constants.damageBonus[ATK_SPELLS], game.constants.damageBonus[ATK_MAGIC],
+               sizeof(game.constants.damageBonus[ATK_SPELLS]));
+    }
+    InitMiscValueDefault("DefenseArmor", &game.constants.defenseArmor, 0.06f);
+    InitMiscValueDefault("StrAttackBonus", &game.constants.strAttackBonus, 1.0f);
+    InitMiscValueDefault("AgiDefenseBonus", &game.constants.agiDefenseBonus, 0.3f);
+    InitMiscValueDefault("AgiAttackSpeedBonus", &game.constants.agiAttackSpeedBonus, 0.02f);
+    game.constants.combatConstantsLoaded = true;
+
     InitMiscValue("FoodCeiling", &food_ceiling);
     game.constants.foodCeiling = MAX(0, (LONG)food_ceiling);
     game.constants.upkeepUsageCount = InitMiscList("UpkeepUsage", game.constants.upkeepUsage, MAX_UPKEEP_TIERS);

--- a/games/warcraft-3/game/g_monster.c
+++ b/games/warcraft-3/game/g_monster.c
@@ -606,8 +606,27 @@ void SP_SpawnUnit(LPEDICT self) {
     self->attack1.factorSmall = w->attack1.factorSmall;
     self->attack1.maxTargets = w->attack1.maxTargets;
     self->attack1.damageLoss = w->attack1.damageLossFactor;
-    /* Heroes: fold the primary-attribute attack-damage bonus into damageBase now
-     * that base attributes + attack1 are loaded (no-op for non-heroes). */
+
+    /* Keep Attack 2 runtime state parallel with Attack 1 even though order
+     * selection still uses Attack 1 today. This lets upgrades/HUD math operate
+     * on mutable runtime values instead of immutable SLK rows. */
+    self->attack2.type = FindEnumValue(w->attack2.attackType, attack_type);
+    self->attack2.weapon = FindEnumValue(w->attack2.weaponType, weapon_type);
+    self->attack2.damageBase = w->attack2.damageBase;
+    self->attack2.numberOfDice = w->attack2.damageDice;
+    self->attack2.sidesPerDie = w->attack2.damageSides;
+    self->attack2.cooldown = w->attack2.cooldown;
+    self->attack2.damagePoint = w->attack2.damagePoint;
+    self->attack2.range = w->attack2.range;
+    self->attack2.areaFull = w->attack2.areaFull;
+    self->attack2.areaMedium = w->attack2.areaMedium;
+    self->attack2.areaSmall = w->attack2.areaSmall;
+    self->attack2.factorMedium = w->attack2.factorMedium;
+    self->attack2.factorSmall = w->attack2.factorSmall;
+    self->attack2.maxTargets = w->attack2.maxTargets;
+    self->attack2.damageLoss = w->attack2.damageLossFactor;
+    /* Heroes: fold the primary-attribute attack-damage bonus into runtime
+     * attacks now that base attributes and both weapon slots are loaded. */
     G_RecomputeHeroStats(self);
     /* Completed player upgrades are persistent techtree state, not producer
      * buffs. New units inherit the owner's current levels at spawn. */

--- a/games/warcraft-3/game/g_phys.c
+++ b/games/warcraft-3/game/g_phys.c
@@ -54,7 +54,12 @@ void SV_Physics_Toss(LPEDICT ent) {
         if (ent->currentmove && ent->currentmove->endfunc) {
             ent->currentmove->endfunc(ent);
         } else {
-            T_Damage(ent->goalentity, ent->owner, ent->damage);
+            /* Basic attack missiles carry the launch-time raw roll. Resolve
+             * target defense/armor on impact, matching Warsmash and allowing
+             * in-flight armor/defense changes to affect the hit. Spell
+             * missiles install currentmove/endfunc and bypass this branch. */
+            int const damage = G_AttackDamage(ent->owner, ent->goalentity, ent->damage);
+            T_Damage(ent->goalentity, ent->owner, damage);
             G_FreeEdict(ent);
         }
     } else {

--- a/games/warcraft-3/game/hud/hud_infopanel.c
+++ b/games/warcraft-3/game/hud/hud_infopanel.c
@@ -159,6 +159,20 @@ static void HideLegacyUnitStats(void) {
         UI_SetHidden(frames_to_hide[i], true);
 }
 
+static void FormatAttackDamageValue(char *buffer, size_t buffer_size,
+                                    LONG min_damage, LONG max_damage, FLOAT temporary_bonus) {
+    LONG const bonus = (LONG)temporary_bonus;
+    if (bonus > 0) {
+        snprintf(buffer, buffer_size, "%ld - %ld |cff00ff00+%ld|r",
+                 (long)min_damage, (long)max_damage, (long)bonus);
+    } else if (bonus < 0) {
+        snprintf(buffer, buffer_size, "%ld - %ld |cffff0000%ld|r",
+                 (long)min_damage, (long)max_damage, (long)bonus);
+    } else {
+        snprintf(buffer, buffer_size, "%ld - %ld", (long)min_damage, (long)max_damage);
+    }
+}
+
 static void WriteLegacyUnitStats(LPEDICT ent, UnitWeapons_t const *weapons,
                                  BOOL has_attack2, LONG min_damage, LONG max_damage,
                                  LONG min_damage2, LONG max_damage2, BOOL is_hero,
@@ -166,9 +180,13 @@ static void WriteLegacyUnitStats(LPEDICT ent, UnitWeapons_t const *weapons,
     char buffer[128];
 
     UI_SetText(hud.unit.AttackLabel1, "Damage:");
-    UI_SetText(hud.unit.AttackValue1, "%ld - %ld", (long)min_damage, (long)max_damage);
+    FormatAttackDamageValue(buffer, sizeof(buffer), min_damage, max_damage,
+                            ent->attack1.temporaryDamageBonus);
+    UI_SetText(hud.unit.AttackValue1, "%s", buffer);
     UI_SetText(hud.unit.AttackLabel2, "Damage:");
-    UI_SetText(hud.unit.AttackValue2, "%ld - %ld", (long)min_damage2, (long)max_damage2);
+    FormatAttackDamageValue(buffer, sizeof(buffer), min_damage2, max_damage2,
+                            ent->attack2.temporaryDamageBonus);
+    UI_SetText(hud.unit.AttackValue2, "%s", buffer);
     UI_SetHidden(hud.unit.AttackLabel2, !has_attack2);
     UI_SetHidden(hud.unit.AttackValue2, !has_attack2);
     UI_SetText(hud.unit.DefenseLabel, "Armor:");
@@ -178,7 +196,7 @@ static void WriteLegacyUnitStats(LPEDICT ent, UnitWeapons_t const *weapons,
     UI_SetText(hud.unit.RangeTitle1, "Range:");
     UI_SetText(hud.unit.RangeValue1, "%d", (int)(ent->attack1.range + 0.5f));
     UI_SetText(hud.unit.RangeTitle2, "Range:");
-    UI_SetText(hud.unit.RangeValue2, "%d", (int)(weapons->attack2.range + 0.5f));
+    UI_SetText(hud.unit.RangeValue2, "%d", (int)(ent->attack2.range + 0.5f));
     UI_SetHidden(hud.unit.RangeTitle2, !has_attack2);
     UI_SetHidden(hud.unit.RangeValue2, !has_attack2);
 
@@ -518,7 +536,8 @@ static void WriteSelectedUnitStatusFrames(LPEDICT ent, UnitWeapons_t const *weap
     if (has_attack1) {
         SetTypedInfoPanelIcon(hud.simple.InfoPanelIconBackdrop, "Damage", weapons->attack1.attackType,
                               weapon_upgrade != 0);
-        snprintf(value, sizeof(value), "%ld - %ld", (long)min_damage, (long)max_damage);
+        FormatAttackDamageValue(value, sizeof(value), min_damage, max_damage,
+                                ent->attack1.temporaryDamageBonus);
         UI_SetText(hud.simple.InfoPanelIconValue, "%s", value);
         SetUpgradeLevel(hud.simple.InfoPanelIconLevel, weapon_upgrade, ent);
         UI_WriteFrame(&hud.attack1);
@@ -527,7 +546,8 @@ static void WriteSelectedUnitStatusFrames(LPEDICT ent, UnitWeapons_t const *weap
     if (has_attack2) {
         SetTypedInfoPanelIcon(hud.attack2_icon_backdrop, "Damage", weapons->attack2.attackType,
                               weapon_upgrade != 0);
-        snprintf(value, sizeof(value), "%ld - %ld", (long)min_damage2, (long)max_damage2);
+        FormatAttackDamageValue(value, sizeof(value), min_damage2, max_damage2,
+                                ent->attack2.temporaryDamageBonus);
         UI_SetText(hud.attack2_icon_value, "%s", value);
         SetUpgradeLevel(hud.attack2_icon_level, weapon_upgrade, ent);
         UI_WriteFrame(&hud.attack2);
@@ -659,12 +679,12 @@ void UI_WriteSingleInfo(LPEDICT ent) {
                                                  : MAX(1, balance->level);
     LONG dice = ent->attack1.numberOfDice;
     BOOL has_attack1 = dice > 0;
-    LONG min_damage = has_attack1 ? (LONG)(ent->attack1.damageBase + dice) : 0;
-    LONG max_damage = has_attack1 ? (LONG)(ent->attack1.damageBase + dice * ent->attack1.sidesPerDie) : 0;
-    LONG dice2 = weapons->attack2.damageDice;
-    BOOL has_attack2 = UI_HasSecondAttack(weapons);
-    LONG min_damage2 = has_attack2 ? weapons->attack2.damageBase + dice2 : 0;
-    LONG max_damage2 = has_attack2 ? weapons->attack2.damageBase + dice2 * weapons->attack2.damageSides : 0;
+    LONG min_damage = has_attack1 ? MAX(0, (LONG)(ent->attack1.damageBase + dice)) : 0;
+    LONG max_damage = has_attack1 ? MAX(0, (LONG)(ent->attack1.damageBase + dice * ent->attack1.sidesPerDie)) : 0;
+    LONG dice2 = ent->attack2.numberOfDice;
+    BOOL has_attack2 = UI_HasSecondAttack(weapons) && dice2 > 0;
+    LONG min_damage2 = has_attack2 ? MAX(0, (LONG)(ent->attack2.damageBase + dice2)) : 0;
+    LONG max_damage2 = has_attack2 ? MAX(0, (LONG)(ent->attack2.damageBase + dice2 * ent->attack2.sidesPerDie)) : 0;
 
     if (!unit_name || !*unit_name) unit_name = GetClassName(ent->class_id);
     if (!name || !*name) name = unit_name;

--- a/games/warcraft-3/game/m_unit.c
+++ b/games/warcraft-3/game/m_unit.c
@@ -761,7 +761,10 @@ void G_RecomputeHeroStats(LPEDICT ent) {
     }
     FLOAT const newMaxHP = balance->maxHealth + ((LONG)ent->hero.str - baseStr) * 25.0f;
     FLOAT const newMaxMana = balance->maxMana + ((LONG)ent->hero.intel - baseInt) * 15.0f;
-    FLOAT const newArmor = balance->armor + ((LONG)ent->hero.agi - baseAgi) * 0.3f;
+    FLOAT const agiDefenseBonus = game.constants.combatConstantsLoaded
+                                ? game.constants.agiDefenseBonus
+                                : 0.3f;
+    FLOAT const newArmor = balance->armor + ((LONG)ent->hero.agi - baseAgi) * agiDefenseBonus;
 
     BOOL const alive = ent->health.value > 0.0f;
     FLOAT const dHP = newMaxHP - ent->health.max_value;
@@ -775,19 +778,32 @@ void G_RecomputeHeroStats(LPEDICT ent) {
     ent->mana.max_value = MAX(0.0f, newMaxMana);
     ent->mana.value = MAX(0.0f, MIN(ent->mana.max_value, ent->mana.value + dMana));
 
-    ent->armor_value = newArmor;
+    ent->armor_value = newArmor + ent->permanent_armor_bonus + ent->temporary_armor_bonus;
 
-    /* Primary attribute adds +1 attack damage per point (WC3 "green" bonus
-     * damage = the hero's current primary-attribute value).  Primary is the
-     * UnitBalance "Primary" column: STR/AGI/INT. */
+    /* Warsmash applies Misc.StrAttackBonus to whichever attribute is primary.
+     * OpenRealm does not yet split hero base-vs-bonus attributes, so the current
+     * primary value remains in the permanent displayed range; attack/item
+     * bonuses themselves are kept separate below. */
     {
         LPCSTR const prim = balance->primaryAttribute;
         DWORD primVal = ent->hero.str;
+        FLOAT const strAttackBonus = game.constants.combatConstantsLoaded
+                                   ? game.constants.strAttackBonus
+                                   : 1.0f;
+        LONG primaryDamage;
         if (prim) {
             if (!strcmp(prim, "AGI")) primVal = ent->hero.agi;
             else if (!strcmp(prim, "INT")) primVal = ent->hero.intel;
         }
-        ent->attack1.damageBase = ent->UnitWeapons->attack1.damageBase + (FLOAT)primVal;
+        primaryDamage = (LONG)((FLOAT)primVal * strAttackBonus);
+        if (ent->UnitWeapons) {
+            ent->attack1.damageBase = (DWORD)MAX(0,
+                (LONG)ent->UnitWeapons->attack1.damageBase + primaryDamage
+                + (LONG)ent->attack1.permanentDamageBonus);
+            ent->attack2.damageBase = (DWORD)MAX(0,
+                (LONG)ent->UnitWeapons->attack2.damageBase + primaryDamage
+                + (LONG)ent->attack2.permanentDamageBonus);
+        }
     }
 }
 

--- a/games/warcraft-3/game/skills/s_attack.c
+++ b/games/warcraft-3/game/skills/s_attack.c
@@ -72,10 +72,15 @@ void fire_rocket(LPEDICT ent, rocketDesc_t const *desc) {
 
 static FLOAT ai_rolldamage1(LPEDICT self, int weapon) {
     FLOAT damageBase = self->attack1.damageBase;
+    (void)weapon;
     FOR_LOOP(i, self->attack1.numberOfDice) {
-        damageBase += rand() % self->attack1.sidesPerDie + 1;
+        /* Warsmash treats a malformed zero-sided die as contributing +1
+         * instead of taking modulo zero. Normal Warcraft data has S > 0. */
+        damageBase += self->attack1.sidesPerDie
+                    ? (FLOAT)(rand() % self->attack1.sidesPerDie + 1)
+                    : 1.0f;
     }
-    return damageBase;
+    return damageBase + self->attack1.temporaryDamageBonus;
 }
 
 void M_GetEntityMatrix(LPCENTITYSTATE entity, LPMATRIX4 matrix) {
@@ -130,25 +135,26 @@ static BOOL attack_stop_if_target_invalid(LPEDICT attacker) {
     return true;
 }
 
-/* WC3 1.29 attack-type × defense-type damage multiplier table (verified from
- * MiscGame.txt). Rows = attack1.type (none,normal,pierce,siege,spells,chaos,
- * magic,hero); cols = defense_type (small,medium,large,fort,normal,hero,divine,
- * none). */
-static FLOAT const g_damage_table[8][8] = {
+/* Stock fallback for attack-type × defense-type values. Production games load
+ * the active table from MiscGame/war3mapMisc into game.constants; these values
+ * keep unit-level tests and early bootstrap callers deterministic. */
+static FLOAT const g_default_damage_table[8][8] = {
+    /* BZ_HARDCODED_DATA_FALLBACK: WC3 1.29 / Warsmash defaults. */
     /* small  medium large  fort   normal hero   divine none  */
     { 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f }, /* none   */
-    { 1.00f, 1.50f, 1.00f, 0.70f, 1.00f, 1.00f, 1.00f, 1.00f }, /* normal */
-    { 2.00f, 0.75f, 1.00f, 0.35f, 1.00f, 0.50f, 1.00f, 1.50f }, /* pierce */
-    { 1.00f, 0.50f, 1.00f, 1.50f, 1.00f, 0.50f, 1.00f, 1.50f }, /* siege  */
-    { 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 0.70f, 1.00f, 1.00f }, /* spells */
+    { 1.00f, 1.50f, 1.00f, 0.70f, 1.00f, 1.00f, 0.05f, 1.00f }, /* normal */
+    { 2.00f, 0.75f, 1.00f, 0.35f, 1.00f, 0.50f, 0.05f, 1.50f }, /* pierce */
+    { 1.00f, 0.50f, 1.00f, 1.50f, 1.00f, 0.50f, 0.05f, 1.50f }, /* siege  */
+    { 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 0.70f, 0.05f, 1.00f }, /* spells */
     { 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f, 1.00f }, /* chaos  */
-    { 1.25f, 0.75f, 2.00f, 0.35f, 1.00f, 0.50f, 1.00f, 1.00f }, /* magic  */
-    { 1.00f, 1.00f, 1.00f, 0.50f, 1.00f, 1.00f, 1.00f, 1.00f }, /* hero   */
+    { 1.25f, 0.75f, 2.00f, 0.35f, 1.00f, 0.50f, 0.05f, 1.00f }, /* magic  */
+    { 1.00f, 1.00f, 1.00f, 0.50f, 1.00f, 1.00f, 0.05f, 1.00f }, /* hero   */
 };
 
-/* Apply the WC3 damage formula: attack×defense type multiplier, then armor
- * reduction (0.06 coefficient).  Chaos attack bypasses the type table.
- * Result is clamped to a minimum of 1. */
+/* Apply the Warsmash/WC3 damage formula: active attack×defense multiplier,
+ * then numeric armor. Positive armor is 1/(1+K*A); negative armor uses the
+ * Warcraft exponential curve 2-(1-K)^(-A). Result remains minimum 1 for the
+ * existing OpenRealm physical-attack contract. */
 int G_AttackDamage(LPEDICT attacker, LPEDICT target, int base) {
     if (!attacker || !target || base <= 0)
         return base;
@@ -156,13 +162,19 @@ int G_AttackDamage(LPEDICT attacker, LPEDICT target, int base) {
     DWORD def = target->defense_type;
     if (atk >= 8) atk = 0;
     if (def >= 8) def = 7;
-    FLOAT mult = (atk == ATK_CHAOS) ? 1.0f : g_damage_table[atk][def];
+
+    FLOAT const mult = game.constants.combatConstantsLoaded
+                     ? game.constants.damageBonus[atk][def]
+                     : g_default_damage_table[atk][def];
+    FLOAT const armor_coefficient = game.constants.combatConstantsLoaded
+                                  ? game.constants.defenseArmor
+                                  : 0.06f;
     FLOAT dmg = (FLOAT)base * mult;
     FLOAT armor = G_UnitArmorValue(target);
     if (armor >= 0.0f)
-        dmg = dmg / (1.0f + armor * 0.06f);
+        dmg = dmg / (1.0f + armor * armor_coefficient);
     else
-        dmg = dmg * (2.0f - 1.0f / (1.0f - armor * 0.06f));
+        dmg = dmg * (2.0f - powf(1.0f - armor_coefficient, -armor));
     int result = (int)dmg;
     return result < 1 ? 1 : result;
 }
@@ -216,7 +228,9 @@ static void throw_missile(LPEDICT ent) {
         return;
     }
     LPEDICT other = ent->goalentity;
-    int damage = G_AttackDamage(ent, other, ai_rolldamage1(ent, 1));
+    /* Roll at launch, but defer target armor/type mitigation until impact so
+     * armor or defense changes while the projectile is in flight are honored. */
+    int damage = (int)ai_rolldamage1(ent, 1);
     MATRIX4 matrix;
     M_GetEntityMatrix(&ent->s, &matrix);
     VECTOR3 origin = Matrix4_multiply_vector3(&matrix, &ent->attack1.origin);
@@ -327,9 +341,15 @@ void order_attack(LPEDICT self, LPEDICT target) {
 }
 
 static FLOAT attack_speed_divisor(LPEDICT self) {
-    if (self->hero.agi > 0)
-        return 1.0f + (FLOAT)self->hero.agi * 0.02f;
-    return 1.0f;
+    FLOAT const agi_bonus = game.constants.combatConstantsLoaded
+                          ? game.constants.agiAttackSpeedBonus
+                          : 0.02f;
+    FLOAT total_bonus = (FLOAT)self->hero.agi * agi_bonus;
+    /* Warsmash clamps total attack-speed bonus to [-90%, +400%]. OpenRealm
+     * currently has only the Agility contribution, but keeping the clamp here
+     * makes extreme/custom hero data follow the same timing bounds. */
+    total_bonus = MAX(-0.9f, MIN(4.0f, total_bonus));
+    return 1.0f + total_bonus;
 }
 
 void attack_melee_cooldown(LPEDICT self) {

--- a/games/warcraft-3/game/skills/s_item_stats.c
+++ b/games/warcraft-3/game/skills/s_item_stats.c
@@ -25,12 +25,15 @@ static FLOAT item_stat_int_val;
 #define ID_ITEM_STAT     MAKEFOURCC('A', 'I', 'a', 'b')
 
 static void apply_attack(LPEDICT unit, FLOAT amount) {
-    unit->attack1.damageBase += amount;
-    unit->attack2.damageBase += amount;
+    unit->attack1.temporaryDamageBonus += amount;
+    unit->attack2.temporaryDamageBonus += amount;
+    G_InvalidateUnitInfoPanel(unit);
 }
 
 static void apply_defense(LPEDICT unit, FLOAT amount) {
+    unit->temporary_armor_bonus += amount;
     unit->armor_value += amount;
+    G_InvalidateUnitInfoPanel(unit);
 }
 
 static void apply_life(LPEDICT unit, FLOAT amount) {
@@ -53,9 +56,9 @@ static void apply_stat(LPEDICT unit, FLOAT str, FLOAT agi, FLOAT intel) {
     if (!G_UnitIsHero(unit)) {
         return;
     }
-    unit->hero.str += (DWORD)str;
-    unit->hero.agi += (DWORD)agi;
-    unit->hero.intel += (DWORD)intel;
+    unit->hero.str = (DWORD)MAX(0, (LONG)unit->hero.str + (LONG)str);
+    unit->hero.agi = (DWORD)MAX(0, (LONG)unit->hero.agi + (LONG)agi);
+    unit->hero.intel = (DWORD)MAX(0, (LONG)unit->hero.intel + (LONG)intel);
     G_RecomputeHeroStats(unit);
 }
 

--- a/games/warcraft-3/game/tests/t_building.c
+++ b/games/warcraft-3/game/tests/t_building.c
@@ -103,7 +103,7 @@ static const char building_repair_slk[] =
 
 static const char building_upgrade_slk[] =
     "ID;PWXL;N;E\n"
-    "B;X13;Y6;D0\n"
+    "B;X13;Y7;D0\n"
     "C;X1;Y1;K\"upgradeid\"\n"
     "C;X2;K\"class\"\n"
     "C;X3;K\"maxlevel\"\n"
@@ -160,6 +160,12 @@ static const char building_upgrade_slk[] =
     "C;X10;K\"rarm\"\n"
     "C;X11;K0\n"
     "C;X12;K0\n"
+    "C;X1;Y7;K\"Rhat\"\n"
+    "C;X2;K\"melee\"\n"
+    "C;X3;K3\n"
+    "C;X10;K\"ratx\"\n"
+    "C;X11;K2\n"
+    "C;X12;K1\n"
     "E\n";
 
 static slkTestData_t *building_install_upgrade_data(slkTestData_t **rows_out) {
@@ -356,6 +362,43 @@ TEST(wc3_building, researched_blacksmith_effects_update_existing_and_future_unit
 
     G_SetPlayerTechResearched(client, weapon, 0);
     G_SetPlayerTechResearched(client, armor, 0);
+    building_restore_upgrade_data(old, rows);
+}
+
+TEST(wc3_building, researched_attack_damage_effect_tracks_level_delta) {
+    LPGAMECLIENT client = &game.clients[0];
+    LPEDICT unit = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0, 0);
+    UnitBalance_t balance = { .upgrades = "Rhat" };
+    slkTestData_t *rows = NULL;
+    slkTestData_t *old = building_install_upgrade_data(&rows);
+    DWORD const attack_damage = MAKEFOURCC('R','h','a','t');
+
+    memset(client->tech, 0, sizeof(client->tech));
+    unit->s.player = client->ps.number;
+    unit->UnitBalance = &balance;
+    unit->attack1.numberOfDice = 1;
+    unit->attack1.damageBase = 10;
+    unit->attack2.numberOfDice = 1;
+    unit->attack2.damageBase = 20;
+
+    G_SetPlayerTechResearched(client, attack_damage, 1);
+    T_EQ(unit->attack1.damageBase, 12);
+    T_EQ(unit->attack2.damageBase, 22);
+    T_FEQ(unit->attack1.permanentDamageBonus, 2.0f, 0.001f);
+    T_FEQ(unit->attack2.permanentDamageBonus, 2.0f, 0.001f);
+
+    G_SetPlayerTechResearched(client, attack_damage, 3);
+    T_EQ(unit->attack1.damageBase, 14);
+    T_EQ(unit->attack2.damageBase, 24);
+    T_FEQ(unit->attack1.permanentDamageBonus, 4.0f, 0.001f);
+    T_FEQ(unit->attack2.permanentDamageBonus, 4.0f, 0.001f);
+
+    G_SetPlayerTechResearched(client, attack_damage, 0);
+    T_EQ(unit->attack1.damageBase, 10);
+    T_EQ(unit->attack2.damageBase, 20);
+    T_FEQ(unit->attack1.permanentDamageBonus, 0.0f, 0.001f);
+    T_FEQ(unit->attack2.permanentDamageBonus, 0.0f, 0.001f);
+
     building_restore_upgrade_data(old, rows);
 }
 

--- a/games/warcraft-3/game/tests/t_combat.c
+++ b/games/warcraft-3/game/tests/t_combat.c
@@ -18,8 +18,8 @@ void free_slk_rows(slkTestData_t *rows);
  *   G_AttackDamage       — representative attack×defense table cells (pierce/
  *                          small=2.0, normal/medium=1.5, siege/fort=1.5,
  *                          magic/large=2.0, chaos passthrough, hero/fort=0.5),
- *                          armor reduction (0.06/point), negative armor,
- *                          minimum-1 clamp, zero-armor passthrough
+ *                          data-driven armor/type constants, Divine reduction,
+ *                          exponential negative armor, minimum-1 clamp
  *   Ability lookup       — FindAbilityByClassname hit/miss,
  *                          command-name/rawcode resolution, GetAbilityByIndex,
  *                          GetAbilityIndex
@@ -540,6 +540,28 @@ TEST(wc3_combat, hero_primary_attribute_adds_damage) {
     T_FEQ(h->attack1.damageBase, dmg0 + 8.0f, 0.01f);
 }
 
+TEST(wc3_combat, hero_recompute_preserves_attack_and_armor_modifiers) {
+    LPEDICT h = make_combat_unit(MAKEFOURCC('H','p','a','l'), 650.0f, 0.0f, 0.0f);
+    h->hero.str = 22;
+    h->hero.agi = 13;
+    h->attack1.permanentDamageBonus = 2.0f;
+    h->attack1.temporaryDamageBonus = 5.0f;
+    h->permanent_armor_bonus = 2.0f;
+    h->temporary_armor_bonus = 3.0f;
+
+    G_RecomputeHeroStats(h);
+    T_FEQ(h->attack1.temporaryDamageBonus, 5.0f, 0.001f);
+    T_EQ(h->attack1.damageBase, h->UnitWeapons->attack1.damageBase + 22 + 2);
+    T_FEQ(h->armor_value, h->UnitBalance->armor + 5.0f, 0.001f);
+
+    h->hero.str = 30;
+    h->hero.agi = 23;
+    G_RecomputeHeroStats(h);
+    T_FEQ(h->attack1.temporaryDamageBonus, 5.0f, 0.001f);
+    T_EQ(h->attack1.damageBase, h->UnitWeapons->attack1.damageBase + 30 + 2);
+    T_FEQ(h->armor_value, h->UnitBalance->armor + 10 * 0.3f + 5.0f, 0.001f);
+}
+
 TEST(wc3_combat, hero_stats_noop_for_non_hero) {
     /* Footman has no attributes — recompute must leave its stats untouched. */
     LPEDICT u            = make_combat_unit(MAKEFOURCC('h','f','o','o'), 420.0f, 0.0f, 0.0f);
@@ -828,6 +850,18 @@ TEST(wc3_combat, attack_speed_scales_with_agility) {
     T_FEQ(h->wait, 0.3f / 1.4f, 0.001f);            /* windup scaled */
 }
 
+TEST(wc3_combat, attack_speed_agility_bonus_caps_at_five_times) {
+    LPEDICT h = make_combat_unit(MAKEFOURCC('H','p','a','l'), 650.0f, 0.0f, 0.0f);
+    h->hero.agi = 1000;
+    h->attack1.cooldown = 1.5f;
+    h->attack1.damagePoint = 0.3f;
+
+    attack_melee_cooldown(h);
+    T_FEQ(h->wait, (1.5f - 0.3f) / 5.0f, 0.001f);
+    attack_melee(h);
+    T_FEQ(h->wait, 0.3f / 5.0f, 0.001f);
+}
+
 /* ==========================================================================
  * G_AttackDamage — attack×defense table and armor reduction
  *
@@ -894,6 +928,33 @@ TEST(wc3_combat, attack_damage_hero_vs_fort) {
     T_EQ(G_AttackDamage(a, t, 100), 50);
 }
 
+/* Divine defense takes only 5% from ordinary attack classes; Chaos remains 100%. */
+TEST(wc3_combat, attack_damage_divine_uses_wc3_multiplier) {
+    LPEDICT normal = make_attacker(ATK_NORMAL);
+    LPEDICT chaos = make_attacker(ATK_CHAOS);
+    LPEDICT divine = make_target(6 /* divine */, 0.0f);
+    T_EQ(G_AttackDamage(normal, divine, 100), 5);
+    T_EQ(G_AttackDamage(chaos, divine, 100), 100);
+}
+
+/* Active Misc/war3mapMisc values override the stock fallback table/coefficient. */
+TEST(wc3_combat, attack_damage_uses_loaded_gameplay_constants) {
+    BOOL const old_loaded = game.constants.combatConstantsLoaded;
+    FLOAT const old_mult = game.constants.damageBonus[ATK_NORMAL][4];
+    FLOAT const old_armor = game.constants.defenseArmor;
+    LPEDICT a = make_attacker(ATK_NORMAL);
+    LPEDICT t = make_target(4 /* normal */, 2.0f);
+
+    game.constants.combatConstantsLoaded = true;
+    game.constants.damageBonus[ATK_NORMAL][4] = 1.25f;
+    game.constants.defenseArmor = 0.10f;
+    T_EQ(G_AttackDamage(a, t, 100), 104); /* 125 / 1.2 = 104.16... */
+
+    game.constants.combatConstantsLoaded = old_loaded;
+    game.constants.damageBonus[ATK_NORMAL][4] = old_mult;
+    game.constants.defenseArmor = old_armor;
+}
+
 /* Armor reduction: dmg / (1 + armor * 0.06). 100 base, 2 armor: 100/1.12 ≈ 89. */
 TEST(wc3_combat, attack_damage_armor_reduces_damage) {
     LPEDICT a = make_attacker(ATK_NORMAL);
@@ -902,12 +963,14 @@ TEST(wc3_combat, attack_damage_armor_reduces_damage) {
     T_ASSERT(result >= 88 && result <= 90);
 }
 
-/* Negative armor amplifies damage: dmg * (2 - 1/(1 + 2*0.06)) ≈ 111. */
-TEST(wc3_combat, attack_damage_negative_armor_amplifies) {
+/* Negative armor uses Warsmash's exponential WC3 curve: 2-(1-K)^(-armor).
+ * At -10 armor and K=.06 this is about 1.4614x, clearly distinct from the old
+ * reciprocal approximation (~1.375x). */
+TEST(wc3_combat, attack_damage_negative_armor_uses_exponential_curve) {
     LPEDICT a = make_attacker(ATK_NORMAL);
-    LPEDICT t = make_target(4 /* normal */, -2.0f);
+    LPEDICT t = make_target(4 /* normal */, -10.0f);
     int result = G_AttackDamage(a, t, 100);
-    T_ASSERT(result >= 110 && result <= 112);
+    T_ASSERT(result >= 145 && result <= 147);
 }
 
 /* Minimum 1: even a tiny base through heavy armor can't go below 1. */


### PR DESCRIPTION
Load attack and armor constants from active Warcraft misc data and fix Divine and negative-armor damage calculations.

Preserve permanent and temporary attack/armor modifiers across hero stat recomputation, add ratx attack-damage research, initialize Attack 2 runtime stats, and display temporary attack bonuses separately in the HUD.

Defer missile target mitigation until impact so in-flight armor changes affect the resulting hit, and apply Warsmash attack-speed limits and data-driven hero combat constants.

Document the attack-damage pipeline and extend combat/research coverage.