### PR TITLE
wc3: add Warsmash-style floating resource gain text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 Allies/F11 dialog, directional alliances, shared vision/control, draft/Accept semantics | [docs/games/warcraft-3/allies-menu.md](docs/games/warcraft-3/allies-menu.md) |
 | WC3 Hero skill tree, skill points, rank requirements, learning UI, JASS progression | [docs/games/warcraft-3/hero-abilities.md](docs/games/warcraft-3/hero-abilities.md) |
 | WC3 gathering, immobile units, construction HUD, overhead bars | [docs/games/warcraft-3/economy-and-unit-presentation.md](docs/games/warcraft-3/economy-and-unit-presentation.md) |
+| WC3 gold/lumber gain transactions and world-space `+N` presentation | [docs/games/warcraft-3/resource-gain-text.md](docs/games/warcraft-3/resource-gain-text.md) |
 | WC3 Human Call to Arms, Peasant/Militia pairing, timed in-place transform, Back to Work | [docs/games/warcraft-3/call-to-arms-and-militia.md](docs/games/warcraft-3/call-to-arms-and-militia.md) |
 | WC3 enemy/neutral selection, relationship colours, command authority, fog/death deselection | [docs/games/warcraft-3/selection-and-control.md](docs/games/warcraft-3/selection-and-control.md) |
 | WC3 numbered control groups, recall reconciliation, double-tap camera focus, map lifecycle | [docs/games/warcraft-3/control-groups.md](docs/games/warcraft-3/control-groups.md) |

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -242,27 +242,39 @@ static HANDLE layout_hovered;
 static HANDLE layout_current;
 static BOOL layout_current_window;
 
+/* Project a world point through the active camera into the virtual UI canvas.
+ * The world scissor is authoritative: callers should not turn an off-screen
+ * world event into a HUD notification pinned to the nearest edge. */
+BOOL SCR_ProjectWorldPoint(LPCVECTOR3 point, LPVECTOR2 screen) {
+    FLOAT const *m;
+    FLOAT cx, cy, cw, vx, vy;
+
+    if (!point || !screen) return false;
+    m = cl.viewDef.viewProjectionMatrix.v;
+    cx = m[0] * point->x + m[4] * point->y + m[8] * point->z + m[12];
+    cy = m[1] * point->x + m[5] * point->y + m[9] * point->z + m[13];
+    cw = m[3] * point->x + m[7] * point->y + m[11] * point->z + m[15];
+    if (cw <= 0.0001f) return false;
+    vx = cl.viewDef.viewport.x + (cx / cw * 0.5f + 0.5f) * cl.viewDef.viewport.w;
+    vy = cl.viewDef.viewport.y + (cy / cw * 0.5f + 0.5f) * cl.viewDef.viewport.h;
+    if (vx < cl.viewDef.scissor.x || vx > cl.viewDef.scissor.x + cl.viewDef.scissor.w ||
+        vy < cl.viewDef.scissor.y || vy > cl.viewDef.scissor.y + cl.viewDef.scissor.h) return false;
+    *screen = MAKE(VECTOR2, vx * SCR_UICanvasWidth(), (1.0f - vy) * UI_BASE_HEIGHT);
+    return true;
+}
+
 /* Entity-context layouts use a server-authored tree rooted at the client-projected model top. */
 BOOL SCR_LayoutWorldHoverRoot(LPRECT root) {
     LPCENTITYSTATE ent = SCR_LayoutContextEntity();
-    FLOAT const *m;
-    FLOAT cx, cy, cw, vx, vy;
     VECTOR3 top;
+    VECTOR2 screen;
 
     if (!root || !ent) return false;
     FOR_LOOP(i, cl.viewDef.num_entities) {
         if (cl.viewDef.entities[i].number != cl.hover_entity) continue;
         if (!re.GetEntityOverheadPosition(&cl.viewDef.entities[i], &top)) return false;
-        m = cl.viewDef.viewProjectionMatrix.v;
-        cx = m[0] * top.x + m[4] * top.y + m[8] * top.z + m[12];
-        cy = m[1] * top.x + m[5] * top.y + m[9] * top.z + m[13];
-        cw = m[3] * top.x + m[7] * top.y + m[11] * top.z + m[15];
-        if (cw <= 0.0001f) return false;
-        vx = cl.viewDef.viewport.x + (cx / cw * 0.5f + 0.5f) * cl.viewDef.viewport.w;
-        vy = cl.viewDef.viewport.y + (cy / cw * 0.5f + 0.5f) * cl.viewDef.viewport.h;
-        if (vx < cl.viewDef.scissor.x || vx > cl.viewDef.scissor.x + cl.viewDef.scissor.w ||
-            vy < cl.viewDef.scissor.y || vy > cl.viewDef.scissor.y + cl.viewDef.scissor.h) return false;
-        *root = MAKE(RECT, vx * UI_BASE_WIDTH, (1.0f - vy) * UI_BASE_HEIGHT, 0, 0);
+        if (!SCR_ProjectWorldPoint(&top, &screen)) return false;
+        *root = MAKE(RECT, screen.x, screen.y, 0, 0);
         return true;
     }
     return false;

--- a/client/cl_tent.c
+++ b/client/cl_tent.c
@@ -2,6 +2,8 @@
 
 #define MAX_MISSILES 64
 #define MAX_SPELL_IMPACTS 32
+#define MAX_FLOATING_TEXTS 64      /* entries; bounds simultaneous transient world labels */
+#define FLOATING_TEXT_CAPACITY 32  /* bytes including terminator; numeric gains are much shorter */
 #define SPELL_IMPACT_LIFETIME 800  /* ms — one-shot birth animation duration */
 
 typedef struct  {
@@ -33,9 +35,23 @@ typedef struct {
     DWORD lifetime;    /* ms */
 } spellImpact_t;
 
+typedef struct {
+    BOOL active;
+    VECTOR3 origin;
+    char text[FLOATING_TEXT_CAPACITY];
+    COLOR32 color;
+    DWORD font;        /* configstring font index */
+    DWORD starttime;
+    DWORD lifetime;    /* ms */
+    DWORD fade_start;  /* ms from spawn */
+    FLOAT velocity_x;  /* screen pixels per second */
+    FLOAT velocity_y;  /* screen pixels per second; positive rises */
+} floatingText_t;
+
 struct {
     missile_t missiles[MAX_MISSILES];
     spellImpact_t impacts[MAX_SPELL_IMPACTS];
+    floatingText_t texts[MAX_FLOATING_TEXTS];
 } tents = { 0 };
 
 moveConfirmation_t cl_confs[MAX_CONFIRMATION_OBJECTS] = { 0 };
@@ -47,6 +63,17 @@ static spellImpact_t *CL_AllocSpellImpact(void) {
     FOR_LOOP(i, MAX_SPELL_IMPACTS) {
         if (!tents.impacts[i].active) return &tents.impacts[i];
         if (tents.impacts[i].starttime < oldest->starttime) oldest = &tents.impacts[i];
+    }
+    return oldest;
+}
+
+/* Transient labels are presentation-only. If a pathological burst fills the
+ * bounded pool, replacing the oldest label avoids unbounded client memory. */
+static floatingText_t *CL_AllocFloatingText(void) {
+    floatingText_t *oldest = &tents.texts[0];
+    FOR_LOOP(i, MAX_FLOATING_TEXTS) {
+        if (!tents.texts[i].active) return &tents.texts[i];
+        if (tents.texts[i].starttime < oldest->starttime) oldest = &tents.texts[i];
     }
     return oldest;
 }
@@ -99,6 +126,32 @@ void CL_ParseTEnt(LPSIZEBUF msg) {
                 imp->starttime = cl.time;
                 imp->lifetime  = SPELL_IMPACT_LIFETIME;
                 imp->active    = true;
+            }
+            break;
+        case TE_FLOATING_TEXT:
+            {
+                floatingText_t *text = CL_AllocFloatingText();
+                DWORD packed;
+                LONG font, lifetime, fade_start;
+
+                memset(text, 0, sizeof(*text));
+                MSG_ReadPos(msg, &text->origin);
+                MSG_ReadStringN(msg, text->text, sizeof(text->text));
+                packed = (DWORD)MSG_ReadLong(msg);
+                text->color = MAKE(COLOR32,
+                    packed & 0xffu, (packed >> 8) & 0xffu,
+                    (packed >> 16) & 0xffu, (packed >> 24) & 0xffu);
+                font = MSG_ReadShort(msg);
+                text->font = font > 0 && font < MAX_FONTSTYLES ? (DWORD)font : 0;
+                lifetime = MSG_ReadLong(msg);
+                fade_start = MSG_ReadLong(msg);
+                text->lifetime = lifetime > 0 ? (DWORD)lifetime : 0;
+                text->fade_start = fade_start > 0 ? (DWORD)fade_start : 0;
+                text->fade_start = MIN(text->fade_start, text->lifetime);
+                text->velocity_x = MSG_ReadFloat(msg);
+                text->velocity_y = MSG_ReadFloat(msg);
+                text->starttime = cl.time;
+                text->active = text->text[0] && text->lifetime > 0;
             }
             break;
         default:
@@ -174,6 +227,59 @@ static void CL_AddSpellImpacts(void) {
         ent.model     = cl.models[imp->model];
         ent.flags     = RF_GROUND_ANCHOR | RF_NO_SHADOW | RF_NO_FOGOFWAR;
         V_AddEntity(&ent);
+    }
+}
+
+/* Draw generic world labels after the 3D frame so they remain presentation
+ * overlays while still projecting from a stable world-space spawn point. */
+void CL_DrawTEnts(void) {
+    size2_t const window = re.GetWindowSize();
+    FLOAT const pixel_x = window.width ? SCR_UICanvasWidth() / (FLOAT)window.width : 0.0f;
+    FLOAT const pixel_y = window.height ? UI_BASE_HEIGHT / (FLOAT)window.height : 0.0f;
+
+    FOR_LOOP(i, MAX_FLOATING_TEXTS) {
+        floatingText_t *text = &tents.texts[i];
+        VECTOR2 screen;
+        DWORD age;
+        FLOAT seconds, alpha = 1.0f;
+        COLOR32 color, shadow;
+        RECT rect;
+
+        if (!text->active) continue;
+        age = cl.time - text->starttime;
+        if (age >= text->lifetime) {
+            text->active = false;
+            continue;
+        }
+        if (!text->font || !cl.fonts[text->font] || !SCR_ProjectWorldPoint(&text->origin, &screen))
+            continue;
+
+        if (age >= text->fade_start && text->lifetime > text->fade_start) {
+            alpha = (FLOAT)(text->lifetime - age) /
+                    (FLOAT)(text->lifetime - text->fade_start);
+        }
+        seconds = (FLOAT)age / 1000.0f;
+        screen.x += text->velocity_x * seconds * pixel_x;
+        screen.y -= text->velocity_y * seconds * pixel_y;
+        color = text->color;
+        color.a = (BYTE)(color.a * MAX(0.0f, MIN(1.0f, alpha)));
+        shadow = MAKE(COLOR32, 0, 0, 0, color.a);
+
+        /* Warsmash's built-in gain labels are left-origin text with a small
+         * dark drop shadow; the game, not this generic client path, supplies
+         * resource-specific colour/font/timing. */
+        rect = MAKE(RECT, screen.x + 3.0f * pixel_x, screen.y + 1.0f * pixel_y,
+                    SCR_UICanvasWidth(), UI_BASE_HEIGHT);
+        re.DrawText(&MAKE(drawText_t,
+            .font = cl.fonts[text->font], .text = text->text, .rect = rect,
+            .color = shadow, .textWidth = SCR_UICanvasWidth(),
+            .halign = FONT_JUSTIFYLEFT, .valign = FONT_JUSTIFYTOP));
+        rect.x = screen.x;
+        rect.y = screen.y;
+        re.DrawText(&MAKE(drawText_t,
+            .font = cl.fonts[text->font], .text = text->text, .rect = rect,
+            .color = color, .textWidth = SCR_UICanvasWidth(),
+            .halign = FONT_JUSTIFYLEFT, .valign = FONT_JUSTIFYTOP));
     }
 }
 

--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -511,6 +511,7 @@ void V_RenderView(void) {
     }
 
     re.RenderFrame(&cl.viewDef);
+    CL_DrawTEnts();
     
 //    re.DrawPic(tex1, 0, 0);
 //    re.DrawPic(tex2, 512, 0);

--- a/client/client.h
+++ b/client/client.h
@@ -194,6 +194,9 @@ DWORD CL_MinimapRecentCount(void);
 LPCENTITYSTATE SCR_LayoutContextEntity(void);
 BOOL SCR_LayoutContextValue(DWORD stat, LPFLOAT value);
 BOOL SCR_LayoutWorldHoverRoot(LPRECT root);
+FLOAT SCR_UICanvasWidth(void);
+VECTOR2 SCR_ScreenToUI(int x, int y);
+BOOL SCR_ProjectWorldPoint(LPCVECTOR3 point, LPVECTOR2 screen);
 VECTOR2 SCR_GetAxisBounds(LPCRECT rect, bool is_x_axis);
 FLOAT SCR_NormalizeAnchorOffset(uiFramePoint_t const *p, bool is_x_axis);
 VECTOR2 SCR_SolveAxisPosition(LPCUIFRAME frame,
@@ -224,6 +227,7 @@ void CL_InitInput(void);
 // cl_tent.c
 void CL_ParseTEnt(LPSIZEBUF msg);
 void CL_AddTEnts(void);
+void CL_DrawTEnts(void);
 void CL_ClearTEnts(void);
 
 // cl_main.c - UI integration

--- a/common/shared.h
+++ b/common/shared.h
@@ -744,6 +744,9 @@ typedef enum {
     TE_FIREBOLT_IMPACT,    /* WoW: fire explosion — payload: POSITION, model SHORT */
     TE_FROSTBOLT_IMPACT,   /* WoW: frost burst — payload: POSITION, model SHORT */
     TE_ATTACK_CONFIRMATION,
+    /* Generic server-selected world text. Payload: POSITION, STRING, RGBA LONG,
+     * font SHORT, lifetime LONG ms, fade-start LONG ms, velocity FLOAT/FLOAT px/s. */
+    TE_FLOATING_TEXT,
 } tempEvent_t;
 
 typedef enum {

--- a/docs/architecture/server-selected-effects.md
+++ b/docs/architecture/server-selected-effects.md
@@ -56,3 +56,9 @@ do not substitute a per-game preprocessor guard or a hardcoded command branch in
 Persistent local markers such as Warcraft III's Rally destination are ordinary game-owned edicts. The game resolves and registers the model, sets `SVF_OWNER_ONLY`, and stores the recipient in `entityState_t.player`; `SV_BuildClientFrame` excludes the edict from every other client's snapshot. Point markers use an authoritative world origin, while widget markers use the normal linked-edict movement path to follow their target.
 
 The owning game client keeps the marker edict pointer so selection changes update or free the same entity. Save/load does not serialize that runtime cache pointer: the marker's saved `owner` edict reconstructs it after pointer fixups. One-shot acknowledgements such as move and attack confirmations remain temporary events.
+
+## One-shot resolved world text
+
+Short-lived world text follows the same ownership rule as model effects. `TE_FLOATING_TEXT` is a generic temporary event: it carries an already-resolved string, RGBA colour, font index, lifetime/fade timings, screen-space velocity, and world anchor. The owning game must resolve semantic identity such as Warcraft gold/lumber before writing the event. Shared/client code must not grow `TE_GOLD_TEXT`, race/resource tables, or game-data lookups.
+
+The client captures the event anchor and projects it through the active camera each draw. It does not create a persistent network entity and does not attach the text to the source after spawn. This is appropriate for one-shot feedback such as a committed resource gain; persistent/script-addressable text belongs to a separate handle/entity contract. See [WC3 Resource-Gain Floating Text](../games/warcraft-3/resource-gain-text.md).

--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -227,6 +227,8 @@ and dispatch are the Warcraft/JASS trigger contract. `G_SubscribeMessage` instal
 
 Harvest publishes transitions only: move-to-resource, enter-mine/start-chop, chop/tree-felled, return-to-base, deposit, and resume.
 Movement ticks do not publish messages. Tests subscribe immediately before the order and assert both sequence and entity numbers.
+
+Resource-gain presentation is deliberately separate from this transition stream. `G_CreditResourceIncome()` applies upkeep, commits the net amount to player stats, then emits the one-shot world `+N` presentation from the transaction source. The existing deposit message remains `{type, actor, target}` and may be observed before the accounting statement; consumers that need the amount must use the committed income path rather than extending `GAMEMSG`. See [resource-gain-text.md](resource-gain-text.md) for the server-selected data, generic temporary-event payload, and client lifetime rules.
 The lethal-trip test specifically requires `CHOP -> TREE_FELLED -> RETURN_LUMBER -> DEPOSIT_LUMBER -> RESUME_LUMBER -> START_CHOP`,
 with the resume/start target equal to the next live tree rather than the felled entity.
 

--- a/docs/games/warcraft-3/food-and-upkeep.md
+++ b/docs/games/warcraft-3/food-and-upkeep.md
@@ -101,7 +101,7 @@ Upkeep is derived from authoritative Food Used, not Food Cap. `InitConstants()` 
 
 `G_SetUnitFoodUsed()` recomputes the rates whenever accounted food changes. Direct JASS `SetPlayerState(PLAYER_STATE_RESOURCE_FOOD_USED, ...)` does the same. Fresh player state initializes both upkeep-rate slots to 100 before the first food recomputation.
 
-Resource acquisition remains split into gross gathering and player income. Workers keep the full carried amount; gold/lumber deposit calls `G_ApplyResourceIncome()` immediately before crediting the player. Standard lumber remains 100%, while the generic lumber-rate player state is still honored if explicitly changed. Blighted-mine and Wisp interval income use the same helper rather than bypassing player income policy.
+Resource acquisition remains split into gross gathering and player income. Workers keep the full carried amount; income sites now commit through `G_CreditResourceIncome()`, which uses the pure `G_ApplyResourceIncome()` calculation, credits the resulting net amount, then emits the matching resource-gain presentation event. Standard lumber remains 100%, while the generic lumber-rate player state is still honored if explicitly changed. Blighted-mine and Wisp interval income use the same commit helper rather than bypassing player income policy. The floating `+N` therefore reports the same net amount that reached the resource bar; see [resource-gain-text.md](resource-gain-text.md).
 
 Stored resources are never retroactively changed when the upkeep tier changes.
 

--- a/docs/games/warcraft-3/resource-gain-text.md
+++ b/docs/games/warcraft-3/resource-gain-text.md
@@ -1,0 +1,106 @@
+# WC3 Resource-Gain Floating Text
+
+## Scope
+
+Warcraft resource income has two separate responsibilities:
+
+1. gameplay commits the final amount to the owning player's resource state; and
+2. presentation reports that committed amount as a transient world label such as `+10`.
+
+For ordinary workers the label belongs to **deposit**, not extraction. A Peasant may leave a Gold Mine carrying ten gold without changing the player's gold total or creating a gain label. When it reaches a compatible drop-off, the income transaction commits and a label is spawned from the worker's position. Lumber follows the same rule. Direct-income paths such as the current Wisp and Blighted Gold Mine implementations emit at the source unit when their existing income transaction commits.
+
+`G_CreditResourceIncome()` is the common commit boundary. It calls the existing pure `G_ApplyResourceIncome()` upkeep calculation, updates `playerState_t.stats`, and only then calls `G_ResourceGainEvent()` with the **net credited amount**. This keeps the visual number consistent with the resource bar under Low/High Upkeep. Existing `GAME_MSG_HARVEST_DEPOSIT_*` messages remain transition observations with `{type, actor, target}` and are not overloaded with presentation data.
+
+## Server-selected presentation contract
+
+`games/warcraft-3/game/g_resource_text.c` owns Warcraft data lookup and turns GOLD/LUMBER into resolved presentation values. The generic engine sees only `TE_FLOATING_TEXT` with this payload:
+
+```text
+POSITION world anchor
+STRING   final text (for example "+7")
+LONG     packed RGBA colour
+SHORT    registered font index
+LONG     lifetime in milliseconds
+LONG     fade-start in milliseconds
+FLOAT    horizontal screen velocity in pixels/second
+FLOAT    vertical screen velocity in pixels/second
+```
+
+There are deliberately no `TE_GOLD_TEXT` / `TE_LUMBER_TEXT` shared enums and no resource-name table in `client/`. This follows [server-selected-effects.md](../../architecture/server-selected-effects.md): game code resolves game-specific content, while shared/client code transports and renders generic resolved presentation.
+
+Current Warsmash accepts a player index in `unitGainResourceEvent()` but drops it before `SimulationRenderController.spawnTextTag()`. OpenRealm therefore multicasts this parity event without owner filtering. The client still draws it only while its world anchor projects inside the active world scissor. This document does not infer stricter retail multiplayer visibility from Warsmash's unused player-index parameter.
+
+## Warcraft data and fallback rules
+
+The active merged Misc cache already loads `UI\\MiscData.txt`, `UI\\MiscUI.txt`, and `war3mapMisc.txt`. `G_ResourceGainEvent()` reads:
+
+```text
+GoldTextColor / LumberTextColor
+GoldTextLifetime / LumberTextLifetime
+GoldTextFadeStart / LumberTextFadeStart
+GoldTextHeight / LumberTextHeight
+```
+
+`*TextColor` is authored as `alpha,red,green,blue` and is converted to the engine's RGBA `COLOR32`. The label uses the active `MasterFont` skin entry, falling back to `Fonts\\FRIZQT__.TTF`.
+
+When active data omits a field, the implementation has narrow stock-compatible fallbacks:
+
+| Style | Colour (RGBA) | Lifetime | Fade start | Height |
+|---|---:|---:|---:|---:|
+| Gold | `255,220,0,255` | 2.0 s | 1.0 s | 0.024 UI |
+| Lumber | `0,200,80,255` | 2.0 s | 1.0 s | 0.024 UI |
+
+The font-size conversion mirrors Warsmash's built-in text-tag path: Warsmash renders at `TextHeight * 0.5` UI height, while OpenRealm fonts are registered in authored thousandths, so `0.024 * 500 = 12` pixels for stock data.
+
+Warsmash parses `GoldTextVelocity`/`LumberTextVelocity`, but its built-in numeric `spawnTextTag()` currently constructs the tag with a hard-coded `(0, 60)` screen-pixel velocity. OpenRealm intentionally follows that current built-in behavior instead of claiming the parsed velocity is authoritative: labels rise at 60 px/s with no horizontal drift.
+
+## Client lifecycle
+
+`client/cl_tent.c` owns a bounded pool of transient floating labels. A label captures its world anchor at spawn; it is not attached to the worker afterward. Therefore a Peasant can immediately walk back to the mine while the number continues rising from the deposit location.
+
+Every frame after the 3D world is rendered:
+
+1. `SCR_ProjectWorldPoint()` projects the stored world anchor through the active view-projection matrix.
+2. If the projected point is outside the world scissor, the label is not drawn that frame.
+3. Screen-space travel is applied; positive vertical velocity moves upward.
+4. Alpha remains at the authored value until fade start, then scales to zero over the remaining lifetime.
+5. A small black shadow is drawn, then the resolved coloured label.
+6. When lifetime expires, the pool slot is released.
+
+Multiple gains are independent objects. Two workers depositing ten gold at the same time produce two `+10` labels rather than an aggregated `+20`.
+
+## Implemented income hooks
+
+The common commit helper is used at the existing high-confidence income sites:
+
+- normal Gold Mine worker deposit (`s_goldmine.c`);
+- normal lumber worker deposit (`s_harvest_lumber.c`);
+- Call to Arms' immediate carried-resource return (`s_militia.c`);
+- the currently implemented Wisp direct lumber credit;
+- the currently implemented Blighted Gold Mine direct gold credit.
+
+The event source is the entity that owns the current transaction. Normal worker deposits and militia conversion therefore originate at the worker. Current direct Wisp income originates at the Wisp; current Blighted Mine income originates at the mine.
+
+## Deliberate non-goals / remaining parity gaps
+
+This patch does **not** use floating text as a reason to redesign incomplete gameplay systems:
+
+- Wisp harvesting currently credits once and consumes the Wisp; Warsmash's persistent periodic Wisp harvesting remains a separate gameplay gap.
+- `Aegm` Entangled Mine is still only a marker in OpenRealm, so there is no correct income transaction to instrument yet.
+- Gold/lumber bounty semantics and their distinct Warsmash `Bounty` / `LumberBounty` styles remain separate work.
+- General JASS `texttag` natives (`CreateTextTag`, `SetTextTag*`, etc.) remain unimplemented. `TE_FLOATING_TEXT` is a generic one-shot presentation primitive, not a JASS handle/lifetime implementation.
+- The resource label does not modify harvesting orders, carry state, camera, fog, selection, or HUD resource accounting.
+
+## Regression coverage
+
+`wc3_food.credited_gold_emits_net_resource_gain_world_text` checks the server-side contract without external Warcraft data. At 70% Gold Upkeep, gross income 10 must:
+
+- credit exactly 7 gold;
+- emit text `+7`, not `+10`;
+- anchor ten world units above the source position;
+- select the generic `TE_FLOATING_TEXT` event;
+- use the fallback gold colour/timing/font size when Misc data is absent;
+- encode 0/60 px/s built-in motion; and
+- multicast exactly once.
+
+Runtime visual validation should additionally exercise ordinary gold and lumber deposits in both ROC and TFT data modes and confirm independent rising/fading labels while workers immediately resume their normal harvesting loop.

--- a/games/warcraft-3/game/g_food.c
+++ b/games/warcraft-3/game/g_food.c
@@ -190,3 +190,15 @@ LONG G_ApplyResourceIncome(LPPLAYER player, DWORD resource_state, LONG gross_amo
     rate = MAX(0, rate);
     return (gross_amount * rate) / 100;
 }
+
+/* Commit an income transaction before publishing its presentation event.
+ * Callers use the returned net amount when they need the credited value; the
+ * existing G_ApplyResourceIncome helper remains pure for previews/tests. */
+LONG G_CreditResourceIncome(LPPLAYER player, LPEDICT source, DWORD resource_state, LONG gross_amount) {
+    LONG const credited = G_ApplyResourceIncome(player, resource_state, gross_amount);
+
+    if (!player || resource_state >= MAX_STATS || credited <= 0) return 0;
+    player->stats[resource_state] += credited;
+    G_ResourceGainEvent(source, resource_state, credited);
+    return credited;
+}

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -1445,6 +1445,8 @@ void G_CancelTrainingQueue(LPEDICT producer, BOOL refund);
 void G_SetUnitPlayer(LPEDICT unit, DWORD player);
 void G_RecomputePlayerUpkeep(LPGAMECLIENT client);
 LONG G_ApplyResourceIncome(LPPLAYER player, DWORD resource_state, LONG gross_amount);
+LONG G_CreditResourceIncome(LPPLAYER player, LPEDICT source, DWORD resource_state, LONG gross_amount);
+void G_ResourceGainEvent(LPEDICT source, DWORD resource_state, LONG amount);
 BOOL G_UnitCanReviveHeroes(LPCEDICT altar);
 BOOL G_HeroCanBeRevivedAt(LPCEDICT altar, LPCEDICT hero);
 

--- a/games/warcraft-3/game/g_resource_text.c
+++ b/games/warcraft-3/game/g_resource_text.c
@@ -1,0 +1,116 @@
+#include "g_local.h"
+
+#define RESOURCE_TEXT_WORLD_Z_OFFSET 10.0f /* world units; current Warsmash TextTag constructor lift */
+#define RESOURCE_TEXT_VELOCITY_X 0.0f      /* screen pixels per second; current Warsmash built-in motion */
+#define RESOURCE_TEXT_VELOCITY_Y 60.0f     /* screen pixels per second; positive values rise on the client */
+#define RESOURCE_TEXT_FONT_SCALE 500.0f    /* px per WC3 UI-height unit; Warsmash uses TextHeight * 0.5 */
+
+/* These values are only fallbacks when the active Warcraft data omits the
+ * corresponding Misc fields. Stock data remains authoritative when present. */
+typedef struct {
+    LPCSTR name;
+    COLOR32 fallback_color;
+    FLOAT fallback_lifetime;   /* seconds */
+    FLOAT fallback_fade_start; /* seconds */
+    FLOAT fallback_height;     /* WC3 UI units */
+} resourceTextStyle_t;
+
+static BYTE resource_text_byte(int value) {
+    return (BYTE)MAX(0, MIN(255, value));
+}
+
+/* Warcraft Misc *TextColor fields are authored as alpha, red, green, blue. */
+static COLOR32 resource_text_color(LPCSTR field, COLOR32 fallback) {
+    LPCSTR value = Stb_IniCacheFind(&game.config.misc, "Misc", field);
+    int a, r, g, b;
+
+    if (!value || sscanf(value, "%d,%d,%d,%d", &a, &r, &g, &b) != 4)
+        return fallback;
+    return MAKE(COLOR32,
+        resource_text_byte(r), resource_text_byte(g),
+        resource_text_byte(b), resource_text_byte(a));
+}
+
+static FLOAT resource_text_float(LPCSTR field, FLOAT fallback) {
+    LPCSTR value = Stb_IniCacheFind(&game.config.misc, "Misc", field);
+    return value && *value ? (FLOAT)atof(value) : fallback;
+}
+
+static DWORD resource_text_color_bits(COLOR32 color) {
+    return (DWORD)color.r | ((DWORD)color.g << 8) |
+           ((DWORD)color.b << 16) | ((DWORD)color.a << 24);
+}
+
+static BOOL resource_text_style(DWORD resource_state, resourceTextStyle_t *style) {
+    if (!style) return false;
+    switch (resource_state) {
+        case PLAYERSTATE_RESOURCE_GOLD:
+            *style = MAKE(resourceTextStyle_t,
+                .name = "Gold",
+                .fallback_color = MAKE(COLOR32, 255, 220, 0, 255),
+                .fallback_lifetime = 2.0f,
+                .fallback_fade_start = 1.0f,
+                .fallback_height = 0.024f);
+            return true;
+        case PLAYERSTATE_RESOURCE_LUMBER:
+            *style = MAKE(resourceTextStyle_t,
+                .name = "Lumber",
+                .fallback_color = MAKE(COLOR32, 0, 200, 80, 255),
+                .fallback_lifetime = 2.0f,
+                .fallback_fade_start = 1.0f,
+                .fallback_height = 0.024f);
+            return true;
+        default:
+            return false;
+    }
+}
+
+void G_ResourceGainEvent(LPEDICT source, DWORD resource_state, LONG amount) {
+    resourceTextStyle_t style;
+    char field[64], text[32];
+    VECTOR3 origin;
+    COLOR32 color;
+    FLOAT lifetime, fade_start, height;
+    DWORD color_bits, lifetime_ms, fade_start_ms, font_size;
+    LONG font;
+
+    if (!source || amount <= 0 || !resource_text_style(resource_state, &style)) return;
+    if (!gi.Write || !gi.multicast || !gi.FontIndex) return;
+
+    snprintf(field, sizeof(field), "%sTextColor", style.name);
+    color = resource_text_color(field, style.fallback_color);
+    snprintf(field, sizeof(field), "%sTextLifetime", style.name);
+    lifetime = resource_text_float(field, style.fallback_lifetime);
+    snprintf(field, sizeof(field), "%sTextFadeStart", style.name);
+    fade_start = resource_text_float(field, style.fallback_fade_start);
+    snprintf(field, sizeof(field), "%sTextHeight", style.name);
+    height = resource_text_float(field, style.fallback_height);
+
+    if (lifetime <= 0.0f || height <= 0.0f) return;
+    fade_start = MAX(0.0f, MIN(fade_start, lifetime));
+    lifetime_ms = (DWORD)(lifetime * 1000.0f + 0.5f);
+    fade_start_ms = (DWORD)(fade_start * 1000.0f + 0.5f);
+    font_size = (DWORD)MAX(1.0f, height * RESOURCE_TEXT_FONT_SCALE + 0.5f);
+    font = gi.FontIndex(Theme_String("MasterFont", "Fonts\\FRIZQT__.TTF"), font_size);
+    if (font <= 0 || font >= MAX_FONTSTYLES) return;
+
+    snprintf(text, sizeof(text), "+%d", (int)amount);
+    origin = source->s.origin;
+    origin.z += RESOURCE_TEXT_WORLD_Z_OFFSET;
+    color_bits = resource_text_color_bits(color);
+
+    gi.Write(PF_BYTE, &(LONG){ svc_temp_entity });
+    gi.Write(PF_BYTE, &(LONG){ TE_FLOATING_TEXT });
+    gi.Write(PF_POSITION, &origin);
+    gi.Write(PF_STRING, text);
+    gi.Write(PF_LONG, &(LONG){ (LONG)color_bits });
+    gi.Write(PF_SHORT, &font);
+    gi.Write(PF_LONG, &(LONG){ (LONG)lifetime_ms });
+    gi.Write(PF_LONG, &(LONG){ (LONG)fade_start_ms });
+    gi.Write(PF_FLOAT, &(FLOAT){ RESOURCE_TEXT_VELOCITY_X });
+    gi.Write(PF_FLOAT, &(FLOAT){ RESOURCE_TEXT_VELOCITY_Y });
+
+    /* Current Warsmash accepts a player index for resource tags but drops it
+     * before rendering, so this parity path intentionally has no owner filter. */
+    gi.multicast(&origin, MULTICAST_ALL);
+}

--- a/games/warcraft-3/game/skills/s_goldmine.c
+++ b/games/warcraft-3/game/skills/s_goldmine.c
@@ -283,8 +283,8 @@ static void goldmine_finish_deposit(LPEDICT ent, LPEDICT dropoff, int debug) {
     ent->goalentity = ent->secondarygoal;
     player = G_GetPlayerByNumber(ent->s.player);
     if (player) {
-        player->stats[PLAYERSTATE_RESOURCE_GOLD] +=
-            G_ApplyResourceIncome(player, PLAYERSTATE_RESOURCE_GOLD, (LONG)ent->harvested_gold);
+        G_CreditResourceIncome(player, ent, PLAYERSTATE_RESOURCE_GOLD,
+                               (LONG)ent->harvested_gold);
     }
     if (debug >= 1)
         fprintf(stderr,
@@ -593,8 +593,8 @@ void blight_mine_think(LPEDICT ent) {
         return;
     }
     /* Apply the same player income rate used by worker deposits. */
-    player->stats[PLAYERSTATE_RESOURCE_GOLD] +=
-        G_ApplyResourceIncome(player, PLAYERSTATE_RESOURCE_GOLD, (LONG)blight_gold_per_interval);
+    G_CreditResourceIncome(player, ent, PLAYERSTATE_RESOURCE_GOLD,
+                           (LONG)blight_gold_per_interval);
     ent->freetime = now + (DWORD)(blight_interval_duration * 1000.0f);
 }
 

--- a/games/warcraft-3/game/skills/s_harvest_lumber.c
+++ b/games/warcraft-3/game/skills/s_harvest_lumber.c
@@ -479,8 +479,8 @@ static void ai_harvest_walkback(LPEDICT ent) {
         G_PublishMessage(ent, GAME_MSG_HARVEST_DEPOSIT_LUMBER, dropoff);
         LPPLAYER player = G_GetPlayerByNumber(ent->s.player);
         if (player) {
-            player->stats[PLAYERSTATE_RESOURCE_LUMBER] +=
-                G_ApplyResourceIncome(player, PLAYERSTATE_RESOURCE_LUMBER, (LONG)ent->harvested_lumber);
+            G_CreditResourceIncome(player, ent, PLAYERSTATE_RESOURCE_LUMBER,
+                                   (LONG)ent->harvested_lumber);
         }
         S_SetCarriedResource(ent, RETURN_RESOURCE_LUMBER, 0);
         /* Resolve the next live tree at the deposit boundary.  Resuming with
@@ -623,8 +623,8 @@ static void ai_wisp_mine(LPEDICT ent) {
     /* Wisp gathers lumber and is consumed. */
     LPPLAYER player = G_GetPlayerByNumber(ent->s.player);
     if (player) {
-        player->stats[PLAYERSTATE_RESOURCE_LUMBER] +=
-            G_ApplyResourceIncome(player, PLAYERSTATE_RESOURCE_LUMBER, (LONG)wisp_lumber_per_interval);
+        G_CreditResourceIncome(player, ent, PLAYERSTATE_RESOURCE_LUMBER,
+                               (LONG)wisp_lumber_per_interval);
     }
     ent->health.value = 0;
     if (ent->die) {

--- a/games/warcraft-3/game/skills/s_militia.c
+++ b/games/warcraft-3/game/skills/s_militia.c
@@ -145,13 +145,13 @@ static void militia_return_carried_resources(LPEDICT worker) {
 
     if (!worker || !(player = G_GetPlayerByNumber(worker->s.player))) return;
     if (worker->harvested_gold) {
-        player->stats[PLAYERSTATE_RESOURCE_GOLD] +=
-            G_ApplyResourceIncome(player, PLAYERSTATE_RESOURCE_GOLD, (LONG)worker->harvested_gold);
+        G_CreditResourceIncome(player, worker, PLAYERSTATE_RESOURCE_GOLD,
+                               (LONG)worker->harvested_gold);
         S_SetCarriedResource(worker, RETURN_RESOURCE_GOLD, 0);
     }
     if (worker->harvested_lumber) {
-        player->stats[PLAYERSTATE_RESOURCE_LUMBER] +=
-            G_ApplyResourceIncome(player, PLAYERSTATE_RESOURCE_LUMBER, (LONG)worker->harvested_lumber);
+        G_CreditResourceIncome(player, worker, PLAYERSTATE_RESOURCE_LUMBER,
+                               (LONG)worker->harvested_lumber);
         S_SetCarriedResource(worker, RETURN_RESOURCE_LUMBER, 0);
     }
 }

--- a/games/warcraft-3/game/tests/t_food.c
+++ b/games/warcraft-3/game/tests/t_food.c
@@ -16,6 +16,61 @@ static LPCSTR food_limits_off_cvar(LPCSTR name, LPCSTR fallback) {
     return !strcmp(name, "wc3_food_limits") ? "0" : fallback;
 }
 
+typedef struct {
+    pfWriteType_t types[16];
+    LONG integral[16];
+    FLOAT real[16];
+    VECTOR3 position;
+    char text[32];
+    DWORD count;
+    DWORD font_size;
+    char font_name[MAX_PATHLEN];
+    DWORD multicast_count;
+    multicast_t multicast_to;
+    VECTOR3 multicast_origin;
+} resourceGainCapture_t;
+
+static resourceGainCapture_t resource_gain_capture;
+
+static void resource_gain_test_write(pfWriteType_t type, void const *value) {
+    DWORD const slot = resource_gain_capture.count++;
+
+    DWORD const capacity = sizeof(resource_gain_capture.types) / sizeof(resource_gain_capture.types[0]);
+
+    if (slot < capacity) resource_gain_capture.types[slot] = type;
+    if (!value || slot >= capacity) return;
+    switch (type) {
+        case PF_BYTE:
+        case PF_SHORT:
+        case PF_LONG:
+            resource_gain_capture.integral[slot] = *(LONG const *)value;
+            break;
+        case PF_FLOAT:
+            resource_gain_capture.real[slot] = *(FLOAT const *)value;
+            break;
+        case PF_POSITION:
+            resource_gain_capture.position = *(LPCVECTOR3)value;
+            break;
+        case PF_STRING:
+            strlcpy(resource_gain_capture.text, value, sizeof(resource_gain_capture.text));
+            break;
+        default:
+            break;
+    }
+}
+
+static int resource_gain_test_font(LPCSTR name, DWORD size) {
+    strlcpy(resource_gain_capture.font_name, name ? name : "", sizeof(resource_gain_capture.font_name));
+    resource_gain_capture.font_size = size;
+    return 17;
+}
+
+static void resource_gain_test_multicast(LPCVECTOR3 origin, multicast_t to) {
+    resource_gain_capture.multicast_count++;
+    resource_gain_capture.multicast_to = to;
+    if (origin) resource_gain_capture.multicast_origin = *origin;
+}
+
 TEST(wc3_food, unit_food_accounting_is_delta_based_and_death_releases_it) {
     LPGAMECLIENT client = &game.clients[0];
     LPEDICT unit = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0.0f, 0.0f);
@@ -181,6 +236,57 @@ TEST(wc3_food, resource_income_applies_upkeep_rate_only_to_selected_resource) {
 
     player->stats[PLAYERSTATE_GOLD_UPKEEP_RATE] = 40;
     T_EQ(G_ApplyResourceIncome(player, PLAYERSTATE_RESOURCE_GOLD, 10), 4);
+}
+
+TEST(wc3_food, credited_gold_emits_net_resource_gain_world_text) {
+    LPPLAYER player = &game.clients[0].ps;
+    LPEDICT source = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 100.0f, 200.0f);
+    void (*saved_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*saved_multicast)(LPCVECTOR3, multicast_t) = gi.multicast;
+    int (*saved_font)(LPCSTR, DWORD) = gi.FontIndex;
+
+    memset(&resource_gain_capture, 0, sizeof(resource_gain_capture));
+    source->s.origin = MAKE(VECTOR3, 100.0f, 200.0f, 3.0f);
+    player->stats[PLAYERSTATE_RESOURCE_GOLD] = 500;
+    player->stats[PLAYERSTATE_GOLD_UPKEEP_RATE] = 70;
+    gi.Write = resource_gain_test_write;
+    gi.multicast = resource_gain_test_multicast;
+    gi.FontIndex = resource_gain_test_font;
+
+    T_EQ(G_CreditResourceIncome(player, source, PLAYERSTATE_RESOURCE_GOLD, 10), 7);
+    T_EQ(player->stats[PLAYERSTATE_RESOURCE_GOLD], 507);
+    T_EQ(resource_gain_capture.count, 10);
+    T_EQ(resource_gain_capture.types[0], PF_BYTE);
+    T_EQ(resource_gain_capture.integral[0], svc_temp_entity);
+    T_EQ(resource_gain_capture.types[1], PF_BYTE);
+    T_EQ(resource_gain_capture.integral[1], TE_FLOATING_TEXT);
+    T_EQ(resource_gain_capture.types[2], PF_POSITION);
+    T_FEQ(resource_gain_capture.position.x, 100.0f, 0.001f);
+    T_FEQ(resource_gain_capture.position.y, 200.0f, 0.001f);
+    T_FEQ(resource_gain_capture.position.z, 13.0f, 0.001f);
+    T_EQ(resource_gain_capture.types[3], PF_STRING);
+    T_STREQ(resource_gain_capture.text, "+7");
+    T_EQ(resource_gain_capture.types[4], PF_LONG);
+    T_EQ((DWORD)resource_gain_capture.integral[4], 0xff00dcffu);
+    T_EQ(resource_gain_capture.types[5], PF_SHORT);
+    T_EQ(resource_gain_capture.integral[5], 17);
+    T_EQ(resource_gain_capture.types[6], PF_LONG);
+    T_EQ(resource_gain_capture.integral[6], 2000);
+    T_EQ(resource_gain_capture.types[7], PF_LONG);
+    T_EQ(resource_gain_capture.integral[7], 1000);
+    T_EQ(resource_gain_capture.types[8], PF_FLOAT);
+    T_FEQ(resource_gain_capture.real[8], 0.0f, 0.001f);
+    T_EQ(resource_gain_capture.types[9], PF_FLOAT);
+    T_FEQ(resource_gain_capture.real[9], 60.0f, 0.001f);
+    T_STREQ(resource_gain_capture.font_name, "Fonts\\FRIZQT__.TTF");
+    T_EQ(resource_gain_capture.font_size, 12);
+    T_EQ(resource_gain_capture.multicast_count, 1);
+    T_EQ(resource_gain_capture.multicast_to, MULTICAST_ALL);
+    T_FEQ(resource_gain_capture.multicast_origin.z, 13.0f, 0.001f);
+
+    gi.Write = saved_write;
+    gi.multicast = saved_multicast;
+    gi.FontIndex = saved_font;
 }
 
 TEST(wc3_food, active_training_waits_for_food_and_only_head_reserves) {


### PR DESCRIPTION
Add transient world-space resource gain feedback for Warcraft III gold and lumber income, matching the current Warsmash resource text-tag path.

Introduce a generic TE_FLOATING_TEXT temporary-event contract so shared engine and client code remain unaware of Warcraft-specific resource types. The WC3 game module resolves the final text, colour, font, lifetime, fade timing, and source position before sending the event.

Add G_CreditResourceIncome as the authoritative income commit boundary. It preserves G_ApplyResourceIncome as the pure upkeep calculation, credits the player first, and then emits resource-gain presentation using the net amount actually received. This keeps floating text in sync with the resource bar under Low and High Upkeep; for example, a gross 10-gold return at 70% income displays +7.

Route the existing high-confidence income paths through the new helper:
- normal worker gold deposits
- normal worker lumber deposits
- Call to Arms carried-resource returns
- current Wisp direct lumber income
- current Blighted Gold Mine direct gold income

Implement generic client-side transient world text with:
- captured world-space spawn position
- camera/world-scissor projection
- independent simultaneous labels
- screen-space upward movement
- configured lifetime and fade
- resolved font and RGBA colour
- dark text shadow
- automatic expiry and bounded storage

Resolve GoldTextColor, LumberTextColor, TextLifetime, TextFadeStart, and TextHeight from the existing merged Warcraft Misc data. Preserve narrow stock-compatible fallbacks when those fields are absent. Follow current Warsmash built-in resource-tag behavior by using its fixed 0/60 px/s motion and +10 world-Z spawn offset.

Keep the existing GAME_MSG_HARVEST_DEPOSIT_GOLD/LUMBER observation stream unchanged rather than extending its {type, actor, target} contract with presentation state.

Add regression coverage proving that a gross 10-gold income at 70% upkeep credits 7 and emits a +7 TE_FLOATING_TEXT payload with the expected fallback style, position, timing, font size, and motion.

Document the resource-gain transaction/presentation boundary, generic temporary world-text contract, Warsmash parity details, supported income hooks, and remaining Wisp/Entangled Mine/bounty/JASS text-tag gaps.

No debug logging added.