### PR TITLE
wc3: extend HUD and cinematic chrome across widescreen

### DIFF
--- a/client/cl_layout.c
+++ b/client/cl_layout.c
@@ -334,6 +334,10 @@ LPCRECT SCR_LayoutRect(LPCUIFRAME frame) {
         .w = rect[0].y,
         .h = rect[1].y,
     };
+    if (frame->flagsvalue & UIFLAG_EXTEND_WIDESCREEN_X) {
+        runtimes[frame->number].rect.x = 0.0f;
+        runtimes[frame->number].rect.w = SCR_UICanvasWidth();
+    }
     return &runtimes[frame->number].rect;
 }
 

--- a/common/msg.c
+++ b/common/msg.c
@@ -83,8 +83,8 @@ netField_t entityStateFields[] = {
  * transmission are included.  Conceptually each frame carries:
  *
  *   parent        — parent frame index (UI_PARENT = 255 for layer root)
- *   flagsvalue    — frame type (FT_TEXT, FT_BACKDROP, FT_COMMANDBUTTON, …)
- *                   packed with alpha mode
+ *   flagsvalue    — frame type (FT_TEXT, FT_BACKDROP, FT_COMMANDBUTTON, …),
+ *                   alpha mode, and generic retained-layout behavior flags
  *   x / y         — position on each axis; internally stored as three
  *                   4-byte uiFramePoint_t slots per axis (FPP_MIN/MID/MAX
  *                   = left/center/right for x, top/middle/bottom for y).

--- a/common/shared.h
+++ b/common/shared.h
@@ -826,6 +826,7 @@ typedef enum {
 #define UIFLAG_SIZE_TO_CONTENT   (1 << 10) // flag bit; derives a composite frame's size from rendered content; used by FT_NAMETAG
 #define UIFLAG_ALTERNATE_ACTIVE (1 << 11) // flag bit; secondary command state is active (for example an autocast toggle)
 #define UIFLAG_SPRITE_STAT_SEQUENCE (1 << 12) // FT_SPRITE: frame.value names a stats[] slot selecting an explicit #N sequence
+#define UIFLAG_EXTEND_WIDESCREEN_X (1 << 13) // flag bit; client expands this frame horizontally across the full UI canvas
 
 typedef enum {
     BACKDROP_TOP_LEFT_CORNER,

--- a/docs/games/warcraft-3/cinematics.md
+++ b/docs/games/warcraft-3/cinematics.md
@@ -203,6 +203,12 @@ build/bin/openwarcraft3 -data 'data/Warcraft III' -tft +map 'Maps\Campaign\Human
 
 During each bounded run, drag a world selection marquee downward through the command console and select a living unit near the lower world edge. Overhead health/mana bars must stop at `viewDef.scissor`. The marquee must stop earlier wherever retained bottom-console frames protrude above that rectangular boundary, including the status/info panel and command-card/build-button area; no console pixel may reveal the marquee.
 
+### Widescreen cinematic chrome
+
+The ordinary gameplay HUD remains authored inside the centered `0.8 x 0.6` 4:3 safe area. Cinematic letterbox **chrome** is different: `CinematicTopBorder` and `CinematicBottomBorder` must cover the complete widened UI canvas while the portrait, speaker text, and dialogue retain their original safe-area coordinates. The server marks only those two backdrops with `UIFLAG_EXTEND_WIDESCREEN_X`; `SCR_LayoutRect()` then replaces the marked frame's horizontal rect with `x=0` and `w=SCR_UICanvasWidth()` after normal FDF anchor resolution. At 4:3 this is still exactly `0.8`, so the behavior is a no-op.
+
+A 2880x1620 trace demonstrated the failure mode: canvas width was `1.06667`, HUD root was `x=0.13333,w=0.8`, and both cinematic borders resolved to `x=0.13333,w=0.8` with valid `human-options-menu-background.blp` and `human-cinematic-border.blp` textures. Therefore missing left/right cinematic fill is a geometry-policy issue, not missing art. Do not widen `CinematicPanel` itself: doing so would move safe-area portrait/dialogue anchors.
+
 ### Actor Presentation
 
 `SetUnitScale(unit, x, y, z)` follows Warsmash's current compatibility behavior: the WC3 XYZ API is rendered as a uniform scale using the **X component**. Y/Z are consumed for JASS signature compatibility but are not independent axes in the current entity renderer. Do not use the Z argument as the uniform scale; campaign scripts commonly pass equal values, which can hide that mistake until custom cinematic scaling uses distinct components.

--- a/docs/games/warcraft-3/hud-media.md
+++ b/docs/games/warcraft-3/hud-media.md
@@ -47,3 +47,9 @@ Repeat with `-tft`. Engine coverage: `make test-wc3-engine WC3_PATTERN='wc3_game
 - Leaving `hud` bindings live across `G_LoadMap` while `frames[]` was cleared.
 - Treating `GetConfigstring(CS_IMAGES + old_index)` as the name of a cached frame after the slot has been reused.
 - Preserving `CS_IMAGES` across `SV_Map` as a workaround. The table is per-level.
+
+## Widescreen Console Extension Tiles
+
+`ConsoleUI.fdf` uses symbolic `ConsoleTexture05` and `ConsoleTexture06` for the left/right widescreen console extensions. The client resolves symbolic `CS_IMAGES` names through the local player's `war3skins.txt` race category. Some classic/pre-widescreen skin tables contain the extension art in the archives but omit one or both symbolic fields. In that case `Theme_String()` returns the key itself and the renderer otherwise searches for a literal file named `ConsoleTexture06`, producing the 16x16 placeholder.
+
+When one console extension key remains unresolved, `M_ResolveImagePath()` derives its path from the resolved sibling (`...05[.blp]` ↔ `...06[.blp]`). This keeps the active race/custom skin authoritative instead of hard-coding a race path. Runtime confirmation on a 2880x1620 Human campaign showed the left extension resolving to `HumanUITile05` while the missing right extension was laid out correctly but retained literal `ConsoleTexture06`; this is a media-resolution failure, not an anchor failure.

--- a/docs/games/warcraft-3/unit-shortcuts.md
+++ b/docs/games/warcraft-3/unit-shortcuts.md
@@ -114,10 +114,12 @@ No `entityState_t` or `playerState_t` network fields are added.
 `games/warcraft-3/game/hud/hud_shortcuts.c` owns the layout constants.
 
 - Hero buttons start at the top-left edge of the rendered world immediately below the upper menu and stack vertically.
-- The idle-worker button is immediately above the minimap.
+- The idle-worker button keeps its authored vertical position immediately above the minimap on 4:3, but on widescreen its horizontal offset is measured from the physical left edge rather than from the centered 4:3 HUD safe area.
 - The idle-worker count is a bottom-right text overlay on the worker icon.
 
-Both use `FT_COMMANDBUTTON`, so they share the existing server-authored click/tooltip path rather than adding client-specific gameplay widgets.
+The shortcut layer emits an invisible `FT_SIMPLEFRAME` root with `UIFLAG_EXTEND_WIDESCREEN_X`. Hero buttons, the idle-worker button, and its count are parented to that root using the same authored offsets and sizes as before. On 4:3 the root is still `0.8 x 0.6`, so placement is unchanged; on a wider display only the root expands to the full UI canvas, putting the shortcut controls against the physical left edge while the normal ConsoleUI remains centered in its 4:3 safe area.
+
+Both buttons use `FT_COMMANDBUTTON`, so they share the existing server-authored click/tooltip path rather than adding client-specific gameplay widgets.
 
 ## Lifecycle And Visibility
 

--- a/games/warcraft-3/game/hud/hud.c
+++ b/games/warcraft-3/game/hud/hud.c
@@ -87,6 +87,7 @@ static void UI_CopyFrameBase(LPUIFRAME dest, LPCFRAMEDEF src) {
     dest->tex.index2 = UI_LiveImage(src->Texture.Image2);
     dest->flags.type = src->Type;
     dest->flags.alphaMode = src->AlphaMode;
+    dest->flagsvalue |= src->ui_flags & UIFLAG_EXTEND_WIDESCREEN_X;
     dest->textLength = src->TextLength;
     dest->stat = src->Stat;
     dest->text = src->Text;

--- a/games/warcraft-3/game/hud/hud_cinematic.c
+++ b/games/warcraft-3/game/hud/hud_cinematic.c
@@ -17,6 +17,13 @@
 void UI_LoadHudCinematic(void) {
     if (hud.cinematic.CinematicPanel) return;
     CinematicPanel_Load(&hud.cinematic);
+    /* Cinematic letterbox chrome is presentation, not 4:3 gameplay HUD content.
+     * Keep portrait/text authored in the centered safe area, but let the top
+     * and bottom backdrops reach the physical widescreen edges. */
+    if (hud.cinematic.CinematicBottomBorder)
+        hud.cinematic.CinematicBottomBorder->ui_flags |= UIFLAG_EXTEND_WIDESCREEN_X;
+    if (hud.cinematic.CinematicTopBorder)
+        hud.cinematic.CinematicTopBorder->ui_flags |= UIFLAG_EXTEND_WIDESCREEN_X;
 }
 
 /* Construct the message overlay frame tree inline; no FDF needed. */

--- a/games/warcraft-3/game/hud/hud_shortcuts.c
+++ b/games/warcraft-3/game/hud/hud_shortcuts.c
@@ -11,7 +11,27 @@
 #define IDLE_WORKER_Y         0.4145f
 #define IDLE_WORKER_SIZE      0.0340f
 
-static void UI_WriteShortcutNumber(FLOAT x, FLOAT y, FLOAT w, FLOAT h, DWORD number) {
+static DWORD UI_WriteShortcutRoot(void) {
+    uiFrame_t frame;
+    DWORD number = ui_next_frame_number;
+
+    memset(&frame, 0, sizeof(frame));
+    frame.flags.type = FT_SIMPLEFRAME;
+    frame.flagsvalue |= UIFLAG_EXTEND_WIDESCREEN_X;
+    UI_SetFrameRect(&frame, 0.0f, 0.0f, UI_BASE_WIDTH, UI_BASE_HEIGHT);
+    UI_WriteProxyFrame(&frame, NULL, 0);
+    return number;
+}
+
+static void UI_SetShortcutRect(LPUIFRAME frame, DWORD parent,
+                               FLOAT x, FLOAT y, FLOAT w, FLOAT h) {
+    frame->parent = parent;
+    UI_SetFrameRect(frame, x, y, w, h);
+    frame->points.x[FPP_MIN].relativeTo = UI_PARENT;
+    frame->points.y[FPP_MIN].relativeTo = UI_PARENT;
+}
+
+static void UI_WriteShortcutNumber(DWORD parent, FLOAT x, FLOAT y, FLOAT w, FLOAT h, DWORD number) {
     uiFrame_t frame;
     uiLabel_t label;
     char text[16];
@@ -26,11 +46,11 @@ static void UI_WriteShortcutNumber(FLOAT x, FLOAT y, FLOAT w, FLOAT h, DWORD num
     label.font = gi.FontIndex("Fonts\\FRIZQT__.TTF", HUD_FONT_SIZE);
     label.textalignx = FONT_JUSTIFYRIGHT;
     label.textaligny = FONT_JUSTIFYBOTTOM;
-    UI_SetFrameRect(&frame, x + 0.001f, y + 0.001f, w - 0.002f, h - 0.002f);
+    UI_SetShortcutRect(&frame, parent, x + 0.001f, y + 0.001f, w - 0.002f, h - 0.002f);
     UI_WriteProxyFrame(&frame, &label, sizeof(label));
 }
 
-static void UI_WriteUnitShortcutButton(FLOAT x, FLOAT y, FLOAT size, LPCEDICT unit,
+static void UI_WriteUnitShortcutButton(DWORD parent, FLOAT x, FLOAT y, FLOAT size, LPCEDICT unit,
                                        LPCSTR command, LPCSTR tooltip) {
     uiFrame_t frame;
     LPCSTR art;
@@ -42,7 +62,7 @@ static void UI_WriteUnitShortcutButton(FLOAT x, FLOAT y, FLOAT size, LPCEDICT un
     frame.tex.index = gi.ImageIndex(art);
     frame.onclick = command;
     frame.tooltip = tooltip;
-    UI_SetFrameRect(&frame, x, y, size, size);
+    UI_SetShortcutRect(&frame, parent, x, y, size, size);
     UI_WriteProxyFrame(&frame, NULL, 0);
 }
 
@@ -52,6 +72,7 @@ void UI_WriteUnitShortcutLayer(LPEDICT clent) {
     LPEDICT wrap_idle = NULL;
     DWORD hero_slot = 0;
     DWORD idle_count = 0;
+    DWORD shortcut_root;
     char command[64];
     char tooltip[128];
 
@@ -59,6 +80,7 @@ void UI_WriteUnitShortcutLayer(LPEDICT clent) {
 
     UI_SetCurrentClient(client);
     UI_WriteStart(LAYER_UNIT_SHORTCUTS);
+    shortcut_root = UI_WriteShortcutRoot();
 
     /* One entity pass per dirty rebuild: emit Hero buttons while also counting
      * workers and choosing the next cycle target. */
@@ -72,7 +94,7 @@ void UI_WriteUnitShortcutLayer(LPEDICT clent) {
 
             snprintf(command, sizeof(command), "herobutton %u", (unsigned)number);
             snprintf(tooltip, sizeof(tooltip), "Select %s", name && *name ? name : "Hero");
-            UI_WriteUnitShortcutButton(HERO_SHORTCUT_X,
+            UI_WriteUnitShortcutButton(shortcut_root, HERO_SHORTCUT_X,
                                        HERO_SHORTCUT_Y + hero_slot * (HERO_SHORTCUT_SIZE + HERO_SHORTCUT_GAP),
                                        HERO_SHORTCUT_SIZE, unit, command, tooltip);
             hero_slot++;
@@ -88,9 +110,9 @@ void UI_WriteUnitShortcutLayer(LPEDICT clent) {
     if (idle_count && next_idle) {
         DWORD number = (DWORD)(next_idle - globals.edicts);
         snprintf(command, sizeof(command), "idleworker %u", (unsigned)number);
-        UI_WriteUnitShortcutButton(IDLE_WORKER_X, IDLE_WORKER_Y, IDLE_WORKER_SIZE,
+        UI_WriteUnitShortcutButton(shortcut_root, IDLE_WORKER_X, IDLE_WORKER_Y, IDLE_WORKER_SIZE,
                                    next_idle, command, "Select Idle Worker");
-        UI_WriteShortcutNumber(IDLE_WORKER_X, IDLE_WORKER_Y,
+        UI_WriteShortcutNumber(shortcut_root, IDLE_WORKER_X, IDLE_WORKER_Y,
                                IDLE_WORKER_SIZE, IDLE_WORKER_SIZE, idle_count);
     }
 

--- a/games/warcraft-3/game/tests/t_shortcuts.c
+++ b/games/warcraft-3/game/tests/t_shortcuts.c
@@ -7,6 +7,49 @@ LPEDICT alloc_test_unit(DWORD class_id, FLOAT x, FLOAT y);
 void reset_entities(void);
 void setup_test_world(void);
 
+static DWORD shortcut_root_number;
+static BOOL shortcut_root_extended;
+static BOOL shortcut_hero_parented;
+static BOOL shortcut_worker_parented;
+static BOOL shortcut_count_parented;
+
+static int shortcut_test_image(LPCSTR name) {
+    T_ASSERT(name && *name);
+    return 1;
+}
+
+static int shortcut_test_font(LPCSTR name, DWORD size) {
+    T_ASSERT(name && *name);
+    T_EQ(size, HUD_FONT_SIZE);
+    return 1;
+}
+
+static void shortcut_test_unicast(LPEDICT ent) { (void)ent; }
+
+static void shortcut_test_write(pfWriteType_t type, void const *value) {
+    LPCUIFRAME frame;
+
+    if (type != PF_UIFRAME || !value) return;
+    frame = value;
+    if (frame->flags.type == FT_SIMPLEFRAME &&
+        (frame->flagsvalue & UIFLAG_EXTEND_WIDESCREEN_X)) {
+        shortcut_root_number = frame->number;
+        shortcut_root_extended = true;
+        T_FEQ(frame->size.width, UI_BASE_WIDTH, 0.0001f);
+        T_FEQ(frame->size.height, UI_BASE_HEIGHT, 0.0001f);
+        return;
+    }
+    if (!shortcut_root_number || frame->parent != shortcut_root_number) return;
+    T_EQ(frame->points.x[FPP_MIN].relativeTo, UI_PARENT);
+    T_EQ(frame->points.y[FPP_MIN].relativeTo, UI_PARENT);
+    if (frame->flags.type == FT_COMMANDBUTTON && frame->onclick) {
+        if (!strncmp(frame->onclick, "herobutton ", 11)) shortcut_hero_parented = true;
+        if (!strncmp(frame->onclick, "idleworker ", 11)) shortcut_worker_parented = true;
+    } else if (frame->flags.type == FT_STRING) {
+        shortcut_count_parented = true;
+    }
+}
+
 TEST(wc3_shortcuts, peasant_plain_stand_is_idle_but_busy_move_is_not) {
     umove_t busy = { "walk", NULL, NULL, NULL };
     LPEDICT worker;
@@ -125,5 +168,67 @@ TEST(wc3_shortcuts, hero_function_key_requires_quick_second_press_to_center) {
     G_ActivateHeroKey(clent, 0);
     T_FEQ(client->camera.state.position.x, 112.0f, 0.001f);
     T_FEQ(client->camera.state.position.y, 144.0f, 0.001f);
+}
+
+TEST(wc3_shortcuts, hud_buttons_share_full_canvas_left_root) {
+    LPGAMECLIENT client = &game.clients[0];
+    LPEDICT clent;
+    LPEDICT hero;
+    LPEDICT worker;
+    UnitProfile_t hero_profile;
+    UnitProfile_t worker_profile;
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(edict_t *) = gi.unicast;
+    int (*old_image)(LPCSTR) = gi.ImageIndex;
+    int (*old_font)(LPCSTR, DWORD) = gi.FontIndex;
+
+    reset_entities();
+    setup_test_world();
+    client->ps.number = 0;
+    client->connected = true;
+    clent = &g_edicts[0];
+    clent->client = client;
+
+    hero = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 64.0f, 64.0f);
+    hero->svflags |= SVF_MONSTER;
+    hero->s.player = 0;
+    T_NOT_NULL(hero->data.UnitProfile);
+    hero_profile = *hero->data.UnitProfile;
+    hero_profile.art = "TestUI\\Textures\\solid_white.blp";
+    hero->data.UnitProfile = &hero_profile;
+
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 96.0f, 96.0f);
+    worker->svflags |= SVF_MONSTER;
+    worker->s.player = 0;
+    T_NOT_NULL(worker->data.UnitProfile);
+    worker_profile = *worker->data.UnitProfile;
+    worker_profile.art = "TestUI\\Textures\\solid_white.blp";
+    worker->data.UnitProfile = &worker_profile;
+    worker->stand = unit_stand;
+    unit_stand(worker);
+    T_ASSERT(G_UnitShowsHeroShortcut(client, hero));
+    T_ASSERT(G_UnitShowsIdleWorkerShortcut(client, worker));
+
+    shortcut_root_number = 0;
+    shortcut_root_extended = false;
+    shortcut_hero_parented = false;
+    shortcut_worker_parented = false;
+    shortcut_count_parented = false;
+    gi.Write = shortcut_test_write;
+    gi.unicast = shortcut_test_unicast;
+    gi.ImageIndex = shortcut_test_image;
+    gi.FontIndex = shortcut_test_font;
+
+    UI_WriteUnitShortcutLayer(clent);
+
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+    gi.ImageIndex = old_image;
+    gi.FontIndex = old_font;
+    T_ASSERT(shortcut_root_extended);
+    T_EQ(shortcut_root_number, 1);
+    T_ASSERT(shortcut_hero_parented);
+    T_ASSERT(shortcut_worker_parented);
+    T_ASSERT(shortcut_count_parented);
 }
 #endif

--- a/games/warcraft-3/menu/menu_main.c
+++ b/games/warcraft-3/menu/menu_main.c
@@ -30,10 +30,48 @@ static uiScreen_t *ui_current_screen = NULL;
 static BOOL ui_menu_commands_registered;
 static LoadingScreen_t loading_screen;
 
+/* Some classic/pre-widescreen skin tables expose only one of the paired
+ * ConsoleTexture05/06 fields even though both extension tiles are installed.
+ * When one symbolic key is absent, derive it from the resolved sibling path so
+ * the active race/custom skin remains authoritative. */
+static LPCSTR M_ConsoleExtensionSibling(LPCSTR key) {
+    static PATHSTR path;
+    LPCSTR sibling_key, sibling;
+    char from_digit, to_digit;
+    char *dot, *end;
+
+    if (!key) return NULL;
+    if (!strcmp(key, "ConsoleTexture05")) {
+        sibling_key = "ConsoleTexture06";
+        from_digit = '6';
+        to_digit = '5';
+    } else if (!strcmp(key, "ConsoleTexture06")) {
+        sibling_key = "ConsoleTexture05";
+        from_digit = '5';
+        to_digit = '6';
+    } else {
+        return NULL;
+    }
+
+    sibling = Theme_String(sibling_key, "Default");
+    if (!sibling || !*sibling || !strcmp(sibling, sibling_key)) return NULL;
+    snprintf(path, sizeof(path), "%s", sibling);
+    dot = strrchr(path, '.');
+    end = dot ? dot : path + strlen(path);
+    if (end - path < 2 || end[-2] != '0' || end[-1] != from_digit) return NULL;
+    end[-1] = to_digit;
+    return path;
+}
+
 /* Resolve symbolic server-authored WC3 image names using the local player's skin. */
 LPCSTR M_ResolveImagePath(LPCSTR key) {
+    LPCSTR resolved, fallback;
+
     if (!key || !*key || strchr(key, '\\') || strchr(key, '/')) return key;
-    return Theme_String(key, "Default");
+    resolved = Theme_String(key, "Default");
+    if (resolved && strcmp(resolved, key)) return resolved;
+    fallback = M_ConsoleExtensionSibling(key);
+    return fallback ? fallback : resolved;
 }
 
 static void UI_ClearScreen(void);

--- a/games/warcraft-3/tests/test_menu_fdf.c
+++ b/games/warcraft-3/tests/test_menu_fdf.c
@@ -2472,7 +2472,7 @@ TEST(menu_fdf, unused_template_texture_stays_unloaded) {
 }
 
 static int test_theme_read(LPCSTR name, void **buf) {
-    LPCSTR text = "[Default]\nBackground=Default.blp\n[Human]\nBackground=Human.blp\n";
+    LPCSTR text = "[Default]\nBackground=Default.blp\n[Human]\nBackground=Human.blp\nConsoleTexture05=Custom05.blp\n";
     (void)name; *buf = strdup(text); return (int)strlen(text);
 }
 
@@ -2617,6 +2617,8 @@ TEST(menu_fdf, exported_image_resolver_uses_local_player_skin) {
     menu_player = &player;
     UI_LoadTheme("UI\\war3skins.txt");
     T_STREQ(M_ResolveImagePath("Background"), "Human.blp");
+    T_STREQ(M_ResolveImagePath("ConsoleTexture05"), "Custom05.blp");
+    T_STREQ(M_ResolveImagePath("ConsoleTexture06"), "Custom06.blp");
     T_STREQ(M_ResolveImagePath("UI\\Textures\\fixed.blp"), "UI\\Textures\\fixed.blp");
     menu_player = NULL;
     UI_ClearTheme(); menuimport = saved;

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -30,6 +30,7 @@
 #include "../client/client.h"
 
 void test_client_stubs_init(void);
+void test_client_stubs_set_window_size(DWORD width, DWORD height);
 void test_client_stubs_set_cvar(LPCSTR name, LPCSTR value);
 void test_client_stubs_set_world_bounds(BOX2 bounds);
 void test_client_stubs_set_existing_file(LPCSTR path);
@@ -1016,6 +1017,25 @@ TEST(net, ui_frame_delta_preserves_text_length) {
     T_EQ(out.textLength, 19);
 }
 
+TEST(net, ui_frame_delta_preserves_widescreen_extension_flag) {
+    BYTE buf[128];
+    sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
+    uiFrame_t from = {0}, to = { .number = 8 }, out = {0};
+    DWORD bits = 0;
+    int number;
+
+    to.flags.type = FT_BACKDROP;
+    to.flagsvalue |= UIFLAG_EXTEND_WIDESCREEN_X;
+    MSG_WriteDeltaUIFrame(&sb, &from, &to, true);
+    sb.readcount = 0;
+    number = MSG_ReadEntityBits(&sb, &bits);
+    MSG_ReadDeltaUIFrame(&sb, &out, number, bits);
+
+    T_EQ(number, 8);
+    T_EQ(out.flags.type, FT_BACKDROP);
+    T_ASSERT(out.flagsvalue & UIFLAG_EXTEND_WIDESCREEN_X);
+}
+
 TEST(net, ui_frame_delta_preserves_timed_status_binding) {
     BYTE buf[128];
     sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
@@ -1040,6 +1060,43 @@ static VECTOR2 text_length_mock_size(LPCDRAWTEXT text) {
         return MAKE(VECTOR2, 0.006f, 0.012f);
     }
     return MAKE(VECTOR2, 0.018f, 0.012f);
+}
+
+TEST(net, layout_widescreen_extension_flag_reaches_full_canvas) {
+    BYTE buf[256];
+    sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
+    uiFrame_t empty = {0}, frame = {0};
+    LPCRECT rect;
+
+    frame.number = 1;
+    frame.flags.type = FT_BACKDROP;
+    frame.flagsvalue |= UIFLAG_EXTEND_WIDESCREEN_X;
+    frame.size.width = UI_BASE_WIDTH;
+    frame.size.height = 0.140f;
+    frame.points.x[FPP_MAX].used = 1;
+    frame.points.x[FPP_MAX].targetPos = FPP_MAX;
+    frame.points.x[FPP_MAX].relativeTo = 0;
+    frame.points.y[FPP_MAX].used = 1;
+    frame.points.y[FPP_MAX].targetPos = FPP_MAX;
+    frame.points.y[FPP_MAX].relativeTo = 0;
+
+    test_client_stubs_init();
+    test_client_stubs_set_window_size(1280, 720);
+    MSG_WriteByte(&sb, LAYER_CINEMATIC);
+    MSG_WriteDeltaUIFrame(&sb, &empty, &frame, true);
+    MSG_WriteByte(&sb, 0);
+    MSG_WriteLong(&sb, 0);
+    MSG_WriteShort(&sb, 0);
+    sb.readcount = 0;
+
+    CL_ParseLayout(&sb);
+    SCR_Clear(cl.layout[LAYER_CINEMATIC]);
+    rect = SCR_LayoutRect(SCR_Frame(1));
+    T_NOT_NULL(rect);
+    T_FEQ(rect->x, 0.0f, 0.0001f);
+    T_FEQ(rect->w, UI_BASE_HEIGHT * (1280.0f / 720.0f), 0.0001f);
+    T_FEQ(rect->y, UI_BASE_HEIGHT - 0.140f, 0.0001f);
+    T_FEQ(rect->h, 0.140f, 0.0001f);
 }
 
 TEST(net, layout_text_length_uses_space_advance_for_implicit_width) {


### PR DESCRIPTION
Fix two independent widescreen presentation failures in the Warcraft III interface.

Resolve missing ConsoleTexture05/06 skin entries from the successfully resolved sibling extension tile. Some classic skin tables expose only one of the widescreen console texture fields even though both corresponding assets are present. Previously an unresolved ConsoleTexture06 reached the renderer literally, producing the missing-texture placeholder on the right side of the gameplay HUD.

Add a generic UIFLAG_EXTEND_WIDESCREEN_X retained-layout flag and use it for the cinematic top and bottom borders. The normal Warcraft HUD, cinematic portrait, speaker text and dialogue continue to use the centered 0.8x0.6 authored safe area, while the cinematic letterbox chrome now expands horizontally to the complete widescreen UI canvas.

Preserve the new frame behavior flag over UI delta serialization and add coverage for both widescreen layout expansion and paired console texture resolution.

Document the runtime findings and the distinction between 4:3 gameplay content and full-width cinematic presentation chrome.