### PR TITLE
renderer: support model-based CS_SKY

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | Release/debug builds, MSAA, GL/GLES backends, GLSL version (`GLSL=120/140/150`), shader dialect tokens, bone palette, video modes | [docs/build-and-renderer-platforms.md](docs/build-and-renderer-platforms.md) |
 | Shared model shader lighting and packed grass uniform contracts | [docs/architecture/model-shader.md](docs/architecture/model-shader.md) |
 | Renderer backend: thin pipelines, root struct, GL state cache, MSAA/alpha-key, `r_stats` | [docs/renderer-backend.md](docs/renderer-backend.md) |
+| Quake II `CS_SKY` contract and verified WC3/SC2/WoW skybox data gaps | [docs/architecture/skybox-and-cs-sky.md](docs/architecture/skybox-and-cs-sky.md) |
 
 ## Coding Style
 

--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -29,6 +29,14 @@ static LPCMODEL V_ConfigLightModel(DWORD configstring) {
     return cl.models[index];
 }
 
+static LPCMODEL V_ConfigSkyModel(void) {
+    char *end = NULL;
+    unsigned long index = strtoul(cl.configstrings[CS_SKY], &end, 10);
+    if (!*cl.configstrings[CS_SKY] || end == cl.configstrings[CS_SKY] || *end || index == 0 || index >= MAX_MODELS)
+        return NULL;
+    return cl.models[index];
+}
+
 /* Client copies sampling inputs and the day-phase stat. The game renderer
  * evaluates those into viewDef.terrainLight / entityLight; this path must
  * not include a game header or compile-guard the clock slot. */
@@ -44,6 +52,7 @@ static void V_UpdateEnvironmentLighting(viewDef_t *view, BOOL world) {
     }
     view->terrainLightModel = V_ConfigLightModel(CS_TERRAIN_LIGHT_MODEL);
     view->entityLightModel = V_ConfigLightModel(CS_ENTITY_LIGHT_MODEL);
+    view->skyModel = V_ConfigSkyModel();
     view->environmentPhase =
         (FLOAT)cl.playerstate.stats[UI_PLAYERSTAT_ENV_PHASE] / (FLOAT)USHRT_MAX;
 }

--- a/client/tr_public.h
+++ b/client/tr_public.h
@@ -170,6 +170,7 @@ typedef struct {
     MATRIX4 textureMatrix;
     LPCMODEL terrainLightModel; /* optional sampling source; game renderer evaluates into terrainLight */
     LPCMODEL entityLightModel;  /* optional sampling source; game renderer evaluates into entityLight */
+    LPCMODEL skyModel;          /* optional camera-relative unlit world model */
     FLOAT environmentPhase;     /* normalized 0..1 clock used to sample environment light models */
     ENVIRONLIGHT terrainLight;  /* evaluated world/terrain light; valid=0 keeps the renderer fallback */
     ENVIRONLIGHT entityLight;   /* evaluated entity light; valid=0 reuses terrainLight or the fallback */

--- a/docs/architecture/skybox-and-cs-sky.md
+++ b/docs/architecture/skybox-and-cs-sky.md
@@ -1,0 +1,70 @@
+# Skybox and `CS_SKY`
+
+## Quake II contract
+
+Quake II publishes a logical environment name in `CS_SKY`, then the client
+passes that name to the renderer. The renderer loads six images named
+`env/<name><suffix>` and draws them as an untranslated skybox before world
+geometry. The name is not a model path and is not a single cubemap texture.
+
+## Warsmash precedent
+
+Warsmash exposes a JASS `SetSkyModel(string)` native. Its viewer loads the
+specified MDX, clears the model's lights, marks every material layer unshaded,
+creates one model instance, selects sequence 0, and renders the instance at
+the camera location before the normal scene. The model is therefore an
+infinite-looking animated scene object, not a Quake II cubemap.
+
+The native is explicit and script-driven: Warsmash does not derive the model
+path from `lightEnvironmentTileset`. The historical implementation is in
+`War3MapViewer.setSkyModel()` and its render loop in commit `60db46c8` of the
+vendored `data/WarsmashModEngine` checkout.
+
+## OpenWarcraft status
+
+`CS_SKY` is reserved in `common/shared.h`, but it is currently unused. A
+configstring-only change would not render anything because the generic client
+has no sky metadata in `viewDef_t` and the renderer has no skybox pass.
+
+The intended adaptation is to let `CS_SKY` carry a model path, have the client
+register it through the normal model pool, and pass the resulting model handle
+in `viewDef_t`. The shared renderer can then apply the Warsmash lifecycle to a
+model supplied by each game. The WC3 `SetSkyModel` native now registers the
+model and publishes its index; map scripts remain responsible for choosing the
+authoritative model path.
+
+## Map data audit
+
+- Warcraft III `war3map.w3i` stores `mainGroundType` and, for newer formats,
+  `lightEnvironmentTileset`. Warsmash reads the same latter field through
+  `War3MapW3i.getLightEnvironmentTileset()`. Neither field is a Quake-style
+  six-face environment name, and no authoritative tileset-to-sky asset table
+  was found in the checked archives.
+- StarCraft II `MapInfo` fixtures store dimensions and a display name. The
+  parsed lighting record contains light parameters, but no sky environment
+  name or six-face asset contract.
+- WoW WDT/ADT map data stores terrain, WMO, doodad, and lighting-related map
+  data. The current Classic data path has no per-map skybox name; its outdoor
+  sun is synthesized from the day phase.
+
+Do not publish guessed paths or derive `CS_SKY` from a map name. The renderer
+should be implemented only after an authoritative game-specific sky asset
+mapping is identified, with each game's map loader resolving that value before
+the server publishes the configstring.
+
+## Validation commands
+
+Use the Quake II reference when implementing the renderer:
+
+```sh
+grep -RInE 'CS_SKY|R_DrawSkyBox|sky_images' data/Quake-2-master
+```
+
+Then validate all game variants with the normal bounded runs and test suite:
+
+```sh
+make test
+make run-wc3 ARGS="+com_frame_limit 100"
+make run-sc2 ARGS="+com_frame_limit 100"
+make run-wow ARGS="+com_frame_limit 100"
+```

--- a/games/warcraft-3/game/api/api_misc.h
+++ b/games/warcraft-3/game/api/api_misc.h
@@ -1196,7 +1196,11 @@ DWORD SetDayNightModels(LPJASS j) {
     return 0;
 }
 DWORD SetSkyModel(LPJASS j) {
-    //LPCSTR skyModelFile = jass_checkstring(j, 1);
+    LPCSTR skyModelFile = jass_checkstring(j, 1);
+    int sky_model = skyModelFile && *skyModelFile ? gi.ModelIndex(skyModelFile) : 0;
+    char value[16];
+    snprintf(value, sizeof(value), "%d", sky_model);
+    gi.configstring(CS_SKY, value);
     return 0;
 }
 DWORD EnableUserControl(LPJASS j) {

--- a/games/warcraft-3/game/tests/t_api.c
+++ b/games/warcraft-3/game/tests/t_api.c
@@ -61,6 +61,10 @@ static DWORD dnc_model_index_calls;
 static DWORD dnc_configstring_calls;
 static DWORD dnc_configstring_index[2];
 static char dnc_configstring_value[2][16];
+static DWORD sky_model_index_calls;
+static DWORD sky_configstring_calls;
+static DWORD sky_configstring_index;
+static char sky_configstring_value[16];
 
 static int capture_dnc_model_index(LPCSTR modelName) {
     (void)modelName;
@@ -75,6 +79,18 @@ static void capture_dnc_configstring(DWORD index, LPCSTR value) {
                  "%s", value ? value : "");
     }
     dnc_configstring_calls++;
+}
+
+static int capture_sky_model_index(LPCSTR modelName) {
+    (void)modelName;
+    sky_model_index_calls++;
+    return 41;
+}
+
+static void capture_sky_configstring(DWORD index, LPCSTR value) {
+    sky_configstring_calls++;
+    sky_configstring_index = index;
+    snprintf(sky_configstring_value, sizeof(sky_configstring_value), "%s", value ? value : "");
 }
 
 static void capture_pause(BOOL paused) { captured_pause = paused; }
@@ -780,6 +796,39 @@ TEST(wc3_time, set_day_night_models_publishes_registered_dnc_models) {
     T_STREQ(dnc_configstring_value[0], "41");
     T_EQ(dnc_configstring_index[1], CS_ENTITY_LIGHT_MODEL);
     T_STREQ(dnc_configstring_value[1], "42");
+
+    gi.ModelIndex = old_model_index;
+    gi.configstring = old_configstring;
+}
+
+TEST(wc3_api, set_sky_model_publishes_registered_model) {
+    int (*old_model_index)(LPCSTR) = gi.ModelIndex;
+    void (*old_configstring)(DWORD, LPCSTR) = gi.configstring;
+
+    sky_model_index_calls = sky_configstring_calls = 0;
+    sky_configstring_index = 0;
+    sky_configstring_value[0] = '\0';
+    gi.ModelIndex = capture_sky_model_index;
+    gi.configstring = capture_sky_configstring;
+
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  call SetSkyModel(\"Environment\\Sky\\Sky.mdx\")\n"
+        "endfunction\n"));
+
+    T_EQ(sky_model_index_calls, 1);
+    T_EQ(sky_configstring_calls, 1);
+    T_EQ(sky_configstring_index, CS_SKY);
+    T_STREQ(sky_configstring_value, "41");
+
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  call SetSkyModel(\"\")\n"
+        "endfunction\n"));
+    T_EQ(sky_model_index_calls, 1);
+    T_EQ(sky_configstring_calls, 2);
+    T_EQ(sky_configstring_index, CS_SKY);
+    T_STREQ(sky_configstring_value, "0");
 
     gi.ModelIndex = old_model_index;
     gi.configstring = old_configstring;

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -311,6 +311,7 @@ void R_CacheLoadedTexture(LPCSTR name, LPTEXTURE texture);
 void R_ReleaseTexture(LPTEXTURE texture);
 void R_ShutdownTextureCache(void);
 void R_DrawWorld(void);
+void R_DrawSky(void);
 void R_DrawDecals(void);
 void R_DrawAlphaSurfaces(void);
 void R_RenderFrame(viewDef_t const *viewDef);

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -659,6 +659,29 @@ void R_RevertSettings(void) {
     R_SetupScissor(&(RECT){0,0,1,1});
 }
 
+void R_DrawSky(void) {
+    renderEntity_t sky;
+    viewCamera_t const *a = tr.viewDef.camerastate + 1;
+    viewCamera_t const *b = tr.viewDef.camerastate + 0;
+    DWORD rdflags;
+
+    if (!tr.viewDef.skyModel) return;
+    sky = (renderEntity_t){
+        .origin = Vector3_lerp(&a->origin, &b->origin, tr.viewDef.lerpfrac),
+        .model = tr.viewDef.skyModel,
+        .flags = RF_NO_LIGHTING | RF_NO_FOGOFWAR | RF_NO_SHADOW,
+        .scale = 1.0f,
+    };
+    rdflags = tr.viewDef.rdflags;
+    tr.viewDef.rdflags |= RDF_NOFRUSTUMCULL;
+    R_Call(glDepthMask, GL_FALSE);
+    R_Call(glDisable, GL_DEPTH_TEST);
+    R_RenderModel(&sky);
+    R_Call(glEnable, GL_DEPTH_TEST);
+    R_Call(glDepthMask, GL_TRUE);
+    tr.viewDef.rdflags = rdflags;
+}
+
 #ifdef USE_SHADOWMAPS
 void R_RenderShadowMap(void) {
     tr.render_phase = RENDER_PHASE_LIGHTS;
@@ -683,6 +706,7 @@ void R_RenderView(void) {
     if (tr.viewDef.rdflags & RDF_NOWORLDMODEL) {
         R_Call(glClear, GL_DEPTH_BUFFER_BIT);
     }
+    R_DrawSky();
     R_DrawWorld();
     R_DrawDecals();
     R_DrawEntities();


### PR DESCRIPTION
## Summary

- Treat `CS_SKY` as a compact `CS_MODELS` index for a sky model.
- Resolve the model on the client and render it camera-relative, unlit, and before world geometry.
- Implement Warcraft III `SetSkyModel` using the existing `ModelIndex` and configstring lifecycle.
- Add set/clear API coverage and document the verified Warsmash model-based precedent.

## Validation

- `make -B build/lib/librenderer.dylib` passes.
- `make build` and `make test-wc3-engine` are currently blocked by an existing post-rebase WC3 build failure: multiple files still reference removed `edict_t.data` members (first errors in `api_unit.h`, `api_item.h`, `g_ai.c`, and `g_building.c`).
- `git diff --check` passes.