### PR TITLE
wc3: render MDX geoset colors with Warcraft RGB semantics

### DIFF
--- a/docs/games/warcraft-3/time-of-day.md
+++ b/docs/games/warcraft-3/time-of-day.md
@@ -145,10 +145,13 @@ accumulated light factor to `[0, 1]`, matching Warsmash before texture modulatio
 
 Two MDX animation details are easy to miss and materially affect the stock DNC appearance:
 
-- Warsmash reverses the red/blue components of **animated** light `KLAC` (Color) and `KLBC` (AmbColor) vectors before they are
-  consumed. Static `MdlxLight.color` / `ambientColor` fields are not put through that animation-track conversion. OpenRealm mirrors
-  this at light evaluation time, after interpolation; component-wise interpolation makes that equivalent to flipping every authored
-  key and tangent before interpolation. Without it, the Lordaeron night track presents as warm brown/orange instead of cool blue.
+- Warcraft animated MDX color tracks use BGR component order while static color fields are usually already RGB. GeosetAnimation
+  colors are the important exception used by the HUD clock: Warsmash swizzles both the static GeosetAnimation base color and
+  animated `KGAC` keys from BGR to RGB. OpenRealm mirrors that through `MDLX_GetGeosetAnimationStaticColor()` and
+  `MDLX_GetAnimatedColorTrackValue()`. DNC light `KLAC`/`KLBC` tracks and geoset-animation `KGAC` tracks therefore share the same
+  visible color convention, and the time-of-day indicator's authored cool-blue night glow no longer presents as warm red/orange.
+  This is a semantic float-component conversion performed before shader upload; it is deliberately separate from `PIXEL_BGRA`
+  texture byte handling, so desktop GL native BGRA support and GLES CPU BGRA-to-RGBA fallback produce the same model color.
 - For a global-sequence key track whose first authored key lies beyond the declared global-sequence duration, Warsmash treats that
   first value as a constant. This includes the zero-duration-global-sequence pattern used by DNC-style node rotations. Returning the
   default transform instead leaves a directional light pointing along the unrotated model axis. `MDLX_GetModelKeytrackValue()`

--- a/games/warcraft-3/renderer/mdx/r_mdx.h
+++ b/games/warcraft-3/renderer/mdx/r_mdx.h
@@ -406,6 +406,8 @@ extern MATRIX4 node_matrices[MDX_MAX_NODES];
 
 mdxSequence_t const *R_FindSequenceAtTime(mdxModel_t const *model, DWORD time);
 void MDLX_GetModelKeytrackValue(mdxModel_t const *model, mdxKeyTrack_t const *keytrack, DWORD time, HANDLE output);
+void MDLX_GetAnimatedColorTrackValue(mdxModel_t const *model, mdxKeyTrack_t const *keytrack, DWORD time, LPVECTOR3 output);
+void MDLX_GetGeosetAnimationStaticColor(mdxGeosetAnim_t const *geosetAnim, LPVECTOR3 output);
 void MDLX_BindBoneMatrices(mdxModel_t const *model, LPCMATRIX4 model_matrix, DWORD frame1, DWORD frame0);
 BOOL MDLX_EvaluateLight(mdxModel_t const *model, mdxLight_t const *light,
                         LPCMATRIX4 model_matrix, DWORD frame, BOOL use_visibility,

--- a/games/warcraft-3/renderer/mdx/r_mdx_anim.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_anim.c
@@ -105,6 +105,36 @@ void MDLX_GetModelKeytrackValue(mdxModel_t const *model, mdxKeyTrack_t const *ke
         R_GetKeyframeValue(R_KeyFrameAt(keytrack, right_index - 1), right, keytrack, time, output);
 }
 
+/* Warcraft animated MDX color tracks use BGR component semantics in the file.
+ * Convert the float vector to renderer RGB after interpolation. This is not a
+ * texture byte-order conversion, so it is identical on GL, GLES, and hosts with
+ * or without native BGRA texture-upload support. */
+void MDLX_GetAnimatedColorTrackValue(mdxModel_t const *model,
+                                     mdxKeyTrack_t const *keytrack,
+                                     DWORD time,
+                                     LPVECTOR3 output)
+{
+    FLOAT red;
+
+    if (!model || !keytrack || !output) return;
+    MDLX_GetModelKeytrackValue(model, keytrack, time, output);
+    red = output->x;
+    output->x = output->z;
+    output->z = red;
+}
+
+/* GeosetAnimation is the static-color exception to the usual MDX RGB fields:
+ * Warsmash swizzles its base vector just like KGAC. This semantic conversion is
+ * independent of host endianness and GL/BGRA upload capabilities. */
+void MDLX_GetGeosetAnimationStaticColor(mdxGeosetAnim_t const *geosetAnim,
+                                        LPVECTOR3 output)
+{
+    if (!geosetAnim || !output) return;
+    output->x = geosetAnim->staticColor.z;
+    output->y = geosetAnim->staticColor.y;
+    output->z = geosetAnim->staticColor.x;
+}
+
 static void R_CalculateNodeMatrix(mdxModel_t const *model, mdxNode_t *node, DWORD frame1, DWORD frame0, LPMATRIX4 matrix) {
     VECTOR3 vTranslation = { 0, 0, 0 };
     QUATERNION vRotation = { 0, 0, 0, 1 };

--- a/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
@@ -396,16 +396,17 @@ static VECTOR4 MDLX_EvaluateGeosetColor(mdxModel_t const *model,
         MDLX_GetModelKeytrackValue(model, geoset->geosetAnim->alphas, frame, &color.w);
     }
     if (geoset->geosetAnim->flags & 0x2) {
-        color.x = geoset->geosetAnim->staticColor.x;
-        color.y = geoset->geosetAnim->staticColor.y;
-        color.z = geoset->geosetAnim->staticColor.z;
-        if (geoset->geosetAnim->colors) {
-            VECTOR3 animated = geoset->geosetAnim->staticColor;
-            MDLX_GetModelKeytrackValue(model, geoset->geosetAnim->colors, frame, &animated);
-            color.x = animated.x;
-            color.y = animated.y;
-            color.z = animated.z;
-        }
+        VECTOR3 geosetColor = { 1.0f, 1.0f, 1.0f };
+
+        /* Warsmash swizzles both the static GeosetAnimation base color and
+         * animated KGAC values. Keep this at the semantic VECTOR3 layer rather
+         * than the platform-specific texture BGRA upload path. */
+        MDLX_GetGeosetAnimationStaticColor(geoset->geosetAnim, &geosetColor);
+        if (geoset->geosetAnim->colors)
+            MDLX_GetAnimatedColorTrackValue(model, geoset->geosetAnim->colors, frame, &geosetColor);
+        color.x = geosetColor.x;
+        color.y = geosetColor.y;
+        color.z = geosetColor.z;
     }
     color.x = MIN(MAX(color.x, 0.0f), 1.0f);
     color.y = MIN(MAX(color.y, 0.0f), 1.0f);

--- a/games/warcraft-3/renderer/mdx/r_mdx_light.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_light.c
@@ -26,22 +26,12 @@ BOOL MDLX_EvaluateLight(mdxModel_t const *model,
         MDLX_GetModelKeytrackValue(model, light->keytracks.Visibility, frame, &visibility);
     if (useVisibility && visibility < EPSILON)
         return false;
-    if (light->keytracks.Color) {
-        FLOAT red;
-        MDLX_GetModelKeytrackValue(model, light->keytracks.Color, frame, &color);
-        /* Warcraft's animated light KLAC vectors are stored BGR in MDX.
-         * Warsmash flips only animated light color tracks before evaluation;
-         * static MdlxLight.color values remain in their parser-facing order. */
-        red = color.x; color.x = color.z; color.z = red;
-    }
+    if (light->keytracks.Color)
+        MDLX_GetAnimatedColorTrackValue(model, light->keytracks.Color, frame, &color);
     if (light->keytracks.Intensity)
         MDLX_GetModelKeytrackValue(model, light->keytracks.Intensity, frame, &intensity);
-    if (light->keytracks.AmbColor) {
-        FLOAT red;
-        MDLX_GetModelKeytrackValue(model, light->keytracks.AmbColor, frame, &ambc);
-        /* KLBC has the same animated BGR convention as KLAC. */
-        red = ambc.x; ambc.x = ambc.z; ambc.z = red;
-    }
+    if (light->keytracks.AmbColor)
+        MDLX_GetAnimatedColorTrackValue(model, light->keytracks.AmbColor, frame, &ambc);
     if (light->keytracks.AmbIntensity)
         MDLX_GetModelKeytrackValue(model, light->keytracks.AmbIntensity, frame, &ambIntensity);
     if (light->keytracks.AttenuationStart)

--- a/tests/test_renderer_model.c
+++ b/tests/test_renderer_model.c
@@ -326,6 +326,38 @@ TEST(renderer_model, dnc_first_light_follows_sequence_zero_phase) {
     T_FEQ(sampled.ambient_intensity, 0.25f, 0.001f);
 }
 
+TEST(renderer_model, geoset_animation_static_colors_convert_bgr_to_rgb) {
+    mdxGeosetAnim_t geosetAnim = { .staticColor = { 0.85f, 0.40f, 0.10f } };
+    VECTOR3 rgb = { 0, 0, 0 };
+
+    MDLX_GetGeosetAnimationStaticColor(&geosetAnim, &rgb);
+    T_FEQ(rgb.x, geosetAnim.staticColor.z, 0.001f);
+    T_FEQ(rgb.y, geosetAnim.staticColor.y, 0.001f);
+    T_FEQ(rgb.z, geosetAnim.staticColor.x, 0.001f);
+}
+
+TEST(renderer_model, animated_mdx_color_tracks_convert_bgr_to_rgb) {
+    BYTE storage[sizeof(mdxKeyTrack_t) + sizeof(int) + sizeof(VECTOR3)] = { 0 };
+    mdxKeyTrack_t *track = (mdxKeyTrack_t *)storage;
+    mdxKeyFrame_t *key = (mdxKeyFrame_t *)track->values;
+    VECTOR3 authored_bgr = { 0.85f, 0.40f, 0.10f };
+    VECTOR3 rgb = { 0, 0, 0 };
+    mdxSequence_t seq = { .interval = { 0, 1000 } };
+    mdxModel_t model = { .sequences = &seq, .num_sequences = 1 };
+
+    track->keyframeCount = 1;
+    track->datatype = TDATA_FLOAT3;
+    track->linetype = TRACK_NO_INTERP;
+    track->globalSeqId = (DWORD)-1;
+    key->time = 0;
+    memcpy(key->data, &authored_bgr, sizeof(authored_bgr));
+
+    MDLX_GetAnimatedColorTrackValue(&model, track, 500, &rgb);
+    T_FEQ(rgb.x, authored_bgr.z, 0.001f);
+    T_FEQ(rgb.y, authored_bgr.y, 0.001f);
+    T_FEQ(rgb.z, authored_bgr.x, 0.001f);
+}
+
 TEST(renderer_model, animated_mdx_light_colors_follow_warsmash_rgb_order) {
     BYTE color_storage[sizeof(mdxKeyTrack_t) + sizeof(int) + sizeof(VECTOR3)] = { 0 };
     BYTE ambient_storage[sizeof(mdxKeyTrack_t) + sizeof(int) + sizeof(VECTOR3)] = { 0 };


### PR DESCRIPTION
Fix Warcraft III MDX geoset animation color interpretation so authored time-of-day UI colors render correctly across renderer backends.

Warcraft animated MDX color tracks use BGR component semantics, and GeosetAnimation static colors use the same swizzled convention expected by Warsmash. OpenRealm previously handled the animated DNC light color case but consumed geoset animation colors directly as renderer RGB.

This caused the TimeOfDayIndicator's authored blue midnight glow to be rendered as warm orange/red.

Add shared animated-color evaluation which converts BGR semantic components to renderer RGB after interpolation, and apply the same conversion to the static GeosetAnimation base color.

Use the common animated-color path for:

- KLAC animated light colors
- KLBC animated ambient-light colors
- KGAC animated geoset colors

Also convert static GeosetAnimation colors before they reach the model shader.

Keep this conversion at the semantic VECTOR3 layer rather than the texture upload layer. It is therefore independent of host byte order, desktop OpenGL BGRA support, and the GLES BGRA-to-RGBA fallback used for texture pixels.

Add renderer regression coverage for static and animated color conversion and document the MDX color-order contract.

Remove the temporary time-of-day diagnostic logging and debug CVar now that the authoritative midnight clock path and visual fix have been confirmed.