### PR TITLE
wc3: persist edict C callbacks with F_CFUNCTION

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 attack damage math, runtime modifiers, armor/type multipliers, projectile impact timing | [docs/games/warcraft-3/attack-damage.md](docs/games/warcraft-3/attack-damage.md) |
 | WC3 JASS native coverage, callback contracts, state ownership | [docs/games/warcraft-3/jass-native-coverage.md](docs/games/warcraft-3/jass-native-coverage.md) |
 | WC3 campaign game cache, persisted Hero progression, `StoreUnit`/`RestoreUnit` | [docs/games/warcraft-3/campaign-game-cache.md](docs/games/warcraft-3/campaign-game-cache.md) |
-| WC3 game save/load format, entity pointer fixups, and `field_t` synchronization | [docs/games/warcraft-3/save-load.md](docs/games/warcraft-3/save-load.md) |
+| WC3 game save/load format, entity pointer fixups, `F_CFUNCTION` C callbacks, and `field_t` synchronization | [docs/games/warcraft-3/save-load.md](docs/games/warcraft-3/save-load.md) |
 | WC3 HUD texture/font indices vs names across `SV_Map` / save-load | [docs/games/warcraft-3/hud-media.md](docs/games/warcraft-3/hud-media.md) |
 | WC3 fog states, scripted reveals, fog modifiers, shared vision, cinematic separation | [docs/games/warcraft-3/fog-and-cinematics.md](docs/games/warcraft-3/fog-and-cinematics.md) |
 | WC3 simulation time of day, Dawn/Dusk data, JASS game state, sight/regen consumers | [docs/games/warcraft-3/time-of-day.md](docs/games/warcraft-3/time-of-day.md) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Assertion failures always include `__FILE__` and `__LINE__`. Under GitHub Action
 
 ### Warcraft III Save/Load
 
-The WC3 serializer follows the Quake 2 `g_save.c` pattern but writes a versioned envelope and converts `F_EDICT` references to entity indexes. Keep `games/warcraft-3/game/g_save.c`'s `field_t fields[]` synchronized with every persistent pointer in `struct edict_s`; update the round-trip test whenever the edict contract changes. See [WC3 Save/Load](docs/games/warcraft-3/save-load.md).
+The WC3 serializer follows the Quake 2 `g_save.c` pattern but writes a versioned envelope and converts `F_EDICT` references to entity indexes. Keep `games/warcraft-3/game/g_save.c`'s `field_t fields[]` synchronized with every persistent pointer in `struct edict_s`. Edict C callbacks use `F_CFUNCTION` and must be listed in `save_cfunctions[]`; JASS `F_FUNCTION` stays name-string identity for timers/triggers. Update the round-trip test whenever the edict contract changes. See [WC3 Save/Load](docs/games/warcraft-3/save-load.md).
 
 Do not include `test_framework.h` — it has been removed. Do not write a `main()` for test files; link against `tests/test_runner.c` instead.
 

--- a/docs/games/warcraft-3/save-load.md
+++ b/docs/games/warcraft-3/save-load.md
@@ -6,7 +6,7 @@ The WC3 game module owns save/load. `GetGameAPI()` exposes `SaveGame` and `LoadG
 
 `WriteGame()` writes the current game state to a versioned binary file. The file contains:
 
-- `W3SV` magic, format version 4, canonical map path, `sizeof(edict_t)`, entity count, client count, script identity, and native-handle registry counts;
+- `W3SV` magic, format version 9, canonical map path, `sizeof(edict_t)`, entity count, client count, script identity, and native-handle registry counts;
 - level frame/time, authoritative Warcraft time-of-day state, map-global camera bounds, and started/script-started flags;
 - each client `GAMECLIENT` state, including its `PLAYER` state, JASS settings, runtime removed/result-presentation state, researched tech, text storage, camera values, messages, and HUD caches;
 - each camera target as an entity index;
@@ -67,8 +67,10 @@ common path memcpy-shaped while making pointer exceptions declarative rather tha
 - Add every persistent `edict_t` entity pointer to `fields[]` as `F_EDICT`, including array elements and nested fields.
 - Use `TFC(type, field, kind, capacity, count_field)` for a bounded typedef-backed array. The descriptor writes and restores `count_field` itself, then processes that many elements; do not map the count separately.
 - Persistent movement defaults are part of that rule: Attack-Move/Patrol waypoints and `movement.follow_target` must be encoded as entity indexes rather than raw pointers.
-- Do not add process-owned pointers such as path textures, metadata rows, animations, movement callbacks, or function pointers. `WriteEdict()` clears those pointers and `ReadEdict()` rebinds class metadata plus class-owned unit/destructable lifecycle callbacks; spatial links are rebuilt with `gi.LinkEntity`.
-- Add process-owned edict or client pointers/callbacks to the corresponding runtime-field table so the fixed record copy cannot write an address into the save file.
+- Do not add process-owned pointers such as path textures, metadata rows, or animations. `WriteEdict()` clears `FIELD_RUNTIME` pointers and `ReadEdict()` rebinds class metadata; spatial links are rebuilt with `gi.LinkEntity`.
+- Edict C callbacks (`think`, `stand`, `birth`, `prethink`, `die`, `idle`, `move`, `run`, `attack`, `pain`) use `F_CFUNCTION`, not `F_IGNORE`. Add every production assignment to the append-only `save_cfunctions[]` roster in `g_save.c`; an unrostered pointer fails the save instead of writing an address.
+- JASS `F_FUNCTION` remains name-string identity for timers and triggers. Do not overload it with C symbols.
+- Add remaining process-owned edict or client pointers to the corresponding runtime-field table so the fixed record copy cannot write an address into the save file.
 - When adding a new pointer or changing an existing edict field, update the table and the round-trip test together. A raw pointer omitted from the table can write an address into the save file.
 - Keep the table sentinel `{ NULL, 0, 0, 0 }`; all serializer loops stop at `field->name == NULL`.
 
@@ -101,7 +103,7 @@ call LoadGame("chapter-01", false)
 
 Q2 `ReadLevel` states the contract we hit: SpawnEntities has already run the same way as at save time, the server has cleared world links, then edicts are overwritten and `linkentity` rebuilds the tree. Skipping `ClearWorld` left the baseline area lists pointing at the same edict addresses and hung in `SV_AreaEdicts_r`. Calling `CL_Connect` after that `client_connect` wiped the client netchan and raced the handshake — Q2 never does that on load.
 
-`F_EDICT` / `F_CLIENT` still convert pointers to indexes only at the save boundary. Q2 `F_FUNCTION` stored a process-relative code offset; we store JASS function names instead.
+`F_EDICT` / `F_CLIENT` still convert pointers to indexes only at the save boundary. Q2 `F_FUNCTION` stored a process-relative code offset. We split that job: JASS `F_FUNCTION` stores script names, and edict C callbacks use `F_CFUNCTION` (see [C Callbacks](#c-callbacks-f_cfunction)).
 
 ## JASS Handles Stay Pointers at Runtime
 
@@ -115,7 +117,7 @@ Integer handle tables inside the interpreter would duplicate that field table, b
 
 HUD FDF trees cache `CS_IMAGES` / `CS_FONTS` slots. Those tables die with `memset(&sv)` in `SV_Map`. `G_LoadMap` memsets the single `hud` accumulator and clears the FDF pool; serialize then re-`ImageIndex`es from names. See [HUD Media Lifetime](hud-media.md).
 
-The format does not yet snapshot fog grids, bot runtime, alliances, stock state, or cinematic filter. Client message storage is part of `GAMECLIENT`, but transient presentation lifetimes are not reconstructed. Unit/destructable lifecycle callbacks are restored from class data, preventing resumed orders from calling stale or null process addresses; the active `umove_t` is restored by `F_MMOVE` relocation (see [Active Behavior](#active-behavior-f_mmove)). Menu callbacks are code pointers and are reset on load; restoring an active targeting/build submenu requires a semantic menu-state enum rather than raw function addresses. There is no backwards-compatible reader for v9, v8, or earlier saves.
+The format does not yet snapshot fog grids, bot runtime, alliances, stock state, or cinematic filter. Client message storage is part of `GAMECLIENT`, but transient presentation lifetimes are not reconstructed. Edict C callbacks persist through `F_CFUNCTION` (see [C Callbacks](#c-callbacks-f_cfunction)); the active `umove_t` is restored by `F_MMOVE` relocation (see [Active Behavior](#active-behavior-f_mmove)). Menu callbacks are code pointers and are reset on load; restoring an active targeting/build submenu requires a semantic menu-state enum rather than raw function addresses. There is no backwards-compatible reader for v8 or earlier saves. Version 9 packs C-callback roster indexes into the edict blob that version 8 zeroed and rebound from class data.
 
 The checksum and header preflight protect normal partial/corrupt-file and wrong-map failures before mutation. Record-level semantic validation later in the stream is not fully transactional; do not treat save files as untrusted input until native records are decoded into temporary state before commit.
 
@@ -172,6 +174,33 @@ fails the load loudly on a mismatch rather than resuming with a corrupt behavior
 
 `animation` stays a runtime field: `M_MoveFrame` already rebuilds it via `unit_setmove` when it finds
 a NULL animation, so `currentmove` is the only pointer that has to survive.
+
+## C Callbacks (`F_CFUNCTION`)
+
+`F_FUNCTION` is JASS-only: timers and triggers store `jass_functionname` / `jass_functionbyname` strings.
+Edict C callbacks cannot use that path; `monster_think`, `G_EffectThink`, and `blight_mine_think` are
+C symbols, not JASS names.
+
+`F_CFUNCTION` is the Q2 analog for those pointers. `WriteField1` looks the pointer up in
+`save_cfunctions[]` and packs a 1-based roster index plus an FNV name hash into the 8-byte pointer
+slot of the memcpy'd edict blob (same packing shape as `F_MMOVE`). `ReadField` restores the function
+from that index after the hash matches. NULL stays 0/0. An unrostered pointer fails `WriteGame` with
+`C callback %p is not in the save roster`; a bad index or hash fails the load instead of installing
+a wild pointer.
+
+The roster is append-only because the index is in the file. Production assignments as of version 9:
+`monster_think`, `blight_mine_think`, `G_FreeEdict`, `G_EffectThink`, `G_EffectValidateTarget`,
+`blizzard_think`, `flame_strike_tick`, `siphon_mana_think`, `unit_stand`/`unit_birth`/`unit_die`,
+and `tree_stand`/`tree_birth`/`tree_pain`/`tree_die`. `idle`/`move`/`run`/`attack` have no
+production assignments yet; they still go through `F_CFUNCTION` so a later assignment must be
+rostered.
+
+`ReadEdict()` rebinds SLK table rows with `G_BindEntityData` but does **not** call
+`G_BindEntityRuntime`. Class defaults would clobber a saved `blight_mine_think`, `G_EffectThink`,
+or a valid NULL `think` (finished effect). `G_BindEntityRuntime` remains the spawn/test helper that
+installs class-owned unit/destructable callbacks when those pointers have not been assigned yet.
+
+Regression tests: `wc3_save.round_trip_entity_c_callbacks` and `wc3_save.rejects_unknown_c_callback`.
 
 ## Console Usage
 

--- a/games/warcraft-3/game/g_effects.c
+++ b/games/warcraft-3/game/g_effects.c
@@ -119,7 +119,7 @@ LPCSTR G_AbilityEffectArt(DWORD ability_id, wc3EffectType_t type, DWORD index) {
     return count ? out : NULL;
 }
 
-static void G_EffectValidateTarget(LPEDICT effect) {
+void G_EffectValidateTarget(LPEDICT effect) {
     if (!effect->goalentity || !effect->goalentity->inuse ||
         effect->goalentity->spawn_time != effect->damage) {
         effect->goalentity = NULL;
@@ -128,7 +128,7 @@ static void G_EffectValidateTarget(LPEDICT effect) {
     }
 }
 
-static void G_EffectThink(LPEDICT effect) {
+void G_EffectThink(LPEDICT effect) {
     if (effect->goalentity && effect->wait != 0.0f) {
         effect->s.origin.z += effect->wait;
     }

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -1552,6 +1552,8 @@ LPEDICT G_SpawnModelEffect(LPCSTR model, LPCVECTOR2 point, LPEDICT target, LPCST
 LPEDICT G_SpawnAbilityEffectAtPoint(DWORD ability_id, wc3EffectType_t type, DWORD index, LPCVECTOR2 point, BOOL temporary);
 LPEDICT G_SpawnAbilityEffectTarget(DWORD ability_id, wc3EffectType_t type, DWORD index, LPEDICT target, LPCSTR attach_point, BOOL temporary);
 void G_DestroyEffect(LPEDICT effect);
+void G_EffectThink(LPEDICT);
+void G_EffectValidateTarget(LPEDICT);
 
 // g_unit_ui.c (Phase 8)
 BYTE G_GetCommandButtons(LPEDICT ent, gameCommandButton_t *buttons, BYTE max_buttons);
@@ -1887,6 +1889,9 @@ BOOL harvest_lumber_return_to(LPEDICT, LPEDICT);
 BOOL harvest_gold_return_to(LPEDICT, LPEDICT);
 void cargo_drop_all(LPEDICT);
 void blight_mine_think(LPEDICT);
+void blizzard_think(LPEDICT);
+void flame_strike_tick(LPEDICT);
+void siphon_mana_think(LPEDICT);
 BOOL move_selectlocation(LPEDICT, LPCVECTOR2);
 BOOL move_should_arrive(LPEDICT, FLOAT);
 BOOL move_is_blocked(LPEDICT, FLOAT, FLOAT);

--- a/games/warcraft-3/game/g_save.c
+++ b/games/warcraft-3/game/g_save.c
@@ -13,8 +13,9 @@ typedef enum {
     F_TRIGGER,          // index on disk, pointer in memory
     F_TIMER,            // index on disk, pointer in memory
     F_EVENT,            // index on disk, pointer in memory
-    F_FUNCTION,
+    F_FUNCTION,            // JASS function name; timers/triggers
     F_FUNCTION_LIST,
+    F_CFUNCTION,           // C callback roster index; edict think/stand/die
     F_MMOVE,
     F_STRUCT,
     F_STRUCT_RING,
@@ -54,6 +55,7 @@ typedef struct {
 #define F_METADATA_F_EVENT(count, flags) count, flags
 #define F_METADATA_F_FUNCTION(...) 0, 0
 #define F_METADATA_F_FUNCTION_LIST(...) 0, 0
+#define F_METADATA_F_CFUNCTION(...) 0, 0
 #define F_METADATA_F_MMOVE(...) 0, 0
 #define F(TYPE, x, kind, ...) { #x, FOFS(TYPE, x) - (HANDLE)NULL, kind, sizeof(((struct TYPE *)NULL)->x), F_METADATA(kind, ##__VA_ARGS__), UINT32_MAX }
 #define TF(TYPE, x, kind, ...) { #x, offsetof(TYPE, x), kind, sizeof(((TYPE *)NULL)->x), F_METADATA(kind, ##__VA_ARGS__), UINT32_MAX }
@@ -68,7 +70,7 @@ enum {
 
 static DWORD const save_magic = MAKEFOURCC('W', '3', 'S', 'V');
 static DWORD const save_commit = MAKEFOURCC('W', '3', 'O', 'K');
-static DWORD const save_version = 8; // mapped level fields include map-global camera_bounds
+static DWORD const save_version = 9; // edict C callbacks persist as F_CFUNCTION roster index+name hash
 #define MAX_SAVE_STRING (1u << 20) // bytes; bounds quest-string allocations from corrupt saves
 #define UMOVE_RELOC_RANGE (64 << 20) // bytes; every umove_t is static data in libgame, so a valid offset from the anchor stays well inside one module image
 
@@ -77,6 +79,42 @@ static DWORD const save_version = 8; // mapped level fields include map-global c
 static umove_t umove_reloc;
 
 _Static_assert(sizeof(umove_t *) == 8, "F_MMOVE packs a relocation offset and a validation hash into the pointer field");
+_Static_assert(sizeof(void (*)(LPEDICT)) == 8, "F_CFUNCTION packs a roster index and a name hash into the pointer field");
+
+typedef struct {
+    LPCSTR name;
+    void *func;
+} saveCFunction_t;
+
+#define SAVE_CFUNCTION(fn) { .name = #fn, .func = (void *)(fn) }
+
+/* Append-only: the 1-based index is part of the save format. Reordering rejects older saves.
+ * idle/move/run/attack have no production assignments; they still use F_CFUNCTION so a later
+ * assignment must be rostered here or WriteGame fails instead of writing an ASLR address. */
+static saveCFunction_t const save_cfunctions[] = {
+    SAVE_CFUNCTION(monster_think),
+    SAVE_CFUNCTION(blight_mine_think),
+    SAVE_CFUNCTION(G_FreeEdict),
+    SAVE_CFUNCTION(G_EffectThink),
+    SAVE_CFUNCTION(G_EffectValidateTarget),
+    SAVE_CFUNCTION(blizzard_think),
+    SAVE_CFUNCTION(flame_strike_tick),
+    SAVE_CFUNCTION(siphon_mana_think),
+    SAVE_CFUNCTION(unit_stand),
+    SAVE_CFUNCTION(unit_birth),
+    SAVE_CFUNCTION(unit_die),
+    SAVE_CFUNCTION(tree_stand),
+    SAVE_CFUNCTION(tree_birth),
+    SAVE_CFUNCTION(tree_pain),
+    SAVE_CFUNCTION(tree_die),
+};
+
+static int SaveCFunctionIndex(void *func) {
+    if (!func) return 0;
+    FOR_LOOP(i, sizeof(save_cfunctions) / sizeof(save_cfunctions[0]))
+        if (save_cfunctions[i].func == func) return (int)i + 1;
+    return -1;
+}
 
 typedef struct {
     DWORD magic, version, edict_size, num_edicts, max_clients;
@@ -340,16 +378,16 @@ field_t edict_fields[] = {
     F(edict_s, animation, F_IGNORE, 0, FIELD_RUNTIME),
     F(edict_s, currentmove, F_MMOVE),
     F(edict_s, militia, F_STRUCT, 1, militia_fields),
-    F(edict_s, stand, F_IGNORE, 0, FIELD_RUNTIME),
-    F(edict_s, birth, F_IGNORE, 0, FIELD_RUNTIME),
-    F(edict_s, prethink, F_IGNORE, 0, FIELD_RUNTIME),
-    F(edict_s, think, F_IGNORE, 0, FIELD_RUNTIME),
-    F(edict_s, die, F_IGNORE, 0, FIELD_RUNTIME),
-    F(edict_s, idle, F_IGNORE, 0, FIELD_RUNTIME),
-    F(edict_s, move, F_IGNORE, 0, FIELD_RUNTIME),
-    F(edict_s, run, F_IGNORE, 0, FIELD_RUNTIME),
-    F(edict_s, attack, F_IGNORE, 0, FIELD_RUNTIME),
-    F(edict_s, pain, F_IGNORE, 0, FIELD_RUNTIME),
+    F(edict_s, stand, F_CFUNCTION),
+    F(edict_s, birth, F_CFUNCTION),
+    F(edict_s, prethink, F_CFUNCTION),
+    F(edict_s, think, F_CFUNCTION),
+    F(edict_s, die, F_CFUNCTION),
+    F(edict_s, idle, F_CFUNCTION),
+    F(edict_s, move, F_CFUNCTION),
+    F(edict_s, run, F_CFUNCTION),
+    F(edict_s, attack, F_CFUNCTION),
+    F(edict_s, pain, F_CFUNCTION),
     F(edict_s, data, F_STRUCT, 1, edict_data_fields),
     { NULL, 0, 0, 0, 0, 0 }
 };
@@ -690,6 +728,20 @@ static BOOL WriteField1(field_t const *field, BYTE *base) {
             *(DWORD *)((BYTE *)p + 4) = SaveHash(0, move->animation, strlen(move->animation) + 1);
             break;
         }
+        case F_CFUNCTION: {
+            void *func = *(void **)p;
+            int index = SaveCFunctionIndex(func);
+            memset(p, 0, size);
+            if (!func) break;
+            if (index < 1) {
+                fprintf(stderr, "WC3 SaveGame: field %s[%u] C callback %p is not in the save roster\n",
+                    field->name, i, func);
+                return false;
+            }
+            *(int *)p = index;
+            *(DWORD *)((BYTE *)p + 4) = SaveHash(0, save_cfunctions[index - 1].name, strlen(save_cfunctions[index - 1].name) + 1);
+            break;
+        }
         default: break;
         }
     }
@@ -736,6 +788,19 @@ static BOOL ReadField(field_t const *field, BYTE *base) {
                 return false;
             }
             *(umove_t **)p = move;
+            break;
+        }
+        case F_CFUNCTION: {
+            DWORD hash = *(DWORD *)((BYTE *)p + 4);
+            int nfunctions = (int)(sizeof(save_cfunctions) / sizeof(save_cfunctions[0]));
+            if (!index && !hash) { *(void **)p = NULL; break; }
+            if (index < 1 || index > nfunctions ||
+                SaveHash(0, save_cfunctions[index - 1].name, strlen(save_cfunctions[index - 1].name) + 1) != hash) {
+                fprintf(stderr, "WC3 LoadGame: field %s[%u] C callback index %d does not resolve in this build\n",
+                    field->name, i, index);
+                return false;
+            }
+            *(void **)p = save_cfunctions[index - 1].func;
             break;
         }
         default: break;
@@ -943,8 +1008,8 @@ static BOOL ReadEdict(FILE *f, LPEDICT ent) {
     if (!LoadBytes(f, ent, sizeof(*ent))) return false;
     for (field = edict_fields; field->name; field++)
         if (!ReadField(field, (BYTE *)ent)) return false;
-    /* Raw callback addresses are invalid across processes; class data determines the persistent callback family. */
-    if (ent->class_id) { G_BindEntityData(ent); G_BindEntityRuntime(ent); }
+    /* Table rows are process-owned; C callbacks already came back through F_CFUNCTION. */
+    if (ent->class_id) G_BindEntityData(ent);
     return true;
 }
 

--- a/games/warcraft-3/game/g_spawn.c
+++ b/games/warcraft-3/game/g_spawn.c
@@ -199,7 +199,9 @@ void G_BindEntityData(LPEDICT edict) {
     edict->data.DestructableData = G_DestructableData(edict->class_id);
 }
 
-/* Save files omit process addresses; restore class-owned callbacks without replaying spawn-time gameplay initialization. */
+/* Install class-owned unit/destructable lifecycle callbacks. Load restores the saved C callbacks
+ * through F_CFUNCTION; this helper is for spawn/tests that have class data but have not assigned
+ * those pointers yet. */
 void G_BindEntityRuntime(LPEDICT edict) {
     if (edict->data.DestructableData->file) {
         edict->stand = tree_stand; edict->birth = tree_birth; edict->pain = tree_pain; edict->die = tree_die;

--- a/games/warcraft-3/game/skills/s_area_spell.c
+++ b/games/warcraft-3/game/skills/s_area_spell.c
@@ -31,7 +31,7 @@ static void area_spell_damage(LPEDICT ent, FLOAT maxtotal) {
 #undef AREA_HITS
 }
 
-static void blizzard_think(LPEDICT ent) {
+void blizzard_think(LPEDICT ent) {
     DWORD now = G_Time();
 
     if (ent->freetime && now < ent->freetime)

--- a/games/warcraft-3/game/skills/s_flame_strike.c
+++ b/games/warcraft-3/game/skills/s_flame_strike.c
@@ -6,7 +6,7 @@
 
 #define ID_FLAME_STRIKE MAKEFOURCC('A', 'N', 'f', 's')
 
-static void flame_strike_tick(LPEDICT ent) {
+void flame_strike_tick(LPEDICT ent) {
     LPEDICT caster = ent->owner;
     FLOAT radius = ent->collision;
     DWORD now = G_Time();

--- a/games/warcraft-3/game/skills/s_siphon_mana.c
+++ b/games/warcraft-3/game/skills/s_siphon_mana.c
@@ -6,7 +6,7 @@
 
 #define ID_SIPHON_MANA MAKEFOURCC('A', 'N', 'd', 'r')
 
-static void siphon_mana_think(LPEDICT ent) {
+void siphon_mana_think(LPEDICT ent) {
     LPEDICT caster = ent->owner;
     LPEDICT target = ent->goalentity;
     DWORD now = G_Time();

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -1607,6 +1607,7 @@ TEST(wc3_save, round_trip_edict_and_player_state) {
     first->movement.follow_target = second;
     first->inventory[2] = second;
     first->cargo.units[3] = second;
+    first->stand = unit_stand; first->birth = unit_birth; first->die = unit_die; first->think = monster_think;
     unit_stand(first);
     T_ASSERT(first->currentmove != NULL);
     umove_t const *const saved_move = first->currentmove;
@@ -1697,6 +1698,7 @@ TEST(wc3_save, round_trip_edict_and_player_state) {
     T_ASSERT(g_edicts[first - g_edicts].inventory[2] == &g_edicts[second - g_edicts]);
     T_ASSERT(g_edicts[first - g_edicts].cargo.units[3] == &g_edicts[second - g_edicts]);
     T_ASSERT(g_edicts[first - g_edicts].stand == unit_stand);
+    T_ASSERT(g_edicts[first - g_edicts].think == monster_think);
     /* currentmove is a process pointer; F_MMOVE relocates it so a loaded unit keeps behaving. */
     T_ASSERT(g_edicts[first - g_edicts].currentmove == saved_move);
     T_ASSERT(unit_issueimmediateorder(g_edicts + (first - g_edicts), "stop"));
@@ -1926,6 +1928,44 @@ TEST(wc3_save, rebinds_process_owned_entity_callbacks) {
     T_ASSERT(dest.stand == tree_stand && dest.birth == tree_birth && dest.pain == tree_pain && dest.die == tree_die);
     T_ASSERT(dest.think == monster_think);
     T_ASSERT(!unknown.stand && !unknown.birth && !unknown.pain && !unknown.die && !unknown.think);
+}
+
+static void unknown_save_think(LPEDICT ent) { (void)ent; }
+
+TEST(wc3_save, round_trip_entity_c_callbacks) {
+    LPCSTR filename = "/tmp/openwarcraft3-wc3-save-cfunctions.bin";
+    reset_entities();
+    LPEDICT unit = alloc_test_unit(MAKEFOURCC('h', 'p', 'e', 'a'), 0.0f, 0.0f);
+    LPEDICT mine = alloc_test_unit(MAKEFOURCC('h', 'p', 'e', 'a'), 1.0f, 0.0f);
+    LPEDICT idle = alloc_test_unit(MAKEFOURCC('h', 'p', 'e', 'a'), 2.0f, 0.0f);
+    LPEDICT effect = alloc_test_unit(MAKEFOURCC('h', 'p', 'e', 'a'), 3.0f, 0.0f);
+    LPEDICT tree = alloc_test_unit(MAKEFOURCC('h', 'p', 'e', 'a'), 4.0f, 0.0f);
+    unit->stand = unit_stand; unit->birth = unit_birth; unit->die = unit_die; unit->think = monster_think;
+    mine->stand = unit_stand; mine->think = blight_mine_think;
+    idle->stand = unit_stand; idle->think = NULL;
+    effect->think = G_EffectThink; effect->prethink = G_EffectValidateTarget;
+    tree->stand = tree_stand; tree->birth = tree_birth; tree->pain = tree_pain; tree->die = tree_die; tree->think = G_FreeEdict;
+    T_ASSERT(WriteGame(filename));
+    unit->think = mine->think = idle->think = effect->think = tree->think = monster_think;
+    unit->stand = mine->stand = idle->stand = tree->stand = NULL;
+    unit->birth = tree->birth = NULL; unit->die = tree->die = NULL; tree->pain = NULL; effect->prethink = NULL;
+    T_ASSERT(ReadGame(filename));
+    T_ASSERT(unit->stand == unit_stand && unit->birth == unit_birth && unit->die == unit_die && unit->think == monster_think);
+    T_ASSERT(mine->think == blight_mine_think && mine->stand == unit_stand);
+    T_ASSERT(!idle->think && idle->stand == unit_stand);
+    T_ASSERT(effect->think == G_EffectThink && effect->prethink == G_EffectValidateTarget);
+    T_ASSERT(tree->stand == tree_stand && tree->birth == tree_birth && tree->pain == tree_pain && tree->die == tree_die);
+    T_ASSERT(tree->think == G_FreeEdict);
+    remove(filename);
+}
+
+TEST(wc3_save, rejects_unknown_c_callback) {
+    LPCSTR filename = "/tmp/openwarcraft3-wc3-save-unknown-cfunction.bin";
+    reset_entities();
+    LPEDICT unit = alloc_test_unit(MAKEFOURCC('h', 'p', 'e', 'a'), 0.0f, 0.0f);
+    unit->think = unknown_save_think;
+    T_ASSERT(!WriteGame(filename));
+    remove(filename);
 }
 
 TEST(wc3_save, round_trip_game_state_event_condition) {


### PR DESCRIPTION
## Summary

JASS `F_FUNCTION` stays name-string identity for timers and triggers. Edict C callbacks (`think`, `stand`, `birth`, `prethink`, `die`, `idle`, `move`, `run`, `attack`, `pain`) now use `F_CFUNCTION`: `WriteField1` packs a 1-based roster index plus an FNV name hash into the pointer slot, like `F_MMOVE`. An unrostered pointer fails the save instead of writing an ASLR address.

`ReadEdict` still rebinds SLK rows with `G_BindEntityData`, but it no longer calls `G_BindEntityRuntime`. Class defaults would clobber a saved `blight_mine_think`, `G_EffectThink`, or a valid NULL `think`. Save format is version 9.

## Test plan

- [x] `make test-wc3-engine WC3_PATTERN='wc3_save.*'` (ROC and TFT, including `round_trip_entity_c_callbacks` and `rejects_unknown_c_callback`)
- [x] `make test` (4289/4289)