### PR TITLE
wc3: restore edict nested types after stacked PR merges

### DIFF
--- a/games/warcraft-3/common/routing.c
+++ b/games/warcraft-3/common/routing.c
@@ -1,5 +1,3 @@
-#include "game/g_local.h"
-
 #define ge (&globals)
 #ifndef EDICT_NUM
 #define EDICT_NUM(n) (globals.edicts + (n))

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -29,6 +29,7 @@
 #define ITEM_PICKUP_RANGE 150.0f /* world units; classic contextual-pickup reach */
 #define MAX_CARGO 8
 #define MAX_HERO_ABILITIES 4
+#define MAX_ABILITIES 16 // slots; extra ability codes granted or stripped at runtime
 #define MAX_UNIT_STATUSES 8
 #define PLAYER_TEXT_BACKUP 16
 #define PLAYER_TEXT_MASK (PLAYER_TEXT_BACKUP - 1)
@@ -113,6 +114,7 @@ typedef struct {
     BOOL order_queued;         /* transient modifier for the current target callback */
     BOOL ability_off;          /* command-card separate-off variant selected for this dispatch */
 } menu_t;
+typedef menu_t clientMenu_s;
 
 enum {
     AI_HOLD_FRAME = 1 << 0,
@@ -372,7 +374,7 @@ struct client_s {
     DWORD modal_flags;
     BOOL quest_dialog_open;
     menu_t menu;
-    struct {
+    struct clientCamera_s {
         CAMERASETUP state;
         CAMERASETUP old_state;
         DWORD start_time;
@@ -572,6 +574,16 @@ typedef struct {
     FLOAT value;
     FLOAT max_value;
 } EDICTSTAT;
+typedef EDICTSTAT edictStat_s;
+
+typedef struct edictAbilities_s {
+    DWORD added[MAX_ABILITIES];
+    DWORD added_count;
+    DWORD removed[MAX_ABILITIES];
+    DWORD removed_count;
+    DWORD permanent[MAX_ABILITIES];
+    DWORD permanent_count;
+} edictAbilities_s;
 
 typedef struct {
     float MoveSpeed;
@@ -776,7 +788,7 @@ struct edict_s {
     DWORD variation;
     DWORD build_project;
     BOOL rally_indicator;
-    struct {
+    struct edictConstruction_s {
         BOOL active;
         BOOL paused;
         LPEDICT primary_builder;
@@ -794,7 +806,7 @@ struct edict_s {
         FLOAT duration;    /* seconds */
         FLOAT progress;    /* seconds elapsed for the active queue head */
     } research;
-    struct {
+    struct edictRally_s {
         rallyTargetType_t type;
         VECTOR2 point;
         LPEDICT entity;
@@ -813,7 +825,7 @@ struct edict_s {
     /* Hero revival state lives on the persistent Hero edict. While reviving,
      * queue_next links the Hero into a producer's ordinary production chain
      * without borrowing hero->build, which may have independent gameplay use. */
-    struct {
+    struct edictRevival_s {
         BOOL awaiting;
         BOOL reviving;
         LPEDICT producer;
@@ -825,7 +837,7 @@ struct edict_s {
     DWORD spawn_time;
     DWORD harvested_lumber;
     DWORD harvested_gold;
-    struct {
+    struct edictMilitia_s {
         DWORD ability;          /* Amil alias that supplied Data A/B and duration */
         DWORD normal_type;      /* Data A: worker form retained across the timed morph */
         DWORD militia_type;     /* Data B: alternate combat form */
@@ -844,19 +856,19 @@ struct edict_s {
     DWORD damage;
     DWORD resources;
     DWORD freetime;
-    struct {
+    struct edictGoldMine_s {
         LPEDICT mine;
         DWORD mine_spawn_time;
         BOOL restore_invulnerable;
     } goldmine;
     LPEDICT inventory[MAX_INVENTORY];
-    struct {
+    struct edictItem_s {
         LPEDICT carrier;
         LONG inventory_slot;
         BOOL in_world;
         DWORD charges;
     } item;
-    struct {
+    struct edictDestructable_s {
         BOOL initialized;
 
         /* Set only for destructables originating from war3map.doo. */
@@ -883,7 +895,7 @@ struct edict_s {
 
         ARRAY(droppableItemSet_t const, drop_sets);
     } destructable;
-    struct {
+    struct edictCargo_s {
         LPEDICT units[MAX_CARGO];
         DWORD count;
     } cargo;
@@ -895,9 +907,7 @@ struct edict_s {
     doodadHero_t hero;
     heroability_t heroabilities[MAX_HERO_ABILITIES];
     heroabilitystatus_t abilstatus[MAX_UNIT_STATUSES];
-    ARRAY(DWORD, added_abilities);
-    ARRAY(DWORD, removed_abilities);
-    ARRAY(DWORD, permanent_abilities);
+    edictAbilities_s abilities;
     BOOL invulnerable;  // unit cannot take damage when true
     BOOL paused;        // unit AI and movement suspended when true
     BOOL stunned;       // unit AI and movement suspended by timed status
@@ -909,7 +919,7 @@ struct edict_s {
     DWORD unit_color;   // explicit per-unit color override (0 = use owner color)
     VECTOR2 old_origin;
     unitOrderQueue_t order_queue;
-    struct {
+    struct edictMovement_s {
         VECTOR2 last_origin;
         FLOAT last_distance;
         DWORD blocked_frames;
@@ -978,16 +988,30 @@ struct edict_s {
     void (*attack)(LPEDICT);
     void (*pain)(LPEDICT);
 
-    UnitProfile_t const *UnitProfile;
-    UnitBalance_t const *UnitBalance;
-    UnitData_t const *UnitData;
-    UnitUI_t const *UnitUI;
-    UnitWeapons_t const *UnitWeapons;
-    UnitAbilities_t const *UnitAbilities;
-    Doodads_t const *Doodads;
-    ItemData_t const *ItemData;
-    DestructableData_t const *DestructableData;
+    struct edictData_s {
+        UnitProfile_t const *UnitProfile;
+        UnitBalance_t const *UnitBalance;
+        UnitData_t const *UnitData;
+        UnitUI_t const *UnitUI;
+        UnitWeapons_t const *UnitWeapons;
+        UnitAbilities_t const *UnitAbilities;
+        Doodads_t const *Doodads;
+        ItemData_t const *ItemData;
+        DestructableData_t const *DestructableData;
+    } data;
 };
+
+typedef struct edictConstruction_s edictConstruction_s;
+typedef struct edictRally_s edictRally_s;
+typedef struct edictRevival_s edictRevival_s;
+typedef struct edictMilitia_s edictMilitia_s;
+typedef struct edictGoldMine_s edictGoldMine_s;
+typedef struct edictItem_s edictItem_s;
+typedef struct edictDestructable_s edictDestructable_s;
+typedef struct edictCargo_s edictCargo_s;
+typedef struct edictMovement_s edictMovement_s;
+typedef struct edictData_s edictData_s;
+typedef struct clientCamera_s clientCamera_s;
 
 /* An entity that should be ignored by collision and physics: dead, hidden, or
  * not a live model.  Shared by g_phys.c (M_CheckCollision) and g_ai.c

--- a/games/warcraft-3/game/hud/hud_infopanel.c
+++ b/games/warcraft-3/game/hud/hud_infopanel.c
@@ -242,7 +242,7 @@ static void WriteLegacyUnitStats(LPEDICT ent, UnitWeapons_t const *weapons,
     UI_SetHidden(hud.unit.RangeValue2, !has_attack2);
 
     if (is_hero) {
-        LPCSTR const prim = ent->UnitBalance->primaryAttribute;
+        LPCSTR const prim = ent->data.UnitBalance->primaryAttribute;
         struct { LPCSTR code; DWORD val; } attrs[3] = {
             { "STR", ent->hero.str }, { "AGI", ent->hero.agi }, { "INT", ent->hero.intel },
         };
@@ -431,7 +431,7 @@ static DWORD RawcodeFromListToken(LPCSTR text) {
 static DWORD UnitWeaponUpgrade(LPEDICT ent) {
     static LPCSTR const classes[] = { "melee", "ranged", "artillery" };
 
-    if (!ent || !ent->UnitBalance) return 0;
+    if (!ent || !ent->data.UnitBalance) return 0;
     FOR_LOOP(i, sizeof(classes) / sizeof(classes[0])) {
         DWORD const upgrade = G_GetUnitUpgradeForClass(ent, classes[i]);
         if (upgrade) return upgrade;
@@ -440,7 +440,7 @@ static DWORD UnitWeaponUpgrade(LPEDICT ent) {
 }
 
 static DWORD UnitArmorUpgrade(LPEDICT ent) {
-    if (!ent || !ent->UnitBalance) return 0;
+    if (!ent || !ent->data.UnitBalance) return 0;
     return G_GetUnitUpgradeForClass(ent, "armor");
 }
 
@@ -607,7 +607,7 @@ static void WriteSelectedUnitStatusFrames(LPEDICT ent, UnitWeapons_t const *weap
         UI_WriteFrameWithChildren(hud.attack2_icon, &hud.attack2);
     }
 
-    SetTypedInfoPanelIcon(hud.simple.InfoPanelIconBackdrop_2, "Armor", ent->UnitBalance->defenseType,
+    SetTypedInfoPanelIcon(hud.simple.InfoPanelIconBackdrop_2, "Armor", ent->data.UnitBalance->defenseType,
                           armor_upgrade != 0);
     UI_SetText(hud.simple.InfoPanelIconValue_2, "%d", (int)(G_UnitArmorValue(ent) + 0.5f));
     SetUpgradeLevel(hud.simple.InfoPanelIconLevel_2, armor_upgrade, ent);
@@ -626,7 +626,7 @@ static void WriteSelectedUnitStatusFrames(LPEDICT ent, UnitWeapons_t const *weap
         UI_SetText(hud.simple.InfoPanelIconValue_5, "%u", (unsigned)ent->resources);
         UI_WriteFrame(&hud.gold);
         UI_WriteFrameWithChildren(hud.simple.SimpleInfoPanelIconGold, &hud.gold);
-    } else if (ent->UnitBalance->foodMade > 0) {
+    } else if (ent->data.UnitBalance->foodMade > 0) {
         LPCSTR const food_art = "InfoPanelIconFood";
         if (!food_art || !*food_art) {
             fprintf(stderr, "WriteSelectedUnitStatusFrames: missing war3skins InfoPanelIconFood\n");
@@ -635,13 +635,13 @@ static void WriteSelectedUnitStatusFrames(LPEDICT ent, UnitWeapons_t const *weap
         }
         UI_SetText(hud.simple.InfoPanelIconLevel_4, "%s", "");
         UI_SetHidden(hud.simple.InfoPanelIconLevel_4, true);
-        UI_SetText(hud.simple.InfoPanelIconValue_4, "%ld", (long)ent->UnitBalance->foodMade);
+        UI_SetText(hud.simple.InfoPanelIconValue_4, "%ld", (long)ent->data.UnitBalance->foodMade);
         UI_WriteFrame(&hud.food);
         UI_WriteFrameWithChildren(hud.simple.SimpleInfoPanelIconFood, &hud.food);
     }
 
     if (is_hero) {
-        SetHeroPrimaryAttributeIcon(ent->UnitBalance->primaryAttribute);
+        SetHeroPrimaryAttributeIcon(ent->data.UnitBalance->primaryAttribute);
         UI_SetText(hud.simple.InfoPanelIconHeroStrengthValue, "%lu", (unsigned long)ent->hero.str);
         UI_SetText(hud.simple.InfoPanelIconHeroAgilityValue, "%lu", (unsigned long)ent->hero.agi);
         UI_SetText(hud.simple.InfoPanelIconHeroIntellectValue, "%lu", (unsigned long)ent->hero.intel);
@@ -770,8 +770,8 @@ DWORD UI_WriteBuildingQueueShell(LPEDICT ent, LPCSTR action_key) {
 }
 
 void UI_WriteSingleInfo(LPEDICT ent, LPGAMECLIENT viewer) {
-    UnitBalance_t const *balance = ent->UnitBalance;
-    UnitWeapons_t const *weapons = ent->UnitWeapons;
+    UnitBalance_t const *balance = ent->data.UnitBalance;
+    UnitWeapons_t const *weapons = ent->data.UnitWeapons;
     LPCSTR name = G_UnitProfile(ent->class_id)->properNames;
     LPCSTR unit_name = G_UnitProfile(ent->class_id)->name;
     BOOL const is_hero = balance->strength > 0 || balance->agility > 0 || balance->intelligence > 0;
@@ -838,7 +838,7 @@ void UI_WriteMultiselect(LPEDICT *ents, DWORD count) {
 }
 
 static BOOL UI_UsesBuildingQueuePanel(LPGAMECLIENT viewer, LPEDICT unit) {
-    if (!viewer || !unit || !unit->UnitBalance || !unit->UnitBalance->isBuilding)
+    if (!viewer || !unit || !unit->data.UnitBalance || !unit->data.UnitBalance->isBuilding)
         return false;
     if (!G_UnitCanControl(viewer, unit))
         return false;

--- a/games/warcraft-3/game/skills/s_build.c
+++ b/games/warcraft-3/game/skills/s_build.c
@@ -188,8 +188,8 @@ void build_build(LPEDICT ent) {
         building->construction.payer = client->ps.number;
         if (!G_BuildAllEnabled()) {
             building->construction.paid = true;
-            building->construction.gold = MAX(0, building->UnitBalance->goldCost);
-            building->construction.lumber = MAX(0, building->UnitBalance->lumberCost);
+            building->construction.gold = MAX(0, building->data.UnitBalance->goldCost);
+            building->construction.lumber = MAX(0, building->data.UnitBalance->lumberCost);
         }
         repair_build_primary(ent, building);
     } else {

--- a/games/warcraft-3/game/skills/s_harvest_lumber.c
+++ b/games/warcraft-3/game/skills/s_harvest_lumber.c
@@ -385,6 +385,10 @@ BOOL G_ActorSkillPermanent(LPEDICT ent, DWORD code) {
     return ent && skill_index(ent->abilities.permanent, ARRAY_COUNT(ent->abilities.permanent), code) >= 0;
 }
 
+void G_FreeActorSkills(LPEDICT ent) {
+    if (ent) memset(&ent->abilities, 0, sizeof(ent->abilities));
+}
+
 static void ai_walktree(LPEDICT ent) {
     FLOAT const distance = M_DistanceToGoal(ent);
 

--- a/games/warcraft-3/game/tests/t_building.c
+++ b/games/warcraft-3/game/tests/t_building.c
@@ -877,7 +877,7 @@ TEST(wc3_building, replacing_pre_spawn_build_order_clears_project) {
     setup_test_world();
     builder = alloc_test_unit(MAKEFOURCC('h','p','e','a'), -128, -128);
     builder->s.player = client->ps.number;
-    builder->UnitProfile = &profile;
+    builder->data.UnitProfile = &profile;
     client->ps.stats[PLAYERSTATE_RESOURCE_GOLD] = G_UnitBalance(barracks)->goldCost;
     client->ps.stats[PLAYERSTATE_RESOURCE_LUMBER] = G_UnitBalance(barracks)->lumberCost;
     client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP] = 100;
@@ -901,18 +901,18 @@ TEST(wc3_building, cancel_human_construction_refunds_releases_and_publishes) {
     setup_test_world();
     builder = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
     building = alloc_test_unit(barracks, 64, 0);
-    builder->UnitAbilities = &abilities;
+    builder->data.UnitAbilities = &abilities;
     builder->stand = unit_stand;
     builder->collision = 16.0f;
     builder->s.player = client->ps.number;
     building->s.player = client->ps.number;
     building->svflags |= SVF_MONSTER;
     building->stand = unit_stand;
-    balance = *building->UnitBalance;
+    balance = *building->data.UnitBalance;
     balance.goldCost = 100;
     balance.lumberCost = 80;
     balance.foodUsed = 2;
-    building->UnitBalance = &balance;
+    building->data.UnitBalance = &balance;
     building->health.max_value = 1000.0f;
     building->health.value = 1000.0f;
 

--- a/games/world-of-warcraft/game/g_world.c
+++ b/games/world-of-warcraft/game/g_world.c
@@ -21,7 +21,6 @@ static inline BOMStatus G_WorldTextRemoveBom(LPSTR buffer) {
 #define PF_TextRemoveBom G_WorldTextRemoveBom
 #define Com_Error(code, ...) gi.error(__VA_ARGS__)
 #include "common/world.c"
-#include "games/warcraft-3/common/routing.c"
 #include "common/world_wow.c"
 
 #undef FS_ReadFile


### PR DESCRIPTION
## Summary

Merging the stacked PRs left `edict_s` and `g_save.c` talking past each other. Runtime extra abilities are now `edictAbilities_s abilities` with inline `added`/`removed`/`permanent` arrays so `abilities_fields` / `TFC(..., added_count)` stays valid. SLK table pointers live in `edict.data`. `routing.c` no longer includes WC3 `g_local.h`, so SC2 can keep sharing the pathing file.

## Test plan

- [x] `make openwarcraft3 openwow opensc2`
- [x] `make test` (4279/4279 engine assertions plus standalone suites)