### PR TITLE
wc3: present victory and defeat results in standard menu window

### DIFF
--- a/client/cl_window.c
+++ b/client/cl_window.c
@@ -493,6 +493,8 @@ BOOL CL_WindowKeyEvent(int key) {
     /* Quake II pops the active menu on Escape. Dismiss locally first, then
      * release only the server-side pause owner associated with this window. */
     if (key == K_ESCAPE) {
+        if (window->flags & UI_WINDOW_NO_ESCAPE)
+            return (window->flags & UI_WINDOW_MODAL) != 0;
         CL_WindowClose(window->id);
         return true;
     }

--- a/common/shared.h
+++ b/common/shared.h
@@ -451,6 +451,7 @@ typedef enum {
 #define UI_WINDOW_MODAL   (1u << 1) // flag bit; blocks input outside the topmost modal window; used by confirmation-style windows
 #define UI_WINDOW_UNIQUE  (1u << 2) // flag bit; keeps one instance per class; used by singleton inventory and journal windows
 #define UI_WINDOW_NO_PAUSE (1u << 3) // flag bit; modal input capture without acquiring the client-owned simulation pause
+#define UI_WINDOW_NO_ESCAPE (1u << 4) // flag bit; Escape is consumed without dismissing the window; used by mandatory result/decision windows
 #define UI_WINDOW_CLOSE_ACTION "close_window" // client action; closes the owning window without a server command
 #define UI_WINDOW_CLOSE_NOTIFY_ACTION "close_window_notify" // client action; closes locally and notifies server of modal release
 #define UI_WINDOW_CLOSE_COMMAND_PREFIX "close_window_command " // client action prefix; forwards suffix then closes the owning window

--- a/docs/architecture/client-windows.md
+++ b/docs/architecture/client-windows.md
@@ -30,10 +30,12 @@ WoW incoming messages use `FT_MESSAGE_QUEUE` on `LAYER_MESSAGE`. The server emit
 when selected, one additional record carrying the server-owned popup text. `cl_scrn.c` draws both the unread icon pool and the
 popup; clicks send `message_open <id>` or `message_close` back to the server, which updates the authoritative layer.
 
-`UI_WINDOW_MODAL`, `UI_WINDOW_NO_PAUSE`, and `UI_WINDOW_UNIQUE` are independent. Modal means the topmost modal window consumes
-input outside its bounds. `NO_PAUSE` means that modal does not acquire the client-owned simulation pause. Unique means only one
-instance of that class may exist. Inventory and quest-detail windows can be unique without being modal; confirmation-style
-windows are normally modal pause owners, while the WC3 Allies dialog is modal plus `NO_PAUSE`.
+`UI_WINDOW_MODAL`, `UI_WINDOW_NO_PAUSE`, `UI_WINDOW_NO_ESCAPE`, and `UI_WINDOW_UNIQUE` are independent. Modal means the topmost
+modal window consumes input outside its bounds. `NO_PAUSE` means that modal does not acquire the client-owned simulation pause.
+`NO_ESCAPE` consumes Escape without dismissing the window, for mandatory result/decision flows that must close through an
+explicit action. Unique means only one instance of that class may exist. Inventory and quest-detail windows can be unique without
+being modal; confirmation-style windows are normally modal pause owners, while the WC3 Allies and game-result windows are modal
+plus `NO_PAUSE` for their respective gameplay/script-owned timing semantics.
 
 ## Wire Format
 
@@ -67,6 +69,7 @@ retained arena; it does not duplicate strings.
 - Mouse-down on non-command background starts a drag when `UI_WINDOW_MOVABLE` is set.
 - Drag capture continues through motion and mouse-up outside the window.
 - Keyboard hotkeys are searched only in the focused window, or the topmost modal window.
+- Escape closes the active window unless it has `UI_WINDOW_NO_ESCAPE`; a no-Escape modal consumes the key and stays open.
 - Clicking outside all non-modal windows clears focus.
 - A modal window blocks world hit testing, control groups, bindings, minimap actions, and manual camera movement.
 - Key-up still reaches gameplay `+command` releases so opening or focusing a window cannot leave an input held.

--- a/docs/games/warcraft-3/architecture/ui-flow.md
+++ b/docs/games/warcraft-3/architecture/ui-flow.md
@@ -163,9 +163,12 @@ frame's first event pass, the new VICTORY/DEFEAT event was otherwise stranded: t
 simulation frame that would consume it. `G_DrainPausedResultEvents()` therefore drains only result events actively
 blocking pending result handoffs before the paused scheduler takes over. Once that event has run, a script-paused
 result fallback may overlay `CLIENT_UI_CINEMATIC`, because waiting for a later cinematic-to-game transition would
-again require a simulation frame that the script pause has intentionally frozen. `UI_ShowGameResult()` clears only
-the `LAYER_GAME_RESULT` hide bit from `playerState_t.uiflags`; it does not restore the rest of the gameplay HUD over
-the ending cinematic.
+again require a simulation frame that the script pause has intentionally frozen. `UI_ShowGameResult()` sends a
+dedicated modal `svc_window` instead of un-hiding a persistent layout layer. Transient windows render above the
+persistent HUD, so the rest of the ending-cinematic suppression stays untouched. The result window reuses the
+Esc-menu backdrop art at the authored dialog bounds; on victory, Quit is re-anchored directly below Continue with a
+small gap so both actions stay inside that window. The result is not Escape-dismissable because its explicit buttons
+own the Blizzard.j/session continuation.
 
 The fallback exists because the stock Blizzard.j result path still cannot build its normal ScriptDialogs: generic
 `DialogCreate` / `DialogAddButton` / `DialogDisplay` and dialog-button event support remain incomplete. It therefore
@@ -253,7 +256,11 @@ SCR_UpdateScreen();
 
 ## Server-Authored Modal Gameplay UI
 
-`LAYER_QUESTDIALOG` and `LAYER_GAME_RESULT` are modal `svc_layout` layers. The generic client layout path, not the glue UI module, owns their input exclusion. While either is visible, lower HUD hotkeys and all WC3 world interaction/camera scrolling are suppressed, but the modal's own button commands continue to reach the server.
+Quest, Log, Allies, Menu, and the temporary Game Result fallback use the generic `svc_window` manager. Modal windows
+own their input exclusion there: while the topmost modal is visible, lower HUD/world interaction and camera scrolling
+are suppressed, while the modal's own button commands continue to reach the server. The game-result window uses
+`UI_WINDOW_NO_PAUSE` because stock result scripts may already own `PauseGame(true)`, and `UI_WINDOW_NO_ESCAPE` because
+closing it without choosing a result action would strand the result lifecycle.
 
 The single-client Quest dialog additionally owns a Warcraft simulation pause. The server continues packet processing and frozen-state client traffic while `SV_RunGameFrame()` is gated, so the modal can close without deadlocking and the normal 10-second client timeout does not fire. See [Pause And Modal UI](../pause-and-modal-ui.md).
 

--- a/docs/games/warcraft-3/jass-native-coverage.md
+++ b/docs/games/warcraft-3/jass-native-coverage.md
@@ -102,10 +102,13 @@ if the player is in `CLIENT_UI_CINEMATIC`, the fallback normally waits until cin
 Blizzard.j single-player result dialogs are the exception: `CustomVictoryBJ` / `CustomDefeatBJ` call `RemovePlayer`
 and then `PauseGame(true)`. A result event published from that late JASS action must be drained before the pause can
 stop future simulation frames, and the fallback may then display over cinematic UI because the paused scheduler cannot
-advance that UI state. When this override is used, only `LAYER_GAME_RESULT` is unhidden in `playerState_t.uiflags`;
-the rest of the cinematic HUD suppression remains intact. The fallback uses `GlobalStrings.fdf` `GAMEOVER_*` labels
-where available, distinguishes the safe single-player/multiplayer button subset, and only exposes actions the current
-engine can execute.
+advance that UI state. Result presentation now uses the same client-managed `svc_window` path as the other in-game
+menus, so it draws above the still-suppressed cinematic HUD without changing `playerState_t.uiflags`. The window is
+modal/unique, does not acquire a second client-owned pause, and cannot be dismissed with Escape; its buttons close the
+window while forwarding the existing result commands. `GameResultBackdrop` reuses the loaded Esc-menu backdrop art
+for a consistent race-skinned menu panel and extends one action row below the nominal dialog bounds so the authored
+Quit button remains inside that panel. The fallback still uses `GlobalStrings.fdf`
+`GAMEOVER_*` labels where available and only exposes actions the current engine can execute.
 
 `EndGame`, `ChangeLevel`, `RestartGame`, `DisplayLoadDialog`, and `ForceCampaignSelectScreen` now cross the existing
 `gi.MenuAction` session boundary. `EndGame` returns the local client to the frontend, `ChangeLevel` loads the requested

--- a/docs/games/warcraft-3/pause-and-modal-ui.md
+++ b/docs/games/warcraft-3/pause-and-modal-ui.md
@@ -7,7 +7,7 @@ OpenRealm separates application/network progress from deterministic Warcraft III
 - `server/sv_main.c` owns the authoritative simulation pause gate. `SV_SetPaused(true)` stops `SV_RunGameFrame()`; it does **not** stop `SV_ReadPackets()` or client transport.
 - `SV_SetPaused` publishes the authoritative state through the shared `paused` cvar, matching Quake II's client/server pause contract without widening snapshot structs.
 - `games/warcraft-3/game/` owns Warcraft pause policy. `PauseGame` and single-client Quest-dialog ownership are combined before calling the generic `game_import.SetPaused` hook.
-- `client/cl_scrn.c` owns server-authored modal layout input. `LAYER_QUESTDIALOG` and `LAYER_GAME_RESULT` are modal layers: when either is visible, lower layout buttons and the 3D world do not receive pointer/hotkey interaction.
+- `client/cl_window.c` owns transient server-authored modal windows such as Quest, Menu, Allies, Log, and Game Result. A topmost modal consumes input outside itself before persistent HUD/world handlers run.
 - `client/cl_input_w3.c` owns WC3 camera/selection gestures. A modal cancels active pan, minimap drag, selection drag, hover, arrow scrolling, and edge scrolling.
 - `client/cl_view.c` keeps submitting the cached world while `paused`, but does not rebuild the scene and sets `viewDef.deltaTime` to zero. UI and transport remain live while world animation and model-owned effects stay frozen.
 
@@ -35,8 +35,12 @@ UI_WriteWindow -> client parses and opens svc_window
 ```
 
 A window may combine `UI_WINDOW_MODAL | UI_WINDOW_NO_PAUSE` when it must capture world/camera input without freezing the
-simulation. The Warcraft III Allies dialog uses that combination. Pause synchronization scans all windows for a remaining
-pause-owning modal rather than assuming the topmost modal owns pause.
+simulation. The Warcraft III Allies dialog and the result fallback use that combination; the latter preserves the existing
+script-owned `PauseGame(true)` result lifecycle rather than acquiring a second client pause. Pause synchronization scans all
+windows for a remaining pause-owning modal rather than assuming the topmost modal owns pause.
+
+`UI_WINDOW_NO_ESCAPE` is separate from modal/pause ownership. The result window uses it so Escape is consumed without closing
+the fallback; Continue/Load/Restart/Quit must run their explicit continuation commands before the window disappears.
 
 Do not acquire the modal pause owner in the command that writes the window. The local client shares the authoritative
 `paused` cvar and can observe it before reliable window delivery; modal-list synchronization makes the popup itself the pause
@@ -88,22 +92,22 @@ Quest pause is intentionally single-client-only. A local campaign Quest dialog m
 
 Each WC3 client tracks `quest_dialog_open`. Disconnect clears that ownership and recomputes pause state, preventing an abandoned modal from leaving the server paused.
 
-## Modal Layout Input
+## Modal Window Input
 
-`SCR_LayoutModalActive()` is true when a visible `LAYER_GAME_RESULT` or `LAYER_QUESTDIALOG` exists. These layers are server-authored `svc_layout` data, so they remain interactive even when normal gameplay input is rejected.
-
-A terminator-only `svc_layout` payload is a layer clear. `CL_ParseLayout()` leaves that layer slot `NULL` instead of retaining an empty allocation; modal ownership therefore ends in the same packet that hides the dialog.
+`CL_WindowModalActive()` is true when the client window list contains a modal window. `CL_WindowMouseEvent()` dispatches only
+to the topmost modal and returns consumed even for clicks outside its bounds; `CL_WindowKeyEvent()` likewise scopes hotkeys to
+that modal. Windows are retained from `svc_window` packets and removed locally by the client-owned close actions.
 
 While a modal is active:
 
-- `CL_GameplayInputReady()` is false for WC3 world input;
-- mouse clicks are dispatched only inside the active modal layout layer;
-- layout hotkeys are dispatched only inside the active modal layer;
-- `SCR_LayoutHitTest()` treats the whole screen as UI-owned, including transparent areas around the dialog;
+- mouse clicks are dispatched only to the active modal window;
+- window hotkeys are dispatched only inside the active modal window;
+- clicks in transparent space outside a modal are still consumed by the window manager;
 - selection, Smart orders, minimap recenter/drag, control groups, middle-button pan, arrow-key scrolling, and edge scrolling are suppressed;
 - any world drag already in progress is cancelled.
 
-This is separate from the client-side glue/menu modal system in `games/warcraft-3/menu/menu_render.c`. In-game Quest/Game Result frames arrive through `svc_layout`, so their modal ownership belongs in the generic layout client path.
+Persistent `svc_layout` layers remain a separate HUD path. New transient gameplay dialogs should use `svc_window` rather than
+adding another modal layout layer.
 
 ## Time Semantics
 
@@ -120,6 +124,7 @@ Global pause freezes anything that depends on server simulation advancement beca
 - **Do not use only frame hit-testing for a modal.** Transparent modal areas must still block world input, and camera edge/arrow scrolling has no pointer hit-test at all.
 - **Do not globally pause multiplayer because one Quest dialog opened.** Quest ownership is local presentation; only the single-client session policy maps it to a simulation pause.
 - **Do not equate modal input with simulation pause.** `UI_WINDOW_NO_PAUSE` exists for dialogs such as Allies that must block world input while time continues.
+- **Do not make mandatory result/decision windows Escape-dismissable.** Use `UI_WINDOW_NO_ESCAPE` when explicit button commands own the continuation.
 - **Do not conflate `PauseUnit` with global pause.** `PauseUnit` is WC3 entity state and intentionally has narrower gameplay semantics.
 - **Do not keep rebuilding or advancing the world refdef while paused.** Cached MDX entities still execute model render code, so submit them with zero `deltaTime` or particle emitters can saturate the main thread.
 

--- a/games/warcraft-3/common/ui_constants.h
+++ b/games/warcraft-3/common/ui_constants.h
@@ -12,6 +12,7 @@
 #define BZ_WC3_WINDOW_LOG   MAKEFOURCC('L','O','G',' ') // opaque class/instance ID; identifies the singleton Message Log window
 #define BZ_WC3_WINDOW_MENU  MAKEFOURCC('M','E','N','U') // opaque class/instance ID; identifies the singleton pause menu window
 #define BZ_WC3_WINDOW_ALLIES MAKEFOURCC('A','L','L','Y') // opaque class/instance ID; identifies the singleton Allies window
+#define BZ_WC3_WINDOW_RESULT MAKEFOURCC('R','S','L','T') // opaque class/instance ID; identifies the singleton victory/defeat result window
 #define WC3_MODAL_QUEST  (1u << 0) // modal owner bit; retained for the Quest/JASS ownership compatibility path
 #define WC3_MODAL_CLIENT (1u << 1) // modal owner bit; tracks whether the client has any open modal window
 

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -1238,6 +1238,7 @@ struct level_locals {
     TIMEOFDAY timeofday;
     BOOL started;
     BOOL scriptsStarted;
+    BOOL cinematic_debug_result_window; /* per-map debug latch for result-window tracing */
 };
 
 typedef struct {

--- a/games/warcraft-3/game/hud/hud_game_result.c
+++ b/games/warcraft-3/game/hud/hud_game_result.c
@@ -13,6 +13,42 @@
 
 static DWORD game_result_last_defer_log[MAX_PLAYERS];
 
+/* The stock GameResult dialog is authored as a standalone DIALOG, while the
+ * rest of OpenRealm's in-game menus are sent through the client window path.
+ * Reuse the already-loaded Esc-menu frame art so victory/defeat has the same
+ * race-skinned panel background, pinned to the authored dialog bounds. */
+static void GameResultPrepareWindow(void) {
+    LPFRAMEDEF dialog = hud.result.GameResultDialog;
+    LPFRAMEDEF backdrop = hud.result.GameResultBackdrop;
+    LPFRAMEDEF menu_backdrop = hud.menu.EscMenuBackdrop;
+
+    if (!dialog || !backdrop || backdrop->Type != FT_BACKDROP) return;
+    if (menu_backdrop && menu_backdrop->Type == FT_BACKDROP)
+        backdrop->Backdrop = menu_backdrop->Backdrop;
+
+    memset(&backdrop->Points, 0, sizeof(backdrop->Points));
+    backdrop->AnyPointsSet = true;
+    UI_SetPoint(backdrop, FRAMEPOINT_TOPLEFT, dialog, FRAMEPOINT_TOPLEFT, 0.0f, 0.0f);
+    UI_SetPoint(backdrop, FRAMEPOINT_BOTTOMRIGHT, dialog, FRAMEPOINT_BOTTOMRIGHT,
+                0.0f, 0.0f);
+    UI_SetHidden(backdrop, false);
+    UI_CenterFrame(dialog);
+}
+
+/* The stock victory fallback leaves Quit below the nominal dialog rectangle.
+ * Keep the window itself unchanged and place Quit directly below Continue,
+ * matching the compact vertical button stack used by the other game menus. */
+static void GameResultPositionVictoryQuit(void) {
+    LPFRAMEDEF quit = hud.result.GameResultQuitButton;
+    LPFRAMEDEF continue_button = hud.result.GameResultContinueButton;
+
+    if (!quit || !continue_button) return;
+    memset(&quit->Points, 0, sizeof(quit->Points));
+    quit->AnyPointsSet = true;
+    UI_SetPoint(quit, FRAMEPOINT_TOP, continue_button, FRAMEPOINT_BOTTOM,
+                0.0f, -0.008f);
+}
+
 void UI_LoadHudGameResult(void) {
     BOOL global_strings;
     BOOL dialog_loaded;
@@ -20,6 +56,7 @@ void UI_LoadHudGameResult(void) {
     if (hud.result.GameResultDialog) return;
     global_strings = UI_EnsureFDF("UI\\FrameDef\\GlobalStrings.fdf");
     dialog_loaded = GameResultDialog_Load(&hud.result);
+    if (dialog_loaded) GameResultPrepareWindow();
     G_GameResultDebug("hud load global_strings=%u dialog_loaded=%u root=%p text=%p continue=%p restart=%p quit=%p",
         (unsigned)global_strings, (unsigned)dialog_loaded,
         (void *)hud.result.GameResultDialog, (void *)hud.result.GameResultText,
@@ -52,12 +89,6 @@ void UI_ShowGameResult(LPEDICT ent, DWORD result) {
         return;
     }
 
-    /* ShowInterface(false) hides every ordinary HUD layer while cinematic UI
-     * is active. Stock result dialogs are allowed to appear on top of that
-     * state, so explicitly expose only the result layer rather than restoring
-     * the whole gameplay interface. */
-    ent->client->ps.uiflags &= ~(1u << LAYER_GAME_RESULT);
-
     UI_SetText(hud.result.GameResultText, "%s", GameResultString(
         victory ? "GAMEOVER_VICTORY_MSG" : "GAMEOVER_DEFEAT_MSG",
         victory ? "Victory!" : "Defeat!"));
@@ -69,27 +100,36 @@ void UI_ShowGameResult(LPEDICT ent, DWORD result) {
             : "GAMEOVER_LOAD",
         victory ? (single_player ? "Continue" : "Continue Game") : "Load"));
     UI_SetOnClick(hud.result.GameResultContinueButton,
-        !victory && single_player ? "gameresult_load" : "hidegameresult");
+        !victory && single_player
+            ? UI_WINDOW_CLOSE_COMMAND_PREFIX "gameresult_load"
+            : UI_WINDOW_CLOSE_COMMAND_PREFIX "hidegameresult");
 
     UI_SetHidden(hud.result.GameResultRestartButton, victory || !single_player);
     UI_SetText(hud.result.GameResultRestartButtonText, "%s",
         GameResultString("GAMEOVER_RESTART", "Restart"));
-    UI_SetOnClick(hud.result.GameResultRestartButton, "gameresult_restart");
+    UI_SetOnClick(hud.result.GameResultRestartButton,
+        UI_WINDOW_CLOSE_COMMAND_PREFIX "gameresult_restart");
 
     UI_SetHidden(hud.result.GameResultQuitButton, false);
     UI_SetText(hud.result.GameResultQuitButtonText, "%s", GameResultString(
         single_player ? "GAMEOVER_QUIT_MISSION" : "GAMEOVER_QUIT_GAME",
         single_player ? "Quit Mission" : "Quit Game"));
-    UI_SetOnClick(hud.result.GameResultQuitButton, "gameresult_quit");
+    UI_SetOnClick(hud.result.GameResultQuitButton,
+        UI_WINDOW_CLOSE_COMMAND_PREFIX "gameresult_quit");
+    if (victory) GameResultPositionVictoryQuit();
 
-    G_GameResultDebug("hud show write layer=%u ent=%u connected=%u victory=%u single_player=%u uiflags=0x%08x hidden=%u",
-        (unsigned)LAYER_GAME_RESULT, (unsigned)ent->s.number,
+    G_GameResultDebug("hud show write window=%08x ent=%u connected=%u victory=%u single_player=%u uiflags=0x%08x",
+        (unsigned)BZ_WC3_WINDOW_RESULT, (unsigned)ent->s.number,
         (unsigned)ent->client->connected, (unsigned)victory, (unsigned)single_player,
-        (unsigned)ent->client->ps.uiflags,
-        (unsigned)((ent->client->ps.uiflags & (1u << LAYER_GAME_RESULT)) != 0));
-    UI_WriteLayout(ent, hud.result.GameResultDialog, LAYER_GAME_RESULT);
-    G_GameResultDebug("hud show write complete layer=%u ent=%u",
-        (unsigned)LAYER_GAME_RESULT, (unsigned)ent->s.number);
+        (unsigned)ent->client->ps.uiflags);
+    UI_SetCurrentClient(ent->client);
+    UI_WriteWindow(ent, hud.result.GameResultDialog, &MAKE(uiWindowDef_t,
+        .id = BZ_WC3_WINDOW_RESULT,
+        .class_id = BZ_WC3_WINDOW_RESULT,
+        .flags = UI_WINDOW_MODAL | UI_WINDOW_UNIQUE | UI_WINDOW_NO_PAUSE | UI_WINDOW_NO_ESCAPE));
+    UI_SetCurrentClient(NULL);
+    G_GameResultDebug("hud show write complete window=%08x ent=%u",
+        (unsigned)BZ_WC3_WINDOW_RESULT, (unsigned)ent->s.number);
 }
 
 void UI_FlushPendingGameResults(void) {
@@ -148,5 +188,8 @@ void UI_FlushPendingGameResults(void) {
 void UI_HideGameResult(LPEDICT ent) {
     if (!ent) return;
     G_GameResultDebug("hud hide ent=%u", (unsigned)ent->s.number);
+    /* svc_window result buttons close the client-owned window before forwarding
+     * their server command.  Retain the legacy layer clear so upgraded clients
+     * cannot keep a stale pre-window result layout around. */
     UI_ClearLayer(ent, LAYER_GAME_RESULT);
 }

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -909,6 +909,16 @@ TEST(net, window_escape_closes_and_releases_server_modal_owner) {
     CL_WindowClear();
 }
 
+TEST(net, window_no_escape_consumes_escape_without_dismissal) {
+    test_client_stubs_init(); CL_WindowClear();
+    test_send_window(13, 103, UI_WINDOW_MODAL | UI_WINDOW_NO_PAUSE | UI_WINDOW_NO_ESCAPE,
+                     0.05f, "Choose", UI_WINDOW_CLOSE_ACTION);
+    T_ASSERT(CL_WindowModalActive());
+    T_ASSERT(CL_WindowKeyEvent(K_ESCAPE));
+    T_ASSERT(CL_WindowModalActive());
+    CL_WindowClear();
+}
+
 TEST(net, stacked_modal_windows_unpause_only_after_last_close) {
     test_client_stubs_init(); CL_WindowClear();
     test_send_window(6, 96, UI_WINDOW_MODAL, 0.05f, "First", UI_WINDOW_CLOSE_NOTIFY_ACTION);


### PR DESCRIPTION
Move the game-result fallback from the legacy modal layout path to the same client-managed window system used by the other in-game menus.

Render the result dialog with the standard Esc-menu backdrop so victory and defeat screens visually match the rest of the Warcraft III menu UI.

Keep the result window modal and unique while preserving the existing Blizzard/JASS pause and result-command lifecycle. Prevent Escape from dismissing the window without choosing a result action.

Wire Continue, Load, Restart, and Quit through normal window actions while retaining their existing server commands.

Reposition Quit Campaign/Quit Mission directly below Continue with a small gap so all result actions remain inside the window without artificially enlarging the backdrop.

Add the missing per-level cinematic result debug state used by result window tracing, allowing it to reset naturally with normal level state.

Document the result-window behavior and add coverage for the new no-Escape window flag.