### PR TITLE
wc3: fix repair goal cleanup across order transitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 research queues, upgrade costs/requirements, player tech state, Blacksmith attack/armor effects | [docs/games/warcraft-3/research-and-upgrades.md](docs/games/warcraft-3/research-and-upgrades.md) |
 | WC3 building damage fire thresholds, MDX Sprite attachments, race-specific effect families | [docs/games/warcraft-3/building-damage-rendering.md](docs/games/warcraft-3/building-damage-rendering.md) |
 | WC3 Build/Repair blocked-footprint approach routing | [docs/games/warcraft-3/build-repair-routing.md](docs/games/warcraft-3/build-repair-routing.md) |
+| WC3 generic autocast hooks, command-button right click, Auto Repair nearest-valid acquisition | [docs/games/warcraft-3/autocast.md](docs/games/warcraft-3/autocast.md) |
 | WC3 food/supply ownership, training reservations, provider lifecycle, upkeep income | [docs/games/warcraft-3/food-and-upkeep.md](docs/games/warcraft-3/food-and-upkeep.md) |
 | WC3 Hero death persistence and Altar revival lifecycle | [docs/games/warcraft-3/hero-revival.md](docs/games/warcraft-3/hero-revival.md) |
 | WC3 Rally producer state, Smart handoff, target lifetime, JASS getters | [docs/games/warcraft-3/rally-points.md](docs/games/warcraft-3/rally-points.md) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ The registry lives in `libshared` so game-module constructors register into the 
 Available assertions: `T_ASSERT(cond)`, `T_EQ(a,b)`, `T_NE(a,b)`, `T_FEQ(a,b,eps)`, `T_STREQ(a,b)`, `T_NULL(p)`, `T_NOT_NULL(p)`.
 
 Warcraft III tests share `alloc_test_unit()` from `games/warcraft-3/game/tests/t_utils.c`. For IDs backed by a real `UnitBalance` row, the helper initializes current/max health to the authored `maxHealth`, matching the live-unit contract of `SP_SpawnUnit`. Tests that need a dead unit must set `health.value = 0` explicitly; otherwise selection and order validation will correctly reject the fixture through `M_IsDead()`.
+`setup_test_world()` installs a mutable synthetic `MAPINFO`, but production exposes it through `level.mapinfo` as `LPCMAPINFO`. Tests that need to configure synthetic player-slot metadata must cast that fixture view back to `LPMAPINFO` (for example `((LPMAPINFO)level.mapinfo)->players[1].playerType = ...`) rather than assigning through the const production pointer.
 
 Assertion failures always include `__FILE__` and `__LINE__`. Under GitHub Actions, the runner also emits a workflow error annotation so failures are clickable at the originating source line.
 

--- a/client/cl_input.c
+++ b/client/cl_input.c
@@ -153,7 +153,7 @@ void CL_Input(void) {
                     break;
                 }
                 if (CL_WindowMouseEvent(UI_MOUSE_DOWN, event.button.x, event.button.y, event.button.button)) break;
-                SCR_LayoutMouseEvent(UI_MOUSE_DOWN, event.button.x, event.button.y, event.button.button);
+                if (SCR_LayoutMouseEvent(UI_MOUSE_DOWN, event.button.x, event.button.y, event.button.button)) break;
                 if (cls.key_dest == key_menu) {
                     if (event.button.button == SDL_BUTTON_LEFT) {
                         mouse.event = UI_LEFT_MOUSE_DOWN;
@@ -176,7 +176,7 @@ void CL_Input(void) {
                     break;
                 }
                 if (CL_WindowMouseEvent(UI_MOUSE_UP, event.button.x, event.button.y, event.button.button)) break;
-                SCR_LayoutMouseEvent(UI_MOUSE_UP, event.button.x, event.button.y, event.button.button);
+                if (SCR_LayoutMouseEvent(UI_MOUSE_UP, event.button.x, event.button.y, event.button.button)) break;
                 if (cls.key_dest == key_menu) {
                     if (event.button.button == SDL_BUTTON_LEFT) {
                         mouse.event = UI_LEFT_MOUSE_UP;

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -817,7 +817,8 @@ void SCR_LayoutDrawCommandButton(LPCUIFRAME frame, LPCRECT screen) {
         .uv          = suv,
         .color       = COLOR32_WHITE,
         .shader      = SHADER_COMMANDBUTTON,
-        .uActiveGlow = sel ? sel->ability == frame->stat : 0));
+        .uActiveGlow = (frame->flagsvalue & UIFLAG_ALTERNATE_ACTIVE) ||
+                       (sel && sel->ability == frame->stat)));
     (void)frame;
 }
 
@@ -1108,7 +1109,7 @@ static int SCR_LayoutModalLayer(void) {
 
 BOOL SCR_LayoutModalActive(void) { return SCR_LayoutModalLayer() >= 0; }
 
-void SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param) {
+BOOL SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param) {
     VECTOR2 const point = SCR_ScreenToUI(x, y);
     LPCUIFRAME hovered_frame = NULL;
     int const modal_layer = SCR_LayoutModalLayer();
@@ -1143,19 +1144,35 @@ void SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param) {
         if (layout_hovered_number) break;
     }
 
-    if (param != 1) return;
+    /* Proxy command buttons may carry a secondary command in text. Warcraft
+     * uses this for right-click autocast toggles while preserving left-click
+     * targeting on the same icon. Consume both right-button edges so the click
+     * cannot also become a world Smart order. */
+    if (param == SDL_BUTTON_RIGHT) {
+        if (!hovered_frame || hovered_frame->flags.type != FT_COMMANDBUTTON ||
+            !hovered_frame->text || !*hovered_frame->text) {
+            return false;
+        }
+        if (event == UI_MOUSE_DOWN) return true;
+        if (event != UI_MOUSE_UP) return false;
+        MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
+        SZ_Printf(&cls.netchan.message, "%s", hovered_frame->text);
+        return true;
+    }
+
+    if (param != SDL_BUTTON_LEFT) return false;
     if (event == UI_MOUSE_DOWN) {
         char command[CMDARG_LEN * 2];
         layout_left_down = true;
-        if (!hovered_frame || layout_held_command[0]) return;
+        if (!hovered_frame || layout_held_command[0]) return false;
         SCR_LayoutFormatOnClickCommand(hovered_frame->onclick, command, sizeof(command));
-        if (command[0] != '+') return;
+        if (command[0] != '+') return false;
         strlcpy(layout_held_command, command, sizeof(layout_held_command));
         MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
         SZ_Printf(&cls.netchan.message, "%s", layout_held_command);
-        return;
+        return false;
     }
-    if (event != UI_MOUSE_UP) return;
+    if (event != UI_MOUSE_UP) return false;
     layout_left_down = false;
     if (layout_held_command[0]) {
         char command[sizeof(layout_held_command)];
@@ -1164,7 +1181,7 @@ void SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param) {
         layout_held_command[0] = '\0';
         MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
         SZ_Printf(&cls.netchan.message, "%s", command);
-        return;
+        return false;
     }
 
     FOR_LOOP(layer, MAX_LAYOUT_LAYERS) {
@@ -1182,7 +1199,7 @@ void SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param) {
                 if (entity) {
                     MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
                     SZ_Printf(&cls.netchan.message, "focus %u", (unsigned)entity);
-                    return;
+                    return false;
                 }
                 continue;
             }
@@ -1192,10 +1209,11 @@ void SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param) {
                 SCR_LayoutFormatOnClickCommand(frame->onclick, command, sizeof(command));
                 MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
                 SZ_Printf(&cls.netchan.message, "%s", command);
-                return;
+                return false;
             }
         }
     }
+    return false;
 }
 
 /* Dispatch a command-button hotkey the same way a mouse click on that */

--- a/client/ui_layout.h
+++ b/client/ui_layout.h
@@ -31,7 +31,7 @@ BOOL SCR_LayoutHitTest(int x, int y);
 BOOL SCR_LayoutModalActive(void);
 void SCR_LayoutClampSelectionRect(LPRECT rect);
 void SCR_DrawLayout(void);
-void SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param);
+BOOL SCR_LayoutMouseEvent(uiMouseEvent_t event, int x, int y, int32_t param);
 BOOL SCR_LayoutScrollTextAreaAt(HANDLE layout, LPCVECTOR2 point, int wheel_y);
 FLOAT SCR_LayoutTextAreaMaxScroll(LPCUIFRAME frame);
 BOOL SCR_LayoutKeyEvent(int key);

--- a/common/msg.c
+++ b/common/msg.c
@@ -100,7 +100,8 @@ netField_t entityStateFields[] = {
  *   stat          — player stat index shown as a live number;
  *                   0 means use the text string instead
  *   color         — RGBA tint
- *   text          — static display string (label, button caption, …)
+ *   text          — type-specific string (display text for text frames; optional
+ *                   secondary click command for command buttons)
  *   tooltip       — tooltip string shown on hover
  *   onclick       — server command sent back when the element is clicked
  *                   (e.g. "button Amov")

--- a/common/shared.h
+++ b/common/shared.h
@@ -792,7 +792,8 @@ typedef enum {
     FT_NAMETAG,
 } FRAMETYPE;
 
-#define UIFLAG_SIZE_TO_CONTENT (1 << 10) // flag bit; derives a composite frame's size from rendered content; used by FT_NAMETAG
+#define UIFLAG_SIZE_TO_CONTENT   (1 << 10) // flag bit; derives a composite frame's size from rendered content; used by FT_NAMETAG
+#define UIFLAG_ALTERNATE_ACTIVE (1 << 11) // flag bit; secondary command state is active (for example an autocast toggle)
 
 typedef enum {
     BACKDROP_TOP_LEFT_CORNER,
@@ -871,7 +872,7 @@ typedef struct uiFrame_s {
     } buffer;
     DWORD textLength;
     DWORD stat;
-    LPCSTR text;
+    LPCSTR text; /* type-specific text; FT_COMMANDBUTTON uses this for its optional secondary click command */
     LPCSTR tooltip;
     LPCSTR onclick;
     FLOAT value;

--- a/docs/games/warcraft-3/architecture/ability-coverage.md
+++ b/docs/games/warcraft-3/architecture/ability-coverage.md
@@ -50,7 +50,7 @@ machines, existing edict fields, and data loaded from SLK/config tables.
 | `CmdSelectSkill` | `s_selectskill.c` | Partial; candidate skill menu, next-rank Research UI, point/level gating, max-rank hiding, and authoritative learning are implemented. Skill-point and next-rank numeric overlays are implemented; multi-selection presentation remains. |
 | `Ahar` | `s_harvest_lumber.c` | Partial worker harvest implementation. |
 | `Amil` | `s_militia.c` | Registered stub. |
-| `Arep` | `s_repair.c` | Partial; entity command, Smart Repair, ranged approach, completed-building DataA/DataB costs, and paused Human power building are wired. Full target masks/naval/autocast remain. |
+| `Arep` | `s_repair.c` | Partial; entity command, Smart Repair, Shift target order, ranged approach, completed-building DataA/DataB costs, paused Human power building, and nearest-valid Auto Repair are wired. Full target masks/naval and broader autocast policy coverage remain. |
 | `Agld` | `s_goldmine.c` | Basic gold mine harvest loop. |
 | `AHad` | `s_devotionaura.c` | Partial local-only aura effect; status application is stubbed. |
 | `AHhb` | `s_holylight.c` | Partial target spell; validates target/range/masks, spends mana, starts cooldown, heals allies, damages undead enemies, and plays target art. |
@@ -100,9 +100,9 @@ generic `Button` command path rather than by a registered ability code.
 | `ANcl` | Channel test | Stub | Opens cancel mode as a generic channel scaffold. |
 | `AUcs` | Carrion Swarm dummy | Partial | Simple point-area enemy damage exists. Needs missile/line travel and art. |
 | `AInv` | Inventory | Partial | Inventory storage and item use exist, but no `AInv` ability type/capacity/drop rules. |
-| `Arep` | Human Repair | Partial | Entity targeting, Smart Repair, ranged approach, DataA/DataB completed repair, and paused Human DataC/DataD power building are implemented. Needs full target masks, naval bonus, destructibles, and autocast. |
-| `Aren` | Repair | Partial | Shares completed-building Repair command/range/cost behavior and rejects construction. Full target masks/destructibles/naval/autocast remain. |
-| `Arst` | Repair | Partial | Shares completed-building Repair command/range/cost behavior and rejects construction. Full target masks/destructibles/naval/autocast remain. |
+| `Arep` | Human Repair | Partial | Entity targeting, Smart Repair, Shift target order, ranged approach, DataA/DataB completed repair, paused Human DataC/DataD power building, right-click toggle, and nearest-valid Auto Repair are implemented. Needs full target masks, naval bonus, and destructibles. |
+| `Aren` | Repair | Partial | Shares completed-building Repair command/range/cost behavior, Shift target order, and nearest-valid Auto Repair; rejects construction. Full target masks/destructibles/naval remain. |
+| `Arst` | Repair | Partial | Shares completed-building Repair command/range/cost behavior, Shift target order, and nearest-valid Auto Repair; rejects construction. Full target masks/destructibles/naval remain. |
 | `Avul` | Invulnerable | Partial | Units with `Avul` spawn with damage immunity; damage guard is tested. Needs targetability/UI status polish. |
 | `Apit` | Shop Purchase Item | TODO | Needs shop inventory and purchase flow. |
 | `Aneu` | Neutral Building | TODO | Needs neutral interaction and command card behavior. |
@@ -140,7 +140,7 @@ generic `Button` command path rather than by a registered ability code.
    implementation with target validation and healing.
 4. Add no-target summon spells (`AHwe`, `AOsf`) once timed-life units are
    available.
-5. Finish Repair target-category coverage, destructible/naval/autocast behavior, and then generalize remaining harvest variants (`Ahrl`, `Awha`, `Aaha`).
+5. Finish Repair target-category coverage and destructible/naval behavior, expand generic autocast beyond Repair's nearest-valid policy, and then generalize remaining harvest variants (`Ahrl`, `Awha`, `Aaha`).
 6. Defer cargo, shops, inventory item modifiers, root/entangle mine, and passive
    autocast abilities until the underlying status, item, and transform systems
    exist.

--- a/docs/games/warcraft-3/autocast.md
+++ b/docs/games/warcraft-3/autocast.md
@@ -1,0 +1,112 @@
+# Warcraft III Autocast and Auto Repair
+
+## Scope
+
+OpenRealm has a small generic autocast contract in `ability_t` and currently uses it for the Repair family (`Arep`, `Aren`, `Arst`). The scheduler owns *when* an idle unit gets an automatic acquisition opportunity; the ability owns toggle state, target selection, and issuance of its ordinary order.
+
+The implementation intentionally does not turn the existing `SPELL_AUTOCAST` metadata flag into behavior for every spell. Cold Arrows and other autocast abilities still need their own targeting/execution rules.
+
+## Ability contract
+
+`ability_t` appends three optional hooks after the existing dispatch fields:
+
+- `autocast_is_on(unit)` reads ability-specific toggle state;
+- `autocast_set(unit, enabled)` changes it;
+- `autocast_acquire(unit)` looks for a target and, on success, issues the normal ability order.
+
+`G_SetUnitAutocast()` enforces the current Warsmash-compatible one-selected-autocast rule: enabling one autocast-capable ability disables the other autocast hooks present on that unit. `AI_AUTOCAST_ACTIVE` is only a fast unit-wide marker; ability-specific state remains authoritative.
+
+The Repair family stores its state in `AI_AUTOCAST_REPAIR`, so the toggle survives ordinary Repair completion and order interruption with the rest of the edict state.
+
+## Command-card toggle
+
+A command button can expose an optional secondary command through `gameCommandButton_t.alternate`. The WC3 HUD serializes it in the command frame's `text` field; `alternate_active` maps to `UIFLAG_ALTERNATE_ACTIVE` for the active glow.
+
+For Repair the secondary command is:
+
+```text
+autocast <repair rawcode>
+```
+
+Left click remains the normal Repair targeting action. Right-button down/up over a command button with a secondary command is consumed by the client layout layer so it cannot also become a world Smart order. Right-button up sends the secondary command.
+
+The server toggles all controllable selected units that carry the same Repair handler and plays `AutoCastButtonClick`. Enabling Auto Repair on an already idle worker immediately tries one acquisition pass; toggling during active movement/work does not interrupt that behavior.
+
+JASS/string immediate orders `repairon` and `repairoff` use the same toggle path. Numeric `IssueImmediateOrderById` coverage is still separate future work.
+
+## Acquisition ordering
+
+`ai_stand()` retains the existing staggered acquisition cadence. At an acquisition slot it now performs:
+
+```text
+try enabled autocast abilities
+    -> if one starts an order, stop
+otherwise
+try normal automatic attack acquisition
+```
+
+This lets a worker with an attack prefer a valid Auto Repair target over an enemy when both are available. Units with no attack can still autocast because the autocast pass occurs before the attack-capability early return.
+
+The current implementation only integrates this with ordinary idle/default stand. Hold Position, Attack-Move, Patrol, Follow, and other behaviors need explicit resume/movement semantics before they should call generic autocast.
+
+## Auto Repair target policy
+
+Repair implements Warsmash's `NEARESTVALID` policy for units:
+
+1. Read the worker's normal acquisition range with `G_AcquisitionRange()`.
+2. Enumerate nearby edicts in a box expanded by the worker collision radius.
+3. Reject candidates that the existing Repair rules do not accept.
+4. Rank valid candidates by collision-aware edge distance:
+
+```text
+max(0, center_distance - worker_collision - target_collision)
+```
+
+5. Issue the ordinary `repair` entity-target order for the nearest candidate.
+
+The acquisition range is a discovery radius, not Repair cast range. Once the normal Repair order is issued, `s_repair.c` remains authoritative for footprint-aware approach routing, `Rng`, work animation, completed-building costs, Human paused-construction/power-building rules, failure, completion, and Shift-order continuation.
+
+Current Auto Repair target coverage deliberately matches the high-confidence Repair validator already implemented in OpenRealm: owned buildings, plus paused Human construction where `Arep` permits it. Allied/mechanical/destructible target-mask expansion and `DataE` naval range remain separate gaps.
+
+## Repair cancellation and replacement orders
+
+Repair cleanup must not destroy state already installed by the replacement order. Move/Attack/Follow paths can install their new goal before `unit_setmove()` switches away from the Repair move, and that switch calls `S_CancelRepair()`.
+
+`S_CancelRepair()` therefore clears `goalentity` only when it still names the Repair-owned target. If a replacement order has already installed a different goal, that goal is preserved. Conversely, an ordinary Stop/stand transition still retires the old Repair target.
+
+This ownership rule prevents the previous crash where Move installed a waypoint, Repair cancellation nulled it, and the new movement behavior subsequently dereferenced the missing goal.
+
+## Diagnostics
+
+Autocast investigative diagnostics are compile-time disabled in normal builds. Build the WC3 game module with `WC3_DEBUG_AUTOCAST` defined, then opt into runtime verbosity with:
+
+```text
++set wc3_autocast_debug 1
+```
+
+Level 1 reports toggle/acquisition/Repair lifecycle summaries. Level 2 also reports every Auto Repair candidate and its rejection reason. Without `WC3_DEBUG_AUTOCAST`, neither the diagnostic CVar lookup nor the per-order/per-candidate tracing is compiled into the game module.
+
+Useful prefixes:
+
+```text
+WC3_AUTOCAST
+WC3_AUTOREPAIR
+```
+
+Typical level-2 candidate output distinguishes reasons such as full health, wrong owner, construction state, missing Repair code, and ordinary Repair target-rule rejection. Keep this logging behind both the `WC3_DEBUG_AUTOCAST` compile-time guard and the runtime CVar; do not add unconditional per-frame acquisition logs.
+
+## Tests
+
+Focused coverage lives primarily in `games/warcraft-3/game/tests/t_building.c` and `tests/test_net.c` and covers:
+
+- Repair toggle state and `repairon` / `repairoff`;
+- command-card secondary command serialization and active state;
+- client right-click dispatch/consumption;
+- nearest valid damaged building selection;
+- collision-aware acquisition of a large nearby building whose centre lies outside `uacq`;
+- ignoring a nearer full-health building;
+- autocast before idle auto-attack, with attack fallback when autocast is off;
+- routing automatic/manual Repair through the normal target-order path;
+- Shift-queued Repair;
+- moving away while repairing without losing the replacement goal;
+- normal Repair cleanup still clearing a Repair-owned goal.

--- a/docs/games/warcraft-3/building-construction.md
+++ b/docs/games/warcraft-3/building-construction.md
@@ -155,6 +155,10 @@ Repair range comes from ability `Rng`. A worker outside range enters a walk beha
 
 Smart/right-click tries Repair on an otherwise non-enemy target before falling back to Move. A full-health target declines Smart Repair silently. Explicit Repair reports `Target is not damaged.` for a completed full-health building and rejects standard Repair on construction.
 
+Repair also participates in the generic autocast hooks documented in [autocast.md](autocast.md). Right-clicking the Repair command button sends the secondary `autocast <rawcode>` command while left click remains ordinary target selection. `Arep`, `Aren`, and `Arst` share the persisted `AI_AUTOCAST_REPAIR` toggle. During an automatic acquisition opportunity, Repair scans the worker's `runtime.acquisition_range`, chooses the **nearest** target accepted by the same Repair validation used by an explicit order, then submits the normal `repair` entity order. The existing Repair behavior therefore remains authoritative for movement into `Rng`, footprint contact, costs, work animation, construction contribution, interruption, and completion. Completing one target does not disable Auto Repair; a later idle/default stand acquisition pass may choose another damaged target. Repair cancellation clears `goalentity` only when it still names the Repair-owned target: Stop/stand therefore retires the old target, while a replacement Move/Attack goal installed before the behavior switch is preserved.
+
+Explicit Repair target selection now submits through `G_IssueUnitTargetOrder("repair", ...)`, so Shift-queued Repair uses the ordinary per-unit FIFO and target `spawn_time` revalidation rather than a Repair-specific queue.
+
 Target eligibility remains intentionally conservative: the target must be a live owned building. Repair deliberately does **not** route this check through `S_SpellAllowsTarget()` because that helper models a smaller spell-oriented subset and treats air/ground as exclusive target types; WC3 Repair targets can combine categories such as ground + structure. Full Repair `Targets Allowed` evaluation remains a separate gap rather than silently rejecting otherwise-valid owned buildings.
 
 ## Known gaps
@@ -175,7 +179,7 @@ Construction and owned-building Repair now share the behavior described above. T
 - Orc worker-inside, Night Elf worker/Ancient consumption, and Undead summon/release construction strategies remain legacy behavior;
 - Repair target masks are not yet complete enough to safely enable allied structures, repairable mechanical non-buildings, or destructibles; the current implementation keeps the pre-existing owned-building boundary;
 - Repair `DataE` naval-range behavior is not implemented;
-- Repair autocast (`repairon` / `repairoff`, nearest-valid acquisition) is not implemented;
+- Auto Repair currently implements the high-confidence nearest-valid owned-building path. Warcraft string immediate orders `repairon` / `repairoff` are exposed through the existing `IssueImmediateOrder` path; broader generic autocast policies and numeric `IssueImmediateOrderById` order-ID exposure remain future work. The command-card transport uses the normalized multi-selection `autocast <rawcode>` command;
 - the per-player technology table is intentionally bounded at `MAX_PLAYER_TECH_STATE`; exhaustion is reported as a warning and does not overwrite an existing entry;
 - `GetPlayerTechResearched` / `GetPlayerTechCount` currently have exact-rawcode semantics for both `specificonly` values because technology-equivalence groups are not represented yet.
 

--- a/docs/games/warcraft-3/order-queue.md
+++ b/docs/games/warcraft-3/order-queue.md
@@ -45,7 +45,7 @@ A small world click now sends either the entity target or the terrain point, not
 
 Each pending entry stores:
 
-- the normalized order name (`smart`, `move`, or `attack` in the currently supported path);
+- the normalized order name (`smart`, `move`, `attack`, or `repair` in the currently supported path);
 - point vs entity target kind;
 - the resolved point for a point order;
 - entity number plus `spawn_time` for an entity order;

--- a/games/warcraft-3/game/g_ai.c
+++ b/games/warcraft-3/game/g_ai.c
@@ -676,17 +676,24 @@ LPEDICT G_FindNearestEnemy(LPEDICT self, FLOAT radius) {
 void ai_stand(LPEDICT self) {
     if (!(self->svflags & SVF_MONSTER))
         return;
-    /* Idle units auto-engage the nearest enemy within acquisition range — for
-     * the player's own units too. Units with no attack (workers/critters) and
-     * units already chasing/attacking stay as they are. */
-    if (!unit_has_attack(self))
-        return;
     /* Neutral/creep units do not initiate (avoids map-wide neutral-vs-neutral
      * aggression); campaign defenders may be rescuable until script takeover
      * and still use normal unit auto-acquisition while hostile. */
     if (level.mapinfo->players[self->s.player].playerType == kPlayerTypeNeutral)
         return;
     if (!G_ShouldAcquireThisFrame(self))
+        return;
+
+    /* Autocast gets the first acquisition opportunity. Its ability owns target
+     * policy and emits an ordinary order; only if no autocast action starts do
+     * we fall through to the existing automatic attack scan. */
+    if (G_TryUnitAutocast(self))
+        return;
+
+    /* Idle units auto-engage the nearest enemy within acquisition range — for
+     * the player's own units too. Units with no attack (workers/critters) and
+     * units already chasing/attacking stay as they are. */
+    if (!unit_has_attack(self))
         return;
 
     LPEDICT best = G_FindNearestEnemy(self, G_AcquisitionRange(self));

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -510,6 +510,67 @@ CLIENTCOMMAND(Button) {
     }
 }
 
+CLIENTCOMMAND(Autocast) {
+    LPGAMECLIENT client;
+    LPEDICT main;
+    ability_t const *ability;
+    LPCSTR classname;
+    BOOL enabled;
+    BOOL changed = false;
+
+    if (!clent || !clent->client || argc < 2) return;
+    client = clent->client;
+    classname = argv[1];
+    if (!classname || strlen(classname) != 4) return;
+    main = G_GetMainSelectedUnit(client);
+    ability = FindAbilityForCommand(classname);
+    if (!G_UnitCanControl(client, main) || !G_ActorHasSkill(main, classname) ||
+        !ability || !ability->autocast_set || !ability->autocast_is_on) {
+#ifdef WC3_DEBUG_AUTOCAST
+        if (G_AutocastDebugLevel() >= 1) {
+            fprintf(stderr,
+                    "WC3_AUTOCAST command_rejected unit=%ld code=%s control=%d has_skill=%d ability=%p set=%d state=%d\n",
+                    main && g_edicts ? (long)(main - g_edicts) : -1L,
+                    classname,
+                    G_UnitCanControl(client, main) ? 1 : 0,
+                    main && G_ActorHasSkill(main, classname) ? 1 : 0,
+                    (void *)ability,
+                    ability && ability->autocast_set ? 1 : 0,
+                    ability && ability->autocast_is_on ? 1 : 0);
+        }
+#endif
+        return;
+    }
+
+    enabled = !G_UnitAutocastIsOn(main, ability);
+    FOR_CONTROLLABLE_SELECTED_UNITS(client, ent) {
+        if (!G_ActorHasSkill(ent, classname)) continue;
+        if (G_SetUnitAutocast(ent, ability, enabled)) {
+            changed = true;
+            /* The toggle itself must not interrupt active work or movement, but
+             * an already-idle worker should respond immediately rather than
+             * waiting for the next staggered 300 ms acquisition slot. */
+            if (enabled && G_UnitIsIdleWorker(ent)) {
+#ifdef WC3_DEBUG_AUTOCAST
+                BOOL const acquired = G_TryUnitAutocast(ent);
+                if (G_AutocastDebugLevel() >= 1) {
+                    fprintf(stderr,
+                            "WC3_AUTOCAST toggle_acquire unit=%ld code=%s acquired=%d\n",
+                            g_edicts ? (long)(ent - g_edicts) : -1L,
+                            classname, acquired ? 1 : 0);
+                }
+#else
+                G_TryUnitAutocast(ent);
+#endif
+            }
+        }
+    }
+    if (!changed) return;
+
+    Get_Commands_f(clent);
+    G_PlayUISoundForPlayer(clent, "AutoCastButtonClick");
+}
+
 CLIENTCOMMAND(Research) {
     LPCSTR classname = argc >= 2 ? argv[1] : NULL;
     LPGAMECLIENT client = clent->client;
@@ -928,6 +989,7 @@ clientCommand_t clientCommands[] = {
     { "god", CMD_God },
     { "kill", CMD_Kill },
     { "button", CMD_Button },
+    { "autocast", CMD_Autocast },
     { "research", CMD_Research },
     { "inventory", CMD_Inventory },
     { "dropitem", CMD_DropItem },

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -119,6 +119,8 @@ enum {
     AI_HOLD_FRAME = 1 << 0,
     AI_FLYING     = 1 << 1,  /* air-layer unit (movetp "fly"): ignores ground collision */
     AI_IMMOBILE   = 1 << 2,  /* fixed unit: may act, but never translates or changes facing */
+    AI_AUTOCAST_REPAIR = 1 << 3, /* persisted Repair-family autocast toggle */
+    AI_AUTOCAST_ACTIVE = 1 << 4, /* fast unit-wide marker: some autocast ability is enabled */
 };
 
 typedef enum {
@@ -542,6 +544,13 @@ typedef struct ability_s {
      * against the previous layout; inserting a field above spell changes the
      * offsets of every existing dispatch member. */
     BOOL (*item_use)(LPEDICT); /* synchronous inventory activation; true only when gameplay effect applies */
+
+    /* Optional generic autocast hooks. Keep these append-only for the same ABI
+     * reason as item_use above. The unit scheduler owns when to try autocast;
+     * each ability owns its toggle state and target acquisition policy. */
+    BOOL (*autocast_is_on)(LPEDICT);
+    void (*autocast_set)(LPEDICT, BOOL);
+    BOOL (*autocast_acquire)(LPEDICT);
 } ability_t;
 
 typedef struct {
@@ -1452,6 +1461,12 @@ ability_t const *GetAbilityByIndex(DWORD);
 DWORD FindAbilityIndex(LPCSTR);
 void InitAbilities(void);
 void SetAbilityNames(void);
+#ifdef WC3_DEBUG_AUTOCAST
+int G_AutocastDebugLevel(void);
+#endif
+BOOL G_UnitAutocastIsOn(LPEDICT ent, ability_t const *ability);
+BOOL G_SetUnitAutocast(LPEDICT ent, ability_t const *ability, BOOL enabled);
+BOOL G_TryUnitAutocast(LPEDICT ent);
 
 // g_metadata.c
 LPCSTR FindConfigValue(LPCSTR, LPCSTR);
@@ -1491,6 +1506,7 @@ void G_UpdateConstructionAnimation(LPEDICT building);
 void G_CompleteConstruction(LPEDICT building);
 BOOL G_UnitHasHumanRepair(LPEDICT ent);
 BOOL S_OrderRepair(LPEDICT ent, LPEDICT target, DWORD preferred);
+BOOL S_SetRepairAutocast(LPEDICT ent, BOOL enabled);
 BOOL S_RepairSmart(LPEDICT ent, LPEDICT target);
 void S_CancelRepair(LPEDICT ent);
 void G_SetPlayerTechMaxAllowed(LPGAMECLIENT client, DWORD techid, LONG maximum);

--- a/games/warcraft-3/game/g_unit_ui.c
+++ b/games/warcraft-3/game/g_unit_ui.c
@@ -216,6 +216,11 @@ BOOL G_BuildCommandButton(LPEDICT ent, LPCSTR code, BOOL research, DWORD level, 
     G_CopyString(button->tooltip, sizeof(button->tooltip), G_CleanTooltipString(tip, level));
     G_CopyString(button->ubertip, sizeof(button->ubertip), G_CleanTooltipString(ubertip, level));
     G_CopyString(button->command, sizeof(button->command), code);
+    if (!research && ability && ability->autocast_set && ability->autocast_is_on) {
+        strlcpy(button->alternate, "autocast ", sizeof(button->alternate));
+        strlcat(button->alternate, code, sizeof(button->alternate));
+        button->alternate_active = G_UnitAutocastIsOn(ent, ability) ? 1 : 0;
+    }
     hotkey = research ? G_StringForLevel(hotkey, level) : hotkey;
     button->hotkey = hotkey && *hotkey ? *hotkey : '\0';
     button->x = x == UINT_MAX ? 255 : (BYTE)MIN(x, 3);

--- a/games/warcraft-3/game/hud/hud_commands.c
+++ b/games/warcraft-3/game/hud/hud_commands.c
@@ -108,10 +108,12 @@ void UI_WriteCommandButtonFrame(gameCommandButton_t const *button) {
     frame.stat = button->active;
     frame.value = button->cooldown;
     frame.hotkey = button->disabled ? 0 : (BYTE)button->hotkey;
+    if (button->alternate_active) frame.flagsvalue |= UIFLAG_ALTERNATE_ACTIVE;
     UI_FormatTooltip(button->command, button->tooltip, button->ubertip, button->manacost, tooltip, sizeof(tooltip));
     frame.tooltip = tooltip;
     snprintf(onclick, sizeof(onclick), "%s %s", button->research ? "research" : "button", button->command);
     frame.onclick = button->disabled ? NULL : onclick;
+    frame.text = button->disabled || !button->alternate[0] ? NULL : button->alternate;
     UI_SetFrameRect(&frame, x, y, 0.039f, 0.039f);
     UI_WriteProxyFrame(&frame, NULL, 0);
     UI_WriteCommandButtonNumber(x, y, 0.039f, 0.039f, button->number);

--- a/games/warcraft-3/game/m_unit.c
+++ b/games/warcraft-3/game/m_unit.c
@@ -282,6 +282,9 @@ static BOOL unit_issuetargetorder_now(LPEDICT self, LPCSTR order, LPEDICT target
     if (S_GoldMineWorkerIsInside(self)) return false;
 
     self->movement.holding_position = false;
+    if (!strcmp(order, "repair")) {
+        return S_OrderRepair(self, target, 0);
+    }
     if (!strcmp(order, "smart")) {
         if (G_IsItem(target)) {
             return G_OrderPickupItem(self, target);
@@ -371,7 +374,7 @@ BOOL G_IssueUnitTargetOrder(LPEDICT self, LPCSTR order, LPEDICT target,
         return G_SetRallyEntity(self, target);
     }
     if (S_GoldMineWorkerIsInside(self)) return false;
-    if (strcmp(order, "smart") && strcmp(order, "move") && strcmp(order, "attack")) return false;
+    if (strcmp(order, "smart") && strcmp(order, "move") && strcmp(order, "attack") && strcmp(order, "repair")) return false;
 
     if (queue && unit_has_active_order(self)) {
         return unit_queue_push(self, order, UNIT_ORDER_TARGET_ENTITY, NULL, target,
@@ -444,6 +447,10 @@ BOOL unit_issueimmediateorder(LPEDICT self, LPCSTR order) {
         order_stop(self);
         return true;
     }
+    if (!strcmp(order, "repairon"))
+        return S_SetRepairAutocast(self, true);
+    if (!strcmp(order, "repairoff"))
+        return S_SetRepairAutocast(self, false);
     if (!strcmp(order, "autoharvestgold"))
         return harvest_auto_start_gold(self);
     if (!strcmp(order, "autoharvestlumber"))

--- a/games/warcraft-3/game/skills/s_repair.c
+++ b/games/warcraft-3/game/skills/s_repair.c
@@ -1,4 +1,5 @@
 #include "s_skills.h"
+#include <float.h>
 
 void repair_build_primary(LPEDICT ent, LPEDICT building);
 void repair_build_legacy(LPEDICT ent, LPEDICT building);
@@ -8,6 +9,8 @@ static umove_t repair_move_work;
 static umove_t repair_generic_move_walk;
 static umove_t repair_generic_move_work;
 static umove_t repair_legacy_move_work;
+
+static BOOL repair_autocast_is_on(LPEDICT ent);
 
 static void repair_code_string(DWORD code, char out[5]) {
     memcpy(out, &code, 4);
@@ -60,7 +63,6 @@ static void repair_release(LPEDICT ent) {
     if (ent->buildwork.primary && building && building->construction.primary_builder == ent) {
         building->construction.primary_builder = NULL;
     }
-    ent->goalentity = NULL;
     if (ent->build == building) ent->build = NULL;
     ent->buildwork.primary = false;
     ent->buildwork.ability = 0;
@@ -70,12 +72,54 @@ static void repair_release(LPEDICT ent) {
 
 void S_CancelRepair(LPEDICT ent) {
     ability_t const *ability;
+    LPEDICT building;
+    LPEDICT goal;
+
     if (!ent || !ent->buildwork.ability) return;
     ability = repair_handler(ent->buildwork.ability);
-    if (ability == &a_repair || ability == &a_repair_generic) repair_release(ent);
+    if (ability != &a_repair && ability != &a_repair_generic) return;
+    building = ent->build;
+    goal = ent->goalentity;
+    /* A replacement order installs its goal before unit_setmove() cancels the
+     * old Repair move. Preserve that replacement goal, but still retire the
+     * Repair-owned goal on an ordinary Stop/stand transition. unit_stand()
+     * clears build before switching moves, so when no build pointer remains the
+     * current Repair goal is the best surviving identity for the old target. */
+    if (!building && ent->currentmove && ent->currentmove->ability == ability)
+        building = goal;
+#ifdef WC3_DEBUG_AUTOCAST
+    if (G_AutocastDebugLevel() >= 1) {
+        fprintf(stderr,
+                "WC3_AUTOREPAIR cancel worker=%ld build=%ld goal=%ld move=%s autocast=%d\n",
+                g_edicts ? (long)(ent - g_edicts) : -1L,
+                building && g_edicts ? (long)(building - g_edicts) : -1L,
+                goal && g_edicts ? (long)(goal - g_edicts) : -1L,
+                ent->currentmove && ent->currentmove->animation ? ent->currentmove->animation : "<none>",
+                repair_autocast_is_on(ent) ? 1 : 0);
+    }
+#endif
+    repair_release(ent);
+    if (ent->goalentity == building) ent->goalentity = NULL;
 }
 
-static void repair_stop(LPEDICT ent) {
+static void repair_stop_reason(LPEDICT ent, LPCSTR reason) {
+#ifdef WC3_DEBUG_AUTOCAST
+    LPEDICT building = ent ? ent->build : NULL;
+
+    if (G_AutocastDebugLevel() >= 1 && ent) {
+        fprintf(stderr,
+                "WC3_AUTOREPAIR stop worker=%ld build=%ld reason=%s hp=%.1f/%.1f autocast=%d\n",
+                g_edicts ? (long)(ent - g_edicts) : -1L,
+                building && g_edicts ? (long)(building - g_edicts) : -1L,
+                reason ? reason : "unknown",
+                building ? building->health.value : 0.0f,
+                building ? building->health.max_value : 0.0f,
+                repair_autocast_is_on(ent) ? 1 : 0);
+    }
+#else
+    (void)reason;
+#endif
+    if (ent) ent->goalentity = NULL;
     repair_release(ent);
     if (ent && ent->stand) ent->stand(ent);
 }
@@ -223,7 +267,7 @@ static BOOL repair_prepare_approach(LPEDICT ent) {
 
 static BOOL repair_set_walk(LPEDICT ent) {
     if (!repair_prepare_approach(ent)) {
-        repair_stop(ent);
+        repair_stop_reason(ent, "no_approach");
         return false;
     }
     if (repair_handler(ent->buildwork.ability) == &a_repair_generic)
@@ -239,7 +283,7 @@ static void ai_repair_walk(LPEDICT ent) {
 
     if (!building || !repair_target_valid(ent, building, ent->buildwork.ability,
                                            ent->buildwork.primary)) {
-        repair_stop(ent);
+        repair_stop_reason(ent, "walk_target_invalid");
         return;
     }
     if (repair_in_range(ent, building)) {
@@ -250,18 +294,18 @@ static void ai_repair_walk(LPEDICT ent) {
     distance = M_DistanceToGoal(ent);
     step = unit_movedistance(ent);
     if (move_is_blocked(ent, distance, step)) {
-        repair_stop(ent);
+        repair_stop_reason(ent, "walk_blocked");
         return;
     }
 
     unit_changeangle_for_radius(ent, ent->collision);
 
     if (ent->movement.flow_goal_reached && !repair_in_range(ent, building)) {
-        repair_stop(ent);
+        repair_stop_reason(ent, "walk_goal_reached_out_of_range");
         return;
     }
     if (ent->movement.flow_unreachable) {
-        repair_stop(ent);
+        repair_stop_reason(ent, "walk_unreachable");
         return;
     }
     unit_moveindirection(ent);
@@ -274,7 +318,7 @@ static void ai_repair(LPEDICT ent) {
 
     if (!building || !repair_target_valid(ent, building, ent->buildwork.ability,
                                            ent->buildwork.primary)) {
-        repair_stop(ent);
+        repair_stop_reason(ent, "work_target_invalid");
         return;
     }
     if (!repair_in_range(ent, building)) {
@@ -293,24 +337,24 @@ static void ai_repair(LPEDICT ent) {
         FLOAT start_hp;
 
         if (!building->construction.paused || !data) {
-            repair_stop(ent);
+            repair_stop_reason(ent, "construction_not_paused_or_no_data");
             return;
         }
         if (ent->buildwork.primary) {
             if (building->construction.primary_builder != ent) {
-                repair_stop(ent);
+                repair_stop_reason(ent, "lost_primary_builder");
                 return;
             }
             ratio = 1.0f;
         } else {
             ratio = data->data[0][3];
             if (ratio <= 0.0f) {
-                repair_stop(ent);
+                repair_stop_reason(ent, "invalid_power_build_ratio");
                 return;
             }
         }
         if (!repair_charge_power_cost(ent, building, data)) {
-            repair_stop(ent);
+            repair_stop_reason(ent, "power_build_unaffordable");
             return;
         }
 
@@ -322,7 +366,7 @@ static void ai_repair(LPEDICT ent) {
         hp->value = MIN(hp->max_value, hp->value + hp_gain);
         if (building->construction.progress >= duration) {
             G_CompleteConstruction(building);
-            repair_stop(ent);
+            repair_stop_reason(ent, "construction_complete");
         }
         return;
     }
@@ -336,14 +380,14 @@ static void ai_repair(LPEDICT ent) {
         FLOAT hp_rate;
 
         if (duration <= 0.0f || time_ratio <= 0.0f) {
-            repair_stop(ent);
+            repair_stop_reason(ent, "invalid_repair_rates");
             return;
         }
         hp_rate = (hp->max_value / duration) * time_ratio;
         if (!repair_charge(ent,
                 ((FLOAT)balance->goldRep / duration) * cost_ratio * time_ratio,
                 ((FLOAT)balance->lumberRep / duration) * cost_ratio * time_ratio)) {
-            repair_stop(ent);
+            repair_stop_reason(ent, "repair_unaffordable");
             return;
         }
         hp->value = MIN(hp->max_value, hp->value + hp_rate * seconds);
@@ -351,7 +395,7 @@ static void ai_repair(LPEDICT ent) {
     if (hp->value >= hp->max_value) {
         hp->value = hp->max_value;
         building->stand(building);
-        repair_stop(ent);
+        repair_stop_reason(ent, "repair_complete");
     }
 }
 
@@ -392,6 +436,19 @@ static BOOL repair_begin(LPEDICT ent, LPEDICT building, DWORD code, BOOL primary
     ent->buildwork.gold_accum = 0.0f;
     ent->buildwork.lumber_accum = 0.0f;
     move_reset_progress(ent);
+#ifdef WC3_DEBUG_AUTOCAST
+    if (G_AutocastDebugLevel() >= 1) {
+        char rawcode[5];
+        repair_code_string(code, rawcode);
+        fprintf(stderr,
+                "WC3_AUTOREPAIR begin worker=%ld target=%ld code=%s primary=%d in_range=%d autocast=%d\n",
+                g_edicts ? (long)(ent - g_edicts) : -1L,
+                g_edicts ? (long)(building - g_edicts) : -1L,
+                rawcode, primary ? 1 : 0,
+                repair_in_range(ent, building) ? 1 : 0,
+                repair_autocast_is_on(ent) ? 1 : 0);
+    }
+#endif
 
     if (primary) {
         /* The initial Human builder starts inside the newly baked footprint.
@@ -475,6 +532,195 @@ BOOL S_RepairSmart(LPEDICT ent, LPEDICT target) {
     return S_OrderRepair(ent, target, 0);
 }
 
+#define REPAIR_AUTOCAST_MAX_TARGETS 256 // entities; bounded candidates considered by one Auto Repair acquisition scan
+
+static BOOL repair_autocast_is_on(LPEDICT ent) {
+    return ent && (ent->aiflags & AI_AUTOCAST_REPAIR) != 0;
+}
+
+static void repair_autocast_set(LPEDICT ent, BOOL enabled) {
+    if (!ent) return;
+    if (enabled) ent->aiflags |= AI_AUTOCAST_REPAIR;
+    else ent->aiflags &= ~AI_AUTOCAST_REPAIR;
+}
+
+static LPCSTR repair_autocast_reject_reason(LPEDICT ent, LPEDICT target, DWORD code) {
+    ability_t const *handler;
+    AbilityData_t const *data;
+    BOOL primary = false;
+
+    if (!ent) return "no_worker";
+    if (!target) return "no_target";
+    if (!code) return "no_repair_code";
+    if (!target->inuse) return "unused";
+    if (M_IsDead(target)) return "dead";
+    if (!G_UnitIsBuilding(target->class_id)) return "not_building";
+    if (!target->UnitBalance) return "no_balance";
+    if (target->s.player != ent->s.player) return "wrong_owner";
+
+    handler = repair_handler(code);
+    data = G_AbilityData(code);
+    if (target->construction.active) {
+        if (handler != &a_repair) return "construction_requires_human_repair";
+        if (!target->construction.paused) return "construction_not_paused";
+        if (!repair_primary_active(target)) primary = true;
+        if (!primary && (!data || data->data[0][3] <= 0.0f)) return "no_power_build_ratio";
+    } else if (target->health.value >= target->health.max_value) {
+        return "full_health";
+    }
+    return repair_target_valid(ent, target, code, primary) ? NULL : "repair_target_rules";
+}
+
+/* Warsmash CUnit.distance() compares unit edges by subtracting both collision
+ * sizes, not just center-to-center distance. This matters most for large
+ * buildings: a Peasant can be visibly close to the footprint while the
+ * building center lies beyond uacq. */
+static FLOAT repair_autocast_distance(LPCEDICT ent, LPCEDICT target) {
+    FLOAT distance;
+
+    if (!ent || !target) return FLT_MAX;
+    distance = Vector2_distance(&target->s.origin2, &ent->s.origin2) -
+               MAX(0.0f, ent->collision) - MAX(0.0f, target->collision);
+    return MAX(0.0f, distance);
+}
+
+BOOL S_SetRepairAutocast(LPEDICT ent, BOOL enabled) {
+    DWORD code;
+    ability_t const *ability;
+
+    if (!ent) return false;
+    code = repair_find_code(ent, NULL, 0);
+    ability = repair_handler(code);
+    if (!ability) return false;
+    return G_SetUnitAutocast(ent, ability, enabled);
+}
+
+/* Repair uses Warsmash's NEARESTVALID autocast policy: acquisition range only
+ * bounds candidate discovery. Once chosen, the ordinary Repair order owns
+ * pathing into Repair range and all subsequent validation/cost behavior. */
+static BOOL repair_autocast_acquire(LPEDICT ent) {
+    LPEDICT candidates[REPAIR_AUTOCAST_MAX_TARGETS];
+    LPEDICT best = NULL;
+    FLOAT radius;
+    FLOAT best_distance;
+    DWORD code;
+    BOX2 area;
+    DWORD count;
+
+    if (!ent) return false;
+    if (M_IsDead(ent) || S_GoldMineWorkerIsInside(ent)) {
+#ifdef WC3_DEBUG_AUTOCAST
+        if (G_AutocastDebugLevel() >= 1) {
+            fprintf(stderr,
+                    "WC3_AUTOREPAIR scan_skip worker=%ld reason=%s\n",
+                    g_edicts ? (long)(ent - g_edicts) : -1L,
+                    M_IsDead(ent) ? "worker_dead" : "worker_inside_goldmine");
+        }
+#endif
+        return false;
+    }
+    code = repair_find_code(ent, NULL, 0);
+    radius = G_AcquisitionRange(ent);
+    if (!code || radius <= 0.0f) {
+#ifdef WC3_DEBUG_AUTOCAST
+        if (G_AutocastDebugLevel() >= 1) {
+            fprintf(stderr,
+                    "WC3_AUTOREPAIR scan_skip worker=%ld reason=%s radius=%.1f abilities=%s\n",
+                    g_edicts ? (long)(ent - g_edicts) : -1L,
+                    !code ? "no_repair_code" : "zero_acquisition_range", radius,
+                    ent->UnitAbilities && ent->UnitAbilities->abilList ? ent->UnitAbilities->abilList : "<none>");
+        }
+#endif
+        return false;
+    }
+
+    /* Warsmash expands from the source collision rectangle, then lets
+     * NEARESTVALID compare collision-aware distances among enumerated units. */
+    area = (BOX2){
+        { ent->s.origin2.x - radius - ent->collision,
+          ent->s.origin2.y - radius - ent->collision },
+        { ent->s.origin2.x + radius + ent->collision,
+          ent->s.origin2.y + radius + ent->collision },
+    };
+    count = gi.BoxEdicts(&area, candidates, REPAIR_AUTOCAST_MAX_TARGETS, NULL);
+    best_distance = FLT_MAX;
+#ifdef WC3_DEBUG_AUTOCAST
+    if (G_AutocastDebugLevel() >= 1) {
+        char rawcode[5];
+        repair_code_string(code, rawcode);
+        fprintf(stderr,
+                "WC3_AUTOREPAIR scan worker=%ld code=%s pos=(%.1f,%.1f) radius=%.1f collision=%.1f candidates=%u\n",
+                g_edicts ? (long)(ent - g_edicts) : -1L, rawcode,
+                ent->s.origin2.x, ent->s.origin2.y, radius, ent->collision, count);
+    }
+#endif
+    FOR_LOOP(i, count) {
+        LPEDICT target = candidates[i];
+        LPCSTR reject;
+        FLOAT distance;
+
+        reject = repair_autocast_reject_reason(ent, target, code);
+        if (reject) {
+#ifdef WC3_DEBUG_AUTOCAST
+            if (G_AutocastDebugLevel() >= 2 && target) {
+                fprintf(stderr,
+                        "WC3_AUTOREPAIR candidate worker=%ld target=%ld class=%.4s owner=%u hp=%.1f/%.1f reject=%s\n",
+                        g_edicts ? (long)(ent - g_edicts) : -1L,
+                        g_edicts ? (long)(target - g_edicts) : -1L,
+                        (LPCSTR)&target->class_id, target->s.player,
+                        target->health.value, target->health.max_value, reject);
+            }
+#endif
+            continue;
+        }
+        distance = repair_autocast_distance(ent, target);
+#ifdef WC3_DEBUG_AUTOCAST
+        if (G_AutocastDebugLevel() >= 2) {
+            fprintf(stderr,
+                    "WC3_AUTOREPAIR candidate worker=%ld target=%ld class=%.4s hp=%.1f/%.1f distance=%.1f valid=1\n",
+                    g_edicts ? (long)(ent - g_edicts) : -1L,
+                    g_edicts ? (long)(target - g_edicts) : -1L,
+                    (LPCSTR)&target->class_id,
+                    target->health.value, target->health.max_value, distance);
+        }
+#endif
+        if (distance < best_distance) {
+            best = target;
+            best_distance = distance;
+        }
+    }
+    if (!best) {
+#ifdef WC3_DEBUG_AUTOCAST
+        if (G_AutocastDebugLevel() >= 1) {
+            fprintf(stderr, "WC3_AUTOREPAIR no_target worker=%ld\n",
+                    g_edicts ? (long)(ent - g_edicts) : -1L);
+        }
+#endif
+        return false;
+    }
+#ifdef WC3_DEBUG_AUTOCAST
+    if (G_AutocastDebugLevel() >= 1) {
+        fprintf(stderr,
+                "WC3_AUTOREPAIR choose worker=%ld target=%ld class=%.4s distance=%.1f hp=%.1f/%.1f\n",
+                g_edicts ? (long)(ent - g_edicts) : -1L,
+                g_edicts ? (long)(best - g_edicts) : -1L,
+                (LPCSTR)&best->class_id, best_distance,
+                best->health.value, best->health.max_value);
+    }
+#endif
+    if (!G_IssueUnitTargetOrder(ent, "repair", best, false, ent->s.player)) {
+#ifdef WC3_DEBUG_AUTOCAST
+        if (G_AutocastDebugLevel() >= 1) {
+            fprintf(stderr, "WC3_AUTOREPAIR order_failed worker=%ld target=%ld\n",
+                    g_edicts ? (long)(ent - g_edicts) : -1L,
+                    g_edicts ? (long)(best - g_edicts) : -1L);
+        }
+#endif
+        return false;
+    }
+    return true;
+}
+
 static BOOL repair_selecttarget(LPEDICT clent, LPEDICT target) {
     DWORD code;
     ability_t const *handler;
@@ -500,7 +746,11 @@ static BOOL repair_selecttarget(LPEDICT clent, LPEDICT target) {
     }
 
     FOR_CONTROLLABLE_SELECTED_UNITS(clent->client, ent) {
-        if (S_OrderRepair(ent, target, code)) issued = true;
+        if (G_IssueUnitTargetOrder(ent, "repair", target,
+                                   clent->client->menu.order_queued,
+                                   clent->client->ps.number)) {
+            issued = true;
+        }
     }
     return issued;
 }
@@ -508,12 +758,19 @@ static BOOL repair_selecttarget(LPEDICT clent, LPEDICT target) {
 static void repair_command(LPEDICT clent) {
     UI_AddCancelButton(clent);
     clent->client->menu.on_entity_selected = repair_selecttarget;
+    clent->client->menu.supports_order_queue = true;
 }
 
 ability_t a_repair = {
     .cmd = repair_command,
+    .autocast_is_on = repair_autocast_is_on,
+    .autocast_set = repair_autocast_set,
+    .autocast_acquire = repair_autocast_acquire,
 };
 
 ability_t a_repair_generic = {
     .cmd = repair_command,
+    .autocast_is_on = repair_autocast_is_on,
+    .autocast_set = repair_autocast_set,
+    .autocast_acquire = repair_autocast_acquire,
 };

--- a/games/warcraft-3/game/skills/s_skills.c
+++ b/games/warcraft-3/game/skills/s_skills.c
@@ -1,5 +1,15 @@
 #include "s_skills.h"
 
+#ifdef WC3_DEBUG_AUTOCAST
+int G_AutocastDebugLevel(void) {
+    LPCSTR value;
+
+    if (!gi.CvarString) return 0;
+    value = gi.CvarString("wc3_autocast_debug", "0");
+    return value ? atoi(value) : 0;
+}
+#endif
+
 typedef struct {
     LPCSTR classname;
     ability_t *ability;
@@ -118,6 +128,126 @@ ability_t const *FindAbilityForCommand(LPCSTR classname) {
         return FindAbilityByClassname(classname);
     }
     return FindAbilityByClassname(GetClassName(G_AbilityCodeName(classname)));
+}
+
+static BOOL unit_has_ability_handler(LPEDICT ent, ability_t const *wanted) {
+    LPCSTR abilities;
+
+    if (!ent || !wanted || !ent->UnitAbilities) return false;
+    abilities = ent->UnitAbilities->abilList;
+    if (!abilities) return false;
+
+    PARSE_LIST(abilities, ability_name, parse_segment) {
+        if (FindAbilityForCommand(ability_name) == wanted) return true;
+    }
+    return false;
+}
+
+BOOL G_UnitAutocastIsOn(LPEDICT ent, ability_t const *ability) {
+    return ent && ability && ability->autocast_is_on && unit_has_ability_handler(ent, ability) &&
+           ability->autocast_is_on(ent);
+}
+
+BOOL G_SetUnitAutocast(LPEDICT ent, ability_t const *ability, BOOL enabled) {
+    LPCSTR abilities;
+
+    if (!ent || !ability || !ability->autocast_set || !unit_has_ability_handler(ent, ability)) {
+#ifdef WC3_DEBUG_AUTOCAST
+        if (G_AutocastDebugLevel() >= 1) {
+            fprintf(stderr, "WC3_AUTOCAST toggle rejected unit=%ld ability=%p enabled=%d flags=0x%x\n",
+                    ent && g_edicts ? (long)(ent - g_edicts) : -1L, (void *)ability,
+                    enabled ? 1 : 0, ent ? ent->aiflags : 0);
+        }
+#endif
+        return false;
+    }
+
+    /* Warsmash keeps one selected autocast ability per unit. Turning a new one
+     * on first disables every other autocast-capable ability currently present
+     * on this unit; abilities without autocast hooks remain untouched. */
+    if (enabled && ent->UnitAbilities && (abilities = ent->UnitAbilities->abilList)) {
+        PARSE_LIST(abilities, ability_name, parse_segment) {
+            ability_t const *other = FindAbilityForCommand(ability_name);
+            if (other && other != ability && other->autocast_set) other->autocast_set(ent, false);
+        }
+    }
+    ability->autocast_set(ent, enabled);
+    if (enabled) {
+        ent->aiflags |= AI_AUTOCAST_ACTIVE;
+    } else {
+        BOOL any_enabled = false;
+        if (ent->UnitAbilities && (abilities = ent->UnitAbilities->abilList)) {
+            PARSE_LIST(abilities, ability_name, parse_segment) {
+                ability_t const *other = FindAbilityForCommand(ability_name);
+                if (other && other->autocast_is_on && other->autocast_is_on(ent)) {
+                    any_enabled = true;
+                    break;
+                }
+            }
+        }
+        if (!any_enabled) ent->aiflags &= ~AI_AUTOCAST_ACTIVE;
+    }
+#ifdef WC3_DEBUG_AUTOCAST
+    if (G_AutocastDebugLevel() >= 1) {
+        fprintf(stderr, "WC3_AUTOCAST toggle unit=%ld class=%.4s enabled=%d flags=0x%x idle_worker=%d abilities=%s\n",
+                g_edicts ? (long)(ent - g_edicts) : -1L, (LPCSTR)&ent->class_id,
+                enabled ? 1 : 0, ent->aiflags, G_UnitIsIdleWorker(ent) ? 1 : 0,
+                ent->UnitAbilities && ent->UnitAbilities->abilList ? ent->UnitAbilities->abilList : "<none>");
+    }
+#endif
+    return true;
+}
+
+BOOL G_TryUnitAutocast(LPEDICT ent) {
+    LPCSTR abilities;
+
+    if (!ent || !(ent->aiflags & AI_AUTOCAST_ACTIVE) || !ent->UnitAbilities ||
+        !(abilities = ent->UnitAbilities->abilList)) {
+#ifdef WC3_DEBUG_AUTOCAST
+        if (G_AutocastDebugLevel() >= 2 && ent) {
+            fprintf(stderr, "WC3_AUTOCAST skip unit=%ld class=%.4s flags=0x%x abilities=%s\n",
+                    g_edicts ? (long)(ent - g_edicts) : -1L, (LPCSTR)&ent->class_id,
+                    ent->aiflags,
+                    ent->UnitAbilities && ent->UnitAbilities->abilList ? ent->UnitAbilities->abilList : "<none>");
+        }
+#endif
+        return false;
+    }
+#ifdef WC3_DEBUG_AUTOCAST
+    if (G_AutocastDebugLevel() >= 2) {
+        fprintf(stderr, "WC3_AUTOCAST try unit=%ld class=%.4s flags=0x%x abilities=%s\n",
+                g_edicts ? (long)(ent - g_edicts) : -1L, (LPCSTR)&ent->class_id,
+                ent->aiflags, abilities);
+    }
+#endif
+    PARSE_LIST(abilities, ability_name, parse_segment) {
+        ability_t const *ability = FindAbilityForCommand(ability_name);
+        BOOL is_on;
+        if (!ability || !ability->autocast_is_on || !ability->autocast_acquire) continue;
+        is_on = ability->autocast_is_on(ent);
+#ifdef WC3_DEBUG_AUTOCAST
+        if (G_AutocastDebugLevel() >= 2) {
+            fprintf(stderr, "WC3_AUTOCAST ability unit=%ld code=%s on=%d\n",
+                    g_edicts ? (long)(ent - g_edicts) : -1L, ability_name, is_on ? 1 : 0);
+        }
+#endif
+        if (is_on && ability->autocast_acquire(ent)) {
+#ifdef WC3_DEBUG_AUTOCAST
+            if (G_AutocastDebugLevel() >= 1) {
+                fprintf(stderr, "WC3_AUTOCAST acquired unit=%ld code=%s\n",
+                        g_edicts ? (long)(ent - g_edicts) : -1L, ability_name);
+            }
+#endif
+            return true;
+        }
+    }
+#ifdef WC3_DEBUG_AUTOCAST
+    if (G_AutocastDebugLevel() >= 2) {
+        fprintf(stderr, "WC3_AUTOCAST no_target unit=%ld\n",
+                g_edicts ? (long)(ent - g_edicts) : -1L);
+    }
+#endif
+    return false;
 }
 
 DWORD FindAbilityIndex(LPCSTR classname) {

--- a/games/warcraft-3/game/tests/t_building.c
+++ b/games/warcraft-3/game/tests/t_building.c
@@ -643,6 +643,32 @@ TEST(wc3_building, disabled_command_button_is_inert_and_available_button_is_clic
     gi.ImageIndex = old_image_index;
 }
 
+TEST(wc3_building, command_button_serializes_secondary_autocast_command_and_state) {
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    int (*old_image_index)(LPCSTR) = gi.ImageIndex;
+    gameCommandButton_t button;
+
+    memset(&button, 0, sizeof(button));
+    snprintf(button.command, sizeof(button.command), "Arep");
+    snprintf(button.alternate, sizeof(button.alternate), "autocast Arep");
+    snprintf(button.art, sizeof(button.art), "test");
+    button.alternate_active = 1;
+
+    gi.Write = building_capture_write;
+    gi.ImageIndex = building_test_image_index;
+    building_command_frame_seen = false;
+
+    UI_WriteCommandButtonFrame(&button);
+
+    T_ASSERT(building_command_frame_seen);
+    T_STREQ(building_command_frame.onclick, "button Arep");
+    T_STREQ(building_command_frame.text, "autocast Arep");
+    T_ASSERT(building_command_frame.flagsvalue & UIFLAG_ALTERNATE_ACTIVE);
+
+    gi.Write = old_write;
+    gi.ImageIndex = old_image_index;
+}
+
 
 TEST(wc3_building, command_button_geometry_matches_warcraft_grid) {
     void (*old_write)(pfWriteType_t, void const *) = gi.Write;
@@ -1072,12 +1098,325 @@ TEST(wc3_building, repair_button_then_target_issues_repair_order) {
     G_ClientCommand(clent, 2, button);
     T_NOT_NULL(client->menu.on_entity_selected);
     T_EQ(client->menu.ability_code, MAKEFOURCC('A','r','e','p'));
+    T_ASSERT(client->menu.supports_order_queue);
 
     G_ClientCommand(clent, 2, select_target);
 
     T_ASSERT(worker->build == building);
     T_EQ(worker->buildwork.ability, MAKEFOURCC('A','r','e','p'));
     T_NOT_NULL(worker->currentmove);
+
+    building_restore_repair_data(old_abilities, rows);
+}
+
+TEST(wc3_building, repair_autocast_toggle_is_unit_state) {
+    LPEDICT worker;
+    UnitAbilities_t abilities = { .abilList = "Aren" };
+    ability_t const *repair;
+    slkTestData_t *rows, *old_abilities;
+
+    old_abilities = building_install_repair_data(&rows);
+    setup_test_world();
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    worker->UnitAbilities = &abilities;
+    repair = FindAbilityForCommand("Aren");
+
+    T_NOT_NULL(repair);
+    T_ASSERT(!G_UnitAutocastIsOn(worker, repair));
+    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    T_ASSERT(worker->aiflags & AI_AUTOCAST_REPAIR);
+    T_ASSERT(worker->aiflags & AI_AUTOCAST_ACTIVE);
+    T_ASSERT(G_UnitAutocastIsOn(worker, repair));
+    T_ASSERT(G_SetUnitAutocast(worker, repair, false));
+    T_ASSERT(!(worker->aiflags & AI_AUTOCAST_REPAIR));
+    T_ASSERT(!(worker->aiflags & AI_AUTOCAST_ACTIVE));
+    T_ASSERT(!G_UnitAutocastIsOn(worker, repair));
+
+    building_restore_repair_data(old_abilities, rows);
+}
+
+TEST(wc3_building, repairon_and_repairoff_immediate_orders_toggle_without_starting_repair) {
+    LPEDICT worker;
+    UnitAbilities_t abilities = { .abilList = "Aren" };
+    ability_t const *repair;
+    slkTestData_t *rows, *old_abilities;
+
+    old_abilities = building_install_repair_data(&rows);
+    setup_test_world();
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    worker->UnitAbilities = &abilities;
+    repair = FindAbilityForCommand("Aren");
+
+    T_NOT_NULL(repair);
+    T_ASSERT(unit_issueimmediateorder(worker, "repairon"));
+    T_ASSERT(G_UnitAutocastIsOn(worker, repair));
+    T_NULL(worker->build);
+    T_ASSERT(unit_issueimmediateorder(worker, "repairoff"));
+    T_ASSERT(!G_UnitAutocastIsOn(worker, repair));
+    T_NULL(worker->build);
+
+    building_restore_repair_data(old_abilities, rows);
+}
+
+TEST(wc3_building, repair_command_button_exposes_autocast_secondary_command) {
+    LPEDICT worker;
+    UnitAbilities_t abilities = { .abilList = "Arep" };
+    gameCommandButton_t button;
+    ability_t const *repair;
+    slkTestData_t *rows, *old_abilities;
+
+    old_abilities = building_install_repair_data(&rows);
+    setup_test_world();
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    worker->UnitAbilities = &abilities;
+    repair = FindAbilityForCommand("Arep");
+
+    T_NOT_NULL(repair);
+    T_ASSERT(G_BuildCommandButton(worker, "Arep", false, 0, &button));
+    T_STREQ(button.alternate, "autocast Arep");
+    T_EQ(button.alternate_active, 0);
+
+    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    T_ASSERT(G_BuildCommandButton(worker, "Arep", false, 0, &button));
+    T_STREQ(button.alternate, "autocast Arep");
+    T_EQ(button.alternate_active, 1);
+
+    building_restore_repair_data(old_abilities, rows);
+}
+
+TEST(wc3_building, repair_autocast_chooses_nearest_valid_damaged_building) {
+    LPEDICT worker;
+    LPEDICT near_building;
+    LPEDICT far_building;
+    UnitAbilities_t abilities = { .abilList = "Aren" };
+    ability_t const *repair;
+    slkTestData_t *rows, *old_abilities;
+
+    old_abilities = building_install_repair_data(&rows);
+    setup_test_world();
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    near_building = alloc_test_unit(MAKEFOURCC('h','b','a','r'), 96, 0);
+    far_building = alloc_test_unit(MAKEFOURCC('h','b','a','r'), 256, 0);
+    worker->UnitAbilities = &abilities;
+    worker->runtime.acquisition_range = 400.0f;
+    worker->collision = 16.0f;
+    near_building->collision = far_building->collision = 32.0f;
+    near_building->s.player = far_building->s.player = worker->s.player;
+    near_building->health.max_value = far_building->health.max_value = 1000.0f;
+    near_building->health.value = 900.0f;
+    far_building->health.value = 100.0f;
+    gi.LinkEntity(worker);
+    gi.LinkEntity(near_building);
+    gi.LinkEntity(far_building);
+    repair = FindAbilityForCommand("Aren");
+
+    T_NOT_NULL(repair);
+    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    T_ASSERT(G_TryUnitAutocast(worker));
+    T_ASSERT(worker->build == near_building);
+    T_ASSERT(worker->build != far_building);
+
+    building_restore_repair_data(old_abilities, rows);
+}
+
+TEST(wc3_building, repair_autocast_uses_collision_aware_nearest_valid_distance) {
+    LPEDICT worker;
+    LPEDICT building;
+    UnitAbilities_t abilities = { .abilList = "Aren" };
+    ability_t const *repair;
+    slkTestData_t *rows, *old_abilities;
+
+    old_abilities = building_install_repair_data(&rows);
+    setup_test_world();
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    building = alloc_test_unit(MAKEFOURCC('h','b','a','r'), 410, 0);
+    worker->UnitAbilities = &abilities;
+    worker->runtime.acquisition_range = 400.0f;
+    worker->collision = 16.0f;
+    building->collision = 64.0f;
+    building->s.player = worker->s.player;
+    building->health.max_value = 1000.0f;
+    building->health.value = 500.0f;
+    gi.LinkEntity(worker);
+    gi.LinkEntity(building);
+    repair = FindAbilityForCommand("Aren");
+
+    T_NOT_NULL(repair);
+    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    /* Center distance is 410 (> uacq 400), but edge distance is only 330.
+     * Warsmash expands from the caster collision rectangle and compares unit
+     * edge distance, so the nearby building remains a valid acquisition. */
+    T_ASSERT(G_TryUnitAutocast(worker));
+    T_ASSERT(worker->build == building);
+
+    building_restore_repair_data(old_abilities, rows);
+}
+
+TEST(wc3_building, moving_away_while_repairing_preserves_replacement_goal) {
+    LPEDICT worker;
+    LPEDICT building;
+    LPEDICT waypoint;
+    UnitAbilities_t abilities = { .abilList = "Aren" };
+    ability_t const *repair;
+    slkTestData_t *rows, *old_abilities;
+    VECTOR2 destination = { 512.0f, 0.0f };
+
+    old_abilities = building_install_repair_data(&rows);
+    setup_test_world();
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    building = alloc_test_unit(MAKEFOURCC('h','b','a','r'), 64, 0);
+    worker->UnitAbilities = &abilities;
+    worker->stand = unit_stand;
+    worker->collision = 16.0f;
+    building->collision = 32.0f;
+    building->s.player = worker->s.player;
+    building->health.max_value = 1000.0f;
+    building->health.value = 500.0f;
+    gi.LinkEntity(worker);
+    gi.LinkEntity(building);
+    repair = FindAbilityForCommand("Aren");
+
+    T_NOT_NULL(repair);
+    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    T_ASSERT(S_OrderRepair(worker, building, MAKEFOURCC('A','r','e','n')));
+    T_ASSERT(worker->build == building);
+    T_NE(worker->buildwork.ability, 0);
+
+    waypoint = Waypoint_add(&destination);
+    T_NOT_NULL(waypoint);
+    order_move(worker, waypoint);
+
+    T_ASSERT(worker->goalentity == waypoint);
+    T_NULL(worker->build);
+    T_EQ(worker->buildwork.ability, 0);
+    T_ASSERT(worker->aiflags & AI_AUTOCAST_REPAIR);
+    T_ASSERT(worker->aiflags & AI_AUTOCAST_ACTIVE);
+
+    building_restore_repair_data(old_abilities, rows);
+}
+
+TEST(wc3_building, idle_acquisition_prefers_auto_repair_over_auto_attack) {
+    LPEDICT worker;
+    LPEDICT building;
+    LPEDICT enemy;
+    UnitAbilities_t abilities = { .abilList = "Aren" };
+    ability_t const *repair;
+    slkTestData_t *rows, *old_abilities;
+    DWORD stagger;
+
+    old_abilities = building_install_repair_data(&rows);
+    setup_test_world();
+    ((LPMAPINFO)level.mapinfo)->players[0].playerType = kPlayerTypeHuman;
+    ((LPMAPINFO)level.mapinfo)->players[1].playerType = kPlayerTypeHuman;
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    building = alloc_test_unit(MAKEFOURCC('h','b','a','r'), 160, 0);
+    enemy = alloc_test_unit(MAKEFOURCC('o','g','r','u'), 64, 0);
+    worker->UnitAbilities = &abilities;
+    worker->svflags |= SVF_MONSTER;
+    worker->runtime.acquisition_range = 400.0f;
+    worker->attack1.cooldown = 1.0f;
+    worker->attack1.damageBase = 1;
+    building->s.player = worker->s.player;
+    building->health.max_value = 1000.0f;
+    building->health.value = 500.0f;
+    enemy->s.player = 1;
+    enemy->svflags |= SVF_MONSTER;
+    gi.LinkEntity(worker);
+    gi.LinkEntity(building);
+    gi.LinkEntity(enemy);
+    repair = FindAbilityForCommand("Aren");
+
+    T_NOT_NULL(repair);
+    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    stagger = (DWORD)(worker - g_edicts) % 300;
+    level.time = (300 - stagger) % 300;
+    ai_stand(worker);
+
+    T_ASSERT(worker->build == building);
+    T_ASSERT(worker->goalentity == building);
+    T_ASSERT(worker->goalentity != enemy);
+
+    building_restore_repair_data(old_abilities, rows);
+}
+
+TEST(wc3_building, idle_acquisition_without_autocast_still_auto_attacks) {
+    LPEDICT worker;
+    LPEDICT enemy;
+    DWORD stagger;
+
+    setup_test_world();
+    ((LPMAPINFO)level.mapinfo)->players[0].playerType = kPlayerTypeHuman;
+    ((LPMAPINFO)level.mapinfo)->players[1].playerType = kPlayerTypeHuman;
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    enemy = alloc_test_unit(MAKEFOURCC('o','g','r','u'), 64, 0);
+    worker->svflags |= SVF_MONSTER;
+    worker->runtime.acquisition_range = 400.0f;
+    worker->attack1.cooldown = 1.0f;
+    worker->attack1.damageBase = 1;
+    enemy->s.player = 1;
+    enemy->svflags |= SVF_MONSTER;
+    gi.LinkEntity(worker);
+    gi.LinkEntity(enemy);
+
+    stagger = (DWORD)(worker - g_edicts) % 300;
+    level.time = (300 - stagger) % 300;
+    ai_stand(worker);
+
+    T_ASSERT(worker->goalentity == enemy);
+}
+
+TEST(wc3_building, repair_autocast_ignores_full_health_nearer_building) {
+    LPEDICT worker;
+    LPEDICT full_building;
+    LPEDICT damaged_building;
+    UnitAbilities_t abilities = { .abilList = "Aren" };
+    ability_t const *repair;
+    slkTestData_t *rows, *old_abilities;
+
+    old_abilities = building_install_repair_data(&rows);
+    setup_test_world();
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    full_building = alloc_test_unit(MAKEFOURCC('h','b','a','r'), 64, 0);
+    damaged_building = alloc_test_unit(MAKEFOURCC('h','b','a','r'), 192, 0);
+    worker->UnitAbilities = &abilities;
+    worker->runtime.acquisition_range = 400.0f;
+    worker->collision = 16.0f;
+    full_building->collision = damaged_building->collision = 32.0f;
+    full_building->s.player = damaged_building->s.player = worker->s.player;
+    full_building->health.max_value = full_building->health.value = 1000.0f;
+    damaged_building->health.max_value = 1000.0f;
+    damaged_building->health.value = 500.0f;
+    gi.LinkEntity(worker);
+    gi.LinkEntity(full_building);
+    gi.LinkEntity(damaged_building);
+    repair = FindAbilityForCommand("Aren");
+
+    T_NOT_NULL(repair);
+    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    T_ASSERT(G_TryUnitAutocast(worker));
+    T_ASSERT(worker->build == damaged_building);
+
+    building_restore_repair_data(old_abilities, rows);
+}
+
+TEST(wc3_building, normal_target_order_routes_repair_through_repair_behavior) {
+    LPEDICT worker;
+    LPEDICT building;
+    UnitAbilities_t abilities = { .abilList = "Aren" };
+    slkTestData_t *rows, *old_abilities;
+
+    old_abilities = building_install_repair_data(&rows);
+    setup_test_world();
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    building = alloc_test_unit(MAKEFOURCC('h','b','a','r'), 64, 0);
+    worker->UnitAbilities = &abilities;
+    building->s.player = worker->s.player;
+    building->health.max_value = 1000.0f;
+    building->health.value = 500.0f;
+
+    T_ASSERT(G_IssueUnitTargetOrder(worker, "repair", building, false, worker->s.player));
+    T_ASSERT(worker->build == building);
+    T_EQ(worker->buildwork.ability, MAKEFOURCC('A','r','e','n'));
 
     building_restore_repair_data(old_abilities, rows);
 }

--- a/games/warcraft-3/tests/resources-src/Units/HumanAbilityFunc.txt
+++ b/games/warcraft-3/tests/resources-src/Units/HumanAbilityFunc.txt
@@ -13,3 +13,8 @@ AreaEffectArt=TestUI\Models\ui_panel.mdx
 
 [AIda]
 TargetArt=TestUI\Models\anim_pulse.mdx
+
+[Arep]
+Art=TestUI\Textures\gather.blp
+Buttonpos=1,1
+Hotkey=R

--- a/games/warcraft-3/tests/resources-src/Units/HumanAbilityStrings.txt
+++ b/games/warcraft-3/tests/resources-src/Units/HumanAbilityStrings.txt
@@ -3,3 +3,7 @@ Tip=Gather
 Ubertip=Gather resources from a Gold Mine or tree.
 Untip=Return Resources
 Unubertip=Return carried resources to a compatible drop-off.
+
+[Arep]
+Tip=Repair
+Ubertip=Repairs a damaged structure.

--- a/server/game.h
+++ b/server/game.h
@@ -102,6 +102,8 @@ typedef struct {
     DWORD number; /* optional command-button numeric overlay; 0 hides it */
     FLOAT cooldown; /* fraction of the ability's cooldown still remaining (0=ready, 1=just used) */
     FLOAT manacost; /* mana cost to cast this ability at its current level (0 if not a spell) */
+    char alternate[256]; /* optional secondary command, normally activated by right click */
+    BYTE alternate_active; /* presentation state for the secondary command */
 } gameCommandButton_t;
 
 typedef struct {

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -2012,6 +2012,78 @@ TEST(client_screen, selection_rect_stops_at_bottom_console_command_button) {
     T_FEQ(rect.y + rect.h, 0.41f / UI_BASE_HEIGHT * 768.0f, 1.0f);
 }
 
+TEST(client_screen, command_button_right_click_sends_secondary_command) {
+    BYTE layout_buf[512];
+    BYTE message_buf[256];
+    char command_buf[128];
+    sizeBuf_t sb = make_msg_buf(layout_buf, sizeof(layout_buf));
+    uiFrame_t empty = {0}, frame = {0};
+
+    test_client_stubs_init();
+    FOR_LOOP(layer, MAX_LAYOUT_LAYERS) SCR_ClearLayoutLayer(layer);
+    SZ_Init(&cls.netchan.message, message_buf, sizeof(message_buf));
+
+    frame.number = 1;
+    frame.flags.type = FT_COMMANDBUTTON;
+    frame.size.width = 0.20f;
+    frame.size.height = 0.20f;
+    frame.points.x[FPP_MIN].used = 1;
+    frame.points.x[FPP_MIN].targetPos = FPP_MIN;
+    frame.points.y[FPP_MIN].used = 1;
+    frame.points.y[FPP_MIN].targetPos = FPP_MIN;
+    frame.onclick = "button Arep";
+    frame.text = "autocast Arep";
+
+    MSG_WriteByte(&sb, LAYER_COMMANDBAR);
+    MSG_WriteDeltaUIFrame(&sb, &empty, &frame, true);
+    MSG_WriteByte(&sb, 0);
+    MSG_WriteLong(&sb, 0);
+    MSG_WriteShort(&sb, 0);
+    sb.readcount = 0;
+    CL_ParseLayout(&sb);
+
+    T_ASSERT(SCR_LayoutMouseEvent(UI_MOUSE_DOWN, 10, 10, 3));
+    T_EQ(cls.netchan.message.cursize, 0);
+    T_ASSERT(SCR_LayoutMouseEvent(UI_MOUSE_UP, 10, 10, 3));
+    cls.netchan.message.readcount = 0;
+    T_EQ(MSG_ReadByte(&cls.netchan.message), clc_stringcmd);
+    MSG_ReadString(&cls.netchan.message, command_buf);
+    T_STREQ(command_buf, "autocast Arep");
+}
+
+TEST(client_screen, command_button_right_click_without_secondary_command_is_not_consumed) {
+    BYTE layout_buf[512];
+    BYTE message_buf[256];
+    sizeBuf_t sb = make_msg_buf(layout_buf, sizeof(layout_buf));
+    uiFrame_t empty = {0}, frame = {0};
+
+    test_client_stubs_init();
+    FOR_LOOP(layer, MAX_LAYOUT_LAYERS) SCR_ClearLayoutLayer(layer);
+    SZ_Init(&cls.netchan.message, message_buf, sizeof(message_buf));
+
+    frame.number = 1;
+    frame.flags.type = FT_COMMANDBUTTON;
+    frame.size.width = 0.20f;
+    frame.size.height = 0.20f;
+    frame.points.x[FPP_MIN].used = 1;
+    frame.points.x[FPP_MIN].targetPos = FPP_MIN;
+    frame.points.y[FPP_MIN].used = 1;
+    frame.points.y[FPP_MIN].targetPos = FPP_MIN;
+    frame.onclick = "button Amov";
+
+    MSG_WriteByte(&sb, LAYER_COMMANDBAR);
+    MSG_WriteDeltaUIFrame(&sb, &empty, &frame, true);
+    MSG_WriteByte(&sb, 0);
+    MSG_WriteLong(&sb, 0);
+    MSG_WriteShort(&sb, 0);
+    sb.readcount = 0;
+    CL_ParseLayout(&sb);
+
+    T_ASSERT(!SCR_LayoutMouseEvent(UI_MOUSE_DOWN, 10, 10, 3));
+    T_ASSERT(!SCR_LayoutMouseEvent(UI_MOUSE_UP, 10, 10, 3));
+    T_EQ(cls.netchan.message.cursize, 0);
+}
+
 /* Upper HUD elements are not part of the bottom-console mask; crossing the
  * resource/upper-button region must not shrink an otherwise valid world drag. */
 TEST(client_screen, selection_rect_ignores_upper_ui_outside_bottom_console) {


### PR DESCRIPTION
Clear a Repair-owned goal when Repair returns to Stand, while preserving a replacement goal already installed by Move or Attack before Repair cancellation.

This restores normal Repair completion/cancellation cleanup without reintroducing the crash caused by clearing a replacement movement goal.

Keep the Auto Repair acquisition fixes and diagnostic logging, and document the Repair goal ownership contract.