### PR TITLE
wc3: fix live resource values and upkeep tooltip legend

### DIFF
--- a/client/cl_layout.c
+++ b/client/cl_layout.c
@@ -210,6 +210,23 @@ LPCSTR SCR_GetStringValue(LPCUIFRAME frame) {
     return text;
 }
 
+LPCSTR SCR_GetTooltipText(LPCUIFRAME frame) {
+    static char text[2048];
+    LPCSTR src, token, value;
+    size_t prefix;
+
+    if (!frame || !frame->tooltip) return NULL;
+    src = frame->tooltip;
+    token = strstr(src, "{value}");
+    if (!token) return src;
+
+    value = SCR_GetStringValue(frame);
+    prefix = (size_t)(token - src);
+    snprintf(text, sizeof(text), "%.*s%s%s", (int)prefix, src,
+             value ? value : "", token + strlen("{value}"));
+    return text;
+}
+
 drawText_t SCR_GetDrawText(LPCUIFRAME frame,
                       FLOAT avl_width,
                       LPCSTR text,

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -238,6 +238,7 @@ static DWORD layout_hovered_layer;
 static DWORD layout_current_layer;
 static HANDLE layout_hovered;
 static HANDLE layout_current;
+static BOOL layout_current_window;
 
 /* Entity-context layouts use a server-authored tree rooted at the client-projected model top. */
 BOOL SCR_LayoutWorldHoverRoot(LPRECT root) {
@@ -533,9 +534,14 @@ static BOOL SCR_LayoutGlueTextButtonIsPushed(LPCUIFRAME frame) {
     return layout_left_down && SCR_LayoutFrameHasClickCommand(frame) && SCR_LayoutFrameIsHovered(frame);
 }
 static BOOL SCR_LayoutFrameIsHovered(LPCUIFRAME frame) {
-    return frame && frame->number == layout_hovered_number &&
-           ((layout_current && layout_current == layout_hovered) ||
-            (!layout_current && layout_current_layer == layout_hovered_layer));
+    if (!frame || frame->number != layout_hovered_number) return false;
+    /* Transient windows identify the hovered layout by handle. Persistent HUD
+     * layers identify it by layer number; layout_current is also used while
+     * drawing those layers, so it must not make ordinary HUD hover look like a
+     * window hover. */
+    if (layout_hovered)
+        return layout_current_window && layout_current == layout_hovered;
+    return !layout_current_window && layout_current_layer == layout_hovered_layer;
 }
 
 static void SCR_LayoutFormatOnClickCommand(LPCSTR src, LPSTR dst, DWORD dsz) {
@@ -580,6 +586,7 @@ void SCR_LayoutSetPointer(HANDLE layout, DWORD number, BOOL down) {
 }
 
 void SCR_WindowPrepare(HANDLE layout, LPCRECT root) {
+    layout_current_window = true;
     SCR_ClearWindow(layout);
     if (root) SCR_SetLayoutRoot(root);
 }
@@ -933,6 +940,14 @@ void SCR_LayoutDrawListBox(LPCUIFRAME frame, LPCRECT screen) {
 
 void SCR_LayoutDrawTooltip(LPCUIFRAME frame, LPCRECT scrn) {
     if (!active_tooltip) return;
+    /* Several HUD layers may carry the shared tooltip presentation frame.
+     * Draw it only in the layer/window that owns the hovered source frame so a
+     * passive resource tooltip is not overdrawn again by command-card layers. */
+    if (layout_hovered) {
+        if (!layout_current_window || layout_current != layout_hovered) return;
+    } else if (layout_current_window || layout_current_layer != layout_hovered_layer) {
+        return;
+    }
     uiTooltip_t const *tt = frame->buffer.data;
     FLOAT const PAD = 0.005f;
     RECT screen = *scrn;
@@ -950,16 +965,10 @@ void SCR_LayoutDrawTooltip(LPCUIFRAME frame, LPCRECT scrn) {
     re.DrawText(&dt);
 }
 
-void SCR_LayoutUpdateCommandButton(LPCUIFRAME frame, LPCRECT screen) {
-    if (SCR_LayoutFrameIsHovered(frame) && frame->tooltip)
-        active_tooltip = frame->tooltip;
-}
-
 typedef struct { FRAMETYPE type; void (*func)(LPCUIFRAME, LPCRECT); } drawer_t;
 
 static drawer_t updaters[] = {
-    { FT_COMMANDBUTTON, SCR_LayoutUpdateCommandButton },
-    { FT_BUILDQUEUE,    SCR_LayoutUpdateBuildQueue },
+    { FT_BUILDQUEUE, SCR_LayoutUpdateBuildQueue },
 };
 
 static drawer_t drawers[] = {
@@ -1006,6 +1015,13 @@ void SCR_LayoutDrawFrame(LPCUIFRAME frame) {
 
 void SCR_LayoutUpdateFrame(LPCUIFRAME frame) {
     RECT const *screen = SCR_LayoutRect(frame);
+
+    /* Tooltip ownership is a generic frame contract, not a command-button
+     * behavior. Resource-bar labels/icons and other passive HUD frames may
+     * carry tooltip text without becoming clickable controls. */
+    if (SCR_LayoutFrameIsHovered(frame) && frame->tooltip && *frame->tooltip)
+        active_tooltip = SCR_GetTooltipText(frame);
+
     FOR_LOOP(j, sizeof(updaters)/sizeof(*updaters)) {
         if (updaters[j].type == frame->flags.type) {
             updaters[j].func(frame, screen);
@@ -1057,6 +1073,7 @@ void SCR_DrawLayout(void) {
         HANDLE layout = layout_layers[layer];
         if (layout) {
             RECT root;
+            layout_current_window = false;
             layout_current_layer = layer;
             SCR_Clear(layout);
             if (layer == LAYER_WORLD_HOVER) {
@@ -1095,6 +1112,9 @@ void SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param) {
     VECTOR2 const point = SCR_ScreenToUI(x, y);
     LPCUIFRAME hovered_frame = NULL;
     int const modal_layer = SCR_LayoutModalLayer();
+    /* This path handles persistent layout layers, not client-managed windows. */
+    layout_current_window = false;
+    layout_hovered = NULL;
     layout_hovered_number = 0;
     FOR_LOOP(layer, MAX_LAYOUT_LAYERS) {
         HANDLE layout = layout_layers[layer];
@@ -1110,7 +1130,9 @@ void SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param) {
             if (frame->flags.type == FT_MULTISELECT)
                 hit = SCR_LayoutMultiselectEntityAt(frame, &point) != 0;
             else
-                hit = SCR_LayoutFrameHasClickCommand(frame) && Rect_contains(SCR_LayoutRect(frame), &point);
+                hit = (SCR_LayoutFrameHasClickCommand(frame) ||
+                       (frame->tooltip && *frame->tooltip)) &&
+                      Rect_contains(SCR_LayoutRect(frame), &point);
             if (hit) {
                 layout_hovered_number = frame->number;
                 hovered_frame = frame;
@@ -1308,7 +1330,9 @@ BOOL SCR_LayoutHitTest(int x, int y) {
                 if (SCR_LayoutMultiselectEntityAt(frame, &point)) return true;
                 continue;
             }
-            if (frame->flags.type != FT_TEXTURE && !SCR_LayoutFrameHasClickCommand(frame)) continue;
+            if (frame->flags.type != FT_TEXTURE &&
+                !SCR_LayoutFrameHasClickCommand(frame) &&
+                !(frame->tooltip && *frame->tooltip)) continue;
             if (Rect_contains(SCR_LayoutRect(frame), &point)) return true;
         }
     }

--- a/client/client.h
+++ b/client/client.h
@@ -202,6 +202,7 @@ VECTOR2 SCR_SolveAxisPosition(LPCUIFRAME frame,
                               bool is_x_axis,
                               bool assigned_size);
 LPCSTR SCR_GetStringValue(LPCUIFRAME frame);
+LPCSTR SCR_GetTooltipText(LPCUIFRAME frame);
 drawText_t SCR_GetDrawText(LPCUIFRAME frame,
                          FLOAT avl_width,
                          LPCSTR text,

--- a/docs/games/warcraft-3/food-and-upkeep.md
+++ b/docs/games/warcraft-3/food-and-upkeep.md
@@ -107,7 +107,17 @@ Stored resources are never retroactively changed when the upkeep tier changes.
 
 ## HUD And JASS
 
-The resource bar displays `FoodUsed/FoodCap` when cap is nonzero and only `FoodUsed` when cap is zero. Supply text turns red when `FoodUsed > FoodCap`. The upkeep label uses `No Upkeep`, `Low Upkeep`, and `High Upkeep` from the same 50/80 thresholds.
+The resource bar displays `FoodUsed/FoodCap` when cap is nonzero and only `FoodUsed` when cap is zero. Supply text turns red when `FoodUsed > FoodCap`. The upkeep tier is still derived by `G_GetPlayerUpkeepTier()` from the active `UpkeepUsage` constants; HUD code does not maintain a second threshold table. `ResourceBarUpkeepText` resolves `UPKEEP_NONE`, `UPKEEP_LOW`, or `UPKEEP_HIGH` from `GlobalStrings.fdf` when present and retains the existing English labels only as a missing-data fallback.
+
+Gold, lumber, supply, and upkeep hover help use the retail global-string identifiers `RESOURCE_UBERTIP_GOLD`, `RESOURCE_UBERTIP_LUMBER`, `RESOURCE_UBERTIP_SUPPLY`, and `RESOURCE_UBERTIP_UPKEEP`. `UI_LoadHudConsole()` explicitly loads `GlobalStrings.fdf` before the four stable named value frames from `ResourceBar.fdf` are serialized. Retail `ResourceBar.fdf` leaves the resource icon textures unnamed, so OpenRealm does not invent icon-frame names or hard-coded replacement hit rectangles. The named value frames retain FDF-owned geometry and are the authoritative passive hover targets.
+
+The resource tooltip heading is live player state, not just the static Ubertip body. Gold, lumber, and food use the externalized `COLON_GOLD`, `COLON_LUMBER`, and `COLON_FOOD` labels followed by a literal `{value}` marker in the server-authored tooltip. The client expands that marker from the hovered frame's `Stat` binding through the same `SCR_GetStringValue()` path used to draw the visible bar. This is intentional: a console layout can have been serialized before the newest playerstate snapshot arrives, so baking the server's then-current Gold/Lumber/Food value into the tooltip can leave a stale `0` while the bar itself correctly displays a newer value. Food therefore also shares the exact `FoodUsed/FoodCap`/ceiling formatter used by the visible text. Upkeep uses `COLON_UPKEEP` plus the current localized `UPKEEP_*` label, followed by `COLON_GOLD_INCOME_RATE` and the current `PLAYERSTATE_GOLD_UPKEEP_RATE`. The console refresh cache includes both upkeep-rate player states so an upkeep-rate change refreshes the server-authored Upkeep heading.
+
+Upkeep string layout is version-aware. If `RESOURCE_UBERTIP_UPKEEP` already contains multiple numeric tier ranges, OpenRealm treats that as a complete authored/localized legend and preserves it verbatim. Otherwise it prefers the split `RESOURCE_UBERTIP_UPKEEP_INFO` (`min-max`, localized tier label, income percent) or `RESOURCE_UBERTIP_UPKEEP_INFO_WOOD` (separate Gold/Lumber rates) format. If neither split key exists, OpenRealm still appends a fallback legend in the same row shape instead of leaving the player without an explanation of No/Low/High Upkeep. All generated rows come from the active `UpkeepUsage` thresholds, `FoodCeiling`, and the same tier-rate helpers used by `G_RecomputePlayerUpkeep()`; an unbounded final tier is shown with `N+ Food` rather than silently omitted. The `_WOOD` shape is selected when gameplay data actually taxes lumber. Thus `war3mapMisc.txt` threshold/tax overrides and generated upkeep legend rows share one source of truth.
+
+The console layer always serializes the ordinary `FT_TOOLTIPTEXT` presentation frame because resource help must work even when no unit is selected and no command-card layer exists. Client layout hover treats any frame with non-empty `uiFrame_t.tooltip` as hoverable without making it clickable. Tooltip selection is generic across frame types, while drawing is restricted to the layer/window that owns the hovered frame so the same tooltip is not painted once per HUD layer.
+
+The generic passive-hover contract and ownership rules are documented in [UI authoring](../../ui-authoring.md).
 
 The JASS rawcode natives `GetFoodMade(unitId)` and `GetFoodUsed(unitId)` read generic `UnitBalance` object data. Unit-instance `GetUnitFoodMade` / `GetUnitFoodUsed` continue to expose the unit type's configured values; the internal `edict.food` fields are bookkeeping, not a new JASS handle contract.
 
@@ -117,8 +127,8 @@ The JASS rawcode natives `GetFoodMade(unitId)` and `GetFoodUsed(unitId)` read ge
 - Hero altar production/revival still needs its command-specific food validation/reservation and displayed revival cost; direct `G_ReviveHero()` only restores the live unit's accounting.
 - Food-block feedback currently uses the existing gameplay text overlay. Race-specific Warcraft command-error sounds/localized `Nofood` strings need a dedicated command-error presentation path rather than hard-coded sound guesses in queue code.
 - `PLAYERSTATE_GOLD_GATHERED` / `PLAYERSTATE_LUMBER_GATHERED` remain storage/API states. This patch does not guess whether their Warcraft-compatible cumulative semantics are gross harvested or net credited.
-- Upkeep HUD strings remain authored directly by the current resource-bar code; localization through Warcraft UI string data is separate work.
 - `war3map.w3u` unit-object overrides remain subject to the existing normalized object-data merge limitations documented elsewhere.
+- Classic data sets that embed multiple numeric tier ranges directly inside `RESOURCE_UBERTIP_UPKEEP` remain authored text. Data sets without an embedded table get generated rows from the active upkeep constants, using split `RESOURCE_UBERTIP_UPKEEP_INFO[_WOOD]` strings when available and a compact fallback row format otherwise.
 
 ## Verification
 
@@ -137,5 +147,7 @@ Also run the existing gold/lumber movement tests because upkeep is applied at th
 make test-wc3-engine WC3_PATTERN='wc3_movement.gold_*'
 make test-wc3-engine WC3_PATTERN='wc3_movement.lumber_*'
 ```
+
+Manual HUD verification should also cover hovering all four resource values with no unit selected, then with a command card visible, to confirm exactly one tooltip backdrop is drawn and moving onto a command button transfers tooltip ownership cleanly. Confirm the Gold/Lumber/Food headings contain the current amounts and continue changing after the HUD layout was first sent, and that the Upkeep heading contains the current Gold income rate. Verify both upkeep-data shapes: an archive exposing `RESOURCE_UBERTIP_UPKEEP_INFO` should use the authored row format, while an archive with only a prose `RESOURCE_UBERTIP_UPKEEP` body should still receive the generated No/Low/High tier legend. Also verify an archive/language with the `UPKEEP_*` global strings so the upkeep label is externalized rather than falling back to English.
 
 These commands are verification guidance only; do not replace the test fixture archives with local Warcraft data.

--- a/docs/ui-authoring.md
+++ b/docs/ui-authoring.md
@@ -22,6 +22,12 @@ small proxy frame in C. Warsmash ships a project-owned `UI\FrameDef\SmashUI\Unit
 that file is not a retail MPQ source and must not be introduced as an OpenRealm data dependency. OpenRealm's portrait remains a runtime
 proxy, with its coordinates kept in parity with the reference runtime layout.
 
+### Passive FDF tooltips
+
+`uiFrame_t.tooltip` is a generic hover contract, not a command-button-only field. Persistent HUD hit testing treats a frame with non-empty tooltip text as hoverable even when `onclick` is empty; this is required for passive FDF labels such as the WC3 resource bar. Do not add fake click commands merely to make a frame hoverable. `FT_TOOLTIPTEXT` remains the shared presentation proxy. When multiple visible HUD layers serialize that presentation frame, the client draws it only in the layer/window that owns the current hovered source.
+
+For the WC3 resource bar, `ResourceBarGoldText`, `ResourceBarLumberText`, `ResourceBarSupplyText`, and `ResourceBarUpkeepText` are the stable named anchors. The retail resource icon textures are unnamed, so bind passive resource help to the named FDF value frames rather than creating project-owned icon geometry. Gold/Lumber/Food resource `Tip` headings use the generic `{value}` marker; `SCR_GetTooltipText()` expands it from the hovered frame's current `Stat` display value, preventing a server-authored layout packet from freezing an older amount while replicated playerstate continues to change. The descriptive `Ubertip` remains driven by Warcraft `GlobalStrings.fdf`. Upkeep prefers split `RESOURCE_UBERTIP_UPKEEP_INFO[_WOOD]` rows, preserves a base body that already contains tier ranges, and generates a gameplay-data-backed fallback legend if neither representation supplies one. See [WC3 food and upkeep](games/warcraft-3/food-and-upkeep.md).
+
 ### TextLength semantics
 
 WC3 FDF `TextLength` is layout geometry, not merely a character limit. When a text frame has no explicit `Width`, its implicit width

--- a/games/warcraft-3/game/g_food.c
+++ b/games/warcraft-3/game/g_food.c
@@ -48,6 +48,14 @@ static LONG G_UpkeepRate(LPCFLOAT taxes, DWORD count, DWORD tier) {
     return MAX(0, MIN(100, (LONG)(100.0f - tax * 100.0f + 0.5f)));
 }
 
+LONG G_GetUpkeepGoldRateForTier(DWORD tier) {
+    return G_UpkeepRate(game.constants.upkeepGoldTax, game.constants.upkeepGoldTaxCount, tier);
+}
+
+LONG G_GetUpkeepLumberRateForTier(DWORD tier) {
+    return G_UpkeepRate(game.constants.upkeepLumberTax, game.constants.upkeepLumberTaxCount, tier);
+}
+
 static void G_AdjustFoodStat(LPGAMECLIENT client, DWORD state, LONG delta) {
     LONG value;
 
@@ -65,10 +73,8 @@ void G_RecomputePlayerUpkeep(LPGAMECLIENT client) {
 
     if (!client) return;
     tier = G_GetPlayerUpkeepTier(client);
-    client->ps.stats[PLAYERSTATE_GOLD_UPKEEP_RATE] = (USHORT)G_UpkeepRate(
-        game.constants.upkeepGoldTax, game.constants.upkeepGoldTaxCount, tier);
-    client->ps.stats[PLAYERSTATE_LUMBER_UPKEEP_RATE] = (USHORT)G_UpkeepRate(
-        game.constants.upkeepLumberTax, game.constants.upkeepLumberTaxCount, tier);
+    client->ps.stats[PLAYERSTATE_GOLD_UPKEEP_RATE] = (USHORT)G_GetUpkeepGoldRateForTier(tier);
+    client->ps.stats[PLAYERSTATE_LUMBER_UPKEEP_RATE] = (USHORT)G_GetUpkeepLumberRateForTier(tier);
 }
 
 BOOL G_PlayerHasFoodFor(LPGAMECLIENT client, LONG food_cost) {

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -407,12 +407,14 @@ struct client_s {
         LONG xp;     /* hero experience, so the XP/attribute display updates live */
     } infopanel;
     /* Last resource values reflected in the resource bar, so the server only
-     * re-sends LAYER_CONSOLE when gold/lumber/food changes. */
+     * re-sends LAYER_CONSOLE when a displayed value or tooltip income rate changes. */
     struct {
         LONG gold;
         LONG lumber;
         LONG food_used;
         LONG food_cap;
+        LONG gold_rate;
+        LONG lumber_rate;
     } resourcebar;
     /* Persistent Hero/idle-worker HUD is rebuilt only after gameplay marks it
      * dirty. last_idle_worker is the cycling cursor, not a per-frame cache. */
@@ -1391,6 +1393,8 @@ BOOL player_pay(LPPLAYER, DWORD);
 BOOL G_FoodLimitsEnabled(void);
 LONG G_GetEffectiveFoodCap(LPGAMECLIENT client);
 DWORD G_GetPlayerUpkeepTier(LPGAMECLIENT client);
+LONG G_GetUpkeepGoldRateForTier(DWORD tier);
+LONG G_GetUpkeepLumberRateForTier(DWORD tier);
 BOOL G_PlayerHasFoodFor(LPGAMECLIENT client, LONG food_cost);
 BOOL G_ReserveTrainingFood(LPEDICT unit);
 void G_SetUnitFoodUsed(LPEDICT unit, LONG amount);

--- a/games/warcraft-3/game/hud/hud.c
+++ b/games/warcraft-3/game/hud/hud.c
@@ -67,11 +67,15 @@ static void UI_CopyFrameBase(LPUIFRAME dest, LPCFRAMEDEF src) {
         dest->points.x[i].offset = (SHORT)(src->Points.x[i].offset * UI_FRAMEPOINT_SCALE);
     }
     static char tooltip[1024];
+    LPCSTR tooltip_text = NULL;
     tooltip[0] = '\0';
-    if (src->Tip || src->Ubertip) {
-        snprintf(tooltip, sizeof(tooltip), "%s\n%s",
-                 src->Tip ? src->Tip : "",
-                 src->Ubertip ? src->Ubertip : "");
+    if (src->Tip && src->Ubertip) {
+        snprintf(tooltip, sizeof(tooltip), "%s\n%s", src->Tip, src->Ubertip);
+        tooltip_text = tooltip;
+    } else if (src->Tip) {
+        tooltip_text = src->Tip;
+    } else if (src->Ubertip) {
+        tooltip_text = src->Ubertip;
     }
     CONVERT_UV(dest->tex.coord, src->Texture.TexCoord);
     dest->number = FindFrameNumber(src, 0);
@@ -86,7 +90,7 @@ static void UI_CopyFrameBase(LPUIFRAME dest, LPCFRAMEDEF src) {
     dest->textLength = src->TextLength;
     dest->stat = src->Stat;
     dest->text = src->Text;
-    dest->tooltip = tooltip[0] ? tooltip : NULL;
+    dest->tooltip = tooltip_text;
     dest->onclick = src->OnClick;
 }
 

--- a/games/warcraft-3/game/hud/hud_console.c
+++ b/games/warcraft-3/game/hud/hud_console.c
@@ -11,8 +11,208 @@
 
 #include "hud_local.h"
 
+#define RESOURCE_TOOLTIP_TIP_SIZE 256
+#define RESOURCE_TOOLTIP_UBERTIP_SIZE 2048
+
+typedef struct {
+    char tip[RESOURCE_TOOLTIP_TIP_SIZE];
+    char ubertip[RESOURCE_TOOLTIP_UBERTIP_SIZE];
+} resourceTooltipText_t;
+
+static resourceTooltipText_t resource_tooltips[4];
+
+static LPCSTR UI_OptionalGlobalString(LPCSTR key) {
+    LPCSTR value;
+
+    if (!key || !*key) return NULL;
+    value = UI_GetString(key);
+    return value && strcmp(value, key) ? value : NULL;
+}
+
+static LPCSTR UI_GlobalStringOrFallback(LPCSTR key, LPCSTR fallback) {
+    LPCSTR value = UI_OptionalGlobalString(key);
+    return value ? value : fallback;
+}
+
+static void UI_AppendTooltipText(LPSTR out, DWORD out_size, LPCSTR text) {
+    DWORD used;
+
+    if (!out || !out_size || !text || !*text) return;
+    used = (DWORD)strlen(out);
+    if (used >= out_size - 1) return;
+    snprintf(out + used, out_size - used, "%s", text);
+}
+
+static LPCSTR UI_UpkeepLabel(DWORD tier) {
+    if (tier > 1) return UI_GlobalStringOrFallback("UPKEEP_HIGH", "High Upkeep");
+    if (tier == 1) return UI_GlobalStringOrFallback("UPKEEP_LOW", "Low Upkeep");
+    return UI_GlobalStringOrFallback("UPKEEP_NONE", "No Upkeep");
+}
+
+static BOOL UI_HasLumberUpkeepTax(void) {
+    FOR_LOOP(i, game.constants.upkeepLumberTaxCount) {
+        if (game.constants.upkeepLumberTax[i] > 0.0001f) return true;
+    }
+    return false;
+}
+
+static BOOL UI_UpkeepBodyHasTierRanges(LPCSTR text) {
+    DWORD ranges = 0;
+
+    if (!text) return false;
+    for (LPCSTR p = text; *p; p++) {
+        LPCSTR q;
+        if (!isdigit((unsigned char)*p)) continue;
+        q = p;
+        while (isdigit((unsigned char)*q)) q++;
+        if (*q == '-' && isdigit((unsigned char)q[1])) {
+            ranges++;
+            p = q;
+        }
+    }
+    return ranges >= 2;
+}
+
+static void UI_FormatUpkeepLegend(LPSTR out, DWORD out_size,
+                                  LPCSTR info, BOOL use_wood_info) {
+    DWORD tier_count;
+
+    if (!out || !out_size || !info || !*info) return;
+    /* Thresholds delimit tiers; the final tier lies above the final threshold.
+     * Tax arrays may be shorter, in which case gameplay clamps to their last
+     * authored rate through G_GetUpkeep*RateForTier(). */
+    tier_count = MIN(game.constants.upkeepUsageCount + 1, MAX_UPKEEP_TIERS + 1);
+
+    FOR_LOOP(tier, tier_count) {
+        LONG lower = 0;
+        LONG upper;
+        LONG gold_rate = G_GetUpkeepGoldRateForTier(tier);
+        LONG lumber_rate = G_GetUpkeepLumberRateForTier(tier);
+        LPCSTR label = UI_UpkeepLabel(tier);
+        char line[512];
+
+        if (tier > 0 && tier - 1 < game.constants.upkeepUsageCount)
+            lower = (LONG)game.constants.upkeepUsage[tier - 1] + 1;
+        if (tier < game.constants.upkeepUsageCount) {
+            upper = (LONG)game.constants.upkeepUsage[tier];
+        } else if (game.constants.foodCeiling > 0) {
+            upper = game.constants.foodCeiling;
+        } else {
+            /* Split Warcraft INFO formats require a min/max pair. If gameplay
+             * has no food ceiling, keep the final reachable tier visible with
+             * a compact fallback rather than silently dropping High Upkeep. */
+            if (use_wood_info) {
+                snprintf(line, sizeof(line), "|n%ld+ Food: %s|R (%ld%% G, %ld%% L)",
+                         (long)lower, label, (long)gold_rate, (long)lumber_rate);
+            } else {
+                snprintf(line, sizeof(line), "|n%ld+ Food: %s|R (%ld%% income)",
+                         (long)lower, label, (long)gold_rate);
+            }
+            UI_AppendTooltipText(out, out_size, line);
+            continue;
+        }
+
+        if (upper < lower) continue;
+        if (use_wood_info) {
+            snprintf(line, sizeof(line), info, (int)lower, (int)upper, label,
+                     (int)gold_rate, (int)lumber_rate);
+        } else {
+            snprintf(line, sizeof(line), info, (int)lower, (int)upper, label,
+                     (int)gold_rate);
+        }
+        UI_AppendTooltipText(out, out_size, line);
+    }
+}
+
+static void UI_FormatUpkeepUbertip(LPSTR out, DWORD out_size) {
+    LPCSTR base = UI_OptionalGlobalString("RESOURCE_UBERTIP_UPKEEP");
+    LPCSTR info = NULL;
+    BOOL wood_tax = UI_HasLumberUpkeepTax();
+    BOOL use_wood_info = false;
+
+    if (!out || !out_size) return;
+    out[0] = '\0';
+    if (base) UI_AppendTooltipText(out, out_size, base);
+
+    /* Some data versions embed the whole tier table directly in the base
+     * Ubertip. Preserve that authored/localized table. Otherwise prefer the
+     * split INFO key and finally fall back to the retail row shape so older or
+     * incomplete data still explains every reachable upkeep tier. */
+    if (UI_UpkeepBodyHasTierRanges(base)) return;
+    if (wood_tax) {
+        info = UI_OptionalGlobalString("RESOURCE_UBERTIP_UPKEEP_INFO_WOOD");
+        use_wood_info = info != NULL;
+    }
+    if (!info) info = UI_OptionalGlobalString("RESOURCE_UBERTIP_UPKEEP_INFO");
+    if (!info) {
+        info = UI_OptionalGlobalString("RESOURCE_UBERTIP_UPKEEP_INFO_WOOD");
+        use_wood_info = info != NULL;
+    }
+    if (!info) {
+        info = wood_tax
+            ? "|n%d-%d Food: %s|R (%d%% G, %d%% L)"
+            : "|n%d-%d Food: %s|R (%d%% income)";
+        use_wood_info = wood_tax;
+    }
+    UI_FormatUpkeepLegend(out, out_size, info, use_wood_info);
+}
+
+#ifdef BZ_TESTS
+BOOL UI_TestUpkeepBodyHasTierRanges(LPCSTR text) {
+    return UI_UpkeepBodyHasTierRanges(text);
+}
+
+void UI_TestFormatUpkeepLegend(LPSTR out, DWORD out_size, LPCSTR info, BOOL use_wood_info) {
+    if (out && out_size) out[0] = '\0';
+    UI_FormatUpkeepLegend(out, out_size, info, use_wood_info);
+}
+#endif
+
+static void UI_SetResourceTooltip(LPFRAMEDEF frame, resourceTooltipText_t *storage,
+                                  LPCSTR label_key, LPCSTR label_fallback,
+                                  LPCSTR ubertip_key) {
+    LPCSTR label;
+    LPCSTR body;
+
+    if (!frame || !storage) return;
+    label = UI_GlobalStringOrFallback(label_key, label_fallback);
+    body = UI_OptionalGlobalString(ubertip_key);
+    /* {value} is expanded on the client from this frame's Stat binding. This
+     * deliberately follows the same replicated playerstate used to draw the
+     * resource bar instead of freezing the value into an older layout packet. */
+    snprintf(storage->tip, sizeof(storage->tip), "%s {value}", label);
+    snprintf(storage->ubertip, sizeof(storage->ubertip), "%s", body ? body : "");
+    frame->Tip = storage->tip;
+    frame->Ubertip = storage->ubertip[0] ? storage->ubertip : NULL;
+}
+
+static void UI_SetUpkeepTooltip(LPFRAMEDEF frame, resourceTooltipText_t *storage,
+                                DWORD tier, LONG gold_rate) {
+    LPCSTR upkeep_label;
+    LPCSTR upkeep_prefix;
+    LPCSTR income_prefix;
+
+    if (!frame || !storage) return;
+    upkeep_label = UI_UpkeepLabel(tier);
+    upkeep_prefix = UI_GlobalStringOrFallback("COLON_UPKEEP", "Upkeep:");
+    income_prefix = UI_GlobalStringOrFallback("COLON_GOLD_INCOME_RATE", "Gold Income Rate:");
+
+    /* UPKEEP_* strings carry their own Warcraft color prefix and intentionally
+     * omit the reset. Close it before the income-rate line so the following
+     * authored text does not inherit the tier color. */
+    snprintf(storage->tip, sizeof(storage->tip), "%s %s|R|n%s %ld%%",
+             upkeep_prefix, upkeep_label, income_prefix, (long)gold_rate);
+    UI_FormatUpkeepUbertip(storage->ubertip, sizeof(storage->ubertip));
+    frame->Tip = storage->tip;
+    frame->Ubertip = storage->ubertip[0] ? storage->ubertip : NULL;
+}
+
 void UI_LoadHudConsole(void) {
     if (hud.console.ConsoleUI) return;
+    /* ResourceBar.fdf references global resource/upkeep strings indirectly;
+     * load that catalog explicitly instead of relying on another HUD panel to
+     * have parsed it first. Missing strings degrade to descriptive fallbacks. */
+    UI_EnsureFDF("UI\\FrameDef\\GlobalStrings.fdf");
     if (!ConsoleUI_Load(&hud.console)) return;
     UI_SetAllPoints(hud.console.ConsoleUI);
     ResourceBar_Load(&hud.res);
@@ -55,6 +255,7 @@ void UI_WriteConsoleBackdrop(LPGAMECLIENT client, LONG food_used, LONG food_cap)
     DWORD upkeep_tier;
     LPCSTR upkeep_text;
     COLOR32 upkeep_color;
+    LONG gold_rate;
 
     /* Keep symbolic DecorateFileNames keys in the payload; the local WC3 UI
      * resolves them for the recipient's race when the image configstring loads. */
@@ -74,8 +275,10 @@ void UI_WriteConsoleBackdrop(LPGAMECLIENT client, LONG food_used, LONG food_cap)
         FOR_LOOP(i, 4) UI_SetOnClick(buttons[i], "%s", hud.upper_cmds[i]);
     }
 
+    gold_rate = (LONG)client->ps.stats[PLAYERSTATE_GOLD_UPKEEP_RATE];
+
     upkeep_tier = G_GetPlayerUpkeepTier(client);
-    upkeep_text = upkeep_tier > 1 ? "High Upkeep" : upkeep_tier == 1 ? "Low Upkeep" : "No Upkeep";
+    upkeep_text = UI_UpkeepLabel(upkeep_tier);
     upkeep_color = upkeep_tier > 1 ? MAKE(COLOR32, 255, 64, 64, 255)
                  : upkeep_tier == 1 ? MAKE(COLOR32, 255, 200, 64, 255)
                                     : MAKE(COLOR32, 96, 255, 96, 255);
@@ -85,6 +288,21 @@ void UI_WriteConsoleBackdrop(LPGAMECLIENT client, LONG food_used, LONG food_cap)
         ? MAKE(COLOR32, 255, 64, 64, 255)
         : COLOR32_WHITE;
 
+    /* Resource-bar tooltip listeners follow these named value frames. Their
+     * headings contain a client-side {value} token so hover text always uses
+     * the same current Stat value as the visible resource bar. */
+    UI_SetResourceTooltip(hud.res.ResourceBarGoldText, &resource_tooltips[0],
+                          "COLON_GOLD", "Gold:", "RESOURCE_UBERTIP_GOLD");
+    UI_SetResourceTooltip(hud.res.ResourceBarLumberText, &resource_tooltips[1],
+                          "COLON_LUMBER", "Lumber:", "RESOURCE_UBERTIP_LUMBER");
+    UI_SetResourceTooltip(hud.res.ResourceBarSupplyText, &resource_tooltips[2],
+                          "COLON_FOOD", "Food:", "RESOURCE_UBERTIP_SUPPLY");
+    UI_SetUpkeepTooltip(hud.res.ResourceBarUpkeepText, &resource_tooltips[3],
+                        upkeep_tier, gold_rate);
+
     UI_WriteFrameWithChildren(hud.console.ConsoleUI, NULL);
+    /* Resource-bar fields are present even with no unit selected, so the
+     * console layer must carry its own standard tooltip presentation frame. */
+    UI_WriteTooltipFrame();
     UI_SetCurrentClient(NULL);
 }

--- a/games/warcraft-3/game/hud/hud_infopanel.c
+++ b/games/warcraft-3/game/hud/hud_infopanel.c
@@ -1109,22 +1109,26 @@ void G_UpdateClientInfoPanels(void) {
     }
 }
 
-/* Re-send LAYER_CONSOLE only when a resource value changed. */
+/* Re-send LAYER_CONSOLE only when resource display/tooltip state changed. */
 void G_RefreshResourceBar(LPEDICT ent) {
     LPPLAYER ps;
-    LONG gold, lumber, food_u, food_c;
+    LONG gold, lumber, food_u, food_c, gold_rate, lumber_rate;
 
     if (!ent || !ent->client) return;
-    ps     = &ent->client->ps;
-    gold   = (LONG)ps->stats[PLAYERSTATE_RESOURCE_GOLD];
-    lumber = (LONG)ps->stats[PLAYERSTATE_RESOURCE_LUMBER];
-    food_u = (LONG)ps->stats[PLAYERSTATE_RESOURCE_FOOD_USED];
-    food_c = G_GetEffectiveFoodCap(ent->client);
+    ps          = &ent->client->ps;
+    gold        = (LONG)ps->stats[PLAYERSTATE_RESOURCE_GOLD];
+    lumber      = (LONG)ps->stats[PLAYERSTATE_RESOURCE_LUMBER];
+    food_u      = (LONG)ps->stats[PLAYERSTATE_RESOURCE_FOOD_USED];
+    food_c      = G_GetEffectiveFoodCap(ent->client);
+    gold_rate   = (LONG)ps->stats[PLAYERSTATE_GOLD_UPKEEP_RATE];
+    lumber_rate = (LONG)ps->stats[PLAYERSTATE_LUMBER_UPKEEP_RATE];
 
-    if (gold   == ent->client->resourcebar.gold   &&
-        lumber == ent->client->resourcebar.lumber  &&
-        food_u == ent->client->resourcebar.food_used &&
-        food_c == ent->client->resourcebar.food_cap)
+    if (gold        == ent->client->resourcebar.gold        &&
+        lumber      == ent->client->resourcebar.lumber      &&
+        food_u      == ent->client->resourcebar.food_used   &&
+        food_c      == ent->client->resourcebar.food_cap    &&
+        gold_rate   == ent->client->resourcebar.gold_rate   &&
+        lumber_rate == ent->client->resourcebar.lumber_rate)
         return;
 
     UI_WriteStart(LAYER_CONSOLE);
@@ -1132,10 +1136,12 @@ void G_RefreshResourceBar(LPEDICT ent) {
     UI_WriteMinimapFrame();
     UI_WriteEnd(ent);
 
-    ent->client->resourcebar.gold      = gold;
-    ent->client->resourcebar.lumber    = lumber;
-    ent->client->resourcebar.food_used = food_u;
-    ent->client->resourcebar.food_cap  = food_c;
+    ent->client->resourcebar.gold        = gold;
+    ent->client->resourcebar.lumber      = lumber;
+    ent->client->resourcebar.food_used   = food_u;
+    ent->client->resourcebar.food_cap    = food_c;
+    ent->client->resourcebar.gold_rate   = gold_rate;
+    ent->client->resourcebar.lumber_rate = lumber_rate;
 }
 
 /* Once per server frame, keep every player's resource bar in sync. */

--- a/games/warcraft-3/game/tests/t_food.c
+++ b/games/warcraft-3/game/tests/t_food.c
@@ -9,6 +9,9 @@ void ai_train_build(LPEDICT ent);
 void unit_build(LPEDICT ent, DWORD class_id);
 BOOL run_test_jass(LPCSTR src);
 
+BOOL UI_TestUpkeepBodyHasTierRanges(LPCSTR text);
+void UI_TestFormatUpkeepLegend(LPSTR out, DWORD out_size, LPCSTR info, BOOL use_wood_info);
+
 static LPCSTR food_limits_off_cvar(LPCSTR name, LPCSTR fallback) {
     return !strcmp(name, "wc3_food_limits") ? "0" : fallback;
 }
@@ -117,6 +120,35 @@ TEST(wc3_food, food_limits_cvar_allows_training_over_cap_but_keeps_accounting) {
     T_EQ(client->ps.stats[PLAYERSTATE_GOLD_UPKEEP_RATE], 70);
 
     gi.CvarString = saved_cvar;
+}
+
+TEST(wc3_food, upkeep_tier_rate_helpers_match_gameplay_tax_data) {
+    T_EQ(G_GetUpkeepGoldRateForTier(0), 100);
+    T_EQ(G_GetUpkeepGoldRateForTier(1), 70);
+    T_EQ(G_GetUpkeepGoldRateForTier(2), 40);
+    T_EQ(G_GetUpkeepLumberRateForTier(0), 100);
+    T_EQ(G_GetUpkeepLumberRateForTier(1), 100);
+    T_EQ(G_GetUpkeepLumberRateForTier(2), 100);
+}
+
+TEST(wc3_food, upkeep_tooltip_detects_embedded_legend_ranges) {
+    T_ASSERT(UI_TestUpkeepBodyHasTierRanges(
+        "0-50 Food: No Upkeep|n51-80 Food: Low Upkeep|n81-100 Food: High Upkeep"));
+    T_ASSERT(!UI_TestUpkeepBodyHasTierRanges(
+        "Upkeep is determined by the amount of Food your forces are using."));
+}
+
+TEST(wc3_food, upkeep_tooltip_fallback_legend_uses_gameplay_thresholds_and_rates) {
+    char text[1024];
+
+    UI_TestFormatUpkeepLegend(text, sizeof(text),
+                              "|n%d-%d Food: %s|R (%d%% income)", false);
+    T_ASSERT(strstr(text, "0-50 Food:"));
+    T_ASSERT(strstr(text, "51-80 Food:"));
+    T_ASSERT(strstr(text, "81-100 Food:"));
+    T_ASSERT(strstr(text, "(100% income)"));
+    T_ASSERT(strstr(text, "(70% income)"));
+    T_ASSERT(strstr(text, "(40% income)"));
 }
 
 TEST(wc3_food, upkeep_rates_follow_food_used_thresholds) {

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -386,6 +386,22 @@ TEST(wc3_game, hud_multiline_fdf_text_keeps_renderer_auto_height) {
     T_FEQ(wire.size.height, 0.0f, 0.0001f);
 }
 
+TEST(wc3_game, hud_passive_string_serializes_tooltip) {
+    FRAMEDEF frame = { .Type = FT_STRING };
+    uiFrame_t wire = { 0 };
+    BYTE typedata[128] = { 0 };
+    char textbuf[128] = { 0 };
+
+    frame.Text = "500";
+    frame.Tip = "Gold: {value}";
+    frame.Ubertip = "Gold is mined from gold mines.";
+    UI_ResetFrameWriteList();
+    T_ASSERT(UI_BuildFrameForWrite(&frame, &wire, typedata, sizeof(typedata),
+                                   textbuf, sizeof(textbuf)));
+    T_STREQ(wire.tooltip, "Gold: {value}\nGold is mined from gold mines.");
+    T_ASSERT(!wire.onclick || !*wire.onclick);
+}
+
 TEST(wc3_game, hud_checkbox_serializes_authored_states_and_checked_value) {
     BYTE typedata[256];
     char textbuf[128];

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -119,6 +119,33 @@ TEST(client_layout, unknown_high_stat_binding_resolves_empty) {
     T_STREQ(SCR_GetStringValue(&frame), "");
 }
 
+TEST(client_layout, tooltip_value_token_uses_live_player_stat) {
+    uiFrame_t frame = {
+        .stat = PLAYERSTATE_RESOURCE_GOLD,
+        .tooltip = "Gold: {value}\nGold resource help.",
+    };
+
+    test_client_stubs_init();
+    cl.playerstate.stats[PLAYERSTATE_RESOURCE_GOLD] = 500;
+    T_STREQ(SCR_GetTooltipText(&frame), "Gold: 500\nGold resource help.");
+
+    cl.playerstate.stats[PLAYERSTATE_RESOURCE_GOLD] = 725;
+    T_STREQ(SCR_GetTooltipText(&frame), "Gold: 725\nGold resource help.");
+}
+
+TEST(client_layout, tooltip_value_token_uses_food_display_format) {
+    uiFrame_t frame = {
+        .stat = PLAYERSTATE_RESOURCE_FOOD_USED,
+        .tooltip = "Food: {value}\nFood resource help.",
+    };
+
+    test_client_stubs_init();
+    cl.playerstate.stats[PLAYERSTATE_RESOURCE_FOOD_USED] = 18;
+    cl.playerstate.stats[PLAYERSTATE_RESOURCE_FOOD_CAP] = 24;
+    cl.playerstate.stats[PLAYERSTATE_FOOD_CAP_CEILING] = 100;
+    T_STREQ(SCR_GetTooltipText(&frame), "Food: 18/24\nFood resource help.");
+}
+
 TEST(client_layout, world_hover_root_projects_model_top_into_ui_canvas) {
     RECT root;
     renderEntity_t render = { .number = 7 };


### PR DESCRIPTION
Expand resource tooltip values from the same client playerstate bindings used by the visible HUD so gold, lumber, and food cannot freeze at values from an older layout snapshot.

Generate the upkeep tier legend from gameplay thresholds and rates when Warcraft data provides neither an embedded table nor split RESOURCE_UBERTIP_UPKEEP_INFO strings.