### PR TITLE
wc3: extend cinematic fades across widescreen canvas

### DIFF
--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -1139,8 +1139,9 @@ void SCR_DrawLayout(void) {
 
     if (cl.playerstate.cinefade > 0) {
         COLOR32 color = COLOR32_BLACK;
+        RECT const screen = MAKE(RECT, 0, 0, SCR_UICanvasWidth(), UI_BASE_HEIGHT);
         color.a = 255 * cl.playerstate.cinefade;
-        re.DrawImage(cl.pics[0], &MAKE(RECT,0,0,1,1), &MAKE(RECT,0,0,1,1), color);
+        re.DrawImage(cl.pics[0], &screen, &MAKE(RECT,0,0,1,1), color);
     }
 
     FOR_LOOP(layer, MAX_LAYOUT_LAYERS) {

--- a/docs/games/warcraft-3/cinematics.md
+++ b/docs/games/warcraft-3/cinematics.md
@@ -217,6 +217,8 @@ A 2880x1620 trace demonstrated the failure mode: canvas width was `1.06667`, HUD
 
 Full-screen overlay effects (fades, blurs) use `SetCineFilterTexture`/`SetCineFilterStartColor`/`SetCineFilterEndColor`/`SetCineFilterDuration`/`DisplayCineFilter`. The runtime interpolation is in `G_Cinefade()` which lerps between start/end alpha.
 
+The client-side fade is physical-screen presentation, not centered 4:3 HUD content. `SCR_DrawLayout()` must cover `{ x=0, y=0, w=SCR_UICanvasWidth(), h=UI_BASE_HEIGHT }`; using a fixed legacy rectangle leaves part of the widened scene outside the fade at aspect ratios wider than 4:3. Keep this separate from `SCR_LayoutSceneRect()`, which intentionally returns the centered 0.8-wide Warcraft HUD root.
+
 ### Human02 Victory-Cinematic Runtime Findings
 
 A September 2026 trace of the Human02 victory sequence showed the cinematic trigger chain itself continuing correctly through camera moves, sleeps, unit orders, dialogue, cleanup, and level transition. The highest-confidence functional gaps were narrower:

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -61,6 +61,9 @@ static DWORD test_model_loads, test_model_releases, test_tex_loads, test_tex_rel
 static VECTOR3 test_overhead_point;
 static RECT test_status_rect;
 static DWORD test_status_draws;
+static RECT test_fade_rect;
+static COLOR32 test_fade_color;
+static DWORD test_fade_draws;
 static PATHSTR test_model_load_paths[4];
 static char test_sprite_anim[96];
 static DWORD test_sprite_draws;
@@ -98,6 +101,9 @@ static bool capture_overhead_point(renderEntity_t const *entity, LPVECTOR3 out) 
 }
 static void capture_status_image(LPCTEXTURE texture, LPCRECT screen, LPCRECT uv, COLOR32 color) {
     (void)texture; (void)uv; (void)color; test_status_rect = *screen; test_status_draws++;
+}
+static void capture_fade_image(LPCTEXTURE texture, LPCRECT screen, LPCRECT uv, COLOR32 color) {
+    (void)texture; (void)uv; test_fade_rect = *screen; test_fade_color = color; test_fade_draws++;
 }
 static LPTEXTURE capture_load_texture(LPCSTR name) {
     (void)name; test_tex_loads++; return (LPTEXTURE)(uintptr_t)test_tex_loads;
@@ -1060,6 +1066,23 @@ static VECTOR2 text_length_mock_size(LPCDRAWTEXT text) {
         return MAKE(VECTOR2, 0.006f, 0.012f);
     }
     return MAKE(VECTOR2, 0.018f, 0.012f);
+}
+
+TEST(net, cinematic_fade_covers_widescreen_canvas) {
+    test_client_stubs_init();
+    test_client_stubs_set_window_size(1280, 720);
+    test_fade_draws = 0;
+    cl.playerstate.cinefade = 1.0f;
+    re.DrawImage = capture_fade_image;
+
+    SCR_DrawLayout();
+
+    T_EQ(test_fade_draws, 1);
+    T_FEQ(test_fade_rect.x, 0.0f, 0.0001f);
+    T_FEQ(test_fade_rect.y, 0.0f, 0.0001f);
+    T_FEQ(test_fade_rect.w, UI_BASE_HEIGHT * (1280.0f / 720.0f), 0.0001f);
+    T_FEQ(test_fade_rect.h, UI_BASE_HEIGHT, 0.0001f);
+    T_EQ(test_fade_color.a, 255);
 }
 
 TEST(net, layout_widescreen_extension_flag_reaches_full_canvas) {


### PR DESCRIPTION
Cinematic filter fades still used the legacy fixed-width UI rectangle after the Warcraft III renderer gained an aspect-dependent widescreen canvas.

This caused fade-to-black and fade-from-black transitions to affect the original 4:3 presentation area while leaving the extended widescreen edges visible.

Draw cinematic fades using the full aspect-dependent UI canvas width while preserving the centered 0.8x0.6 Warcraft HUD layout.

At 16:9 the fade now spans the complete 1.0667x0.6 virtual canvas and reaches the full renderer viewport without being limited by the gameplay 4:3 safe area.

Add a regression test covering 16:9 fade geometry and document the distinction between full-screen cinematic presentation and the centered Warcraft HUD root.