### PR TITLE
wc3: add live loading progress and isolate loading UI state

### DIFF
--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -17,6 +17,7 @@
 #include "ui_layout.h"
 #include "sound/s_local.h"
 #include "common/net_platform.h"
+#include "common/server_api.h"
 #ifdef BZ_TESTS
 #include "shared/test.h"
 #endif
@@ -450,6 +451,18 @@ static void CL_UICvarSet(LPCSTR name, LPCSTR value) {
     Cvar_Set(name, value);
 }
 
+FLOAT CL_GetLoadingProgress(void) {
+    return cl.loading_progress;
+}
+
+void CL_SetLoadingProgress(FLOAT progress) {
+    if (progress < 0.0f) progress = 0.0f;
+    if (progress > 1.0f) progress = 1.0f;
+    if (progress <= cl.loading_progress) return;
+    cl.loading_progress = progress;
+    SCR_UpdateLoadingPlaque();
+}
+
 void CL_BeginLoadingMap(LPCSTR mapName) {
     /* Per-map input conveniences must never retain entity numbers into the
      * next world, where those numbers may refer to unrelated entities. */
@@ -460,6 +473,7 @@ void CL_BeginLoadingMap(LPCSTR mapName) {
     /* Same-map load keeps CS_WORLD unchanged; forget the previous world's begin
      * so PrepRefresh sends it again and CL_ParseFrame can end the plaque. */
     CL_RestartRefresh();
+    cl.loading_progress = 0.0f;
     cl.playerstate.client_ui_state = CLIENT_UI_LOADING;
     cls.state = ca_connected;
     CL_MenuCommand("menu_ingame");
@@ -609,6 +623,7 @@ static void CL_ProcessPendingMenuAction(void) {
         CL_SetGameplayBindings();
         CL_BeginLoadingMap(pending.arg);
         SV_Map(pending.arg);
+        if (SV_IsActive()) CL_SetLoadingProgress(0.05f);
         break;
     case CL_MENU_ACTION_MENU:
         /* Returning from a world is a session boundary, not an in-place menu
@@ -628,6 +643,23 @@ static void CL_ProcessPendingMenuAction(void) {
 }
 
 #ifdef BZ_TESTS
+TEST(client_loading, progress_is_clamped_and_monotonic) {
+    FLOAT saved = cl.loading_progress;
+    DWORD saved_disable_screen = cls.disable_screen;
+
+    cls.disable_screen = 0;
+    cl.loading_progress = 0.0f;
+    CL_SetLoadingProgress(0.25f);
+    T_FEQ(cl.loading_progress, 0.25f, 0.0001f);
+    CL_SetLoadingProgress(0.10f);
+    T_FEQ(cl.loading_progress, 0.25f, 0.0001f);
+    CL_SetLoadingProgress(2.0f);
+    T_FEQ(cl.loading_progress, 1.0f, 0.0001f);
+
+    cl.loading_progress = saved;
+    cls.disable_screen = saved_disable_screen;
+}
+
 TEST(client_session, menu_action_map_is_deferred_until_client_frame) {
     memset(&cl_pending_menu_action, 0, sizeof(cl_pending_menu_action));
 
@@ -744,6 +776,7 @@ void CL_Init(void) {
         .Cvar_String = Cvar_String,
         .Cvar_Set = CL_UICvarSet,
         .GetConfigString = CL_GetConfigString,
+        .LoadingProgress = CL_GetLoadingProgress,
         .LAN_RefreshServers = CL_LANRefreshServers,
         .LAN_NumServers = CL_LANNumServers,
         .LAN_Server = CL_LANServer,

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -112,6 +112,13 @@ static void SCR_DrawCursor(void) {
     int const x = (int)mouse.origin.x, y = (int)mouse.origin.y;
     BOOL drawn = false;
 
+    /* Loading plaques are non-interactive. Hide both the authored cursor and
+     * the native SDL cursor until normal menu/game presentation resumes. */
+    if (cl.playerstate.client_ui_state == CLIENT_UI_LOADING) {
+        SCR_UpdateSystemCursor(true);
+        return;
+    }
+
     if (Cvar_Integer("r_cursor", 0) == 1) {
         VECTOR2 const pos = SCR_ScreenToUI(x, y);
         drawn = re.DrawCursor(pos.x, pos.y, SCR_CursorTint());
@@ -177,6 +184,14 @@ void SCR_DrawScreenField(DWORD msec) {
     }
 #endif
     re.EndFrame();
+}
+
+void SCR_UpdateLoadingPlaque(void) {
+    if (!scr_initialized) return;
+    if (!cls.disable_screen) return;
+    if (Cvar_Integer("r_norefresh", 0)) return;
+    if (cl.playerstate.client_ui_state != CLIENT_UI_LOADING) return;
+    SCR_DrawScreenField(0);
 }
 
 void SCR_UpdateScreen(DWORD msec) {

--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -67,6 +67,13 @@ void CL_RestartRefresh(void) {
     cl.refresh_prepped = false;
 }
 
+static void CL_LoadingStage(FLOAT progress) {
+    /* CL_PrepRefresh may still be entered after the first active frame.
+     * Progress is loading-screen presentation state, so ignore later passes. */
+    if (cl.playerstate.client_ui_state != CLIENT_UI_LOADING) return;
+    CL_SetLoadingProgress(progress);
+}
+
 static void CL_SendBegin(void) {
     fprintf(stderr,
             "CL_SendBegin: sending begin world=\"%s\" state=%d player=%u team=%u race=%u color=%u\n",
@@ -360,6 +367,8 @@ void CL_PrepRefresh(void) {
         return;
     }
 
+    CL_LoadingStage(0.10f);
+
     if (!world_loaded) {
         if (!CM_IsMapLoaded(cl.configstrings[CS_WORLD])) {
             CM_LoadMap(cl.configstrings[CS_WORLD]);
@@ -367,6 +376,7 @@ void CL_PrepRefresh(void) {
         re.RegisterMap(cl.configstrings[CS_WORLD]);
         world_loaded = true;
     }
+    CL_LoadingStage(0.40f);
 
     BOOL register_sounds = !cl.refresh_prepped;
     if (register_sounds) S_BeginRegistration();
@@ -397,32 +407,38 @@ void CL_PrepRefresh(void) {
             continue;
         CL_RegisterConfigString(CS_MODELS + i);
     }
+    CL_LoadingStage(0.60f);
 
     for (DWORD i = 1; i < MAX_IMAGES; i++) {
         if (!*cl.configstrings[CS_IMAGES + i])
             continue;
         CL_RegisterConfigString(CS_IMAGES + i);
     }
+    CL_LoadingStage(0.75f);
 
     if (register_sounds)
         for (DWORD i = 1; i < MAX_SOUNDS; i++)
             if (*cl.configstrings[CS_SOUNDS + i]) S_RegisterSound(cl.configstrings[CS_SOUNDS + i]);
+    CL_LoadingStage(0.87f);
 
     for (DWORD i = 1; i < MAX_FONTSTYLES; i++) {
         if (!*cl.configstrings[CS_FONTS + i])
             continue;
         CL_RegisterConfigString(CS_FONTS + i);
     }
+    CL_LoadingStage(0.94f);
 
     if (world_loaded && !begin_sent) {
         CL_SendBegin();
         begin_sent = true;
     }
+    CL_LoadingStage(0.98f);
 
     if (world_loaded && !cl.refresh_prepped) {
         S_EndRegistration();
         cl.refresh_prepped = true;
     }
+    if (cl.refresh_prepped) CL_LoadingStage(1.0f);
 }
 
 void V_RenderView(void) {

--- a/client/client.h
+++ b/client/client.h
@@ -66,6 +66,7 @@ struct frame {
 
 struct client_state {
     BOOL refresh_prepped;
+    FLOAT loading_progress;   /* client-owned normalized loading progress [0,1] */
     LPMODEL models[MAX_MODELS];
     LPMODEL portraits[MAX_MODELS];
     LPMODEL minimap_model;
@@ -136,6 +137,8 @@ void CL_SetMenuBindings(void);
 void CL_SetGameplayInput(void);
 void CL_SetGameplayBindings(void);
 void CL_BeginLoadingMap(LPCSTR mapName);
+FLOAT CL_GetLoadingProgress(void);
+void CL_SetLoadingProgress(FLOAT progress);
 void CL_RequestUnitUI(DWORD num_selected, DWORD *entity_nums);
 VECTOR2 CL_ClampCameraPosition(VECTOR2 position);
 
@@ -219,6 +222,7 @@ drawText_t SCR_GetDrawText(LPCUIFRAME frame,
                          uiLabel_t const *label);
 void SCR_UpdateScreen(DWORD msec);
 void SCR_BeginLoadingPlaque(void);
+void SCR_UpdateLoadingPlaque(void);
 void SCR_EndLoadingPlaque(void);
 void SCR_ClearLayoutResources(void);
 

--- a/client/menu.h
+++ b/client/menu.h
@@ -132,6 +132,7 @@ typedef struct {
     LPCSTR (*Cvar_String)(LPCSTR name, LPCSTR fallback);
     void (*Cvar_Set)(LPCSTR name, LPCSTR value);
     LPCSTR (*GetConfigString)(DWORD index);
+    FLOAT (*LoadingProgress)(void); /* normalized client-owned loading progress [0,1] */
     void (*LAN_RefreshServers)(void);
     DWORD (*LAN_NumServers)(void);
     BOOL (*LAN_Server)(DWORD index, menuLanGame_t *out);

--- a/common/main.c
+++ b/common/main.c
@@ -413,6 +413,7 @@ int main(int argc, LPSTR argv[]) {
         if (load_map_from_save) {
             CL_BeginLoadingMap(map);
             SV_Map(map);
+            if (SV_IsActive()) CL_SetLoadingProgress(0.05f);
         }
         Cbuf_AddLateCommands();
         Cbuf_Execute();
@@ -430,6 +431,7 @@ int main(int argc, LPSTR argv[]) {
                 CL_BeginLoadingMap(map);
                 SCR_UpdateScreen(0);
                 SV_Map(map);
+                if (SV_IsActive()) CL_SetLoadingProgress(0.05f);
             }
         }
         // Menu mode: UI runs client-side, no server connection needed (Quake 3 pattern)

--- a/docs/architecture/ui-system.md
+++ b/docs/architecture/ui-system.md
@@ -230,7 +230,7 @@ typedef enum {
 } CLIENTUISTATE;
 ```
 
-Set by the server. The client reads it to decide what to draw — game HUD, loading progress, or cinematic overlay.
+Ownership is phase-dependent: normal gameplay/cinematic values arrive from authoritative player state, while `CL_BeginLoadingMap()` locally forces `CLIENT_UI_LOADING` during a session transition and the first usable frame restores `CLIENT_UI_GAME`. The client reads the value to decide what to draw — game HUD, loading presentation, or cinematic overlay.
 
 ### Frame Rendering
 
@@ -277,9 +277,12 @@ The loading screen is owned by the UI library and drawn when `playerState_t.clie
 1. Loads `Loading.fdf` frames
 2. Reads map info from `.w3m`/`.w3x` (title, subtitle, custom loading screen model)
 3. Binds frames: `LoadingBackground` (3D portrait), `LoadingBar` (progress), `LoadingTitleText`, `LoadingSubtitleText`, `LoadingText`
-4. Updates progress from `cl.connectionProgress` each frame
+4. Reads normalized client-owned progress through `menuImport_t.LoadingProgress` and drives the WC3 progress MDX as `#0@ratio`
 
-The loading screen stays visible until the server sets `client_ui_state = CLIENT_UI_GAME` and the client reaches `ca_active`.
+`CL_PrepRefresh()` advances that value at real registration phase boundaries. The Quake-style plaque remains frozen for ordinary
+frame submission, but `SCR_UpdateLoadingPlaque()` explicitly repaints after a progress change. The value is local client state, not
+a player-state/network field. The loading screen stays visible until the first usable server frame sets
+`client_ui_state = CLIENT_UI_GAME`, promotes the client to `ca_active`, and ends the plaque.
 
 ## WC3 vs SC2 vs WoW UI
 

--- a/docs/games/warcraft-3/architecture/ui-flow.md
+++ b/docs/games/warcraft-3/architecture/ui-flow.md
@@ -44,13 +44,13 @@ Important cvars:
 
 Loading follows the Quake-style client state split:
 
-1. `CL_BeginLoadingMap()` sets `cls.state = ca_loading` and seeds the loading text/progress.
-2. `SCR_DrawScreenField()` draws the loading plaque only while `cls.state == ca_loading`.
-3. `CL_PrepRefresh()` loads configstring-backed assets and registers the map.
-4. Only after all required assets are ready does `CL_PrepRefresh()` send `begin` and promote the client to `ca_active`.
-5. Snapshot parsing may update `playerstate`, but it must not flip `cls.state` by itself.
+1. `CL_BeginLoadingMap()` resets `cl.loading_progress`, sets `playerState_t.client_ui_state = CLIENT_UI_LOADING`, keeps the connection in `ca_connected`, and raises the frozen loading plaque.
+2. The WC3 menu draws the loading screen before standalone-screen dispatch and reads progress through `menuImport_t.LoadingProgress`.
+3. A successful local `SV_Map()` completion advances the local plaque to its first milestone; remote clients skip that listen-server-only milestone. `CL_PrepRefresh()` then loads/registers the world, models, images, sounds, and fonts and advances progress at those real phase boundaries; `SCR_UpdateLoadingPlaque()` explicitly repaints the frozen plaque after each increase.
+4. Once registration is complete, `CL_PrepRefresh()` queues `begin`, closes sound registration, sets `cl.refresh_prepped`, and advances the bar to 1.0.
+5. The first usable server frame then promotes `cls.state` to `ca_active`, changes `client_ui_state` to `CLIENT_UI_GAME`, and calls `SCR_EndLoadingPlaque()`.
 
-That separation matters because `ca_active` means "gameplay can render now", not "we already received a player snapshot." If the loading plaque disappears before the world is ready, the client should keep `ca_loading` until the precache gate completes.
+That separation matters because `ca_active` means "gameplay can render now", not merely "we received some server state." Progress is client-local presentation state and must not be added to `playerState_t` or the snapshot protocol.
 
 ## Main Menu Glue Edition Selection
 
@@ -267,11 +267,12 @@ The following Warsmash/retail-style lifecycle work is intentionally not approxim
 - profile creation/deletion/persistence is not implemented;
 - map `config()` is not yet run as a distinct pre-lobby configuration phase; doing so correctly requires separating
   authored map configuration from later lobby overrides;
-- map/server loading remains synchronous, and the WC3 loading progress sprite does not yet represent incremental
-  loader work.
+- map/server loading remains synchronous. The WC3 loading bar now represents coarse client registration phases, but
+  `SV_Map()` / game-module map loading still has no owned incremental progress source and may hold the bar near its
+  initial position during a long load.
 
 Do not paper over these with fixed timers, hard-coded campaign assets, a second custom-game implementation, or fake
-loading percentages. They require the corresponding lifecycle/data ownership to exist first.
+sub-percentages inside synchronous server work. They require the corresponding lifecycle/data ownership to exist first.
 
 ## Draw Flow
 

--- a/docs/games/warcraft-3/hud-media.md
+++ b/docs/games/warcraft-3/hud-media.md
@@ -23,7 +23,7 @@ G_LoadMap
 
 Do not parse ConsoleUI.fdf on every resource-bar write. Isolated scene files stay; they share one accumulator.
 
-Glue UI (`games/warcraft-3/menu/`) is a separate `stb_fdf` instance with its own `ui_textures[]`. It is not this contract.
+Glue UI (`games/warcraft-3/menu/`) is a separate `stb_fdf` instance with its own `frames[]` and `ui_textures[]`. It is not this contract.  Keep the `frames[]` definition hidden per shared library: on ELF/Linux an exported duplicate symbol can be interposed between `libgame` and `libmenu`, causing this server-side `UI_ClearTemplates()` to erase the client's glue/loading frame registry during `SV_Map`.
 
 ## Client
 

--- a/docs/games/warcraft-3/loading-and-assets.md
+++ b/docs/games/warcraft-3/loading-and-assets.md
@@ -8,6 +8,7 @@ For measured menu/loading resource residency and reclamation priorities, see [WC
 `SCR_BeginLoadingPlaque` freezes a frame. This covers console launches, menu selections, game menu actions,
 and incoming `CS_WORLD`. The client owns loading state; only `CL_PrepRefresh` promotes it to `ca_active`.
 The WC3 UI reads the current destination and caches metadata per path, not per UI lifetime.
+Loading plaques are non-interactive: `SCR_DrawCursor` suppresses both the game-authored cursor and the native SDL cursor while `CLIENT_UI_LOADING` is active, then the existing cursor-state handoff restores the configured cursor automatically when loading ends.
 
 `UI_UpdateLoadingMapInfo` reads the nested map MPQ's `war3map.w3i` and `war3map.wts` through
 `UI_ReadMapInfo`. Custom loading models take precedence; otherwise the campaign background number indexes
@@ -28,6 +29,12 @@ under TFT archives. Fixed ROC indices interpreted HumanX01's sequence `6` as a f
 consumes the optional numeric category and validates the sequence/model fields; malformed rows log their key.
 
 Preserve the loading-state draw check before standalone-screen dispatch: `menu_ingame` is queued asynchronously, so loading must remain authoritative even after the glue screen is released.
+
+### FDF registry isolation
+
+`libmenu` and `libgame` intentionally have separate `stb_fdf` frame registries.  The parser implementation functions are hidden per shared library, and the `frames[]` backing store must be hidden as well.  On ELF/Linux, exporting `frames` allows normal symbol interposition to alias the two registries even though each library defines its own copy.  `G_LoadMap -> UI_ResetHud -> UI_ClearTemplates` then clears/reuses the menu's live `Loading`/`LoadingBar` slots during `SV_Map`; cached non-NULL loading-frame pointers survive but no longer describe the loading sprites, so later progress updates reach `M_DrawLoadingScreen` without reaching the MDX renderer.
+
+A characteristic failure is that the initial loading sprite renders before `SV_Map`, while later progress values change without reaching the MDX sprite renderer. Verify registry isolation before changing progress math or swap/present code.
 
 ## Level-transition asset ownership
 
@@ -69,6 +76,33 @@ implement JASS `Preload`/`Preloader`, or expose staged byte/task loading progres
 registered `UnitProfile`/`UnitUI` subset (including Required Animation Names and custom model paths), but the remaining
 Balance/Data/Weapons/Abilities tables and true per-map `war3mapMisc.txt`/skin overlays remain separate data-layer work;
 do not infer those capabilities from the renderer's map-import lookup.
+## Loading progress contract
+
+Loading progress is client-owned and intentionally coarse. `CL_BeginLoadingMap` resets `cl.loading_progress` to
+zero. `CL_PrepRefresh` advances it monotonically at existing registration boundaries and
+`SCR_UpdateLoadingPlaque` explicitly repaints the otherwise frozen Quake-style loading plaque after each advance.
+The menu module reads the normalized value through `menuImport_t.LoadingProgress`; WC3 maps it directly onto the
+`LoadingProgressBar` MDX sequence using `#0@ratio`. No player-state/network field is involved.
+
+Current phase values are:
+
+| Progress | Completed boundary |
+| ---: | --- |
+| 0.05 | local listen-server `SV_Map()` returned successfully (local games only) |
+| 0.10 | `CS_WORLD` is available and client refresh preparation has started |
+| 0.40 | collision/world map and renderer map registration are ready |
+| 0.60 | model configstrings are registered |
+| 0.75 | image configstrings are registered |
+| 0.87 | sound configstrings are registered |
+| 0.94 | font configstrings are registered |
+| 0.98 | client `begin` has been queued |
+| 1.00 | sound registration is closed and `cl.refresh_prepped` is true |
+
+These are **phase milestones, not byte percentages or time estimates**. In particular, local `SV_Map()` /
+`ge->LoadMap()` remains synchronous and publishes only its completed boundary, not progress from inside its
+server/game loading work, so the bar can remain at its initial position during a long map load. Do not manufacture sub-percentages for that work;
+add progress only when an owned lifecycle can report a real boundary. The plaque stays visible at 100% until the
+first usable server frame promotes the client to `ca_active` and `SCR_EndLoadingPlaque` runs.
 
 ## Asset names are data
 

--- a/games/warcraft-3/common/stb_fdf.h
+++ b/games/warcraft-3/common/stb_fdf.h
@@ -342,7 +342,16 @@ struct uiFrameDef_s {
 #ifndef STB_FDF_GLOBALS
 extern FRAMEDEF frames[MAX_UI_CLASSES];
 #else
+/*
+ * libgame and libmenu each instantiate stb_fdf.  Keep the backing frame
+ * registry module-local just like the implementation functions below.
+ * Without hidden visibility, ELF symbol interposition can make both shared
+ * libraries resolve `frames` to the same BSS object; then UI_ResetHud() in
+ * libgame clears the live glue/loading frames owned by libmenu during SV_Map.
+ */
+#pragma GCC visibility push(hidden)
 FRAMEDEF frames[MAX_UI_CLASSES] = { 0 };
+#pragma GCC visibility pop
 #endif
 
 /* -------------------------------------------------------------------------- */

--- a/games/warcraft-3/menu/menu_main.c
+++ b/games/warcraft-3/menu/menu_main.c
@@ -425,7 +425,10 @@ static void M_DrawLoadingScreen(void) {
         loading_screen.LoadingBackground->Portrait.model = loading_state.background_model;
     }
     if (loading_screen.LoadingBar) {
-        snprintf(loading_screen.LoadingBar->TextStorage, sizeof(loading_screen.LoadingBar->TextStorage), "#0@%.4f", 1.0f);
+        FLOAT progress = menuimport.LoadingProgress ? menuimport.LoadingProgress() : 1.0f;
+        if (progress < 0.0f) progress = 0.0f;
+        if (progress > 1.0f) progress = 1.0f;
+        snprintf(loading_screen.LoadingBar->TextStorage, sizeof(loading_screen.LoadingBar->TextStorage), "#0@%.4f", progress);
         loading_screen.LoadingBar->Text = loading_screen.LoadingBar->TextStorage;
         loading_screen.LoadingBar->Portrait.model = loading_state.progress_model;
     }

--- a/games/warcraft-3/tests/test_menu_fdf.c
+++ b/games/warcraft-3/tests/test_menu_fdf.c
@@ -42,6 +42,7 @@ static int test_campaign_played_mission = -1;
 static VECTOR2 test_mouse_pos;
 static LPCSTR test_map = "";
 static DWORD map_reads, texture_releases;
+static FLOAT test_loading_progress = 1.0f;
 static int fake_image_index(LPCSTR name) {
     captured_model_path = name;
     return (name && *name) ? 456 : 0;
@@ -301,6 +302,9 @@ static void test_cvar_set(LPCSTR name, LPCSTR value) {
     if (name && !strcmp(name, "fs_expansion")) test_fs_expansion = value && atoi(value) != 0;
 }
 
+static FLOAT test_get_loading_progress(void) {
+    return test_loading_progress;
+}
 
 static void load_ui_files(LPCSTR const *file_names, size_t count) {
     menuImport_t saved = menuimport;
@@ -339,6 +343,7 @@ static void reset_ui_state(void) {
     captured_death_sprites = 0;
     fake_texture_id = 0;
     texture_releases = map_reads = 0;
+    test_loading_progress = 1.0f;
     menu_player = NULL; test_map = "";
     test_vid_native = -1;
     hover_texture = NULL;
@@ -2566,6 +2571,8 @@ TEST(menu_fdf, loading_screen_uses_current_destination_and_caches_per_map) {
     reset_ui_state();
     menuimport.FS_ReadFile = test_fs_read_file; menuimport.FS_FreeFile = test_fs_free_file;
     menuimport.Cvar_String = test_cvar_string; menuimport.Cmd_ExecuteText = test_cmd_execute_text;
+    menuimport.LoadingProgress = test_get_loading_progress;
+    test_loading_progress = 0.375f;
     M_Init();
     menu_player = &player;
     M_Refresh(0);
@@ -2576,6 +2583,7 @@ TEST(menu_fdf, loading_screen_uses_current_destination_and_caches_per_map) {
     if (require_not_null(title)) {
         T_STREQ(title->Text, "Human02");
         T_ASSERT(UI_FindFrame("LoadingBackground")->Portrait.model != 0);
+        T_STREQ(UI_FindFrame("LoadingBar")->Text, "#0@0.3750");
         T_EQ(map_reads, 1);
         M_Refresh(2); T_EQ(map_reads, 1);
         test_map = "Maps\\Campaign\\Orc01.w3m";


### PR DESCRIPTION
Implement staged Warcraft III loading-screen progress using the existing MDX LoadingProgressBar animation instead of leaving the bar permanently full.

Track client-local loading progress through the major map/refresh phases and feed that normalized value into the WC3 loading UI as a `#0@ratio` animation selector. Progress is clamped and monotonic so individual loading stages cannot move the bar backwards.

Allow the loading plaque to repaint explicitly as progress advances while preserving the normal Quake-style disabled-screen behavior for unrelated screen updates. This lets the WC3 loading background and progress bar remain visible and update during synchronous client registration work without changing the existing first-server-frame readiness gate.

Report progress at the existing high-confidence lifecycle boundaries:

- initial loading screen
- local server/map creation complete
- client refresh preparation started
- world registered
- models registered
- images registered
- sounds registered
- fonts registered
- begin command queued
- refresh fully prepared

Keep the current synchronous `SV_Map()` / game `LoadMap()` architecture intact rather than introducing speculative incremental server-side loading tasks. The bar therefore represents known client loading stages rather than fake byte-based progress.

Fix the WC3 loading UI becoming invalid after `SV_Map()` by isolating the stb_fdf backing frame registry per shared library. The `frames[]` definition was externally visible even though the surrounding FDF implementation used hidden visibility, allowing ELF symbol interposition between libmenu and libgame. As a result, the game HUD's `UI_ClearTemplates()` could clear or reuse the menu module's loading-screen frames during map startup.

Give the FDF frame registry hidden visibility so libmenu and libgame retain independent frame tables. This preserves the loading screen across `UI_ResetHud()` and allows subsequent progress-bar animation updates to reach the renderer correctly.

Hide both the authored Warcraft cursor and the native SDL cursor while the client is in `CLIENT_UI_LOADING`. Loading plaques are non-interactive, and the normal configured cursor mode is restored automatically once the client returns to menu or gameplay UI state.

Also:

- expose loading progress through the menu import interface;
- keep the final transition to gameplay gated by `cl.refresh_prepped` and the first usable server frame;
- add regression coverage for loading-progress clamping/monotonic behavior and WC3 progress-bar ratio generation;
- update WC3 loading documentation to describe the staged progress model, loading-plaque repaint behavior, FDF module isolation, and hidden loading cursor;
- correct stale documentation that referred to the nonexistent `cl.connectionProgress` / `ca_loading` path.