### PR TITLE
wc3: cap client frame rate at 64 FPS by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ Common runtime cvars:
 | `connect` | `""` | Remote server address |
 | `menu_module` | `"ui"` | UI module name for the Quake-style module boundary |
 | `g_module` | `"game"` | Game module name for the server game boundary |
-| `com_frame_limit` | `"0"` | Exit after N frames |
+| `com_frame_limit` | `"0"` | Exit after N main-loop iterations (diagnostic; not an FPS cap) |
+| `com_maxfps` | `"64"` in OpenWarcraft3, `"0"` otherwise | Maximum client FPS; `0` is unlimited |
 | `vid_modes` | `"0"` | Log SDL display modes at renderer startup; enabled by `-vid_modes`, not archived |
 | `r_cursor` | `"0"` | Native SDL platform cursor; set to `1` for Warcraft III's authored animated cursor |
 

--- a/common/cvar.c
+++ b/common/cvar.c
@@ -484,7 +484,12 @@ void Cvar_Init(void) {
     Cvar_GetD("sv_hostname",      "OpenWarcraft3",     CVAR_ARCHIVE, "server name shown in lobby browser");
     Cvar_GetD("sv_cheats",        "0",                 0,            "enable cheat commands on this server");
     Cvar_GetD("dedicated",        "0",                 0,            "dedicated server mode (no client)");
-    Cvar_GetD("com_frame_limit",  "0",                 0,            "cap frame rate in fps; 0=unlimited");
+    Cvar_GetD("com_frame_limit",  "0",                 0,            "exit after N main-loop iterations; 0=disabled");
+#ifdef WC3
+    Cvar_GetD("com_maxfps",       "64",                CVAR_ARCHIVE, "maximum client frame rate; 0=unlimited");
+#else
+    Cvar_GetD("com_maxfps",       "0",                 CVAR_ARCHIVE, "maximum client frame rate; 0=unlimited");
+#endif
     Cvar_GetD("com_fast_forward", "0",                 0,            "run one fixed server tick per main-loop frame");
     Cvar_GetD("scr_showfps",      "1",                 CVAR_ARCHIVE, "show FPS counter on screen");
     Cvar_GetD("skip_cutscene",    "0",                 0,            "skip intro cutscene on startup");

--- a/common/main.c
+++ b/common/main.c
@@ -67,6 +67,38 @@
 
 extern LPTEXTURE Texture;
 
+static void Com_LimitFrameRate(Uint64 frame_start, Uint64 frequency, BOOL dedicated) {
+    int maxfps;
+    Uint64 target_ticks;
+
+    if (dedicated || !frequency) return;
+
+    maxfps = Cvar_Integer("com_maxfps", 0);
+    if (maxfps <= 0) return;
+
+    target_ticks = frequency / (Uint64)maxfps;
+    if (!target_ticks) return;
+
+    for (;;) {
+        Uint64 now = SDL_GetPerformanceCounter();
+        Uint64 elapsed = now - frame_start;
+        Uint64 remaining;
+        Uint32 delay_ms;
+
+        if (elapsed >= target_ticks) return;
+
+        remaining = target_ticks - elapsed;
+        delay_ms = (Uint32)((remaining * 1000ULL) / frequency);
+
+        /* Leave the final millisecond to scheduler yields so coarse sleeps do
+         * not systematically push every frame far beyond the requested cap. */
+        if (delay_ms > 1)
+            SDL_Delay(delay_ms - 1);
+        else
+            SDL_Delay(0);
+    }
+}
+
 #ifdef _WIN32
 static BOOL Sys_FileExists(LPCSTR filename) {
     FILE *file = fopen(filename, "rb");
@@ -439,7 +471,9 @@ int main(int argc, LPSTR argv[]) {
 
     DWORD startTime = SDL_GetTicks();
     DWORD frameCount = 0;
+    Uint64 performanceFrequency = SDL_GetPerformanceFrequency();
     while (true) {
+        Uint64 frameStart = SDL_GetPerformanceCounter();
         DWORD currentTime = SDL_GetTicks();
         DWORD msec = currentTime - startTime;
         if (SV_IsActive()) {
@@ -462,6 +496,7 @@ int main(int argc, LPSTR argv[]) {
             frameCount >= (DWORD)Cvar_Integer("com_frame_limit", 0)) {
             Com_Quit();
         }
+        Com_LimitFrameRate(frameStart, performanceFrequency, dedicated);
     }
 
     return 0;

--- a/docs/games/warcraft-3/performance.md
+++ b/docs/games/warcraft-3/performance.md
@@ -4,6 +4,25 @@ For process footprint, allocation profiling, and RAM reduction priorities, see [
 
 Profile-driven optimizations across the renderer, client, and server. The five sampled hot spots and the fixes applied to each are listed below so a future reader understands *why* each path is shaped the way it is.
 
+## Client frame-rate limiter
+
+OpenWarcraft3 registers the archived `com_maxfps` cvar with a default of `64`, matching the intended classic-Warcraft presentation target. `0` disables the limiter. The same engine main loop is shared with the other game binaries, but their built-in default remains `0` unless their own configuration overrides it.
+
+The limiter lives in `common/main.c` and applies only to non-dedicated clients. It measures the complete main-loop iteration with SDL's performance counter, including simulation, client work, rendering, and any VSync blocking, then sleeps/yields only for the remaining part of the target frame interval. It therefore does **not** change `FRAMETIME`, server tick accounting, animation/game timers, or `com_fast_forward`; if a frame already takes longer than the cap interval, no extra delay is added. `r_vsync` can still impose a lower effective frame rate than `com_maxfps`.
+
+Keep `com_maxfps` separate from `com_frame_limit`: the latter is a diagnostic auto-quit counter for main-loop iterations. Useful commands are:
+
+```bash
+# Default Warcraft III cap: 64 FPS
+build/bin/openwarcraft3 -data 'data/Warcraft III' +map 'Maps/Campaign/Human02.w3m'
+
+# Uncapped rendering/performance measurement
+build/bin/openwarcraft3 -data 'data/Warcraft III' +set com_maxfps 0 +set r_vsync 0 +map 'Maps/Campaign/Human02.w3m'
+
+# Explicit alternate cap
+build/bin/openwarcraft3 -data 'data/Warcraft III' +set com_maxfps 120 +map 'Maps/Campaign/Human02.w3m'
+```
+
 ## MDX bone setup (was ~16%)
 
 `MDLX_BindBoneMatrices` (`games/warcraft-3/renderer/mdx/r_mdx_anim.c`) is called once per rendered model per frame. The old path:


### PR DESCRIPTION
Add a configurable client-side frame-rate limiter to the shared engine main loop while preserving Warcraft III's classic 64 FPS presentation target as the OpenWarcraft3 default.

Introduce the archived com_maxfps cvar:

- default to 64 for OpenWarcraft3
- leave other game binaries unlimited by default
- treat 0 as unlimited
- allow arbitrary positive limits such as 120 or 144
- persist user overrides through the normal archived-cvar path

Implement frame pacing with SDL's high-resolution performance counter. The limiter measures the complete main-loop iteration, including simulation, client processing, rendering, and any VSync wait, and only delays for the unused portion of the requested frame interval.

Keep dedicated servers unthrottled and leave simulation timing independent from presentation rate. The limiter does not modify FRAMETIME, server tick accumulation, animation timers, or com_fast_forward behavior.

Keep com_frame_limit separate from frame-rate limiting. That cvar is an existing diagnostic mechanism which terminates the process after a specified number of main-loop iterations. Correct its misleading description accordingly.

Document com_maxfps, the Warcraft III 64 FPS default, unlimited mode, VSync interaction, and the distinction between frame-rate limiting and bounded diagnostic runs.