### PR TITLE
wc3: reset map assets cleanly across level transitions

### DIFF
--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -97,10 +97,30 @@ void CL_ClearState(void) {
     SAFE_DELETE(cl.fow.explored, MemFree);
     SAFE_DELETE(cl.fow.texture, MemFree);
     SAFE_DELETE(cl.minimap_model, re.ReleaseModel);
+    SAFE_DELETE(cl.moveConfirmation, re.ReleaseModel);
+    FOR_LOOP(model, MAX_MODELS) {
+        SAFE_DELETE(cl.models[model], re.ReleaseModel);
+        SAFE_DELETE(cl.portraits[model], re.ReleaseModel);
+    }
+    FOR_LOOP(image, MAX_IMAGES) {
+        if (cl.pics[image]) {
+            re.ReleaseTexture((LPTEXTURE)cl.pics[image]);
+            cl.pics[image] = NULL;
+        }
+    }
+    FOR_LOOP(image, MAX_DYNAMIC_IMAGES) {
+        SAFE_DELETE(cl.dynamicPics[image], re.ReleaseTexture);
+    }
+    SCR_ClearLayoutResources();
 
     FOR_LOOP(layer, MAX_LAYOUT_LAYERS) {
         SCR_ClearLayoutLayer(layer);
     }
+
+    /* Release per-map model ownership before advancing the renderer's
+     * registration sequence, and clear any map-archive asset scope so
+     * menus cannot inherit the previous level's imported overrides. */
+    if (re.RegisterMap) re.RegisterMap(NULL);
 
     memset(&cl, 0, sizeof(struct client_state));
 

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -1127,6 +1127,14 @@ void SCR_ClearLayoutLayer(DWORD layer) {
     if (layer < MAX_LAYOUT_LAYERS) layout_layers[layer] = NULL;
 }
 
+void SCR_ClearLayoutResources(void) {
+    FOR_LOOP(i, MAX_DYNAMIC_IMAGES) {
+        SAFE_DELETE(layout_dynamic_pics[i], re.ReleaseTexture);
+        layout_dynamic_pic_names[i][0] = '\0';
+    }
+    layout_dynamic_pic_cursor = 0;
+}
+
 static BOOL SCR_LayoutLayerVisible(DWORD layer) { return layer < MAX_LAYOUT_LAYERS && layout_layers[layer] && !((1u << layer) & cl.playerstate.uiflags); }
 
 /* Result screens outrank Quest when malformed/server-overlapping modal layers coexist. */

--- a/client/client.h
+++ b/client/client.h
@@ -213,6 +213,7 @@ drawText_t SCR_GetDrawText(LPCUIFRAME frame,
 void SCR_UpdateScreen(DWORD msec);
 void SCR_BeginLoadingPlaque(void);
 void SCR_EndLoadingPlaque(void);
+void SCR_ClearLayoutResources(void);
 
 // cl_screenshot.c
 extern BOOL cl_screenshot_pending;

--- a/docs/fs-loading-architecture.md
+++ b/docs/fs-loading-architecture.md
@@ -13,7 +13,10 @@
 | `FS_ReadFileAll(name, cb, ud)` | loose or MPQ path | none (callback) | same as FS_ReadFile | caller owns buffer in callback |
 
 `FS_ReadFile` tries MPQ archives first (`FS_OpenFile` → the in-tree `common/mpq.c` reader), then falls back to
-`FS_ReadLooseFile`.
+`FS_ReadLooseFile`. `SFileOpenFileEx` also recognizes an archive component inside the requested path and can open
+that file as a nested MPQ. A game renderer can use the generic map-asset scope to probe
+`<map/archive path>\<model-or-texture path>` before its ordinary asset path. Keep the full nested path as the cache
+identity; path-only caches otherwise let one map's imported resource satisfy a later map's lookup.
 
 WC3 voice WAV sectors commonly use an encrypted mixed compression stream: the first sector is zlib (`0x02`), while
 later sectors use adaptive Huffman followed by mono ADPCM (`0x41`; stereo is `0x81`). `common/mpq.c` applies

--- a/docs/games/warcraft-3/loading-and-assets.md
+++ b/docs/games/warcraft-3/loading-and-assets.md
@@ -29,6 +29,46 @@ consumes the optional numeric category and validates the sequence/model fields; 
 
 Preserve the loading-state draw check before standalone-screen dispatch: `menu_ingame` is queued asynchronously, so loading must remain authoritative even after the glue screen is released.
 
+## Level-transition asset ownership
+
+A campaign `ChangeLevel` is a **map replacement**, not a mutation of the current world. The client clears its
+map-owned renderer handles before the next registration sequence, while `G_LoadMap` clears the server-side model
+metadata cache because `CS_MODELS` indices restart for each `SV_Map`. The WC3 map loader releases the previous
+map's W3I/WTS/object-modification allocations, placements, terrain arrays, and pathing storage before reading the
+destination archive. These boundaries prevent a model index, trigger string, placement, or pathing allocation from
+retaining the previous level by accident.
+
+The WC3 renderer likewise replaces its map state at `_W3M_RegisterMap`: old terrain segment/layer VAOs, ground
+layer lists, cliff model choices, fog render targets, minimap handle, terrain shadow, and source W3E arrays are
+released before the destination world is built. Ground and cliff lookup caches are map-scoped and reset at the
+same boundary. Do not append a new campaign map to the previous terrain lists.
+
+### Map-imported model and texture overrides
+
+The MPQ reader supports nested archive paths: a lookup such as
+`Maps\Campaign\Human03.w3m\Textures\Foo.blp` opens `Human03.w3m` and then resolves the inner path. WC3 installs
+the currently registered map as the renderer's generic map-asset scope, so ordinary model and texture references
+resolve with this order:
+
+1. `<current .w3m/.w3x>\<logical Warcraft asset path>`;
+2. the ordinary base-data path.
+
+The resolved scoped path is also the renderer cache key. This is required for consecutive maps that import
+different bytes under the same logical name; a `Textures\Foo.blp` cached for Human02 must not satisfy Human03's
+own `Textures\Foo.blp`. Missing scoped models/textures fall back to Blizzard data without turning the scoped miss
+into a missing-resource placeholder. Texture fallbacks alias the scoped key to the resolved base texture so later
+lookups do not repeat the nested-archive miss. Clearing client state clears the generic renderer asset scope so a
+map import cannot continue overriding menu assets after disconnect.
+
+Standalone renderer regression coverage exercises both a present scoped model/cache hit and a missing scoped
+model that falls back to the base path, including scope clearing at a registration boundary.
+
+This is intentionally narrower than a full Warsmash-style data-source stack. The current transition still does
+**not** rebuild all WC3 SLK/TXT data per map, merge all `war3map.w3a/.w3t/.w3b/.w3d/.w3q` object modifications,
+implement JASS `Preload`/`Preloader`, or expose staged byte/task loading progress. `war3map.w3u` field application
+and true per-map `war3mapMisc.txt`/skin overlays remain separate data-layer work; do not infer those capabilities
+from the renderer's map-import lookup.
+
 ## Asset names are data
 
 | Source | Meaning / resolution |

--- a/docs/games/warcraft-3/readme.md
+++ b/docs/games/warcraft-3/readme.md
@@ -116,6 +116,7 @@ File formats, renderer notes, UI/FDF behavior, and gameplay coverage work used b
 - [Hero Revival](hero-revival.md)
 - [Sounds](sounds.md)
 - [HUD Media Lifetime](hud-media.md)
+- [Campaign Loading And Asset Resolution](loading-and-assets.md)
 - [Quest And Message Log UI](quest-and-message-log-ui.md)
 - [Allies Menu](allies-menu.md)
 - [Building Damage Rendering](building-damage-rendering.md)

--- a/games/warcraft-3/common/world_w3.c
+++ b/games/warcraft-3/common/world_w3.c
@@ -41,12 +41,60 @@ void CM_ReadUnits(HANDLE archive);
 void CM_ReadStrings(HANDLE archive);
 void CM_ReadMapScript(HANDLE archive);
 
+static void CM_W3FreeUnitOverrides(DWORD count, unitData_t **units_ptr) {
+    unitData_t *units = units_ptr ? *units_ptr : NULL;
+
+    if (!units) return;
+    FOR_LOOP(i, count) {
+        FOR_LOOP(j, units[i].numbeOfModifications)
+            SAFE_DELETE(units[i].modifications[j].data, MemFree);
+        SAFE_DELETE(units[i].modifications, MemFree);
+    }
+    MemFree(units);
+    *units_ptr = NULL;
+}
+
+static void CM_W3FreeDroppedItemSets(DWORD num_sets, droppableItemSet_t *sets) {
+    if (!sets) return;
+    FOR_LOOP(i, num_sets)
+        SAFE_DELETE(sets[i].droppableItems, MemFree);
+    MemFree(sets);
+}
+
+static void CM_W3FreeDoodadPlacement(LPDOODAD doodad) {
+    if (!doodad) return;
+    CM_W3FreeDroppedItemSets(doodad->num_droppedItemSets, doodad->droppableItemSets);
+    SAFE_DELETE(doodad->inventoryItems, MemFree);
+    SAFE_DELETE(doodad->modifiedAbilities, MemFree);
+    SAFE_DELETE(doodad->diffAvailUnits, MemFree);
+}
+
+static void CM_W3ClearMapData(void) {
+    CM_W3FreeUnitOverrides(world.info.num_originalUnits, &world.info.originalUnits);
+    CM_W3FreeUnitOverrides(world.info.num_userCreatedUnits, &world.info.userCreatedUnits);
+    CM_ReleaseModel();
+    while (world.doodads) {
+        LPDOODAD doodad = world.doodads;
+        world.doodads = doodad->next;
+        CM_W3FreeDoodadPlacement(doodad);
+        MemFree(doodad);
+    }
+    if (world.map) {
+        SAFE_DELETE(world.map->grounds, MemFree);
+        SAFE_DELETE(world.map->cliffs, MemFree);
+        SAFE_DELETE(world.map->vertices, MemFree);
+        MemFree(world.map);
+    }
+    CM_SetupPathMap(0, 0, NULL);
+    memset(&world, 0, sizeof(world));
+}
+
 bool CM_LoadMapFormat(LPCSTR mapFilename) {
     HANDLE mapArchive;
     HANDLE mapData;
     DWORD mapSize = 0;
 
-    memset(&world, 0, sizeof(world));
+    CM_W3ClearMapData();
     mapData = FS_ReadFile(mapFilename, &mapSize);
     if (!mapData || mapSize == 0) {
         Com_Error(ERR_DROP, "CM_LoadMap: failed to read map %s\n", mapFilename);

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -127,6 +127,10 @@ static bool G_LoadMap(LPCSTR mapFilename) {
     if (!CM_LoadMap(mapFilename)) {
         return false;
     }
+    /* CS_MODELS is rebuilt from index 1 for every SV_Map.  The server-side
+     * animation metadata cache uses those indices too, so retaining it across
+     * levels can make a new index resolve to the previous map's filename. */
+    G_FreeModels();
     if (gi.ApplyLobbySettings) {
         gi.ApplyLobbySettings((LPMAPINFO)CM_GetMapInfo());
     }

--- a/games/warcraft-3/renderer/r_game.c
+++ b/games/warcraft-3/renderer/r_game.c
@@ -103,6 +103,7 @@ void R_Init(void) {
 }
 
 void R_Shutdown(void) {
+    _W3M_ClearMap();
     /* R_ShutdownModels runs first and owns the cached model allocation; only clear our borrowed handle here. */
     cursor_model = NULL; cursor_load_attempted = false;
     FS_SLKFreeIndex(&g_terrain_idx);
@@ -168,6 +169,8 @@ void R_DrawMinimap(LPCRECT screen) {
 }
 
 void R_RegisterMap(LPCSTR mapFileName) {
+    R_SetMapAssetScope(mapFileName);
+    memset(&model_texture_cache, 0, sizeof(model_texture_cache));
     _W3M_RegisterMap(mapFileName);
 }
 

--- a/games/warcraft-3/renderer/w3m/r_war3map.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map.c
@@ -3,6 +3,49 @@
 LPMAPSEGMENT g_mapSegments = NULL;
 LPMAPLAYER g_groundLayers = NULL;
 
+static void R_FreeMapLayers(LPMAPLAYER *layers) {
+    while (*layers) {
+        LPMAPLAYER layer = *layers;
+        *layers = layer->next;
+        if (layer->buffer) R_ReleaseVertexArrayObject((LPBUFFER)layer->buffer);
+        ri.MemFree(layer);
+    }
+}
+
+static void R_FreeMapSegments(void) {
+    while (g_mapSegments) {
+        LPMAPSEGMENT segment = g_mapSegments;
+        g_mapSegments = segment->next;
+        R_FreeMapLayers(&segment->layers);
+        ri.MemFree(segment);
+    }
+}
+
+static void R_FreeWar3Map(LPWAR3MAP map) {
+    if (!map) return;
+    SAFE_DELETE(map->grounds, ri.MemFree);
+    SAFE_DELETE(map->cliffs, ri.MemFree);
+    SAFE_DELETE(map->vertices, ri.MemFree);
+    ri.MemFree(map);
+}
+
+void _W3M_ClearMap(void) {
+    LPTEXTURE shadow = tr.texture[TEX_TERRAIN_SHADOW];
+
+    R_FreeMapSegments();
+    R_FreeMapLayers(&g_groundLayers);
+    R_ResetGroundTextures();
+    R_ResetCliffCache();
+    R_ShutdownFogOfWar();
+    SAFE_DELETE(tr.minimap, R_ReleaseTexture);
+    tr.texture[TEX_TERRAIN_SHADOW] = NULL;
+    if (shadow) R_ReleaseTexture(shadow);
+    if (tr.world) {
+        R_FreeWar3Map((LPWAR3MAP)tr.world);
+        tr.world = NULL;
+    }
+}
+
 static void R_FileReadShadowMap(HANDLE hMpq, LPWAR3MAP  pWorld) {
     HANDLE file;
     if (!SFileOpenFileEx(hMpq, "war3map.shd", SFILE_OPEN_FROM_MPQ, &file)) {
@@ -208,6 +251,11 @@ void _W3M_RegisterMap(char const *mapFilename) {
     LPBYTE mapData;
     int mapSize;
     LPWAR3MAP map;
+
+    /* A map registration replaces the whole WC3 world.  Free GPU buffers,
+     * map-owned models, fog targets and source terrain before creating the
+     * next level so repeated campaign transitions do not accumulate state. */
+    _W3M_ClearMap();
 
     /* Load .w3m file (which is itself an MPQ archive) */
     mapSize = ri.FS_ReadFile(mapFilename, (void **)&mapData);

--- a/games/warcraft-3/renderer/w3m/r_war3map.h
+++ b/games/warcraft-3/renderer/w3m/r_war3map.h
@@ -8,6 +8,9 @@ LPMAPLAYER R_BuildMapSegmentLayer(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD laye
 LPMAPLAYER R_BuildGroundLayerGlobal(LPCWAR3MAP map, DWORD layer);
 LPMAPLAYER R_BuildMapSegmentCliffs(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD cliff);
 LPMAPLAYER R_BuildMapSegmentWater(LPCWAR3MAP map, DWORD sx, DWORD sy);
+void R_ResetGroundTextures(void);
+void R_ResetCliffCache(void);
+void _W3M_ClearMap(void);
 
 VECTOR2 GetWar3MapPosition(LPCWAR3MAP war3Map, float x, float y);
 float GetTileDepth(float waterlevel, float height);

--- a/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
@@ -76,7 +76,21 @@ struct tCliffTexture {
     struct tCliffTexture *next;
 };
 
-static struct tCliffTexture *g_cliff_textures = NULL; /* TODO: verify if still needed — R_LoadTexture doesn't cache by path, so this avoids redundant file reads for the same cliff texture across map segments */
+static struct tCliffTexture *g_cliff_textures = NULL; /* Per-map resolved cliff texture choices; renderer texture storage remains cache-owned. */
+
+void R_ResetCliffCache(void) {
+    while (g_cliffs) {
+        struct tCliff *next = g_cliffs->next;
+        if (g_cliffs->model) R_ReleaseModel((LPMODEL)g_cliffs->model);
+        ri.MemFree(g_cliffs);
+        g_cliffs = next;
+    }
+    while (g_cliff_textures) {
+        struct tCliffTexture *next = g_cliff_textures->next;
+        ri.MemFree(g_cliff_textures);
+        g_cliff_textures = next;
+    }
+}
 
 // HELPERS
 
@@ -142,9 +156,12 @@ static LPCMODEL R_LoadCliffModel(cliffData_t const *data, char const *ccfg, bool
             return it->model;
     }
     struct tCliff *cliff = ri.MemAlloc(sizeof(struct tCliff));
+    PATHSTR scoped;
     cliff->cliffid = cliffid;
     snprintf(zBuffer, sizeof(zBuffer), "Doodads\\Terrain\\%s\\%s%s0.mdx", dir, dir, ccfg);
-    cliff->model = R_LoadModel(zBuffer);
+    cliff->model = NULL;
+    if (R_MapAssetCandidate(zBuffer, scoped, sizeof(scoped))) cliff->model = R_LoadModel(scoped);
+    if (!cliff->model) cliff->model = R_LoadModel(zBuffer);
     ADD_TO_LIST(cliff, g_cliffs);
     return cliff->model;
 }

--- a/games/warcraft-3/renderer/w3m/r_war3map_ground.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_ground.c
@@ -6,6 +6,10 @@ MakeColor(color[INDEX], LerpNumber(color[INDEX], 1, 0.25f), LerpNumber(color[IND
 
 LPCTEXTURE g_groundTextures[MAX_MAP_LAYERS] = { NULL };
 
+void R_ResetGroundTextures(void) {
+    memset(g_groundTextures, 0, sizeof(g_groundTextures));
+}
+
 #define GROUND_VERTEX_BUFFER_CAPACITY (SEGMENT_SIZE * SEGMENT_SIZE * 6)
 
 static VERTEX ground_vertex_buffer[GROUND_VERTEX_BUFFER_CAPACITY];

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -386,6 +386,8 @@ void R_ReleaseModel(LPMODEL model);
 LPMODEL R_LoadRegisteredModel(LPCSTR modelFilename);
 void R_ReleaseRegisteredModel(LPMODEL model);
 void R_RegisterMapAssets(LPCSTR mapFileName);
+BOOL R_MapAssetCandidate(LPCSTR asset, LPSTR candidate, DWORD candidate_size);
+void R_SetMapAssetScope(LPCSTR scope);
 void R_ShutdownModels(void);
 
 size2_t R_GetWindowSize(void);

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -234,19 +234,22 @@ static LPTEXTURE R_MakeBlobShadowTexture(void) {
     return texture;
 }
 
-LPTEXTURE R_LoadTexture(LPCSTR textureFilename) {
-    LPTEXTURE texture = NULL;
+static LPTEXTURE R_LoadTexturePath(LPCSTR textureFilename, BOOL *found) {
+    LPTEXTURE texture = R_FindLoadedTexture(textureFilename);
     void *buffer = NULL;
     PATHSTR load_path;
-    texture = R_FindLoadedTexture(textureFilename);
-    if (texture) return texture;
-    int fileSize = R_ReadTextureFile(textureFilename, load_path, &buffer);
-    if (fileSize < 0 || !buffer) {
-        /* Missing registrations are resident too: repeated draw paths must not search every MPQ again. */
-        fprintf(stderr, "R_LoadTexture: not found: %s\n", textureFilename);
-        R_CacheLoadedTexture(textureFilename, tr.texture[TEX_PLACEHOLDER]);
-        return tr.texture[TEX_PLACEHOLDER];
+    int fileSize;
+
+    if (texture) {
+        if (found) *found = true;
+        return texture;
     }
+    fileSize = R_ReadTextureFile(textureFilename, load_path, &buffer);
+    if (fileSize < 0 || !buffer) {
+        if (found) *found = false;
+        return NULL;
+    }
+    if (found) *found = true;
     switch (*(DWORD *)buffer) {
         case ID_BLP1:
             texture = R_LoadTextureBLP1(buffer, fileSize);
@@ -272,6 +275,30 @@ LPTEXTURE R_LoadTexture(LPCSTR textureFilename) {
     if (!texture) texture = tr.texture[TEX_PLACEHOLDER];
     R_CacheLoadedTexture(textureFilename, texture);
     return texture;
+}
+
+LPTEXTURE R_LoadTexture(LPCSTR textureFilename) {
+    PATHSTR scoped;
+    LPTEXTURE texture;
+    BOOL found = false;
+    BOOL has_scope;
+
+    if (!textureFilename || !*textureFilename) return tr.texture[TEX_PLACEHOLDER];
+    has_scope = R_MapAssetCandidate(textureFilename, scoped, sizeof(scoped));
+    if (has_scope) {
+        texture = R_LoadTexturePath(scoped, &found);
+        if (found) return texture;
+    }
+    texture = R_LoadTexturePath(textureFilename, &found);
+    if (found) {
+        if (has_scope) R_CacheLoadedTexture(scoped, texture);
+        return texture;
+    }
+    /* Missing registrations are resident too: repeated draw paths must not search every MPQ again. */
+    fprintf(stderr, "R_LoadTexture: not found: %s\n", textureFilename);
+    R_CacheLoadedTexture(textureFilename, tr.texture[TEX_PLACEHOLDER]);
+    if (has_scope) R_CacheLoadedTexture(scoped, tr.texture[TEX_PLACEHOLDER]);
+    return tr.texture[TEX_PLACEHOLDER];
 }
 
 LPRENDERTARGET

--- a/renderer/r_model.c
+++ b/renderer/r_model.c
@@ -13,6 +13,27 @@ typedef struct {
 
 static KNOWNMODEL mod_known[MAX_MOD_KNOWN];
 static DWORD mod_registration_sequence = 1;
+static PATHSTR r_map_asset_scope;
+
+/* A game renderer may install an archive/directory scope for map-local assets.
+ * Shared model/texture caches use the resolved scoped path as their identity. */
+BOOL R_MapAssetCandidate(LPCSTR asset, LPSTR candidate, DWORD candidate_size) {
+    size_t scope_len;
+    int written;
+
+    if (!asset || !*asset || !candidate || candidate_size == 0 || !r_map_asset_scope[0]) return false;
+    scope_len = strlen(r_map_asset_scope);
+    if (strlen(asset) > scope_len && !strncasecmp(asset, r_map_asset_scope, scope_len) &&
+        (asset[scope_len] == '\\' || asset[scope_len] == '/')) return false;
+    if (asset[0] == '/' || asset[0] == '\\' || (asset[0] && asset[1] == ':')) return false;
+    written = snprintf(candidate, candidate_size, "%s\\%s", r_map_asset_scope, asset);
+    return written > 0 && (DWORD)written < candidate_size;
+}
+
+void R_SetMapAssetScope(LPCSTR scope) {
+    r_map_asset_scope[0] = '\0';
+    if (scope && *scope) snprintf(r_map_asset_scope, sizeof(r_map_asset_scope), "%s", scope);
+}
 
 /* Missing files remain valid cached handles, matching Quake II registration semantics. */
 static LPMODEL R_LoadEmptyModel(LPCSTR modelFilename, LPCSTR reason) {
@@ -23,27 +44,43 @@ static LPMODEL R_LoadEmptyModel(LPCSTR modelFilename, LPCSTR reason) {
     return model;
 }
 
-/* Quake II keeps one renderer model entry per filename and marks it during registration. */
-LPMODEL R_LoadRegisteredModel(LPCSTR modelFilename) {
+static LPMODEL R_LoadRegisteredModelPath(LPCSTR modelFilename, BOOL cache_missing) {
     KNOWNMODEL *entry = NULL;
     LPMODEL model;
-    if (!modelFilename || !*modelFilename) return R_LoadEmptyModel("<empty>", "empty filename");
+
     FOR_LOOP(i, MAX_MOD_KNOWN) {
         if (mod_known[i].model && !strcasecmp(mod_known[i].name, modelFilename)) {
-            mod_known[i].references++; mod_known[i].registration_sequence = mod_registration_sequence;
+            mod_known[i].references++;
+            mod_known[i].registration_sequence = mod_registration_sequence;
             return mod_known[i].model;
         }
         if (!entry && !mod_known[i].model) entry = &mod_known[i];
     }
     if (!entry) {
         ri.error("R_LoadModel: MAX_MOD_KNOWN (%u) reached", MAX_MOD_KNOWN);
-        return R_LoadEmptyModel(modelFilename, "model registry exhausted");
+        return cache_missing ? R_LoadEmptyModel(modelFilename, "model registry exhausted") : NULL;
     }
     model = R_LoadModel(modelFilename);
+    if (!model && !cache_missing) return NULL;
     if (!model) model = R_LoadEmptyModel(modelFilename, "not found");
     snprintf(entry->name, sizeof(entry->name), "%s", modelFilename);
-    entry->model = model; entry->references = 1; entry->registration_sequence = mod_registration_sequence;
+    entry->model = model;
+    entry->references = 1;
+    entry->registration_sequence = mod_registration_sequence;
     return model;
+}
+
+/* Quake II keeps one renderer model entry per resolved filename and marks it during registration. */
+LPMODEL R_LoadRegisteredModel(LPCSTR modelFilename) {
+    PATHSTR scoped;
+    LPMODEL model;
+
+    if (!modelFilename || !*modelFilename) return R_LoadEmptyModel("<empty>", "empty filename");
+    if (R_MapAssetCandidate(modelFilename, scoped, sizeof(scoped))) {
+        model = R_LoadRegisteredModelPath(scoped, false);
+        if (model) return model;
+    }
+    return R_LoadRegisteredModelPath(modelFilename, true);
 }
 
 /* Release drops caller ownership; stale resident images are reclaimed at the next registration boundary. */
@@ -69,10 +106,14 @@ static void R_FreeUnusedModels(BOOL shutdown) {
 }
 
 void R_RegisterMapAssets(LPCSTR mapFileName) {
+    if (!mapFileName || !*mapFileName) R_SetMapAssetScope(NULL);
     mod_registration_sequence++;
     if (!mod_registration_sequence) mod_registration_sequence = 1;
-    R_RegisterMap(mapFileName);
+    if (mapFileName && *mapFileName) R_RegisterMap(mapFileName);
     R_FreeUnusedModels(false);
 }
 
-void R_ShutdownModels(void) { R_FreeUnusedModels(true); }
+void R_ShutdownModels(void) {
+    R_SetMapAssetScope(NULL);
+    R_FreeUnusedModels(true);
+}

--- a/tests/test_renderer_model.c
+++ b/tests/test_renderer_model.c
@@ -125,7 +125,8 @@ static _Noreturn void BZ_TestShaderExit(int code) { shader_test.exitcode = code;
 refImport_t ri;
 struct render_globals tr;
 static DWORD load_count, release_count, register_count;
-static BOOL fail_load, touch_during_registration;
+static BOOL fail_load, fail_scoped_load, touch_during_registration;
+static PATHSTR last_model_load;
 static DWORD spawn_count;
 static LPTEXTURE texture_load_result;
 static GLenum upload_format, upload_internal;
@@ -213,14 +214,18 @@ static void test_spawn(void *context) { (*(DWORD *)context)++; }
 LPTEXTURE R_LoadTexture(LPCSTR filename) { (void)filename; return texture_load_result; }
 
 LPMODEL R_LoadModel(LPCSTR filename) {
-    (void)filename; load_count++;
-    return fail_load ? NULL : test_alloc(sizeof(model_t));
+    load_count++;
+    snprintf(last_model_load, sizeof(last_model_load), "%s", filename ? filename : "");
+    if (fail_load || (fail_scoped_load && strstr(last_model_load, ".w3m\\"))) return NULL;
+    return test_alloc(sizeof(model_t));
 }
 
 void R_ReleaseModel(LPMODEL model) { release_count++; test_free(model); }
 
 void R_RegisterMap(LPCSTR map) {
-    (void)map; register_count++;
+    if (map && (strstr(map, ".w3m") || strstr(map, ".w3x"))) R_SetMapAssetScope(map);
+    else R_SetMapAssetScope(NULL);
+    register_count++;
     if (touch_during_registration) R_LoadRegisteredModel("models/touched.mdx");
 }
 
@@ -228,7 +233,8 @@ static void reset_registry(void) {
     R_ShutdownModels();
     ri.MemAlloc = test_alloc; ri.MemFree = test_free; ri.error = test_error;
     load_count = release_count = register_count = 0;
-    fail_load = touch_during_registration = false;
+    fail_load = fail_scoped_load = touch_during_registration = false;
+    last_model_load[0] = '\0';
 }
 
 static LPTEXTURE reset_texture_registry(void) {
@@ -312,6 +318,39 @@ TEST(renderer_model, mdx_geometry_packs_two_geosets_into_model_ranges) {
     T_EQ(vertices[0].color.b, 255); T_EQ(vertices[0].color.a, 255);
     T_EQ(indices[2], 0); T_EQ(indices[3], 0); T_EQ((int)first.indexofs, 0); T_EQ((int)second.indexofs, 6);
     ri.MemFree(first.matrixPalette); ri.MemFree(second.matrixPalette);
+}
+
+TEST(renderer_model, map_scope_precedes_base_model_and_clears_at_boundary) {
+    LPMODEL first, second;
+
+    reset_registry();
+    R_RegisterMapAssets("Maps\\Campaign\\Human02.w3m");
+    first = R_LoadRegisteredModel("Units\\Human\\Footman\\Footman.mdx");
+    second = R_LoadRegisteredModel("Units\\Human\\Footman\\Footman.mdx");
+    T_ASSERT(first == second);
+    T_EQ(load_count, 1);
+    T_STREQ(last_model_load, "Maps\\Campaign\\Human02.w3m\\Units\\Human\\Footman\\Footman.mdx");
+    R_ReleaseRegisteredModel(first);
+    R_ReleaseRegisteredModel(second);
+    R_RegisterMapAssets(NULL);
+    T_EQ(register_count, 1);
+    T_EQ(release_count, 1);
+
+    first = R_LoadRegisteredModel("Units\\Human\\Footman\\Footman.mdx");
+    T_STREQ(last_model_load, "Units\\Human\\Footman\\Footman.mdx");
+    R_ReleaseRegisteredModel(first);
+}
+
+TEST(renderer_model, map_scope_falls_back_when_import_is_absent) {
+    LPMODEL model;
+
+    reset_registry();
+    R_RegisterMapAssets("Maps\\Campaign\\Human03.w3m");
+    fail_scoped_load = true;
+    model = R_LoadRegisteredModel("Units\\Human\\Peasant\\Peasant.mdx");
+    T_EQ(load_count, 2);
+    T_STREQ(last_model_load, "Units\\Human\\Peasant\\Peasant.mdx");
+    R_ReleaseRegisteredModel(model);
 }
 
 TEST(renderer_model, filename_cache_hit_and_miss) {


### PR DESCRIPTION
Reset map-owned simulation, client, and renderer resources when replacing a Warcraft III map so campaign ChangeLevel transitions cannot retain stale models, terrain data, doodads, pathing, fog, minimap state, or render handles from the previous level.

Add a generic renderer map-asset scope and resolve models and textures from the current map archive before falling back to base game data. Keep resolved map paths as cache identities so different maps may import different assets under the same logical Warcraft path without cross-level cache collisions.

Reset server model metadata when a new map is loaded, release client map resources during CL_ClearState, and add explicit Warcraft terrain, ground, cliff, fog, minimap, shadow, object-data, and placement cleanup at map boundaries.

Add renderer regression coverage for map-scoped model resolution and fallback, and document the level-transition asset lifecycle and remaining object-data, preload, and staged-loading limitations.