### PR TITLE
Implement Warcraft III-style Shift+number control group updates.

### DIFF
--- a/client/cl_control_groups.c
+++ b/client/cl_control_groups.c
@@ -1,0 +1,22 @@
+#include "cl_control_groups.h"
+
+DWORD CL_ControlGroupAppendUnique(DWORD *group, DWORD count, DWORD capacity,
+                                  DWORD const *ids, DWORD num_ids) {
+    if (!group || capacity == 0) return 0;
+    if (count > capacity) count = capacity;
+    if (!ids) return count;
+
+    FOR_LOOP(i, num_ids) {
+        BOOL duplicate = false;
+        FOR_LOOP(j, count) {
+            if (group[j] == ids[i]) {
+                duplicate = true;
+                break;
+            }
+        }
+        if (!duplicate && count < capacity) {
+            group[count++] = ids[i];
+        }
+    }
+    return count;
+}

--- a/client/cl_control_groups.h
+++ b/client/cl_control_groups.h
@@ -1,0 +1,12 @@
+#ifndef cl_control_groups_h
+#define cl_control_groups_h
+
+#include "common/shared.h"
+
+/* Append entity IDs to a control-group array while preserving existing order.
+ * Existing entries win when capacity is reached; incoming duplicates are
+ * ignored. Returns the resulting number of stored IDs. */
+DWORD CL_ControlGroupAppendUnique(DWORD *group, DWORD count, DWORD capacity,
+                                  DWORD const *ids, DWORD num_ids);
+
+#endif

--- a/client/cl_input_w3.c
+++ b/client/cl_input_w3.c
@@ -1,4 +1,5 @@
 #include "cl_input_local.h"
+#include "cl_control_groups.h"
 #include "ui_layout.h"
 
 #ifndef WOW
@@ -21,7 +22,7 @@ static BOOL CL_TracePan(float x, float y, LPVECTOR3 point) {
 #endif
 }
 
-/* --- Control groups (Ctrl+0..9 assign, 0..9 recall) ------------------------ */
+/* --- Control groups (Ctrl+0..9 assign, Shift+0..9 append, 0..9 recall) ------ */
 #define CL_CONTROL_GROUP_COUNT 10 // groups; Warcraft III number-key groups; used for client control-group storage
 #define CL_CONTROL_GROUP_DOUBLE_TAP_MS 500 // milliseconds; double-tap focus window; used to recenter a recalled group
 #define CL_CONTROL_GROUP_NONE CL_CONTROL_GROUP_COUNT
@@ -107,11 +108,22 @@ BOOL CL_HandleGameKey(int sym, Uint16 mod, BOOL repeat) {
 
     g = (DWORD)(sym - SDLK_0); /* 0..9 */
     if (mod & KMOD_CTRL) {
-        /* Assign the current selection to this control group. */
+        /* Assign the current selection to this control group. Ctrl keeps
+         * precedence when both Ctrl and Shift are held. */
         DWORD n = cl.selection.num_selected;
         if (n > MAX_SELECTED_ENTITIES) n = MAX_SELECTED_ENTITIES;
         cg_count[g] = n;
         memcpy(cg_ids[g], cl.selection.entity_nums, sizeof(DWORD) * n);
+        CL_ResetControlGroupRecall();
+    } else if (mod & KMOD_SHIFT) {
+        /* Append without recalling the group. This deliberately leaves the
+         * active selection untouched so newly selected units can be added to
+         * a group and still receive the player's next command by themselves. */
+        DWORD n = cl.selection.num_selected;
+        if (n > MAX_SELECTED_ENTITIES) n = MAX_SELECTED_ENTITIES;
+        cg_count[g] = CL_ControlGroupAppendUnique(
+            cg_ids[g], cg_count[g], MAX_SELECTED_ENTITIES,
+            cl.selection.entity_nums, n);
         CL_ResetControlGroupRecall();
     } else if (cg_count[g] > 0) {
         /* Recall immediately. A deliberate rapid second press also recenters

--- a/docs/games/warcraft-3/control-groups.md
+++ b/docs/games/warcraft-3/control-groups.md
@@ -2,14 +2,17 @@
 
 ## Contract
 
-Warcraft III control groups allow players to assign a selection of units to a number key (0–9) and recall that selection later with a single keypress. The implementation is entirely client-side and does not involve server authority beyond the normal selection mechanism.
+Warcraft III control groups allow players to assign a selection of units to a number key (0–9), append newly selected units to an existing group, and recall that group later. The stored group is entirely client-side; recalling it uses the normal server-authoritative selection mechanism.
 
 ## Key Bindings
 
 | Key | Action |
 |-----|--------|
-| Ctrl+0–9 | Assign current selection to the control group |
+| Ctrl+0–9 | Replace the control group with the current selection |
+| Shift+0–9 | Append the current selection to the control group without changing the active selection |
 | 0–9 | Recall the control group |
+
+If Ctrl and Shift are both held, Ctrl assignment takes precedence. This preserves the existing Ctrl+number replacement path and avoids interpreting Ctrl+Shift+number as an append.
 
 ## Implementation
 
@@ -22,24 +25,44 @@ static DWORD cg_ids[10][MAX_SELECTED_ENTITIES];
 static DWORD cg_count[10];
 ```
 
-Each group stores up to `MAX_SELECTED_ENTITIES` (64) entity IDs.
+Each group stores up to `MAX_SELECTED_ENTITIES` (64) entity IDs. Warcraft III's authoritative `CMD_Select` path currently applies `WC3_SELECTION_LIMIT` (12) when the group is recalled, so the client storage ceiling is intentionally broader than the server-side simultaneous-selection ceiling.
 
 ### Assign (Ctrl+N)
 
 When Ctrl+0–9 is pressed:
-1. The current `cl.selection.num_selected` and `cl.selection.entity_nums` are copied to `cg_count[g]` and `cg_ids[g]`.
+1. The current `cl.selection.num_selected` and `cl.selection.entity_nums` replace the stored group.
 2. The count is clamped to `MAX_SELECTED_ENTITIES`.
+3. Control-group double-tap state is reset.
+
+Assignment does not itself send a selection command because the assigned units are already the active selection.
+
+### Append (Shift+N)
+
+When Shift+0–9 is pressed:
+1. `CL_ControlGroupAppendUnique` in `client/cl_control_groups.c` walks the current selection in order.
+2. IDs already present in the group are skipped.
+3. New IDs are appended after existing members.
+4. Existing members win when `MAX_SELECTED_ENTITIES` capacity is reached.
+5. The active `cl.selection` is left unchanged and no `select` command or unit-UI refresh is sent.
+6. Control-group double-tap state is reset so Shift+N cannot count as the first half of a camera-focus double tap.
+
+Appending to an empty group therefore behaves like assignment, while appending a partially overlapping selection adds only new entity IDs.
+
+Keeping append separate from recall is important for the Warcraft III workflow: a player can select newly produced units, Shift+N them into a larger army group, then immediately issue an order only to those newly selected units.
 
 ### Recall (N)
 
-When 0–9 is pressed (without Ctrl):
+When 0–9 is pressed (without Ctrl or Shift):
 1. If `cg_count[g] > 0`, `CL_ApplySelection` is called with the stored IDs.
-2. `CL_ApplySelection` writes a `select` command to the netchan and updates `cl.selection`.
-3. `CL_RequestUnitUI` refreshes the UI with the new selection.
+2. `CL_ApplySelection` writes a `select` command to the netchan and updates the local selection cache.
+3. `CL_RequestUnitUI` refreshes the UI with the new local selection hint.
+4. The server's Warcraft III `CMD_Select` path remains authoritative and filters/reconciles the actual selected unit set.
 
 ### Camera Focus
 
 Recall always selects immediately. A second deliberate press of the same group within `CL_CONTROL_GROUP_DOUBLE_TAP_MS` (500 ms) centers the camera on the average position of live, modeled, selectable members. Key-repeat events are consumed but do not count as a second deliberate press.
+
+Ctrl+N and Shift+N both reset double-tap recall state.
 
 ## Modal Window Interaction
 
@@ -50,7 +73,7 @@ Recall always selects immediately. A second deliberate press of the same group w
 - `cl.playerstate.client_ui_state != CLIENT_UI_GAME`
 - `SCR_LayoutModalActive()` returns true (WC3 only)
 
-This means all digit presses (including Ctrl+N for assign) are swallowed while a modal window is open. This is intentional: blocking reassignment behind Quest/Log/modals prevents accidental group changes during UI interactions.
+This means all digit presses, including Ctrl+N assignment and Shift+N append, are swallowed while a modal window is open. This is intentional: blocking control-group mutation behind Quest/Log/modals prevents accidental group changes during UI interactions.
 
 ## Map Lifecycle Reset
 
@@ -58,7 +81,9 @@ This means all digit presses (including Ctrl+N for assign) are swallowed while a
 
 ## Filtering on Recall
 
-Recall sends the stored IDs to the server, where the authoritative selection path filters invalid, dead, hidden, fogged, and non-selectable entities. Camera centering independently ignores IDs that are invalid, unmodeled, dead, or marked non-selectable; the group storage itself remains unchanged until reassigned or the map resets.
+Recall sends the stored IDs to the server, where the authoritative Warcraft III selection path filters invalid, dead, hidden, fogged, non-selectable, and otherwise ineligible entities. Camera centering independently ignores IDs that are invalid, unmodeled, dead, or marked non-selectable.
+
+The client deliberately does **not** prune stored group membership based only on its current entity snapshot. Client visibility/state may be incomplete, while the server owns final selection legality; eagerly deleting an ID during append or recall could therefore destroy a still-valid control-group member. Stored IDs remain until reassignment, map reset, or process exit.
 
 ## Lifetime
 
@@ -68,17 +93,28 @@ Groups are client-local and last until reassignment, map reset, or process exit.
 
 ### Manual Testing
 
-1. **Rapid double-tap on a group that has units off-screen**: Camera should recenter only on the second press within 500 ms, not the first; holding the key should not recenter.
-
-2. **Load a new map with existing control groups assigned**: Confirm they are empty on the new map.
+1. **Append without recall**: assign A+B to group 1, select C+D, press Shift+1. C+D must remain selected. Press 1 afterward and confirm A+B+C+D are recalled subject to the server selection limit/filtering.
+2. **Deduplication**: assign A+B+C, then select B+C+D and press Shift+1. Recalling group 1 must preserve A+B+C+D ordering without duplicate B/C entries.
+3. **Empty-group append**: with an unused group, select A+B and press Shift+N. Pressing N afterward must recall A+B.
+4. **Capacity**: append to a full stored group and confirm existing members are never displaced by later additions.
+5. **Rapid double-tap on a group that has units off-screen**: Camera should recenter only on the second unmodified number press within 500 ms, not after Ctrl+N or Shift+N; holding the key should not recenter.
+6. **Load a new map with existing control groups assigned**: Confirm they are empty on the new map.
 
 ### Automated Tests
+
+`games/warcraft-3/tests/test_control_groups.c` covers the pure append contract:
+
+- existing-order preservation and duplicate suppression;
+- append-to-empty behavior;
+- existing-member priority at capacity.
 
 The network parser has rejection coverage in `tests/test_net.c`; in-engine selection behavior is covered by `games/warcraft-3/game/tests/t_api.c`.
 
 ## References
 
-- `client/cl_input_w3.c` — Control group storage and key handling
-- `client/cl_input.c` — Main input dispatch, calls `CL_HandleGameKey`
-- `client/cl_parse.c` — `CL_ParseSetSelection` for server-authoritative selection
-- `docs/games/warcraft-3/selection-and-control.md` — Server-authoritative selection contract
+- `client/cl_input_w3.c` — Warcraft III control-group key handling and stored groups
+- `client/cl_control_groups.c` — pure append/deduplication helper
+- `client/cl_input.c` — main input dispatch, calls `CL_HandleGameKey`
+- `client/cl_parse.c` — `CL_ParseSetSelection` for server-authoritative selection reconciliation
+- `games/warcraft-3/game/g_commands.c` — authoritative `CMD_Select` filtering and 12-unit selection ceiling
+- `docs/games/warcraft-3/selection-and-control.md` — server-authoritative selection contract

--- a/docs/games/warcraft-3/selection-and-control.md
+++ b/docs/games/warcraft-3/selection-and-control.md
@@ -122,7 +122,7 @@ Death has a stronger immediate path in `unit_die`: it sets health to zero, clear
 
 ## Known Gaps
 
-Shift order queuing is documented separately in [Shift Order Queue](order-queue.md); the remaining Shift-click item below is selection toggling, not command queuing.
+Numbered group assignment, Shift+number append, recall, and double-tap camera focus are documented separately in [Control Groups](control-groups.md). Shift order queuing is documented in [Shift Order Queue](order-queue.md); the remaining Shift-click item below is selection toggling, not command queuing.
 
 The following are deliberately not inferred by the current implementation:
 

--- a/games/warcraft-3/game.mk
+++ b/games/warcraft-3/game.mk
@@ -140,8 +140,8 @@ TEST_JOBS ?= 16
  test: test-assets $(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB) | $(BIN_DIR)
 	@$(CC) $(TEST_CFLAGS) -DBZ_TESTS -o $(BIN_DIR)/test_openwarcraft3$(EXE_EXT) \
 		tests/test_runner.c tests/test_compat.c tests/test_net.c tests/test_tool_common.c \
-		$(WC3_TEST_DIR)/test_client_stubs.c \
-			common/net.c common/msg.c client/cl_parse.c client/cl_configstrings.c client/cl_scrn.c client/cl_minimap.c client/cl_layout.c client/cl_window.c \
+		$(WC3_TEST_DIR)/test_client_stubs.c $(WC3_TEST_DIR)/test_control_groups.c \
+			common/net.c common/msg.c client/cl_control_groups.c client/cl_parse.c client/cl_configstrings.c client/cl_scrn.c client/cl_minimap.c client/cl_layout.c client/cl_window.c \
 		$(RPATH) $(LDFLAGS) -lsheet -lshared -lm
 	@$(BIN_DIR)/test_openwarcraft3$(EXE_EXT)
 	@# Run independent suites concurrently while preserving recursive-make failure propagation.

--- a/games/warcraft-3/tests/test_control_groups.c
+++ b/games/warcraft-3/tests/test_control_groups.c
@@ -1,0 +1,36 @@
+#include "test.h"
+#include "cl_control_groups.h"
+
+TEST(wc3_control_groups, append_preserves_existing_order_and_deduplicates) {
+    DWORD group[6] = { 10, 20 };
+    DWORD incoming[] = { 20, 30, 10, 40 };
+    DWORD count = CL_ControlGroupAppendUnique(group, 2, 6, incoming, 4);
+
+    T_EQ(count, 4);
+    T_EQ(group[0], 10);
+    T_EQ(group[1], 20);
+    T_EQ(group[2], 30);
+    T_EQ(group[3], 40);
+}
+
+TEST(wc3_control_groups, append_to_empty_group_assigns_current_selection) {
+    DWORD group[4] = { 0 };
+    DWORD incoming[] = { 7, 8 };
+    DWORD count = CL_ControlGroupAppendUnique(group, 0, 4, incoming, 2);
+
+    T_EQ(count, 2);
+    T_EQ(group[0], 7);
+    T_EQ(group[1], 8);
+}
+
+TEST(wc3_control_groups, append_keeps_existing_members_when_capacity_is_reached) {
+    DWORD group[4] = { 1, 2, 3 };
+    DWORD incoming[] = { 2, 4, 5 };
+    DWORD count = CL_ControlGroupAppendUnique(group, 3, 4, incoming, 3);
+
+    T_EQ(count, 4);
+    T_EQ(group[0], 1);
+    T_EQ(group[1], 2);
+    T_EQ(group[2], 3);
+    T_EQ(group[3], 4);
+}


### PR DESCRIPTION
Shift+0-9 now appends the current selection to the existing group without recalling the group or changing the active selection. Preserve existing members first, suppress duplicate entity IDs, and respect the existing client control-group capacity.

Keep Ctrl+number replacement semantics and reset recall double-tap state after both assignment and append operations.

Add focused tests for append ordering, deduplication, empty groups, and capacity behavior, and document the control-group ownership, selection limit boundary, and server-authoritative recall filtering.