### PR TITLE
weather: replace svc_weather with per-frame game datagram

### DIFF
--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -12,7 +12,6 @@
 #include <stdlib.h>
 
 #include "client.h"
-#include "common/weather.h"
 #include "sound/s_local.h"
 #include "ui_layout.h"
 
@@ -231,9 +230,8 @@ static void CL_ParseBaseline(LPSIZEBUF msg) {
     }
 }
 
-/* Handle the svc_frame header: record the server frame number and time, then
- * snapshot the current entity states into their "prev" fields so the renderer
- * can interpolate between the previous and current positions. */
+/* Handle the svc_frame header and its game-owned datagram, then snapshot entity
+ * states into "prev" so the renderer can interpolate the current scene. */
 void CL_ParseFrame(LPSIZEBUF msg) {
     cl.frame.serverframe = MSG_ReadLong(msg);
     cl.frame.servertime = MSG_ReadLong(msg);
@@ -251,6 +249,16 @@ void CL_ParseFrame(LPSIZEBUF msg) {
         centity_t *ce = &cl.ents[cl.active_entities[i]];
         ce->prev = ce->current;
     }
+    DWORD count = MSG_ReadShort(msg);
+    if (count > MAX_WEATHER_EFFECTS || msg->readcount + count * sizeof(wc3WeatherEffect_t) > msg->cursize) {
+        fprintf(stderr, "CL_ParseFrame: invalid weather snapshot count=%u\n", (unsigned)count);
+        msg->readcount = msg->cursize;
+        return;
+    }
+    cl.viewDef.weather_effects = cl.weather_effects;
+    cl.viewDef.num_weather_effects = count;
+    cl.num_weather_effects = count;
+    FOR_LOOP(i, count) MSG_Read(msg, &cl.weather_effects[i], sizeof(wc3WeatherEffect_t));
 }
 
 void CL_ParsePlayerInfo(LPSIZEBUF msg) {
@@ -890,15 +898,6 @@ void CL_ParseServerMessage(LPSIZEBUF msg) {
                 break;
             case svc_fogofwar:
                 CL_ParseFogOfWar(msg);
-                break;
-            case svc_weather:
-                if (msg->readcount + sizeof(wc3WeatherCommand_t) > msg->cursize) {
-                    fprintf(stderr, "CL_ParseServerMessage: truncated weather payload\n");
-                    msg->readcount = msg->cursize;
-                    goto done;
-                }
-                re.WeatherCommand(msg->data + msg->readcount, sizeof(wc3WeatherCommand_t));
-                msg->readcount += sizeof(wc3WeatherCommand_t);
                 break;
             case svc_temp_entity:
                 CL_ParseTEnt(msg);

--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -444,6 +444,8 @@ void CL_PrepRefresh(void) {
 void V_RenderView(void) {
     static DWORD lastTime = 0;
     BOOL rebuild;
+    cl.viewDef.weather_effects = cl.weather_effects;
+    cl.viewDef.num_weather_effects = cl.num_weather_effects;
     cl.viewDef.fow_width = cl.fow.width;
     cl.viewDef.fow_height = cl.fow.height;
     cl.viewDef.fow_data = cl.fow.texture;

--- a/client/client.h
+++ b/client/client.h
@@ -79,6 +79,8 @@ struct client_state {
     centity_t ents[MAX_CLIENT_ENTITIES];
     HANDLE layout[MAX_LAYOUT_LAYERS];
     viewDef_t viewDef;
+    wc3WeatherEffect_t weather_effects[MAX_WEATHER_EFFECTS];
+    DWORD num_weather_effects;
     struct frame frame;
     VECTOR2 startingPosition;
     PLAYER playerstate;

--- a/client/tr_public.h
+++ b/client/tr_public.h
@@ -11,6 +11,7 @@
  */
 
 #include "../common/common.h"
+#include "../common/weather.h"
 
 KNOWN_AS(modelInfo_s, MODELINFO);
 
@@ -165,6 +166,8 @@ typedef struct {
     renderEntity_t *entities;
     DWORD num_decals;
     renderDecal_t *decals;
+    DWORD num_weather_effects;
+    wc3WeatherEffect_t const *weather_effects;
     MATRIX4 viewProjectionMatrix;
     MATRIX4 lightMatrix;
     MATRIX4 textureMatrix;
@@ -201,7 +204,6 @@ typedef struct {
     void (*Shutdown)(void);
     void (*RegisterMap)(LPCSTR mapFileName);
     void (*RenderFrame)(viewDef_t const *viewdef);
-    void (*WeatherCommand)(void const *data, DWORD size);
     LPTEXTURE (*LoadTexture)(LPCSTR fileName);
     LPMODEL (*LoadModel)(LPCSTR filename);
     LPFONT (*LoadFont)(LPCSTR filename, DWORD size);

--- a/common/common.h
+++ b/common/common.h
@@ -22,6 +22,7 @@
 #define FOW_CELLS_PER_TILE_SIDE 2
 #define FOW_CELL_SIZE (TILE_SIZE / FOW_CELLS_PER_TILE_SIDE)
 #define FOW_CHUNK_TARGET_BYTES 8192
+#define MAX_GAME_DATAGRAM_SIZE 8192 // bytes; bounds game-owned per-frame payloads appended after entity state
 
 enum {
     FOW_MSG_FULL = 1 << 0,
@@ -79,7 +80,6 @@ enum svc_ops {
     svc_window,                  // [byte open] [long id] [long class, long flags, frames, long text size, text]
     svc_ui_window,               // [string window_id] [byte show] legacy menu-module-owned named XML window toggle
     svc_disconnect,               // server is closing or dropped this client
-    svc_weather,                 // [long type] [long handle] [long effect_id] [box2 bounds] [long enabled]
     svc_lobby_chat,              // [byte own] [string text]
     svc_set_selection,           // [byte count] [count * long entity]
 };

--- a/common/weather.h
+++ b/common/weather.h
@@ -3,19 +3,13 @@
 
 #include "common/shared.h"
 
-typedef enum {
-    WC3_WEATHER_CMD_CLEAR = 1,
-    WC3_WEATHER_CMD_ADD,
-    WC3_WEATHER_CMD_ENABLE,
-    WC3_WEATHER_CMD_REMOVE,
-} wc3WeatherCommandType_t;
+#define MAX_WEATHER_EFFECTS 256 // effects; bounds the per-client weather snapshot and stable server registry
 
 typedef struct {
-    DWORD type;
     DWORD handle;
     DWORD effect_id;
     BOX2 bounds;
     DWORD enabled;
-} wc3WeatherCommand_t;
+} wc3WeatherEffect_t;
 
 #endif

--- a/docs/architecture/server-selected-effects.md
+++ b/docs/architecture/server-selected-effects.md
@@ -65,9 +65,9 @@ When a shared dispatcher needs a new game behavior, first locate its function-ta
 exists, implement the command in the selected game's module. If it does not exist, add a narrow table entry;
 do not substitute a per-game preprocessor guard or a hardcoded command branch in the shared dispatcher.
 
-## Opaque game commands to a selected renderer
+## Game-owned presentation datagrams
 
-Presentation state that is neither an entity snapshot nor generic client state may use the reliable `svc_gamecmd` channel. `CL_ParseGameCommand()` forwards every bounded opaque payload through `refExport_t.GameCommand`; each selected game renderer decides whether it owns the command. Shared client code must not branch on a game-specific command string. Warcraft III weather is the reference: `games/warcraft-3/game/g_weather.c` sends `wc3_weather`, while `games/warcraft-3/renderer/r_weather.c` consumes it. WoW/SC2 renderer hooks remain no-ops. See [WC3 Weather](../games/warcraft-3/weather.md).
+Presentation state that is neither an entity snapshot nor generic client state may use a game-owned per-frame datagram. Warcraft III weather is carried in that datagram, cached by the client, and exposed through `viewDef`; `games/warcraft-3/renderer/r_weather.c` consumes the view state. See [WC3 Weather](../games/warcraft-3/weather.md).
 
 ## Selection-scoped world indicators
 

--- a/docs/games/warcraft-3/ability-and-item-effects.md
+++ b/docs/games/warcraft-3/ability-and-item-effects.md
@@ -92,7 +92,7 @@ These migrations are deliberately presentation-only. They do not change damage/h
 
 `AddSpecialEffect*` takes an explicit model path and does not consult ability data. `AddSpellEffect*` takes an ability rawcode/string plus a converted effect type and resolves the corresponding ability presentation field. A returned JASS `effect` handle points at the independent effect edict, not at the target unit. Destroying the effect therefore cannot overwrite or clear the target unit's `model2` state.
 
-Weather effects now use a separate map-lifetime handle/renderer path rather than effect edicts: W3I/W3R/JASS weather is keyed by `TerrainArt\Weather.slk`, synchronized through a renderer game command, and emitted through the shared particle pool. See [Weather](weather.md) for the implemented fields and deliberate compatibility gaps. JASS `effect` extends `agent`, not `widget`; effect edicts therefore carry `EF_NOT_SELECTABLE` so destination markers render without intercepting world picking. `LIGHTNING` remains unsupported by the model-effect resolver because Warcraft lightning requires a dedicated endpoint/colour/movement lifecycle rather than an MDX model path.
+Weather effects now use a separate map-lifetime handle/renderer path rather than effect edicts: W3I/W3R/JASS weather is keyed by `TerrainArt\Weather.slk`, carried in the per-frame game datagram, and emitted through the shared particle pool. See [Weather](weather.md) for the implemented fields and deliberate compatibility gaps. `LIGHTNING` remains unsupported by the model-effect resolver because Warcraft lightning requires a dedicated endpoint/colour/movement lifecycle rather than an MDX model path.
 
 ## Item Use And Charges
 

--- a/docs/games/warcraft-3/weather.md
+++ b/docs/games/warcraft-3/weather.md
@@ -124,9 +124,10 @@ Texture rows/columns reuse the existing lifetime atlas path.
 
 `level.weather_effects[]` owns stable weather handles for the map lifetime.
 JASS gets light handles to those slots; renderer objects are not JASS objects.
-Every add/enable/remove sends a compact game command to connected clients.
-`G_WeatherSyncClient()` first clears client weather state and then replays all
-live effects so late/reconnected clients receive the authoritative set.
+Each `svc_frame` carries the complete registered weather set in its game-owned
+datagram. The client caches that set in `client_state` and passes it through
+`viewDef`; the renderer reconciles its particle runtime while rendering, so
+packet loss and reconnects converge without a renderer command API.
 
 Map-authored W3I/W3R weather starts enabled.  JASS-created weather starts
 disabled until `EnableWeatherEffect(..., true)`.

--- a/games/starcraft-2/game/g_sc2.c
+++ b/games/starcraft-2/game/g_sc2.c
@@ -16,6 +16,13 @@ sc2Level_t sc2_level;
 struct game_import gi;
 struct game_export globals;
 
+static DWORD G_WriteClientDatagram(LPEDICT ent, LPBYTE data, DWORD size) {
+    (void)ent;
+    if (size < sizeof(USHORT)) return 0;
+    memset(data, 0, sizeof(USHORT));
+    return sizeof(USHORT);
+}
+
 static edict_t sc2_edicts[SC2_MAX_EDICTS];
 static struct client_s sc2_clients[SC2_MAX_CLIENTS];
 static edict_t sc2_waypoints[SC2_MAX_EDICTS];
@@ -834,6 +841,7 @@ struct game_export *GetGameAPI(struct game_import *import) {
     globals.ClientSetCameraPosition = SC2_ClientSetCameraPosition;
     globals.CanSeeEntity          = SC2_CanSeeEntity;
     globals.CustomizeEntity       = SC2_CustomizeEntity;
+    globals.WriteClientDatagram    = G_WriteClientDatagram;
     globals.GetThemeValue         = SC2_GetThemeValue;
     globals.LoadMap               = SC2_LoadMap;
     globals.GetWorldBounds        = CM_GetWorldBounds;

--- a/games/starcraft-2/renderer/r_game.c
+++ b/games/starcraft-2/renderer/r_game.c
@@ -207,7 +207,6 @@ void R_DrawMinimap(LPCRECT screen) {
     R_DrawImage(tex, screen, &MAKE(RECT, 0, 0, 1, 1), COLOR32_WHITE);
 }
 
-void R_WeatherCommand(void const *data, DWORD size) { (void)data; (void)size; }
 
 void R_RegisterMap(LPCSTR mapFileName) {
     R_SC2RegisterMap(mapFileName);

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -6,6 +6,7 @@
 #include <limits.h>
 
 #include "common/common.h"
+#include "common/weather.h"
 #include "common/stb_fdf.h"
 #include "common/stb_slk.h"
 #include "server/game.h"
@@ -646,7 +647,6 @@ typedef struct {
 #define MAX_QUESTS 256 // quests; fixed quest slots preserve stable pointers across removal
 #define MAX_QUESTITEMS 16 // items per quest; matches the practical quest objective display capacity
 #define MAX_WAYPOINTS 256 // entities; fixed g_edicts ring used by point-target movement
-#define MAX_WEATHER_EFFECTS 256 // handles; fixed map weather registry keeps JASS pointers stable
 typedef struct {
     LPEDICT units[MAX_GROUP_SIZE];
     DWORD num_units;
@@ -1450,7 +1450,7 @@ LPGWEATHER G_WeatherAdd(LPCBOX2 bounds, DWORD effect_id, BOOL enabled);
 void G_WeatherEnable(LPGWEATHER effect, BOOL enabled);
 void G_WeatherRemove(LPGWEATHER effect);
 void G_WeatherInitMap(void);
-void G_WeatherSyncClient(LPEDICT ent);
+DWORD G_WriteClientDatagram(LPEDICT ent, LPBYTE data, DWORD size);
 LPTRIGGER G_AllocJassTrigger(void);
 LPGTIMER G_AllocJassTimer(void);
 void G_ClearSaveRegistries(void);

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -957,7 +957,6 @@ static void G_ClientBegin(LPEDICT edict) {
             client->ps.name ? client->ps.name : "");
     level.started = true;
     G_StartScripts();
-    G_WeatherSyncClient(edict);
 
     UI_ShowGameInterface(edict);
     UI_WriteHoverLayout(edict);
@@ -1072,6 +1071,7 @@ struct game_export *GetGameAPI(struct game_import *import) {
     globals.ClientBegin = G_ClientBegin;
     globals.CanSeeEntity = G_FowPlayerCanSeeEntity;
     globals.CustomizeEntity = G_CustomizeEntity;
+    globals.WriteClientDatagram = G_WriteClientDatagram;
     globals.GetThemeValue = G_GetThemeValue;
     globals.LoadMap = G_LoadMap;
     globals.SaveGame = WriteGame;

--- a/games/warcraft-3/game/g_save.c
+++ b/games/warcraft-3/game/g_save.c
@@ -1165,13 +1165,6 @@ BOOL ReadGame(LPCSTR filename) {
             ent->owner->client->rally_indicator = ent;
     }
     FOR_LOOP(i, globals.num_edicts) if (g_edicts[i].inuse && gi.LinkEntity) gi.LinkEntity(g_edicts + i);
-    FOR_LOOP(i, game.max_clients) {
-        LPGAMECLIENT client = game.clients + i;
-        LPEDICT ent;
-        if (!client->connected) continue;
-        ent = G_GetPlayerEntityByNumber(client->ps.number);
-        if (ent) G_WeatherSyncClient(ent);
-    }
     fclose(f);
     fprintf(stderr, "WC3 LoadGame: restored %s edicts=%u\n", filename, header.num_edicts);
     return true;

--- a/games/warcraft-3/game/g_weather.c
+++ b/games/warcraft-3/game/g_weather.c
@@ -6,34 +6,6 @@ static BOOL G_WeatherValid(LPCGWEATHER effect) {
            effect < level.weather_effects + MAX_WEATHER_EFFECTS && effect->inuse;
 }
 
-static void G_WeatherSend(LPEDICT ent, LPCGWEATHER effect, wc3WeatherCommandType_t type) {
-    wc3WeatherCommand_t command;
-
-    if (!ent || !ent->client || !ent->client->connected) return;
-    memset(&command, 0, sizeof(command));
-    command.type = type;
-    if (effect) {
-        command.handle = effect->handle_id;
-        command.effect_id = effect->effect_id;
-        command.bounds = effect->bounds;
-        command.enabled = effect->enabled;
-    }
-    gi.Write(PF_BYTE, &(LONG){ svc_weather });
-    gi.Write(PF_DATA, &(pfWriteData_t){ &command, sizeof(command) });
-    gi.unicast(ent);
-}
-
-static void G_WeatherBroadcast(LPCGWEATHER effect, wc3WeatherCommandType_t type) {
-    FOR_LOOP(i, game.max_clients) {
-        LPGAMECLIENT client = game.clients + i;
-        LPEDICT ent;
-
-        if (!client->connected) continue;
-        ent = G_GetPlayerEntityByNumber(client->ps.number);
-        if (ent) G_WeatherSend(ent, effect, type);
-    }
-}
-
 LPGWEATHER G_WeatherAdd(LPCBOX2 bounds, DWORD effect_id, BOOL enabled) {
     LPGWEATHER effect = NULL;
 
@@ -52,7 +24,6 @@ LPGWEATHER G_WeatherAdd(LPCBOX2 bounds, DWORD effect_id, BOOL enabled) {
     effect->bounds = *bounds;
     if (++level.next_weather_id == 0) level.next_weather_id = 1;
     effect->handle_id = level.next_weather_id;
-    G_WeatherBroadcast(effect, WC3_WEATHER_CMD_ADD);
     return effect;
 }
 
@@ -61,12 +32,10 @@ void G_WeatherEnable(LPGWEATHER effect, BOOL enabled) {
     enabled = !!enabled;
     if (effect->enabled == enabled) return;
     effect->enabled = enabled;
-    G_WeatherBroadcast(effect, WC3_WEATHER_CMD_ENABLE);
 }
 
 void G_WeatherRemove(LPGWEATHER effect) {
     if (!G_WeatherValid(effect)) return;
-    G_WeatherBroadcast(effect, WC3_WEATHER_CMD_REMOVE);
     memset(effect, 0, sizeof(*effect));
 }
 
@@ -84,15 +53,28 @@ void G_WeatherInitMap(void) {
     }
 }
 
-void G_WeatherSyncClient(LPEDICT ent) {
-    wc3WeatherCommand_t clear = { .type = WC3_WEATHER_CMD_CLEAR };
+/* Serialize the authoritative weather set into the per-frame game datagram so
+ * reconnects and dropped packets converge without renderer commands. */
+DWORD G_WriteClientDatagram(LPEDICT ent, LPBYTE data, DWORD size) {
+    DWORD count = 0;
+    BYTE *out = data;
+    USHORT wire_count;
 
-    if (!ent || !ent->client || !ent->client->connected) return;
-    gi.Write(PF_BYTE, &(LONG){ svc_weather });
-    gi.Write(PF_DATA, &(pfWriteData_t){ &clear, sizeof(clear) });
-    gi.unicast(ent);
+    (void)ent;
+    if (!data || size < sizeof(wire_count)) return 0;
+    FOR_LOOP(i, MAX_WEATHER_EFFECTS) if (level.weather_effects[i].inuse) count++;
+    wire_count = (USHORT)count;
+    memcpy(out, &wire_count, sizeof(wire_count));
+    out += sizeof(wire_count);
     FOR_LOOP(i, MAX_WEATHER_EFFECTS) {
         LPCGWEATHER effect = level.weather_effects + i;
-        if (effect->inuse) G_WeatherSend(ent, effect, WC3_WEATHER_CMD_ADD);
+        wc3WeatherEffect_t state;
+        if (!effect->inuse) continue;
+        state = (wc3WeatherEffect_t){ .handle = effect->handle_id, .effect_id = effect->effect_id,
+            .bounds = effect->bounds, .enabled = effect->enabled };
+        if ((DWORD)(out - data) + sizeof(state) > size) return 0;
+        memcpy(out, &state, sizeof(state));
+        out += sizeof(state);
     }
+    return (DWORD)(out - data);
 }

--- a/games/warcraft-3/renderer/r_weather.c
+++ b/games/warcraft-3/renderer/r_weather.c
@@ -51,6 +51,7 @@ typedef struct {
     w3WeatherArt_t const *art;
     LPCTEXTURE texture;
     FLOAT emission_accum;
+    DWORD seen;
 } renderWeatherEffect_t;
 
 static slkField_t const weather_schema[] = {
@@ -108,6 +109,7 @@ static DWORD weather_count;
 static slkIndex_t weather_index;
 static renderWeatherEffect_t weather_effects[MAX_RENDER_WEATHER_EFFECTS];
 static uint32_t weather_rng = 0x7f4a7c15u;
+static DWORD weather_sync;
 
 static FLOAT R_WeatherRandom01(void) {
     weather_rng ^= weather_rng << 13;
@@ -155,10 +157,12 @@ static DWORD R_WeatherLoadSlk(LPCSTR filename, void **dest) {
 
 void R_WeatherInit(void) {
     memset(weather_effects, 0, sizeof(weather_effects));
+    weather_sync = 0;
 }
 
 void R_WeatherShutdown(void) {
     memset(weather_effects, 0, sizeof(weather_effects));
+    weather_sync = 0;
     FS_SLKFreeIndex(&weather_index);
     FS_SLKFreeRows(weather_schema, weather_rows, weather_count, sizeof(w3WeatherArt_t));
     weather_rows = NULL;
@@ -173,37 +177,34 @@ void R_WeatherRegisterMap(void) {
     FS_SLKBuildIndex(&weather_index, weather_rows, weather_count, sizeof(w3WeatherArt_t));
     memset(weather_effects, 0, sizeof(weather_effects));
     weather_rng = 0x7f4a7c15u;
+    weather_sync = 0;
 }
 
-void R_WeatherCommand(void const *data, DWORD size) {
-    wc3WeatherCommand_t payload;
-    renderWeatherEffect_t *effect;
+/* Reconcile renderer-owned particle accumulators with the latest client view. */
+static void R_WeatherSync(void) {
+    DWORD sync = ++weather_sync;
 
-    if (!data || size != sizeof(payload)) return;
-    memcpy(&payload, data, sizeof(payload));
-    if (payload.type == WC3_WEATHER_CMD_CLEAR) {
-        memset(weather_effects, 0, sizeof(weather_effects));
-        return;
-    }
-    effect = R_WeatherFind(payload.handle);
-    if (payload.type == WC3_WEATHER_CMD_ADD) {
-        if (!effect) FOR_LOOP(i, MAX_RENDER_WEATHER_EFFECTS) if (!weather_effects[i].inuse) {
-            effect = weather_effects + i;
+    FOR_LOOP(i, tr.viewDef.num_weather_effects) {
+        wc3WeatherEffect_t const *state = tr.viewDef.weather_effects + i;
+        renderWeatherEffect_t *effect = R_WeatherFind(state->handle);
+        if (!effect) FOR_LOOP(j, MAX_RENDER_WEATHER_EFFECTS) if (!weather_effects[j].inuse) {
+            effect = weather_effects + j;
+            memset(effect, 0, sizeof(*effect));
+            effect->inuse = true;
             break;
         }
-        if (!effect) return;
-        memset(effect, 0, sizeof(*effect));
-        effect->inuse = true;
-        effect->enabled = !!payload.enabled;
-        effect->handle = payload.handle;
-        effect->effect_id = payload.effect_id;
-        effect->bounds = payload.bounds;
-        R_WeatherResolve(effect);
-    } else if (payload.type == WC3_WEATHER_CMD_ENABLE) {
-        if (effect) effect->enabled = !!payload.enabled;
-    } else if (payload.type == WC3_WEATHER_CMD_REMOVE) {
-        if (effect) memset(effect, 0, sizeof(*effect));
+        if (!effect) continue;
+        effect->seen = sync;
+        if (effect->effect_id != state->effect_id) {
+            effect->effect_id = state->effect_id;
+            R_WeatherResolve(effect);
+        }
+        effect->enabled = !!state->enabled;
+        effect->handle = state->handle;
+        effect->bounds = state->bounds;
     }
+    FOR_LOOP(i, MAX_RENDER_WEATHER_EFFECTS)
+        if (weather_effects[i].inuse && weather_effects[i].seen != sync) memset(weather_effects + i, 0, sizeof(*weather_effects));
 }
 
 static BOX2 R_WeatherEmissionBounds(void) {
@@ -279,6 +280,7 @@ void R_WeatherEmit(void) {
     DWORD delta_ms;
 
     if (tr.viewDef.rdflags & RDF_NOWORLDMODEL) return;
+    R_WeatherSync();
     delta_ms = tr.viewDef.deltaTime;
     if (!delta_ms) return;
     visible = R_WeatherEmissionBounds();

--- a/games/warcraft-3/renderer/r_weather.h
+++ b/games/warcraft-3/renderer/r_weather.h
@@ -6,7 +6,6 @@
 void R_WeatherInit(void);
 void R_WeatherShutdown(void);
 void R_WeatherRegisterMap(void);
-void R_WeatherCommand(void const *data, DWORD size);
 void R_WeatherEmit(void);
 
 #endif

--- a/games/warcraft-3/tests/test_server_net.c
+++ b/games/warcraft-3/tests/test_server_net.c
@@ -133,6 +133,13 @@ static void test_game_shutdown(void) {
     test_game_shutdowns++;
 }
 
+static DWORD test_write_client_datagram(LPEDICT ent, LPBYTE data, DWORD size) {
+    (void)ent;
+    if (size < sizeof(USHORT)) return 0;
+    memset(data, 0, sizeof(USHORT));
+    return sizeof(USHORT);
+}
+
 static void reset_server_state(int max_players) {
     memset(&sv, 0, sizeof(sv));
     memset(&svs, 0, sizeof(svs));
@@ -157,6 +164,7 @@ static void reset_server_state(int max_players) {
     test_ge.GetWorldBounds = CM_GetWorldBounds;
     test_ge.Shutdown = test_game_shutdown;
     test_ge.CustomizeEntity = test_customize_entity;
+    test_ge.WriteClientDatagram = test_write_client_datagram;
     ge = &test_ge;
     reset_test_gi();
 }

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -15,6 +15,13 @@
 
 struct game_import gi;
 struct game_export globals;
+
+static DWORD G_WriteClientDatagram(LPEDICT ent, LPBYTE data, DWORD size) {
+    (void)ent;
+    if (size < sizeof(USHORT)) return 0;
+    memset(data, 0, sizeof(USHORT));
+    return sizeof(USHORT);
+}
 edict_t wow_edicts[WOW_MAX_EDICTS];
 wowEntityLocal_t wow_entity_locals[WOW_MAX_EDICTS];
 wowClient_t wow_clients[MAX_CLIENTS];
@@ -2486,6 +2493,7 @@ struct game_export *GetGameAPI(struct game_import *import) {
     globals.ClientBegin = Wow_ClientBegin;
     globals.CanSeeEntity = NULL;
     globals.CustomizeEntity = Wow_CustomizeEntity;
+    globals.WriteClientDatagram = G_WriteClientDatagram;
     globals.PlayerCreateMap = Wow_SelectedPlayerCreateMap;
     globals.LoadMap = Wow_LoadMap;
     globals.GetWorldBounds = CM_GetWorldBounds;

--- a/games/world-of-warcraft/renderer/r_game.c
+++ b/games/world-of-warcraft/renderer/r_game.c
@@ -109,7 +109,6 @@ void R_DrawMinimap(LPCRECT screen) {
     Wow_DrawMinimap(screen);
 }
 
-void R_WeatherCommand(void const *data, DWORD size) { (void)data; (void)size; }
 
 void R_RegisterMap(LPCSTR mapFileName) {
     Wow_RegisterMap(mapFileName);

--- a/renderer/r_game.h
+++ b/renderer/r_game.h
@@ -28,7 +28,6 @@ void R_SetupTextureMatrix(void);
 void R_DrawMinimap(LPCRECT screen);
 
 void R_RegisterMap(LPCSTR mapFileName);
-void R_WeatherCommand(void const *data, DWORD size);
 void R_SetupEnvironmentLighting(void);
 void R_DrawWorld(void);
 void R_DrawTerrainShadows(void);

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -1068,7 +1068,6 @@ refExport_t R_GetAPI(refImport_t imp) {
         .LoadTexture = R_LoadTexture,
         .LoadModel = R_LoadRegisteredModel,
         .LoadFont = R_LoadFont,
-        .WeatherCommand = R_WeatherCommand,
         .ReleaseTexture = R_ReleaseTexture,
         .ReleaseModel = R_ReleaseRegisteredModel,
         .RenderFrame = R_RenderFrame,

--- a/server/game.h
+++ b/server/game.h
@@ -132,6 +132,7 @@ struct game_export {
     void (*ClientBegin)(LPEDICT ent);
     BOOL (*CanSeeEntity)(DWORD player, LPCEDICT ent);
     void (*CustomizeEntity)(DWORD player, LPCEDICT ent, LPENTITYSTATE state);
+    DWORD (*WriteClientDatagram)(LPEDICT ent, LPBYTE data, DWORD size);
     DWORD (*PlayerCreateMap)(void);
     bool (*LoadMap)(LPCSTR mapFilename);
     BOOL (*SaveGame)(LPCSTR filename);

--- a/server/sv_ents.c
+++ b/server/sv_ents.c
@@ -301,6 +301,15 @@ void SV_WriteFrameToClient(LPCLIENT client) {
     MSG_WriteLong(&client->netchan.message, sv.framenum);
     MSG_WriteLong(&client->netchan.message, sv.time);
     MSG_WriteLong(&client->netchan.message, client->lastframe);
+    {
+        BYTE data[MAX_GAME_DATAGRAM_SIZE];
+        DWORD size = ge->WriteClientDatagram(client->edict, data, sizeof(data));
+        if (size > sizeof(data)) {
+            fprintf(stderr, "SV_WriteFrameToClient: game datagram too large (%u)\n", (unsigned)size);
+            size = 0;
+        }
+        SZ_Write(&client->netchan.message, data, size);
+    }
 
     SV_WritePlayerstateToClient(oldframe, frame, &client->netchan.message);
     SV_EmitPacketEntities(oldframe, frame, &client->netchan.message);


### PR DESCRIPTION
## Summary

Move weather state from a reliable per-effect svc_weather command to a game-owned datagram appended to svc_frame. The server serialises the authoritative weather set each frame via WriteClientDatagram; the client caches it in client_state and exposes it through viewDef; the renderer reconciles particle accumulators in R_WeatherSync.

## Changes

- game_export.WriteClientDatagram: new callback that each game implements to write a per-frame payload (WC3 serialises weather effects, SC2/WoW write a 2-byte stub)
- SV_WriteFrameToClient: calls WriteClientDatagram and appends the result to the frame message, bounded by MAX_GAME_DATAGRAM_SIZE (8192 bytes)
- CL_ParseFrame: reads the game datagram, caches weather effects in client_state, and passes them through viewDef
- R_WeatherSync: reconciles renderer particle accumulators from viewDef each frame — replaces the old command-driven add/enable/remove/clear API
- Removed: svc_weather message type, WeatherCommand renderer API, G_WeatherSyncClient, per-effect broadcast helpers

## Motivation

The previous design sent individual weather commands over the reliable channel, which required special handling for reconnects and dropped packets (clear + full replay). By carrying the complete weather set in every frame, the renderer naturally converges on any state — no renderer command API needed.

## Testing

- WC3 weather save test updated and passing
- SC2/WoW stub datagrams verified (2-byte zero payload)
- Server net test harness includes WriteClientDatagram mock
- Manual verification: weather effects appear and update correctly in WC3 maps
