### PR TITLE
SC2: restore campaign Galaxy script loading and cutscene diagnostics

### DIFF
--- a/common/cmodel.h
+++ b/common/cmodel.h
@@ -43,6 +43,7 @@ struct war3map {
 };
 
 bool CM_LoadMap(LPCSTR mapFilename);
+DWORD CM_GetMapChecksum(void);
 BOOL CM_IsMapLoaded(LPCSTR mapFilename);
 float CM_GetHeightAtPoint(float sx, float sy);
 LPDOODAD CM_GetDoodads(void);

--- a/common/shared.h
+++ b/common/shared.h
@@ -253,7 +253,7 @@ enum {
     CS_SKY = 2,
     CS_STATUSBAR = 5,        // display program string
     CS_WORLD = 7,
-    CS_MINIMAP = 8,            // alert-ping model path; analogous to Quake's CS_SKY
+    CS_MINIMAP = 8,            // alert-ping model path
     CS_MAXCLIENTS = 30,
     CS_MAPCHECKSUM = 31,        // for catching cheater maps
     CS_MODELS = 32,

--- a/common/world.c
+++ b/common/world.c
@@ -7,6 +7,21 @@
 
 struct world_state world = { 0 };
 static PATHSTR cm_loaded_map = { 0 };
+static DWORD cm_map_checksum;
+
+#define CM_MAP_CRC32_POLY 0xedb88320u // CRC-32 polynomial; identifies the authoritative bytes accepted by the map loader
+
+/* Hash the exact virtual map file supplied to the format loader for Q2-style client map validation. */
+static DWORD CM_CalcMapChecksum(const BYTE *bytes, DWORD size) {
+    DWORD crc = 0xffffffffu;
+
+    FOR_LOOP(i, size) {
+        DWORD bit;
+        crc ^= bytes[i];
+        for (bit = 0; bit < 8; ++bit) crc = (crc >> 1) ^ (CM_MAP_CRC32_POLY & (DWORD)-(LONG)(crc & 1));
+    }
+    return ~crc;
+}
 
 void CM_ReadPathMap(HANDLE archive);
 
@@ -915,15 +930,29 @@ void CM_ReadMapScript(HANDLE archive) {
 }
 
 bool CM_LoadMap(LPCSTR mapFilename) {
+    HANDLE data;
+    DWORD size = 0;
     bool loaded;
 
+    cm_map_checksum = 0;
     snprintf(cm_loaded_map, sizeof(cm_loaded_map), "%s", mapFilename ? mapFilename : "");
+    data = FS_ReadFile(mapFilename, &size);
+    if (data && size) {
+        cm_map_checksum = CM_CalcMapChecksum((const BYTE *)data, size);
+        FS_FreeFile(data);
+    } else {
+        fprintf(stderr, "CM_LoadMap: unable to read map bytes for checksum %s\n", mapFilename ? mapFilename : "");
+        if (data) FS_FreeFile(data);
+    }
     loaded = CM_LoadMapFormat(mapFilename);
     if (!loaded) {
         cm_loaded_map[0] = '\0';
+        cm_map_checksum = 0;
     }
     return loaded;
 }
+
+DWORD CM_GetMapChecksum(void) { return cm_map_checksum; }
 
 BOOL CM_IsMapLoaded(LPCSTR mapFilename) {
 #ifdef WOW

--- a/games/warcraft-3/tests/test_server_net.c
+++ b/games/warcraft-3/tests/test_server_net.c
@@ -21,6 +21,7 @@ struct game_import gi;
 void SV_InitGameProgs(void) {}
 void SV_ClearWorld(void) {}
 bool CM_LoadMap(LPCSTR mapFilename) { (void)mapFilename; return true; }
+DWORD CM_GetMapChecksum(void) { return 0x1234; }
 LPDOODAD CM_GetDoodads(void) { return NULL; }
 static LPMAPINFO test_mapinfo;
 LPCMAPINFO CM_GetMapInfo(void) { return test_mapinfo; }
@@ -550,6 +551,8 @@ TEST(server_net, local_map_uses_loopback_without_udp) {
     SV_Map("Maps\\Melee\\Test.w3m");
 
     T_EQ(sv.state, ss_game);
+    T_STREQ(sv.configstrings[CS_MAXCLIENTS], "4");
+    T_STREQ(sv.configstrings[CS_MAPCHECKSUM], "4660");
     T_EQ(svs.num_clients, 1);
     T_EQ(svs.clients[0].netchan.remote_address.type, NA_LOOPBACK);
     T_ASSERT(!NET_IsConfigured(NS_CLIENT));

--- a/server/sv_init.c
+++ b/server/sv_init.c
@@ -1,4 +1,5 @@
 #include "server.h"
+
 #include "common/net_platform.h"
 
 static BOOL SV_EnsureServerPort(void) {
@@ -8,6 +9,16 @@ static BOOL SV_EnsureServerPort(void) {
         return false;
     }
     return true;
+}
+
+/* Publish server invariants that clients need before interpreting the game snapshot. */
+static void SV_SetMapConfigStrings(void) {
+    char maxclients[16], checksum[16];
+
+    snprintf(maxclients, sizeof(maxclients), "%d", ge->max_clients);
+    SV_SetConfigString(CS_MAXCLIENTS, maxclients, (DWORD)(strlen(maxclients) + 1));
+    snprintf(checksum, sizeof(checksum), "%u", (unsigned)CM_GetMapChecksum());
+    SV_SetConfigString(CS_MAPCHECKSUM, checksum, (DWORD)(strlen(checksum) + 1));
 }
 
 #ifndef TOOL_COMMON_NO_MPQ
@@ -240,11 +251,13 @@ void SV_Map(LPCSTR mapFilename) {
     sv.state = ss_loading;
     strlcpy(sv.configstrings[CS_WORLD], mapFilename, sizeof(sv.configstrings[CS_WORLD]));
     SZ_Init(&sv.multicast, sv.multicast_buf, MAX_MSGLEN);
+    SV_SetConfigString(CS_MAXCLIENTS, "", 1);
     if (!ge->LoadMap(mapFilename)) {
         fprintf(stderr, "SV_Map: map load failed\n");
         sv.state = ss_dead;
         return;
     }
+    SV_SetMapConfigStrings();
     if (!had_lobby) {
         memset(&svs.lobby, 0, sizeof(svs.lobby));
     }


### PR DESCRIPTION
## Summary
- load SC2 campaign MapScript.galaxy from the authoritative .SC2Map archive
- preserve guarded camera and dropship diagnostics for bounded cutscene traces
- expose an opt-in SC2 debug compile flag for cutscene logging

## Validation
- `make test-galaxy` — 86/86 assertions passed
- bounded TRaynor01 Dedicated run loads 127 Galaxy triggers
- default and `SC2_DEBUG_CUTSCENE` game builds succeed

Note: the branch also contains the previously merged UI and WoW changes.