### PR TITLE
wc3: add live RoC/TFT edition switching and safe menu return

### DIFF
--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -121,7 +121,7 @@ void CL_ClearState(void) {
     /* Release per-map model ownership before advancing the renderer's
      * registration sequence, and clear any map-archive asset scope so
      * menus cannot inherit the previous level's imported overrides. */
-    if (re.RegisterMap) re.RegisterMap(NULL);
+    re.RegisterMap(NULL);
 
     memset(&cl, 0, sizeof(struct client_state));
     CL_ControlGroupsReset();
@@ -145,7 +145,7 @@ static void CL_MenuCommand(LPCSTR command) {
     Cbuf_AddText("\n");
 }
 
-void CL_Disconnect(LPCSTR reason, BOOL notify) {
+static void CL_DisconnectInternal(LPCSTR reason, BOOL notify, BOOL queue_menu) {
     if (cls.state == ca_disconnected) {
         return;
     }
@@ -164,11 +164,18 @@ void CL_Disconnect(LPCSTR reason, BOOL notify) {
     cl_last_packet_time = 0;
     CL_SetMenuBindings();
 
+    if (!queue_menu) {
+        return;
+    }
     if (notify) {
         CL_MenuCommand("menu_disconnected");
     } else {
         CL_MenuCommand("menu_main");
     }
+}
+
+void CL_Disconnect(LPCSTR reason, BOOL notify) {
+    CL_DisconnectInternal(reason, notify, true);
 }
 
 /* UI library FS_ReadFile wrapper — tries engine filesystem first,
@@ -537,6 +544,23 @@ static void CL_VideoApply_f(void) {
     }
 }
 
+static void CL_RebuildMenu(LPCSTR target) {
+    Cvar_Set("map", "");
+    menu.Shutdown();
+    re.RegisterMap(NULL);
+    menu.Init();
+    if (target && *target && strcmp(target, "menu_main")) {
+        CL_MenuCommand(target);
+    }
+}
+
+static void CL_MenuRestart_f(void) {
+    if (cls.state != ca_disconnected) {
+        return;
+    }
+    CL_RebuildMenu("menu_main");
+}
+
 static void CL_Quit_f(void) {
     CL_Shutdown();
     Com_Quit();
@@ -587,8 +611,13 @@ static void CL_ProcessPendingMenuAction(void) {
         SV_Map(pending.arg);
         break;
     case CL_MENU_ACTION_MENU:
-        CL_Disconnect("Game ended.", false);
-        if (pending.arg[0] && strcmp(pending.arg, "menu_main")) CL_MenuCommand(pending.arg);
+        /* Returning from a world is a session boundary, not an in-place menu
+         * navigation.  Shut the client/server world down first, then rebuild
+         * the menu after clearing the map asset scope so FDF/model state is
+         * valid again even after a runtime menu restart. */
+        CL_DisconnectInternal("Game ended.", false, false);
+        SV_Shutdown();
+        CL_RebuildMenu(pending.arg[0] ? pending.arg : "menu_main");
         break;
     case CL_MENU_ACTION_QUIT:
         CL_Quit_f();
@@ -611,6 +640,65 @@ TEST(client_session, menu_action_map_is_deferred_until_client_frame) {
      * specifically that MenuAction itself cannot enter SV_Map re-entrantly. */
     memset(&cl_pending_menu_action, 0, sizeof(cl_pending_menu_action));
 }
+
+TEST(client_session, menu_action_menu_is_deferred_until_client_frame) {
+    memset(&cl_pending_menu_action, 0, sizeof(cl_pending_menu_action));
+
+    MenuAction("menu", "menu_main");
+
+    T_EQ(cl_pending_menu_action.type, CL_MENU_ACTION_MENU);
+    T_STREQ(cl_pending_menu_action.arg, "menu_main");
+
+    /* Client-owned leave buttons use this path so they cannot rebuild FDF/menu
+     * state while the gameplay window input callback is still on the stack. */
+    memset(&cl_pending_menu_action, 0, sizeof(cl_pending_menu_action));
+}
+
+static DWORD cl_test_menu_shutdown_count;
+static DWORD cl_test_menu_init_count;
+static DWORD cl_test_register_map_count;
+static BOOL cl_test_register_map_was_null;
+
+static void CL_TestMenuShutdown(void) {
+    cl_test_menu_shutdown_count++;
+}
+
+static void CL_TestMenuInit(void) {
+    cl_test_menu_init_count++;
+}
+
+static void CL_TestRegisterMap(LPCSTR map) {
+    cl_test_register_map_count++;
+    cl_test_register_map_was_null = map == NULL;
+}
+
+TEST(client_session, menu_rebuild_clears_world_scope_before_returning_to_menu) {
+    void (*old_shutdown)(void) = menu.Shutdown;
+    void (*old_init)(void) = menu.Init;
+    void (*old_register_map)(LPCSTR) = re.RegisterMap;
+
+    cl_test_menu_shutdown_count = 0;
+    cl_test_menu_init_count = 0;
+    cl_test_register_map_count = 0;
+    cl_test_register_map_was_null = false;
+    menu.Shutdown = CL_TestMenuShutdown;
+    menu.Init = CL_TestMenuInit;
+    re.RegisterMap = CL_TestRegisterMap;
+    Cvar_Set("map", "maps/test.map");
+
+    CL_RebuildMenu("menu_main");
+
+    T_STREQ(Cvar_String("map", NULL), "");
+    T_EQ(cl_test_menu_shutdown_count, 1);
+    T_EQ(cl_test_register_map_count, 1);
+    T_ASSERT(cl_test_register_map_was_null);
+    T_EQ(cl_test_menu_init_count, 1);
+
+    menu.Shutdown = old_shutdown;
+    menu.Init = old_init;
+    re.RegisterMap = old_register_map;
+}
+
 #endif
 
 void CL_Init(void) {
@@ -674,6 +762,7 @@ void CL_Init(void) {
 
     Cmd_AddCommand("quit", CL_Quit_f);
     Cmd_AddCommand("screenshot", CL_Screenshot_f);
+    Cmd_AddCommand("menu_restart", CL_MenuRestart_f);
 
     CON_Init();
     CL_InitInput();

--- a/client/cl_window.c
+++ b/client/cl_window.c
@@ -354,9 +354,11 @@ static void CL_WindowActivateFrame(clientWindow_t *window, LPCUIFRAME frame) {
         if (*command) Cmd_ForwardToServer(command);
         CL_WindowClose(window->id);
     } else if (!strcmp(frame->onclick, UI_WINDOW_DISCONNECT_ACTION)) {
-        /* Server-authored menus may offer a leave action, but the local client
-         * owns session teardown and only performs it after explicit input. */
-        CL_Disconnect("Left game.", false);
+        /* A gameplay leave is a full world-to-front-end boundary.  Defer it
+         * until input dispatch returns so the client can disconnect, stop the
+         * local server/game module, clear map-scoped renderer state, and then
+         * rebuild the menu/FDF state in that order. */
+        MenuAction("menu", "menu_main");
     } else if (!strcmp(frame->onclick, UI_WINDOW_QUIT_ACTION)) {
         /* Defer normal application shutdown until input dispatch returns. */
         Cbuf_AddText("quit\n");

--- a/common/cmd.c
+++ b/common/cmd.c
@@ -143,6 +143,15 @@ void Cbuf_AddEarlyCommands(bool clear) {
             i += 2;
             continue;
         }
+        /* Single-token startup flags have the same early semantics with a
+         * '+' prefix as their '-' form. Consume recognized compatibility flags
+         * before module initialization instead of queuing them as late commands. */
+        if (arg[0] == '+' && Cvar_ApplyBooleanCommandLineFlag(arg + 1)) {
+            if (clear) {
+                COM_ClearArgv(i);
+            }
+            continue;
+        }
         if (arg[0] == '+' && Cvar_String(arg + 1, NULL) != NULL) {
             LPCSTR value = "1";
             int cmd_index = i;

--- a/common/common.c
+++ b/common/common.c
@@ -620,15 +620,6 @@ static void FS_AddArchiveScanEntry(LPCSTR name, LPCSTR path, BOOL isDirectory, B
         FS_HasExtension(name, ".mpq")
 #endif
         ) {
-#ifndef SC2
-        LPCSTR base = FS_BaseName(path);
-
-        if (!Cvar_Integer("fs_expansion", 0) &&
-            base && !strncasecmp(base, "War3x", 5)) {
-            fprintf(stderr, "Skipping expansion archive '%s' (set fs_expansion 1 or use -tft to mount it).\n", path);
-            return;
-        }
-#endif
         snprintf(scan->paths[scan->count++], sizeof(PATHSTR), "%s", path);
     }
 }
@@ -675,13 +666,24 @@ BOOL FS_AddDataDirectory(LPCSTR dirname) {
     return true;
 }
 
+/* Optional expansion archive families remain mounted so front ends can switch
+ * editions without closing archives underneath live renderer/UI resources. */
 /* War3Local from patched installs can carry TFT race AI; ROC must use the matching scripts from War3.mpq. */
 BOOL FS_ArchiveFileVisible(LPCSTR archive, LPCSTR filename) {
     LPCSTR base;
+    LPCSTR expansion_prefix;
 
-    if (Cvar_Integer("fs_expansion", 0) || !archive || !filename)
+    if (!archive || !filename)
         return true;
     base = FS_BaseName(archive);
+    if (!Cvar_Integer("fs_expansion", 0)) {
+        expansion_prefix = Cvar_String("fs_expansion_archive_prefix", "");
+        if (expansion_prefix && *expansion_prefix &&
+            !strncasecmp(base, expansion_prefix, strlen(expansion_prefix)))
+            return false;
+    } else {
+        return true;
+    }
     return strcasecmp(base, "War3Local.mpq") || strncasecmp(filename, "Scripts\\", 8) ||
            !FS_HasExtension(filename, ".ai");
 }
@@ -1091,8 +1093,10 @@ static BOOL FS_FindAdvance(fsFind_t *find, SFILE_FIND_DATA *findData) {
         return true;
     }
     while (find && find->archiveIndex < MAX_ARCHIVES) {
-        if (find->current && SFileFindNextFile(find->current, findData)) {
-            return true;
+        while (find->current && SFileFindNextFile(find->current, findData)) {
+            if (FS_ArchiveFileVisible(archiveNames[find->archiveIndex], findData->cFileName)) {
+                return true;
+            }
         }
         if (find->current) {
             SFileFindClose(find->current);
@@ -1104,7 +1108,8 @@ static BOOL FS_FindAdvance(fsFind_t *find, SFILE_FIND_DATA *findData) {
         }
         if (find->archiveIndex < MAX_ARCHIVES) {
             find->current = SFileFindFirstFile(archives[find->archiveIndex], find->mask, findData, NULL);
-            if (find->current) {
+            if (find->current &&
+                FS_ArchiveFileVisible(archiveNames[find->archiveIndex], findData->cFileName)) {
                 return true;
             }
         }
@@ -1142,7 +1147,8 @@ HANDLE FS_FindFirstFile(LPCSTR mask, SFILE_FIND_DATA *findData) {
     }
     if (find->archiveIndex < MAX_ARCHIVES) {
         find->current = SFileFindFirstFile(archives[find->archiveIndex], find->mask, findData, NULL);
-        if (find->current) {
+        if (find->current &&
+            FS_ArchiveFileVisible(archiveNames[find->archiveIndex], findData->cFileName)) {
             return find;
         }
     }

--- a/common/common.h
+++ b/common/common.h
@@ -344,6 +344,7 @@ bool Cvar_LoadConfig(LPCSTR filename);
 void Cvar_WriteConfig(LPCSTR filename);
 void Cvar_ApplyConfigCommandLine(int argc, LPCSTR *argv);
 void Cvar_ApplyCommandLine(int argc, LPCSTR *argv);
+bool Cvar_ApplyBooleanCommandLineFlag(LPCSTR name);
 bool Cvar_Command(void);
 void Cvar_ForEachVariable(cmdListFunc_t func, void *userData);
 int Cvar_CompleteVariable(LPCSTR partial, LPSTR out, DWORD out_size, bool print);

--- a/common/cvar.c
+++ b/common/cvar.c
@@ -388,12 +388,27 @@ static bool Cvar_ApplyDashArg(int argc, LPCSTR *argv, int *index, LPCSTR name) {
     return false;
 }
 
-static bool Cvar_ApplyDashFlag(LPCSTR arg, LPCSTR name, LPCSTR cvar, LPCSTR value) {
-    if (!arg || arg[0] != '-' || strcmp(arg + 1, name)) {
+bool Cvar_ApplyBooleanCommandLineFlag(LPCSTR name) {
+    if (!name || !*name) {
         return false;
     }
-    Cvar_Set(cvar, value);
-    return true;
+    if (!strcmp(name, "vid_modes")) {
+        Cvar_Set("vid_modes", "1");
+        return true;
+    }
+    if (!strcmp(name, "com_fast_forward")) {
+        Cvar_Set("com_fast_forward", "1");
+        return true;
+    }
+    if (!strcmp(name, "tft")) {
+        Cvar_Set("fs_expansion", "1");
+        return true;
+    }
+    if (!strcmp(name, "roc")) {
+        Cvar_Set("fs_expansion", "0");
+        return true;
+    }
+    return false;
 }
 
 void Cvar_ApplyConfigCommandLine(int argc, LPCSTR *argv) {
@@ -422,16 +437,7 @@ void Cvar_ApplyCommandLine(int argc, LPCSTR *argv) {
         if (Cvar_ApplyDashArg(argc, argv, &i, "data")) {
             continue;
         }
-        if (Cvar_ApplyDashFlag(arg, "vid_modes", "vid_modes", "1")) {
-            continue;
-        }
-        if (Cvar_ApplyDashFlag(arg, "com_fast_forward", "com_fast_forward", "1")) {
-            continue;
-        }
-        if (Cvar_ApplyDashFlag(arg, "tft", "fs_expansion", "1")) {
-            continue;
-        }
-        if (Cvar_ApplyDashFlag(arg, "roc", "fs_expansion", "0")) {
+        if (arg[0] == '-' && Cvar_ApplyBooleanCommandLineFlag(arg + 1)) {
             continue;
         }
     }
@@ -455,7 +461,8 @@ void Cvar_Init(void) {
     Cvar_GetD("fs_basepath", FS_BasePath(), 0, "read-only engine/share data directory");
     Cvar_GetD("fs_homepath", FS_HomePath(), 0, "writable per-user directory (empty if unavailable)");
     Cvar_GetD("data",             "",                  CVAR_ARCHIVE, "override game data directory path");
-    Cvar_GetD("fs_expansion",     "0",                 0,            "0=RoC data/skin, 1=TFT data/skin (include expansion archives)");
+    Cvar_GetD("fs_expansion",     "0",                 0,            "0=RoC data/skin, 1=TFT data/skin (expose expansion archives)");
+    Cvar_GetD("fs_expansion_archive_prefix", "",             0,            "optional archive basename prefix hidden while fs_expansion is 0");
 #ifdef SC2_DEFAULT_MAP
     Cvar_GetD("map",              SC2_DEFAULT_MAP,     0,            "map file to load at startup");
 #else

--- a/common/main.c
+++ b/common/main.c
@@ -48,7 +48,8 @@
 "  openwarcraft3 -data <folder> -connect <host>  (remote client, default port " \
                                                     PORT_SERVER_STRING ")\n" \
 "  openwarcraft3 -data <folder> -connect <host:port>\n" \
-"  openwarcraft3 -data <folder> -tft             (mount expansion MPQs)\n" \
+"  openwarcraft3 -data <folder> -tft             (select TFT / expose expansion MPQs)\n" \
+"  openwarcraft3 -data <folder> +tft             (compatibility form; same startup selection)\n" \
 "\n" \
 "Examples:\n" \
 "  openwarcraft3 -data /home/user/Warcraft3 +map Maps\\\\Campaign\\\\Human02.w3m\n" \
@@ -58,7 +59,7 @@
 "\n" \
 "Notes:\n" \
 "  - The data folder should contain Warcraft III MPQs and optionally Maps/.\n" \
-"  - Expansion MPQs are skipped by default; use -tft or +fs_expansion 1 to mount them.\n" \
+"  - Expansion MPQs stay hidden in RoC mode; use -tft, +tft, or +fs_expansion 1 to expose them.\n" \
 "  - The data folder may also be saved as data in the generated per-build config.\n" \
 "  - The map path uses the internal MPQ path format; use +map to launch one.\n" \
 "  - Remote clients still need the game data for asset loading.\n" \

--- a/docs/architecture/client-windows.md
+++ b/docs/architecture/client-windows.md
@@ -86,11 +86,13 @@ Most authored window `onclick` strings are sent back to the game server. Four ex
 
 - `UI_WINDOW_CLOSE_ACTION` (`close_window`) closes the owning window;
 - `UI_WINDOW_CLOSE_NOTIFY_ACTION` (`close_window_notify`) closes it and therefore participates in modal-list pause synchronization;
-- `UI_WINDOW_DISCONNECT_ACTION` (`disconnect_game`) leaves the current game and returns to the front-end;
+- `UI_WINDOW_DISCONNECT_ACTION` (`disconnect_game`) defers a full world-to-front-end transition: disconnect the client, shut down the local server/game module, clear map-scoped renderer state, rebuild menu/FDF state, then show the front-end;
 - `UI_WINDOW_QUIT_ACTION` (`quit_application`) queues normal application shutdown.
 
 Disconnect and quit are intended for explicit local activation in server-authored menus. They are never executed merely because a
-window packet is received. Submenu/navigation actions remain ordinary server commands.
+window packet is received. `disconnect_game` must use the deferred session-boundary action rather than calling `CL_Disconnect()`
+directly: gameplay teardown can clear the FDF/template pool, so showing `menu_main` before server/game shutdown leaves the front-end
+with missing bindings. Submenu/navigation actions remain ordinary server commands.
 
 ## Legacy UI Windows
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -117,8 +117,8 @@ SDL key-repeat is ignored while `key_dest == key_game`. Named keys include `TAB`
 | `-connect <host[:port]>` | Sets `connect` cvar (remote server address) |
 | `-config <path>` | Sets `config` cvar (generated config path) |
 | `-vid_modes` | Sets session cvar `vid_modes` to `"1"`; logs SDL display modes during renderer startup |
-| `-tft` | Sets `fs_expansion` to `"1"` (TFT skin/data edition; mount TFT MPQs) |
-| `-roc` | Sets `fs_expansion` to `"0"` (RoC skin/data edition; no expansion MPQs) |
+| `-tft` | Sets `fs_expansion` to `"1"` (TFT skin/data edition; expose mounted TFT MPQs) |
+| `-roc` | Sets `fs_expansion` to `"0"` (RoC skin/data edition; hide `War3x*` archives from lookup) |
 
 ### `+` (plus) Prefix — queue commands
 
@@ -128,6 +128,7 @@ The `+` prefix is for **command-line only**. It tells `Cbuf_AddEarlyCommands` / 
 |------|----------|
 | `+set <name> <value>` | `Cvar_Set(name, value)` immediately |
 | `+<cvar> [<value>]` | If `<cvar>` exists, sets it to `<value>` (or `"1"` if no value) |
+| `+tft` / `+roc` | Compatibility startup flags; consumed early like `-tft` / `-roc` so the first menu uses the requested edition |
 | `+<command> [<args>...]` | Queued via `Cbuf_AddText` — executed after module init |
 
 ## Cursor Ownership
@@ -139,6 +140,8 @@ SDL owns the native platform cursor on macOS, Linux, Windows, and other supporte
 Early commands (`+set`, `+<cvar>`) are processed during `Com_Init()`, before module registration. Late commands (`+map`, `+menu_main`, etc.) are processed after `CL_Init()` when all command handlers are registered.
 
 Game-module `gi.MenuAction` requests are also deferred. The callback only copies a validated map/menu/quit request; the next `CL_Frame` consumes it after `SV_Frame` has returned. This prevents a `ChangeLevel` native from entering `SV_Map` while the old game's VM or gameplay callback is still on the stack. Do not make `MenuAction("map", ...)` synchronously replace the world.
+
+A deferred `MenuAction("menu", target)` is a full world→menu session boundary. The client disconnects without queuing an intermediate menu command, shuts down the local server/game module, clears the `map` cvar and renderer map scope, rebuilds the menu library state, then enters `target` (the rebuilt main menu is already active when `target` is `menu_main`). This is required after campaign missions because renderer/FDF/menu state may have crossed a map registration boundary while the level was active.
 
 In code, always use the bare command name: `"map ..."`, not `"+map ..."`.
 
@@ -154,7 +157,7 @@ openwarcraft3 -data "Warcraft III" -connect 192.168.1.10:27910
 # Client menu only
 openwarcraft3 -data "Warcraft III"
 
-# Mount expansion MPQs
+# Expose expansion MPQs / select TFT (`+tft` is also accepted for compatibility)
 openwarcraft3 -data "Warcraft III" -tft +map "Maps\FrozenThrone\Campaign\NightElfX01.w3m"
 
 # One-frame UI diagnostic
@@ -171,7 +174,8 @@ All cvars registered in `Cvar_Init()`:
 | `fs_basepath` | resolved share dir | 0 | Read-only engine/share data directory |
 | `fs_homepath` | `$XDG_DATA_HOME/<game>/` or `~/.local/share/<game>/` (empty if unavailable) | 0 | Writable per-user directory |
 | `data` | `""` | CVAR_ARCHIVE | Game asset directory (contains MPQs) |
-| `fs_expansion` | `"0"` | 0 | Select RoC (`0`) vs TFT (`1`) data/skin version; TFT mounts expansion archives |
+| `fs_expansion` | `"0"` | 0 | Select base (`0`) vs expansion (`1`) data/skin version |
+| `fs_expansion_archive_prefix` | `""` | 0 | Optional archive basename prefix hidden while `fs_expansion=0`; WC3 sets this in its shipped config |
 | `map` | `""` | 0 | Internal MPQ map path for listen-server mode |
 | `connect` | `""` | 0 | Remote server address |
 | `cl_debug_entities` | `"0"` | 0 | Client entity debug logging |

--- a/docs/games/warcraft-3/architecture/ui-flow.md
+++ b/docs/games/warcraft-3/architecture/ui-flow.md
@@ -58,6 +58,7 @@ The Warcraft III main-menu scene is skin-driven rather than selected by hard-cod
 
 ```text
 fs_expansion
+  -> archive visibility (`War3x*` hidden for RoC, exposed for TFT)
   -> UI\war3skins.txt
   -> Theme_String("GlueSpriteLayerBackground", "Default")
   -> GlueSpriteLayerBackground_V0 (RoC) or _V1 (TFT) when no unversioned field exists
@@ -67,14 +68,55 @@ fs_expansion
 
 `games/warcraft-3/menu/menu_theme.c` treats `fs_expansion=0` as skin version 0 and any non-zero value as version 1. An explicit
 unversioned skin field remains authoritative; otherwise only the matching `_V0`/`_V1` field is considered. The same decorated
-lookup is used by `GlueSpriteLayerTopLeft`, `GlueSpriteLayerTopRight`, `MainMenuLogo`, and other FDF/model/texture keys, so one
-edition selector keeps the glue presentation consistent.
+lookup is used by `GlueSpriteLayerTopLeft`, `GlueSpriteLayerTopRight`, `MainMenuLogo`, `CampaignFile`, and other FDF/model/texture
+keys, so one edition selector keeps the glue presentation and campaign data consistent.
+
+Installed expansion archives are mounted during `FS_AddDataDirectory` even when the process starts in RoC mode.
+`games/warcraft-3/share/config.cfg` sets the generic `fs_expansion_archive_prefix` to `War3x`;
+`common/common.c:FS_ArchiveFileVisible` hides that configured archive family while `fs_expansion=0`, while retaining the existing
+RoC `War3Local.mpq` AI-script filter. TFT mode exposes those already-mounted archives. This avoids closing/remounting MPQs under
+renderer/UI resources and makes the edition cvar safe to change at the disconnected main menu.
+
+The native `EditionButton` is optional and is discovered under the parsed `MainMenuFrame`; OpenRealm does not recreate its layout.
+Its click command is `menu_edition`. The main-menu controller suppresses repeated clicks, hides the current frame tree, draws one
+`MainMenu Death` glue frame, switches the edition cvar, validates expansion campaign data when entering TFT, and queues the generic
+`menu_restart` console command. `Cmd_ExecuteText` appends that command after the current frame's command execution point, so it runs
+on the next client frame after the current UI event/draw call stack has returned. The client then:
+
+```text
+menu EditionButton
+  -> MainMenu Death
+  -> set fs_expansion + validate TFT data
+  -> queue menu_restart
+  -> next client frame: menu.Shutdown()
+       -> release glue models
+       -> release menu-owned model/texture references
+       -> clear parsed FDF/theme state
+  -> renderer RegisterMap(NULL) registration boundary
+  -> menu.Init()
+       -> reload war3skins/FDF from the selected archive view
+       -> rebuild MainMenu and campaign-facing state
+```
+
+If TFT data is unavailable, the WC3 menu restores RoC (`fs_expansion=0`) before queuing the same restart, so the rebuilt menu remains
+in the available edition. The generic engine `menu_restart` command only runs while `cls.state == ca_disconnected`; gameplay/map
+state is never rebuilt inline. `+tft` and `+roc` are consumed during early command-line processing, before `CL_Init()`/`M_Init()`,
+so their first rendered menu already uses the selected skin/archive view rather than changing edition as a late console command.
+
+Returning from a campaign world uses the same rebuild primitive at the session boundary. A game-side `MenuAction("menu", target)`
+is consumed on the next client frame, disconnects the client without queuing a stale `menu_main`, shuts down the local server/game
+module, clears the old map cvar/renderer asset scope, rebuilds the menu, and then enters `target`. This keeps menu FDF/model state
+valid after map registration and makes Quit Campaign / EndGame / campaign-select returns work after an in-process edition switch.
+
+`games/warcraft-3/menu/screens/single_player.c` resolves `CampaignFile` for both editions before falling back to the stock
+`UI\CampaignStrings.txt` / `UI\CampaignStrings_exp.txt` names, so a post-switch Single Player entry reparses the campaign list from
+the same edition selected by the main menu.
 
 `games/warcraft-3/menu/menu_glue_scene.c` renders the selected background as a model with `RDF_USE_ENTITY_CAMERA`; the main menu is
-therefore not a static BLP backdrop. Current lifecycle gaps remain deliberate: OpenRealm starts glue layers directly in their
-`Stand` sequences, does not parse `MenuZFog`, and has no safe in-menu RoC/TFT Edition-button restart flow. Because RoC mode omits
-TFT MPQs at the filesystem layer, an Edition button must not be implemented as a UI-only cvar toggle without a corresponding data
-source/UI restart lifecycle.
+therefore not a static BLP backdrop. Remaining glue parity gaps include `MenuZFog`, edition-sensitive `GlueScreenLoop` ambience, and
+a dedicated post-restart `MainMenu Birth` phase; the current switch rebuilds directly into the normal main-menu `Stand` state.
+The renderer texture cache also deliberately retains released textures, so same-path archive overrides are not globally invalidated by
+this menu restart; edition-decorated paths reload correctly, while broader texture-cache ownership remains separate lifetime work.
 
 ## Menu Navigation Flow
 

--- a/docs/games/warcraft-3/file-docs/fdf.md
+++ b/docs/games/warcraft-3/file-docs/fdf.md
@@ -392,8 +392,10 @@ Theme_String("GlueSpriteLayerBackground", "Default")
   -> unresolved key if no matching field exists
 ```
 
-This matters for menu glue because `fs_expansion` controls both which expansion archives are mounted and which versioned skin
-fields are selected. Do not infer the edition by preferring `_V1` merely because that field exists in the loaded table.
+This matters for menu glue because `fs_expansion` controls both expansion-archive visibility and which versioned skin fields are
+selected. OpenRealm mounts installed `War3x*` archives during data-directory discovery, but `FS_ArchiveFileVisible` hides every file
+from those archives while `fs_expansion=0`; switching to TFT exposes the already-mounted higher-priority expansion data. Do not
+infer the edition by preferring `_V1` merely because that field exists in the loaded table.
 
 ### Main Menu Glue Layer Examples
 

--- a/docs/games/warcraft-3/in-game-menu.md
+++ b/docs/games/warcraft-3/in-game-menu.md
@@ -83,7 +83,9 @@ and manual camera movement; transport remains live so submenu and close commands
 
 `UI_WINDOW_CLOSE_ACTION`, `UI_WINDOW_CLOSE_NOTIFY_ACTION`, `UI_WINDOW_DISCONNECT_ACTION`, and `UI_WINDOW_QUIT_ACTION` are interpreted
 locally by `client/cl_window.c` rather than forwarded as game commands. The server authors which button exposes those tokens, but leave
-and application-exit only happen after explicit local activation.
+and application-exit only happen after explicit local activation. `disconnect_game` queues the generic deferred `MenuAction("menu",
+"menu_main")` session boundary; it must not call `CL_Disconnect()` and immediately show the menu while the campaign server/game module
+is still alive, because game teardown owns FDF/template state that the front-end must rebuild afterward.
 
 Use ordinary `onclick` strings for server-owned state transitions such as `menu_endgame` and `menu_confirm_exit`.
 
@@ -103,8 +105,9 @@ Do not validate this from the front-end menu: `svc_window` requires an active ga
 3. Save/Load/Options/Help/Tips render disabled and do nothing.
 4. Pause and Return close the window and release the modal pause owner.
 5. End Game opens EndGamePanel; Restart is disabled and pause remains owned continuously.
-6. Previous returns to MainPanel without closing/reopening the modal lifecycle.
-7. Quit leaves the map and returns to the Warcraft front-end.
-8. Exit opens ConfirmQuitPanel; Cancel returns to EndGamePanel.
-9. Confirm exits the application.
-10. Leaving the menu open beyond the client timeout interval does not disconnect or advance paused simulation.
+6. Quit Game leaves the world through the deferred session boundary and returns to a freshly rebuilt main menu with valid FDF bindings.
+7. Previous returns to MainPanel without closing/reopening the modal lifecycle.
+8. Quit leaves the map and returns to the Warcraft front-end.
+9. Exit opens ConfirmQuitPanel; Cancel returns to EndGamePanel.
+10. Confirm exits the application.
+11. Leaving the menu open beyond the client timeout interval does not disconnect or advance paused simulation.

--- a/docs/games/warcraft-3/memory.md
+++ b/docs/games/warcraft-3/memory.md
@@ -105,9 +105,12 @@ the UI target does not list this common header directly as a prerequisite.
 ## Asset lifetime
 
 `UI_PreloadGlueSceneModels` loads main-menu and panel models even on the direct-map startup path.
-`UI_ResetGlueSceneModels` only zeroes its cache; it does not release the acquired references.
-At renderer shutdown, registry logging still showed references for `MainMenu3d`, the top-left/right panels,
-the campaign `LordaeronBackground`, loading bar, logo, and other glue assets.
+`UI_ResetGlueSceneModels` remains a zero-only initializer, but menu shutdown now calls `UI_ReleaseGlueSceneModels` first so the
+background/top-left/top-right renderer references are dropped before the cache is cleared. `UI_ReleaseAssets` likewise releases
+menu-owned loaded models/textures before `UI_ClearTemplates` forgets their indices. This is required by the in-process RoC/TFT
+edition restart; otherwise every toggle would retain another set of glue/model references. The same explicit shutdown/re-init is
+used when a gameplay `MenuAction("menu", ...)` returns from a campaign world, after the server is shut down and map scope is cleared,
+so the next menu never depends on renderer/FDF references carried across the world registration boundary.
 
 `renderer/r_model.c:R_FreeUnusedModels` only collects unreferenced models from an older registration sequence.
 `renderer/r_texture.c:R_ReleaseTexture` deliberately preserves every cached texture;

--- a/games/warcraft-3/menu/menu_fdf.c
+++ b/games/warcraft-3/menu/menu_fdf.c
@@ -28,6 +28,16 @@ static BOOL ui_texture_decorated[UI_MAX_TEXTURES] = { 0 };
 static LPCMODEL ui_models[UI_MAX_MODELS] = { 0 };
 static PATHSTR ui_model_names[UI_MAX_MODELS] = { 0 };
 
+void UI_ReleaseAssets(void) {
+    LPRENDERER renderer = menuimport.GetRenderer();
+
+    FOR_LOOP(i, UI_MAX_TEXTURES)
+        if (ui_textures[i]) renderer->ReleaseTexture((LPTEXTURE)ui_textures[i]);
+    FOR_LOOP(i, UI_MAX_MODELS)
+        if (ui_models[i]) renderer->ReleaseModel((LPMODEL)ui_models[i]);
+    UI_ClearTextures();
+}
+
 BZ_HOST_HIDDEN void UI_ClearTextures(void) {
     memset(ui_textures, 0, sizeof(ui_textures));
     memset(ui_texture_names, 0, sizeof(ui_texture_names));

--- a/games/warcraft-3/menu/menu_glue_scene.c
+++ b/games/warcraft-3/menu/menu_glue_scene.c
@@ -49,6 +49,15 @@ void UI_ResetGlueSceneModels(void) {
     memset(&menu_glue_scene, 0, sizeof(menu_glue_scene));
 }
 
+void UI_ReleaseGlueSceneModels(void) {
+    LPRENDERER renderer = menuimport.GetRenderer();
+
+    if (menu_glue_scene.background) renderer->ReleaseModel((LPMODEL)menu_glue_scene.background);
+    if (menu_glue_scene.top_left_panel) renderer->ReleaseModel((LPMODEL)menu_glue_scene.top_left_panel);
+    if (menu_glue_scene.top_right_panel) renderer->ReleaseModel((LPMODEL)menu_glue_scene.top_right_panel);
+    UI_ResetGlueSceneModels();
+}
+
 void UI_PreloadGlueSceneModels(void) {
     LPRENDERER renderer;
 

--- a/games/warcraft-3/menu/menu_local.h
+++ b/games/warcraft-3/menu/menu_local.h
@@ -44,6 +44,7 @@ static inline BOOL UI_ParseLoadingRow(LPCSTR row, LPDWORD sequence, LPSTR model)
 
 /* menu_glue_scene.c */
 void UI_ResetGlueSceneModels(void);
+void UI_ReleaseGlueSceneModels(void);
 void UI_PreloadGlueSceneModels(void);
 void UI_DrawGlueScene(LPCSTR panel_anim);
 void UI_DrawGlueSceneLayers(LPCSTR left_panel_anim, LPCSTR right_panel_anim);
@@ -53,6 +54,7 @@ BOOL UI_EnsureFDF(LPCSTR filename);
 void UI_ParseFDF(LPCSTR filename);
 void UI_ParseFDF_Buffer(LPCSTR filename, LPSTR buffer);
 void UI_ClearTemplates(void);
+void UI_ReleaseAssets(void);
 void UI_WireFrameTypeFunctions(LPFRAMEDEF frame);
 void UI_SetText(LPFRAMEDEF, LPCSTR, ...);
 void UI_SetTextPointer(LPFRAMEDEF, LPCSTR);

--- a/games/warcraft-3/menu/menu_main.c
+++ b/games/warcraft-3/menu/menu_main.c
@@ -467,8 +467,9 @@ void M_Init(void) {
 }
 
 void M_Shutdown(void) {
-    UI_ResetGlueSceneModels();
     UI_SetScreen(NULL);
+    UI_ReleaseGlueSceneModels();
+    UI_ReleaseAssets();
     UI_ClearTemplates();
     memset(&ui_state, 0, sizeof(ui_state));
 }
@@ -650,6 +651,10 @@ void M_MenuCommand(LPCSTR command) {
     }
     if (!strcmp(command, "menu_realm_select")) {
         UI_MenuRealmSelect_f();
+        return;
+    }
+    if (!strcmp(command, "menu_edition")) {
+        MainMenu_BeginEditionSwitch();
         return;
     }
     if (!strcmp(command, "menu_options_gameplay")) {

--- a/games/warcraft-3/menu/menu_screen.h
+++ b/games/warcraft-3/menu/menu_screen.h
@@ -48,6 +48,7 @@ void MainMenu_ShowMainPanel(void);
 void MainMenu_ShowRealmSelect(void);
 void MainMenu_ShowQuitConfirm(void);
 void MainMenu_ShowDisconnected(void);
+void MainMenu_BeginEditionSwitch(void);
 
 void OptionsMenu_ShowGameplay(void);
 void OptionsMenu_ShowVideo(void);

--- a/games/warcraft-3/menu/screens/main_menu.c
+++ b/games/warcraft-3/menu/screens/main_menu.c
@@ -25,6 +25,10 @@ static uiDialogWar3_t quit_dialog;
 
 /* State */
 static BOOL show_realm_select = false;
+static LPFRAMEDEF edition_button;
+static BOOL edition_switch_pending;
+static BOOL edition_switch_requested;
+static BOOL edition_switch_target_expansion;
 
 static BOOL MainMenu_LoadScreen(void) {
     return MainMenu_Load(&main_menu);
@@ -83,6 +87,11 @@ static void MainMenu_InitFrames(void) {
     UI_SetOnClick(main_menu.OptionsButton, "menu_options");
     UI_SetOnClick(main_menu.CreditsButton, "menu_credits");
     UI_SetOnClick(main_menu.ExitButton, "menu_quit");
+    /* EditionButton exists in Blizzard's native MainMenu FDF but is optional
+     * for reduced/test FDFs, so bind it without making generated-load success
+     * depend on the frame being present. */
+    edition_button = UI_FindChildFrame(main_menu.MainMenuFrame, "EditionButton");
+    if (edition_button) UI_SetOnClick(edition_button, "menu_edition");
     MainMenu_InitQuitDialog();
 
     /* Realm select buttons */
@@ -94,23 +103,52 @@ static void MainMenu_InitFrames(void) {
 
 static void MainMenu_Init(void) {
     menuimport.Printf("MainMenu_Init\n");
+    edition_button = NULL;
+    edition_switch_pending = false;
+    edition_switch_requested = false;
     UI_PreloadGlueSceneModels();
     MainMenu_InitFrames();
     MainMenu_ShowMainPanel();
 }
 
 static void MainMenu_Shutdown(void) {
-    /* Nothing to clean up */
+    edition_button = NULL;
+    edition_switch_pending = false;
+    edition_switch_requested = false;
+}
+
+static void MainMenu_ApplyEdition(BOOL expansion) {
+    HANDLE data = NULL;
+    int size;
+
+    menuimport.Cvar_Set("fs_expansion", expansion ? "1" : "0");
+    if (!expansion) return;
+
+    size = menuimport.FS_ReadFile("UI\\CampaignStrings_exp.txt", &data);
+    if (data) menuimport.FS_FreeFile(data);
+    if (size > 0) return;
+
+    menuimport.Cvar_Set("fs_expansion", "0");
+    menuimport.Printf("The Frozen Throne data is unavailable.\n");
 }
 
 static void MainMenu_Refresh(int msec) {
     (void)msec;
-    /* Update animations, etc. */
 }
 
 static void MainMenu_Draw(void) {
     LPCFRAMEDEF roots[2];
     DWORD num_roots = 0;
+
+    if (edition_switch_pending) {
+        UI_DrawGlueScene("MainMenu Death");
+        if (!edition_switch_requested) {
+            edition_switch_requested = true;
+            MainMenu_ApplyEdition(edition_switch_target_expansion);
+            menuimport.Cmd_ExecuteText("menu_restart\n");
+        }
+        return;
+    }
 
     UI_DrawGlueScene(show_realm_select ? "RealmSelection Stand" : "MainMenu Stand");
 
@@ -129,6 +167,19 @@ static void MainMenu_KeyEvent(int key, BOOL down) {
     /* Handle key presses */
     (void)key;
     (void)down;
+}
+
+void MainMenu_BeginEditionSwitch(void) {
+    LPCSTR expansion;
+
+    if (edition_switch_pending || !main_menu.MainMenuFrame) return;
+    expansion = menuimport.Cvar_String("fs_expansion", "0");
+    edition_switch_target_expansion = !(expansion && atoi(expansion) != 0);
+    edition_switch_pending = true;
+    edition_switch_requested = false;
+    show_realm_select = false;
+    UI_DialogWar3Hide(&quit_dialog);
+    UI_SetHidden(main_menu.MainMenuFrame, true);
 }
 
 void MainMenu_ShowMainPanel(void) {

--- a/games/warcraft-3/menu/screens/single_player.c
+++ b/games/warcraft-3/menu/screens/single_player.c
@@ -350,7 +350,7 @@ static void SinglePlayer_LoadCampaignData(void) {
     campaign_count = 0;
     campaign_order_count = 0;
 
-    campaign_file = expansion ? Theme_String("CampaignFile", "Default") : NULL;
+    campaign_file = Theme_String("CampaignFile", "Default");
     if (campaign_file && strcmp(campaign_file, "CampaignFile") &&
         SinglePlayer_LoadCampaignFile(campaign_file)) {
         SinglePlayer_FinalizeCampaignOrder();

--- a/games/warcraft-3/share/config.cfg
+++ b/games/warcraft-3/share/config.cfg
@@ -8,6 +8,10 @@ seta vid_fullscreen "1"
 // 1280x720 widescreen default; writeconfig persists a per-user override.
 seta vid_mode "4"
 
+// The engine keeps optional expansion archives mounted; RoC hides this family
+// from lookup so the main-menu Edition button can switch without remounting MPQs.
+set fs_expansion_archive_prefix "War3x"
+
 bind MOUSE1 "+select"
 bind MOUSE2 "+smart"
 bind MOUSE3 "+pan"

--- a/games/warcraft-3/tests/resources-src/TestUI/FrameDef/Glue/MainMenu.fdf
+++ b/games/warcraft-3/tests/resources-src/TestUI/FrameDef/Glue/MainMenu.fdf
@@ -9,6 +9,9 @@ Frame "FRAME" "MainMenuFrame" {
     Frame "SPRITE" "WarCraftIIILogo" {
     }
 
+    Frame "BUTTON" "EditionButton" {
+    }
+
     Frame "FRAME" "RealmSelect" {
         Frame "TEXT" "RealmSelectText" {
         }

--- a/games/warcraft-3/tests/test_client_stubs.c
+++ b/games/warcraft-3/tests/test_client_stubs.c
@@ -22,6 +22,8 @@ DWORD test_fow_upload_calls;
 DWORD test_cursor_draw_calls;
 COLOR32 test_cursor_tint;
 char test_forwarded_command[128];
+char test_menu_action[32];
+char test_menu_action_arg[128];
 static PATHSTR test_existing_file;
 static BOX2 test_world_bounds;
 static size2_t test_window_size;
@@ -104,6 +106,10 @@ void S_PlaySoundPacket(LPCSTR path, LPCVECTOR3 origin, BOOL positioned, int chan
     (void)path; (void)origin; (void)positioned; (void)channel; (void)volume; (void)attenuation; (void)timeofs;
 }
 void Cbuf_AddText(LPCSTR text) { (void)text; }
+void MenuAction(LPCSTR action, LPCSTR arg) {
+    snprintf(test_menu_action, sizeof(test_menu_action), "%s", action ? action : "");
+    snprintf(test_menu_action_arg, sizeof(test_menu_action_arg), "%s", arg ? arg : "");
+}
 void Cmd_ForwardToServer(LPCSTR text) {
     snprintf(test_forwarded_command, sizeof(test_forwarded_command), "%s", text ? text : "");
 }
@@ -121,6 +127,8 @@ void test_client_stubs_init(void) {
     test_cursor_draw_calls = 0;
     test_cursor_tint = COLOR32_WHITE;
     test_forwarded_command[0] = '\0';
+    test_menu_action[0] = '\0';
+    test_menu_action_arg[0] = '\0';
     test_existing_file[0] = '\0';
     test_world_bounds = (BOX2){ 0 };
     test_window_size = MAKE(size2_t, 1024, 768);

--- a/games/warcraft-3/tests/test_commands.c
+++ b/games/warcraft-3/tests/test_commands.c
@@ -201,7 +201,7 @@ TEST(commands, data_command_line_sets_data_cvar) {
     T_STREQ(Cvar_String("data", NULL), "tests/data dir");
 }
 
-TEST(commands, tft_command_line_enables_expansion_archives) {
+TEST(commands, tft_command_line_exposes_expansion_archives) {
     LPCSTR argv[] = { "test_commands", "-tft" };
 
     setup_command_tests();
@@ -211,7 +211,7 @@ TEST(commands, tft_command_line_enables_expansion_archives) {
     T_STREQ(Cvar_String("fs_expansion", NULL), "1");
 }
 
-TEST(commands, roc_command_line_disables_expansion_archives) {
+TEST(commands, roc_command_line_hides_expansion_archives) {
     LPCSTR argv[] = { "test_commands", "-roc" };
 
     setup_command_tests();
@@ -221,18 +221,59 @@ TEST(commands, roc_command_line_disables_expansion_archives) {
     T_STREQ(Cvar_String("fs_expansion", NULL), "0");
 }
 
+TEST(commands, plus_tft_compatibility_flag_selects_expansion_early) {
+    LPCSTR argv[] = { "test_commands", "+tft" };
+
+    setup_command_tests();
+    reset_map_handoff();
+    Cvar_Set("fs_expansion", "0");
+    COM_InitArgv(2, argv);
+    Cbuf_AddEarlyCommands(true);
+
+    T_STREQ(Cvar_String("fs_expansion", NULL), "1");
+    T_STREQ(COM_Argv(1), "");
+
+    Cbuf_AddLateCommands();
+    Cbuf_Execute();
+    T_STREQ(last_forwarded, "");
+}
+
+TEST(commands, plus_roc_compatibility_flag_selects_base_game_early) {
+    LPCSTR argv[] = { "test_commands", "+roc" };
+
+    setup_command_tests();
+    reset_map_handoff();
+    Cvar_Set("fs_expansion", "1");
+    COM_InitArgv(2, argv);
+    Cbuf_AddEarlyCommands(true);
+
+    T_STREQ(Cvar_String("fs_expansion", NULL), "0");
+    T_STREQ(COM_Argv(1), "");
+
+    Cbuf_AddLateCommands();
+    Cbuf_Execute();
+    T_STREQ(last_forwarded, "");
+}
+
 TEST(commands, roc_uses_base_ai_scripts_without_dropping_localized_data) {
     setup_command_tests();
     Cvar_Set("fs_expansion", "0");
+    Cvar_Set("fs_expansion_archive_prefix", "");
+    T_ASSERT(FS_ArchiveFileVisible("data/War3x.mpq", "UI\\CampaignStrings_exp.txt"));
+    Cvar_Set("fs_expansion_archive_prefix", "War3x");
 
     T_ASSERT(!FS_ArchiveFileVisible("data/War3Local.mpq", "Scripts\\human.ai"));
     T_ASSERT(!FS_ArchiveFileVisible("data/war3local.MPQ", "Scripts\\campaign.ai"));
     T_ASSERT(FS_ArchiveFileVisible("data/War3Local.mpq", "Scripts\\HumanMelee.pld"));
     T_ASSERT(FS_ArchiveFileVisible("data/War3Local.mpq", "UI\\WorldEditStrings.txt"));
     T_ASSERT(FS_ArchiveFileVisible("data/War3.mpq", "Scripts\\human.ai"));
+    T_ASSERT(!FS_ArchiveFileVisible("data/War3x.mpq", "UI\\CampaignStrings_exp.txt"));
+    T_ASSERT(!FS_ArchiveFileVisible("data/War3xLocal.mpq", "UI\\war3skins.txt"));
 
     Cvar_Set("fs_expansion", "1");
     T_ASSERT(FS_ArchiveFileVisible("data/War3Local.mpq", "Scripts\\human.ai"));
+    T_ASSERT(FS_ArchiveFileVisible("data/War3x.mpq", "UI\\CampaignStrings_exp.txt"));
+    T_ASSERT(FS_ArchiveFileVisible("data/War3xLocal.mpq", "UI\\war3skins.txt"));
 }
 
 TEST(commands, dash_cvars_are_not_command_line_cvars) {

--- a/games/warcraft-3/tests/test_menu_fdf.c
+++ b/games/warcraft-3/tests/test_menu_fdf.c
@@ -27,6 +27,7 @@ static DWORD captured_realm_panel_sprites;
 static DWORD captured_sprite_calls;
 static FLOAT captured_sprite_x[2];
 static size2_t test_window_size = { 1000, 750 };
+static DWORD captured_death_sprites;
 static uintptr_t fake_texture_id;
 static LPTEXTURE hover_texture;
 static DWORD captured_hover_draws;
@@ -213,6 +214,8 @@ static void test_draw_sprite(LPCMODEL model, LPCSTR anim, float x, float y) {
         captured_stand_sprites++;
     if (anim && !strcmp(anim, "RealmSelection Stand"))
         captured_realm_panel_sprites++;
+    if (anim && !strcmp(anim, "MainMenu Death"))
+        captured_death_sprites++;
 }
 
 static void test_draw_backdrop(LPCDRAWBACKDROP draw_backdrop) {
@@ -225,12 +228,14 @@ static size2_t test_get_window_size(void) {
 }
 
 static void test_release_texture(LPTEXTURE texture) { (void)texture; texture_releases++; }
+static void test_release_model(LPMODEL model) { (void)model; }
 
 static LPRENDERER test_get_renderer(void) {
     static refExport_t renderer = {
         .LoadTexture = test_load_texture,
         .ReleaseTexture = test_release_texture,
         .LoadModel = test_load_model,
+        .ReleaseModel = test_release_model,
         .LoadFont = test_load_font,
         .GetWindowSize = test_get_window_size,
         .DrawImageEx = test_draw_image_ex,
@@ -293,6 +298,7 @@ static LPCSTR test_cvar_string(LPCSTR name, LPCSTR fallback) {
 static void test_cvar_set(LPCSTR name, LPCSTR value) {
     snprintf(captured_cvar_name, sizeof(captured_cvar_name), "%s", name ? name : "");
     snprintf(captured_cvar_value, sizeof(captured_cvar_value), "%s", value ? value : "");
+    if (name && !strcmp(name, "fs_expansion")) test_fs_expansion = value && atoi(value) != 0;
 }
 
 
@@ -330,6 +336,7 @@ static void reset_ui_state(void) {
     captured_realm_panel_sprites = 0;
     captured_sprite_calls = 0;
     memset(captured_sprite_x, 0, sizeof(captured_sprite_x));
+    captured_death_sprites = 0;
     fake_texture_id = 0;
     texture_releases = map_reads = 0;
     menu_player = NULL; test_map = "";
@@ -2052,6 +2059,7 @@ TEST(menu_fdf, main_menu_realm_select_uses_realm_panel_anim) {
     captured_stand_sprites = 0;
     captured_realm_panel_sprites = 0;
     captured_sprite_calls = 0;
+    captured_death_sprites = 0;
     mainMenuScreen.draw();
     T_EQ(captured_stand_sprites, 0);
     T_EQ(captured_realm_panel_sprites, 2);
@@ -2090,6 +2098,113 @@ TEST(menu_fdf, glue_sprite_layers_follow_widescreen_edges) {
     T_FEQ(centered.x, 0.133333f, 0.0001f);
     T_FEQ(centered.w, 0.8f, 0.0001f);
     test_window_size = MAKE(size2_t, 1000, 750);
+
+    menuimport = saved;
+}
+
+TEST(menu_fdf, main_menu_edition_button_defers_restart_after_death_frame) {
+    LPCSTR files[] = {
+        "UI\\FrameDef\\GlobalStrings.fdf",
+        "UI\\FrameDef\\UI\\EscMenuTemplates.fdf",
+        "UI\\FrameDef\\Glue\\StandardTemplates.fdf",
+        "UI\\FrameDef\\Glue\\DialogWar3.fdf",
+        "UI\\FrameDef\\Glue\\MainMenu.fdf",
+    };
+    menuImport_t saved = menuimport;
+    LPFRAMEDEF root;
+    LPFRAMEDEF edition;
+
+    load_ui_files(files, sizeof(files) / sizeof(files[0]));
+    memset(&menuimport, 0, sizeof(menuimport));
+    menuimport.Printf = test_ui_printf;
+    menuimport.GetRenderer = test_get_renderer;
+    menuimport.MemAlloc = test_ui_mem_alloc;
+    menuimport.MemFree = test_ui_mem_free;
+    menuimport.FS_ReadFile = test_fs_read_file;
+    menuimport.FS_FreeFile = test_fs_free_file;
+    menuimport.Cmd_ExecuteText = test_cmd_execute_text;
+    menuimport.Cvar_String = test_cvar_string;
+    menuimport.Cvar_Set = test_cvar_set;
+    test_fs_expansion = false;
+    hide_expansion_campaign_file = false;
+    captured_command[0] = '\0';
+    captured_cvar_name[0] = '\0';
+    captured_cvar_value[0] = '\0';
+    captured_death_sprites = 0;
+
+    T_ASSERT(mainMenuScreen.load());
+    mainMenuScreen.init();
+    root = UI_FindFrame("MainMenuFrame");
+    edition = root ? UI_FindChildFrame(root, "EditionButton") : NULL;
+    if (!require_not_null(root) || !require_not_null(edition)) {
+        menuimport = saved;
+        return;
+    }
+    T_STREQ(edition->OnClick, "menu_edition");
+
+    M_MenuCommand(edition->OnClick);
+    T_ASSERT(root->hidden);
+    T_STREQ(captured_command, "");
+    mainMenuScreen.draw();
+    T_EQ(captured_death_sprites, 2);
+    T_ASSERT(test_fs_expansion);
+    T_STREQ(captured_cvar_name, "fs_expansion");
+    T_STREQ(captured_cvar_value, "1");
+    T_STREQ(captured_command, "menu_restart\n");
+
+    captured_command[0] = '\0';
+    M_MenuCommand("menu_edition");
+    mainMenuScreen.draw();
+    T_EQ(captured_death_sprites, 4);
+    T_STREQ(captured_command, "");
+    mainMenuScreen.shutdown();
+    menuimport = saved;
+}
+
+TEST(menu_fdf, main_menu_edition_button_rolls_back_when_tft_data_is_missing) {
+    LPCSTR files[] = {
+        "UI\\FrameDef\\GlobalStrings.fdf",
+        "UI\\FrameDef\\UI\\EscMenuTemplates.fdf",
+        "UI\\FrameDef\\Glue\\StandardTemplates.fdf",
+        "UI\\FrameDef\\Glue\\DialogWar3.fdf",
+        "UI\\FrameDef\\Glue\\MainMenu.fdf",
+    };
+    menuImport_t saved = menuimport;
+    LPFRAMEDEF root;
+
+    load_ui_files(files, sizeof(files) / sizeof(files[0]));
+    memset(&menuimport, 0, sizeof(menuimport));
+    menuimport.Printf = test_ui_printf;
+    menuimport.GetRenderer = test_get_renderer;
+    menuimport.MemAlloc = test_ui_mem_alloc;
+    menuimport.MemFree = test_ui_mem_free;
+    menuimport.FS_ReadFile = test_fs_read_file;
+    menuimport.FS_FreeFile = test_fs_free_file;
+    menuimport.Cmd_ExecuteText = test_cmd_execute_text;
+    menuimport.Cvar_String = test_cvar_string;
+    menuimport.Cvar_Set = test_cvar_set;
+    test_fs_expansion = false;
+    hide_expansion_campaign_file = true;
+    captured_command[0] = '\0';
+    captured_printf[0] = '\0';
+
+    T_ASSERT(mainMenuScreen.load());
+    mainMenuScreen.init();
+    root = UI_FindFrame("MainMenuFrame");
+    if (!require_not_null(root)) {
+        hide_expansion_campaign_file = false;
+        menuimport = saved;
+        return;
+    }
+
+    M_MenuCommand("menu_edition");
+    mainMenuScreen.draw();
+    T_ASSERT(!test_fs_expansion);
+    T_STREQ(captured_command, "menu_restart\n");
+    T_ASSERT(strstr(captured_printf, "The Frozen Throne data is unavailable.") != NULL);
+
+    hide_expansion_campaign_file = false;
+    mainMenuScreen.shutdown();
     menuimport = saved;
 }
 
@@ -2368,6 +2483,8 @@ static int test_versioned_theme_read(LPCSTR name, void **buf) {
         "GlueSpriteLayerBackground_V1=TftBackground.mdl\n"
         "GlueSpriteLayerTopLeft_V0=RocTopLeft.mdl\n"
         "GlueSpriteLayerTopLeft_V1=TftTopLeft.mdl\n"
+        "CampaignFile_V0=UI\\CampaignStrings.txt\n"
+        "CampaignFile_V1=UI\\CampaignStrings_exp.txt\n"
         "MainMenuLogo=SharedLogo.mdl\n"
         "MainMenuLogo_V0=RocLogo.mdl\n"
         "MainMenuLogo_V1=TftLogo.mdl\n"
@@ -2387,10 +2504,12 @@ TEST(menu_fdf, versioned_theme_keys_follow_expansion_edition) {
     test_fs_expansion = false;
     T_STREQ(Theme_String("GlueSpriteLayerBackground", "Default"), "RocBackground.mdl");
     T_STREQ(Theme_String("GlueSpriteLayerTopLeft", "Default"), "RocTopLeft.mdl");
+    T_STREQ(Theme_String("CampaignFile", "Default"), "UI\\CampaignStrings.txt");
 
     test_fs_expansion = true;
     T_STREQ(Theme_String("GlueSpriteLayerBackground", "Default"), "TftBackground.mdl");
     T_STREQ(Theme_String("GlueSpriteLayerTopLeft", "Default"), "TftTopLeft.mdl");
+    T_STREQ(Theme_String("CampaignFile", "Default"), "UI\\CampaignStrings_exp.txt");
 
     test_fs_expansion = false;
     UI_ClearTheme();

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -47,6 +47,8 @@ extern DWORD test_fow_upload_calls;
 extern DWORD test_cursor_draw_calls;
 extern COLOR32 test_cursor_tint;
 extern char test_forwarded_command[128];
+extern char test_menu_action[32];
+extern char test_menu_action_arg[128];
 
 static RECT test_scroll_rects[3], test_scroll_uvs[3];
 static LPCTEXTURE test_scroll_tex[3];
@@ -870,6 +872,17 @@ TEST(net, window_click_raises_and_moves_keyboard_focus) {
     test_textarea_draws = 0; CL_WindowDraw();
     T_EQ(test_textarea_draws, 2);
     T_STREQ(test_textarea_draw.text, "First");
+    CL_WindowClear();
+}
+
+TEST(net, window_disconnect_action_defers_world_to_main_menu) {
+    test_client_stubs_init(); CL_WindowClear(); re.GetTextSize = text_length_mock_size;
+    test_send_window(14, 104, UI_WINDOW_MODAL | UI_WINDOW_NO_PAUSE, 0.05f,
+                     "Quit", UI_WINDOW_DISCONNECT_ACTION);
+    T_ASSERT(CL_WindowMouseEvent(MENU_MOUSE_DOWN, 128, 256, 1));
+    T_ASSERT(CL_WindowMouseEvent(MENU_MOUSE_UP, 128, 256, 1));
+    T_STREQ(test_menu_action, "menu");
+    T_STREQ(test_menu_action_arg, "menu_main");
     CL_WindowClear();
 }
 


### PR DESCRIPTION
Add Warcraft III main-menu edition switching between Reign of Chaos and The Frozen Throne using the existing fs_expansion state.

* bind and handle the native EditionButton
* resolve versioned _V0/_V1 menu skin fields per active edition
* rebuild menu UI and glue models after an edition change
* support +roc and +tft as early startup edition selectors
* keep expansion archives available for live switching while hiding them from RoC lookups through the configured archive prefix
* reload campaign definitions for the selected edition
* release menu-owned model references across menu rebuilds
* defer edition restarts and world-to-menu transitions out of UI callbacks to avoid tearing down active frame trees
* route in-game Quit Game through the full session teardown path
* shut down the client/server world and clear map renderer state before rebuilding the front-end menu
* preserve RoC/TFT state when returning from campaign missions
* add coverage for edition selection, campaign data, archive visibility, deferred menu actions, and menu lifecycle behavior
* update Warcraft III UI, FDF, runtime, and memory documentation

This allows switching editions without restarting the process and fixes campaign exits returning to an invalid menu with missing FDF bindings.