### PR TITLE
Add WC3 campaign quest, trigger, objective, JASS, and cinematic cheats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 W3I/W3R/JASS weather lifecycle, Weather.slk particle rendering, rain tails | [docs/games/warcraft-3/weather.md](docs/games/warcraft-3/weather.md) |
 | WC3 alerts, minimap pings, eight-entry Spacebar recent-alert history, quick-position fallback | [docs/games/warcraft-3/alerts-and-minimap-pings.md](docs/games/warcraft-3/alerts-and-minimap-pings.md) |
 | WC3 Quest journal, single-player Message Log, upper-button wiring, retained message history | [docs/games/warcraft-3/quest-and-message-log-ui.md](docs/games/warcraft-3/quest-and-message-log-ui.md) |
+| Developer cheat commands, WC3 quest/trigger/objective/JASS/cinematic debugging and in-game console feedback | [docs/cheat-commands.md](docs/cheat-commands.md) |
 | WC3 in-game Menu/F10 overlay, EscMenu panel flow, modal pause/input, leave/exit actions | [docs/games/warcraft-3/in-game-menu.md](docs/games/warcraft-3/in-game-menu.md) |
 | WC3 Allies/F11 dialog, directional alliances, shared vision/control, draft/Accept semantics | [docs/games/warcraft-3/allies-menu.md](docs/games/warcraft-3/allies-menu.md) |
 | WC3 Hero skill tree, skill points, rank requirements, learning UI, JASS progression | [docs/games/warcraft-3/hero-abilities.md](docs/games/warcraft-3/hero-abilities.md) |

--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -700,6 +700,13 @@ static void CL_ParseLobbySetup(LPSIZEBUF msg) {
     menu.UpdateLobbySetup(&state);
 }
 
+static void CL_ParseConsolePrint(LPSIZEBUF msg) {
+    char text[MAX_CONSOLE_MESSAGE_LEN] = { 0 };
+
+    MSG_ReadStringN(msg, text, sizeof(text));
+    if (text[0]) CON_printf("%s", text);
+}
+
 static void CL_ParseLobbyChat(LPSIZEBUF msg) {
     char text[512] = { 0 };
     char command[sizeof(text) + 32];
@@ -895,6 +902,9 @@ void CL_ParseServerMessage(LPSIZEBUF msg) {
                 break;
             case svc_set_selection:
                 CL_ParseSetSelection(msg);
+                break;
+            case svc_console_print:
+                CL_ParseConsolePrint(msg);
                 break;
             case svc_fogofwar:
                 CL_ParseFogOfWar(msg);

--- a/common/common.h
+++ b/common/common.h
@@ -82,6 +82,7 @@ enum svc_ops {
     svc_disconnect,               // server is closing or dropped this client
     svc_lobby_chat,              // [byte own] [string text]
     svc_set_selection,           // [byte count] [count * long entity]
+    svc_console_print,           // [string text] server/game command feedback for the local console
 };
 
 // client to server

--- a/docs/cheat-commands.md
+++ b/docs/cheat-commands.md
@@ -55,6 +55,47 @@ lose
 
 Both require `sv_cheats 1`. They intentionally use the same authoritative player-removal/result transition as JASS `RemovePlayer`: `win` records `PLAYER_GAME_RESULT_VICTORY` and publishes `EVENT_PLAYER_VICTORY`, while `lose` records `PLAYER_GAME_RESULT_DEFEAT` and publishes `EVENT_PLAYER_DEFEAT`. Existing map result triggers, ending cinematics, pause-aware result-event draining, and the normal campaign/result dialog continuation therefore remain in control; the cheats do not directly switch maps or force a UI screen. Repeating either command after the player has already been removed is a no-op, matching `RemovePlayer` idempotence.
 
+Campaign quest/script debugging uses several related command families, all gated by `sv_cheats 1`. Their diagnostic/result lines are written both to stderr and to the issuing player's in-game console, so `quest list`, `trigger list`, `objective list`, and `cinematic list` are usable without watching the launch terminal:
+
+```
+quest list
+quest complete <index>
+quest complete all
+
+trigger list [case-sensitive-function-filter]
+trigger fire <index>
+trigger fire <index> selected
+
+objective list [case-sensitive-function-filter]
+objective complete <trigger-index>
+objective complete <trigger-index> selected
+
+jass <zero-argument-function-name>
+
+cinematic list [case-sensitive-function-filter]
+cinematic play <trigger-index>
+cinematic play <trigger-index> selected
+cinematic stop
+```
+
+`quest list` prints the allocated quests in the same 0-based in-use order used by the existing `quest <index>` journal command. `quest complete` marks the chosen quest and every allocated objective item completed; `all` applies that state change to every allocated quest. This is intentionally a **quest-state/UI cheat only**: it does not execute map-authored completion actions, does not fire a synthetic quest-completed event, and does not alter `failed`, `discovered`, `enabled`, or `required`. Campaign scripts usually advance because their own gameplay trigger runs, not because `QuestSetCompleted` changed a journal flag.
+
+`trigger list` prints the stable `level.triggers[]` index, enabled/disabled state, and registered condition/action function names. The optional filter matches those JASS function names. `trigger fire` deliberately behaves like direct `TriggerExecute`: it executes the trigger's registered actions as coroutines without evaluating its conditions and even when the trigger is disabled. This makes it suitable for invoking campaign completion/action triggers that normal progression has not armed yet. Without `selected`, event-response unit/player context is empty. With `selected`, the current primary selected unit is supplied as the trigger unit, which also derives `GetTriggerPlayer()` from that unit's owner. Event fields that require a distinct source unit (for example `GetKillingUnit`) remain unset.
+
+`objective` is a convenience layer for the common campaign case where the map has a completion/victory trigger that performs the real progression work. `objective list` scans trigger **action** names for likely completion triggers. It accepts ordinary `Victory_*` actions and quest/objective names containing completion words such as `Complete`, `Finish`, or `Done`, while rejecting obvious `Cheat`, `Defeat`, cinematic, skip, intro/outro, and time-stop helpers. For the Prologue map observed during development this keeps `Trig_Victory_Found_Medivh_Actions` while rejecting `Trig_Victory_Cheat_Actions`, `Trig_Defeat_Thrall_Dies_Actions`, and `Trig_End_Cinematic_Actions`. `objective complete <trigger-index> [selected]` executes the chosen trigger through the same direct TriggerExecute-style path as `trigger fire`; the index is the stable trigger index printed by the list, not a separate objective ordinal. This remains heuristic discovery, so `trigger list [filter]` is the fallback for unusually named progression triggers.
+
+`jass` starts a named map JASS function as a coroutine, so normal trigger sleeps/waits can yield and resume. It is intended for generated zero-argument functions such as `Trig_*_Actions`; calling functions that require arguments is unsupported. Unlike `trigger fire ... selected`, this command does not manufacture event-response context.
+
+`cinematic` is a higher-level wrapper for in-map scripted cutscenes. `cinematic list` now classifies only trigger **action** names with strong cutscene markers (`cinematic`, `cutscene`, `intro`, `outro`, `ending`, `interlude`) and rejects obvious helper names containing `skip`, `time_stop`/`timestop`, or `cheat`. Generic `victory` and `defeat` markers are intentionally not cinematic evidence: they commonly describe ordinary progression/result triggers. This avoids the observed false positives `Trig_Intro_Cinematic_Skip_Actions`, `Trig_Intro_Time_Stop_Actions`, `Trig_Victory_Cheat_Actions`, `Trig_Defeat_Cheat_Actions`, `Trig_Victory_Found_Medivh_Actions`, and `Trig_Defeat_Thrall_Dies_Actions`, while retaining `Trig_Intro_Cinematic_Actions` and `Trig_End_Cinematic_Actions`. The optional filter further restricts the surviving candidates by JASS function name. Discovery is intentionally heuristic: a map may name a cinematic trigger without any of those words, so a failed candidate search must fall back to `trigger list [filter]` rather than assuming the map contains no cutscene.
+
+`cinematic play <trigger-index> [selected]` uses the same direct TriggerExecute-style path as `trigger fire`: it runs the map-authored trigger actions even if the trigger is disabled and without evaluating its conditions. The index does not have to be one reported by `cinematic list`, which makes `trigger list` a reliable manual fallback. The optional `selected` context has the same GetTriggerUnit/GetTriggerPlayer behavior and limitations as `trigger fire selected`.
+
+`cinematic stop` intentionally does **not** force camera/UI/control state back to gameplay. It publishes the normal `EVENT_PLAYER_END_CINEMATIC` event for the issuing player and other human map players, matching the existing Escape/cancel route. The map's authored skip trigger therefore owns its skip flag, camera reset, unit cleanup, user-control restoration, and termination of the main cinematic coroutine. If a map does not register an end-cinematic handler, the command cannot safely invent that cleanup.
+
+These commands play **in-map JASS cinematics**, not prerendered `PlayCinematic` movie files. Movie decoding/playback remains a separate subsystem.
+
+For campaign skipping, prefer `objective list` followed by `objective complete <trigger-index>` when it finds the relevant authored completion trigger; otherwise use `trigger list <part-of-name>` followed by `trigger fire <index>`. Both execute the map's authored actions so dialogue, spawning, trigger enable/disable changes, quest updates, and later mission state can advance together. For cutscenes, `cinematic list`/`cinematic play` provide the same execution path with narrower cutscene discovery and an authored `cinematic stop` escape route. `quest complete` remains useful when testing only the journal/UI state.
+
 Time-of-day phase cheats set the authoritative Warcraft clock directly and require `sv_cheats 1`:
 
 ```

--- a/docs/games/warcraft-3/cinematics.md
+++ b/docs/games/warcraft-3/cinematics.md
@@ -1,5 +1,44 @@
 # WC3 Cinematic / Cutscene System
 
+## Developer cinematic cheats
+
+In-map Warcraft III cutscenes are ordinary map JASS triggers. With `sv_cheats 1`,
+OpenRealm exposes a thin debugging layer over the same trigger/event machinery:
+
+```text
+cinematic list [filter]
+cinematic play <trigger-index> [selected]
+cinematic stop
+```
+
+`cinematic list` is discovery only. It reports registered triggers whose **action**
+function names contain strong cinematic markers (`cinematic`, `cutscene`, `intro`,
+`outro`, `ending`, or `interlude`). It rejects obvious `skip`, `time_stop`/`timestop`,
+and `cheat` helpers. Generic `victory` and `defeat` names are intentionally not
+cinematic evidence because maps commonly use them for ordinary mission progression.
+The map does not carry a canonical cinematic-trigger table, so this heuristic may
+still miss unusually named cutscenes; use `trigger list [filter]` to inspect every
+registered trigger when that happens.
+
+`cinematic play` deliberately shares `trigger fire` semantics: run the chosen
+trigger's authored actions directly, even if the trigger is disabled and without
+evaluating conditions. This preserves the real camera natives, transmissions,
+unit orders, waits, cinefilters, quest/result changes, and any later map logic.
+`selected` supplies the current selected unit as event subject when the authored
+actions require `GetTriggerUnit()` / unit-derived `GetTriggerPlayer()` context.
+Other event-specific response fields are not synthesized.
+
+`cinematic stop` follows the existing Escape lifecycle instead of directly
+changing `client_ui_state`, camera state, or user control. It publishes
+`EVENT_PLAYER_END_CINEMATIC` for human players so the map's registered
+`TriggerRegisterPlayerEventEndCinematic` actions perform their own skip flag and
+cleanup. This is important because forcibly hiding the cinematic panel would not
+stop the running JASS coroutine or undo map-authored unit/camera state.
+
+These commands cover scripted cutscenes inside the loaded map. The JASS
+`PlayCinematic(movieName)` path for prerendered movie files is separate and still
+depends on movie playback support.
+
 ## Architecture
 
 Cutscenes in Warcraft III are driven entirely by the map's JASS script (`war3map.j`). The engine provides JASS native bindings; the script orchestrates timing, camera, dialogue, and unit movement.

--- a/docs/games/warcraft-3/quest-and-message-log-ui.md
+++ b/docs/games/warcraft-3/quest-and-message-log-ui.md
@@ -106,6 +106,25 @@ the client therefore draws their authored disabled state and cannot dispatch
 those commands until the modal dialog closes. Their original commands are
 restored afterward.
 
+## Developer quest/script cheats
+
+`docs/cheat-commands.md` documents the `sv_cheats`-gated quest and JASS trigger
+debugging commands. Keep the semantic split explicit:
+
+```text
+quest complete <index|all>
+    -> mutates QUEST/QUESTITEM completed flags only
+
+trigger fire <index> [selected]
+    -> executes the map trigger's registered actions directly
+```
+
+Changing `QUEST.completed` is not a campaign-progression event. Maps normally
+call `QuestSetCompleted` as one action inside a larger trigger that can also
+play dialogue, enable later triggers, spawn/remove units, and update other
+mission state. Use direct trigger firing when testing/skipping that authored
+progression; use quest completion when testing journal presentation.
+
 ## Message Log Data Flow
 
 `DisplayTextToPlayer`, `DisplayTimedTextToPlayer`, and

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -1,3 +1,5 @@
+#include <stdarg.h>
+
 #include "g_local.h"
 
 #define CLIENTCOMMAND(NAME) void CMD_##NAME(LPEDICT clent, DWORD argc, LPCSTR argv[])
@@ -874,30 +876,37 @@ CLIENTCOMMAND(DropItem) {
     G_DropItem(unit, (DWORD)slot);
 }
 
+static void G_PublishEndCinematicForHumans(LPEDICT clent, BOOL debug_log) {
+    if (!clent) return;
+    if (debug_log) {
+        fprintf(stderr,
+                "Client cancel command: player=%u edict=%u time=%u\n",
+                clent->client ? (unsigned)clent->client->ps.number : 999u,
+                (unsigned)clent->s.number,
+                (unsigned)G_Time());
+    }
+    G_PublishEvent(clent, EVENT_PLAYER_END_CINEMATIC);
+    if (!level.mapinfo) return;
+
+    FOR_LOOP(i, game.max_clients) {
+        LPEDICT ent = G_GetPlayerEntityByNumber(i);
+        if (!ent || ent == clent || level.mapinfo->players[i].playerType != kPlayerTypeHuman)
+            continue;
+        if (debug_log) {
+            fprintf(stderr,
+                    "Client cancel command: also publishing for human player=%u edict=%u\n",
+                    (unsigned)i,
+                    (unsigned)ent->s.number);
+        }
+        G_PublishEvent(ent, EVENT_PLAYER_END_CINEMATIC);
+    }
+}
+
 CLIENTCOMMAND(Cancel) {
     if (G_CancelBuildPlacement(clent)) {
         return;
     }
-    fprintf(stderr,
-            "Client cancel command: player=%u edict=%u time=%u\n",
-            clent && clent->client ? (unsigned)clent->client->ps.number : 999u,
-            clent ? (unsigned)clent->s.number : 999u,
-            (unsigned)G_Time());
-    G_PublishEvent(clent, EVENT_PLAYER_END_CINEMATIC);
-    if (level.mapinfo) {
-        FOR_LOOP(i, game.max_clients) {
-            LPEDICT ent = G_GetPlayerEntityByNumber(i);
-            if (ent && ent != clent &&
-                level.mapinfo->players[i].playerType == kPlayerTypeHuman)
-            {
-                fprintf(stderr,
-                        "Client cancel command: also publishing for human player=%u edict=%u\n",
-                        (unsigned)i,
-                        (unsigned)ent->s.number);
-                G_PublishEvent(ent, EVENT_PLAYER_END_CINEMATIC);
-            }
-        }
-    }
+    G_PublishEndCinematicForHumans(clent, true);
 }
 
 void UI_ShowQuest(LPEDICT ent, LPCQUEST quest);
@@ -1000,19 +1009,448 @@ CLIENTCOMMAND(AlliesCancel) {
     UI_AlliesCancel(clent);
 }
 
+static void G_CheatPrintf(LPEDICT clent, LPCSTR fmt, ...) {
+    char text[1024];
+    va_list args;
+
+    va_start(args, fmt);
+    vsnprintf(text, sizeof(text), fmt, args);
+    va_end(args);
+
+    fprintf(stderr, "%s\n", text);
+    /* In-engine tests and reserved player slots can issue commands before the
+     * client transport is connected. Console feedback is presentation-only,
+     * so defer the packet instead of writing into an uninitialized multicast
+     * buffer; stderr still records the command result. */
+    if (clent && clent->client && clent->client->connected && gi.Write && gi.unicast) {
+        LONG opcode = svc_console_print;
+        gi.Write(PF_BYTE, &opcode);
+        gi.Write(PF_STRING, text);
+        gi.unicast(clent);
+    }
+}
+
+static LPQUEST G_QuestByOrdinal(DWORD ordinal) {
+    FOR_EACH_QUEST(q) {
+        if (ordinal == 0) return q;
+        ordinal--;
+    }
+    return NULL;
+}
+
+static void G_CheatCompleteQuest(LPQUEST quest) {
+    if (!quest) return;
+    FOR_EACH_QUESTITEM(quest, item) item->completed = true;
+    quest->completed = true;
+}
+
+static void G_CheatListQuests(LPEDICT clent) {
+    DWORD ordinal = 0;
+
+    FOR_EACH_QUEST(q) {
+        G_CheatPrintf(clent,
+                "WC3: quest %u slot=%u completed=%u failed=%u discovered=%u enabled=%u required=%u title=%s",
+                (unsigned)ordinal++,
+                (unsigned)(q - level.quests),
+                (unsigned)q->completed,
+                (unsigned)q->failed,
+                (unsigned)q->discovered,
+                (unsigned)q->enabled,
+                (unsigned)q->required,
+                q->title && *q->title ? q->title : "(untitled)");
+    }
+    if (!ordinal) G_CheatPrintf(clent, "WC3: no quests are currently allocated");
+}
+
+static void G_CheatCompleteQuestCommand(LPEDICT clent, DWORD argc, LPCSTR argv[]) {
+    DWORD index;
+    DWORD count = 0;
+
+    if (argc < 3) {
+        G_CheatPrintf(clent, "WC3: usage: quest complete <index|all>");
+        return;
+    }
+    if (!strcasecmp(argv[2], "all")) {
+        FOR_EACH_QUEST(q) {
+            G_CheatCompleteQuest(q);
+            count++;
+        }
+        G_CheatPrintf(clent, "WC3: completed %u quest%s and their objectives",
+                (unsigned)count, count == 1 ? "" : "s");
+        return;
+    }
+    if (!G_DebugIsNumber(argv[2]) || argv[2][0] == '-') {
+        G_CheatPrintf(clent, "WC3: quest index must be a non-negative integer or 'all'");
+        return;
+    }
+    index = (DWORD)strtoul(argv[2], NULL, 10);
+    LPQUEST quest = G_QuestByOrdinal(index);
+    if (!quest) {
+        G_CheatPrintf(clent, "WC3: quest %u does not exist", (unsigned)index);
+        return;
+    }
+    G_CheatCompleteQuest(quest);
+    G_CheatPrintf(clent, "WC3: completed quest %u and its objectives", (unsigned)index);
+}
+
 CLIENTCOMMAND(Quest) {
     DWORD index;
 
     if (argc < 2 || !argv[1] || !*argv[1]) return;
-    index = atoi(argv[1]);
-    FOR_EACH_QUEST(q) {
-        if (index == 0) {
-            UI_ShowQuest(clent, q);
-            break;
-        } else {
-            index--;
+    if (!strcasecmp(argv[1], "list")) {
+        if (!G_CheatsEnabled()) {
+            G_CheatPrintf(clent, "WC3: cheats are disabled; set sv_cheats 1");
+            return;
+        }
+        G_CheatListQuests(clent);
+        return;
+    }
+    if (!strcasecmp(argv[1], "complete")) {
+        if (!G_CheatsEnabled()) {
+            G_CheatPrintf(clent, "WC3: cheats are disabled; set sv_cheats 1");
+            return;
+        }
+        G_CheatCompleteQuestCommand(clent, argc, argv);
+        return;
+    }
+    if (!G_DebugIsNumber(argv[1]) || argv[1][0] == '-') return;
+    index = (DWORD)strtoul(argv[1], NULL, 10);
+    LPQUEST quest = G_QuestByOrdinal(index);
+    if (quest) UI_ShowQuest(clent, quest);
+}
+
+static BOOL G_TriggerFunctionMatches(LPCSTR filter, struct jass_function const *func) {
+    LPCSTR name = jass_functionname(func);
+    return !filter || !*filter || (name && strstr(name, filter));
+}
+
+static BOOL G_TriggerMatches(LPCSTR filter, LPTRIGGER trigger) {
+    if (!filter || !*filter) return true;
+    FOR_EACH_LIST(TRIGGERCONDITION, condition, trigger->conditions) {
+        if (G_TriggerFunctionMatches(filter, condition->expr)) return true;
+    }
+    FOR_EACH_LIST(TRIGGERACTION, action, trigger->actions) {
+        if (G_TriggerFunctionMatches(filter, action->func)) return true;
+    }
+    return false;
+}
+
+static void G_CheatPrintTriggerFunctions(LPEDICT clent, LPTRIGGER trigger) {
+    FOR_EACH_LIST(TRIGGERCONDITION, condition, trigger->conditions) {
+        LPCSTR name = jass_functionname(condition->expr);
+        G_CheatPrintf(clent, "    condition: %s", name ? name : "(anonymous)");
+    }
+    FOR_EACH_LIST(TRIGGERACTION, action, trigger->actions) {
+        LPCSTR name = jass_functionname(action->func);
+        G_CheatPrintf(clent, "    action:    %s", name ? name : "(anonymous)");
+    }
+}
+
+static void G_CheatListTriggers(LPEDICT clent, LPCSTR filter) {
+    DWORD shown = 0;
+
+    if (!level.vm) {
+        G_CheatPrintf(clent, "WC3: no active JASS VM");
+        return;
+    }
+    FOR_LOOP(i, level.num_triggers) {
+        LPTRIGGER trigger = &level.triggers[i];
+        if (!G_TriggerMatches(filter, trigger)) continue;
+        G_CheatPrintf(clent, "WC3: trigger %u %s",
+                (unsigned)i, trigger->disabled ? "disabled" : "enabled");
+        G_CheatPrintTriggerFunctions(clent, trigger);
+        shown++;
+    }
+    if (!shown) {
+        G_CheatPrintf(clent, "WC3: no triggers%s%s%s",
+                filter && *filter ? " matching '" : " are allocated",
+                filter && *filter ? filter : "",
+                filter && *filter ? "'" : "");
+    }
+}
+
+static BOOL G_CheatFireTrigger(LPEDICT clent, DWORD index, BOOL use_selected, LPCSTR label) {
+    LPEDICT unit = NULL;
+
+    if (!level.vm) {
+        G_CheatPrintf(clent, "WC3: no active JASS VM");
+        return false;
+    }
+    if (index >= level.num_triggers) {
+        G_CheatPrintf(clent, "WC3: trigger %u does not exist", (unsigned)index);
+        return false;
+    }
+    if (use_selected) {
+        unit = clent && clent->client ? G_GetMainSelectedUnit(clent->client) : NULL;
+        if (!unit) {
+            G_CheatPrintf(clent, "WC3: %s %u selected requires a selected unit",
+                    label ? label : "trigger fire", (unsigned)index);
+            return false;
         }
     }
+
+    G_CheatPrintf(clent, "WC3: %s trigger %u directly%s",
+            label ? label : "firing",
+            (unsigned)index,
+            unit ? " with selected-unit event context" : "");
+    /* This is deliberately TriggerExecute-style debug behavior: execute the
+     * authored actions even if the trigger is disabled and without evaluating
+     * its conditions. Campaign/cinematic debug commands need to reach authored
+     * actions that may not yet be armed by normal map progression. */
+    jass_executetrigger(level.vm, &level.triggers[index], unit);
+    return true;
+}
+
+CLIENTCOMMAND(Trigger) {
+    DWORD index;
+    BOOL use_selected = false;
+
+    if (!G_CheatsEnabled()) {
+        G_CheatPrintf(clent, "WC3: cheats are disabled; set sv_cheats 1");
+        return;
+    }
+    if (argc < 2) {
+        G_CheatPrintf(clent, "WC3: usage: trigger list [filter] | trigger fire <index> [selected]");
+        return;
+    }
+    if (!strcasecmp(argv[1], "list")) {
+        G_CheatListTriggers(clent, argc >= 3 ? argv[2] : NULL);
+        return;
+    }
+    if (strcasecmp(argv[1], "fire")) {
+        G_CheatPrintf(clent, "WC3: usage: trigger list [filter] | trigger fire <index> [selected]");
+        return;
+    }
+    if (argc < 3 || !G_DebugIsNumber(argv[2]) || argv[2][0] == '-') {
+        G_CheatPrintf(clent, "WC3: trigger fire requires a non-negative trigger index");
+        return;
+    }
+    if (argc >= 4) {
+        if (strcasecmp(argv[3], "selected")) {
+            G_CheatPrintf(clent, "WC3: optional trigger context must be 'selected'");
+            return;
+        }
+        use_selected = true;
+    }
+    index = (DWORD)strtoul(argv[2], NULL, 10);
+    G_CheatFireTrigger(clent, index, use_selected, "firing");
+}
+
+static BOOL G_StringContainsNoCase(LPCSTR text, LPCSTR needle) {
+    size_t needle_len;
+
+    if (!text || !needle || !*needle) return false;
+    needle_len = strlen(needle);
+    while (*text) {
+        if (!strncasecmp(text, needle, needle_len)) return true;
+        text++;
+    }
+    return false;
+}
+
+static BOOL G_FunctionNameContainsAny(LPCSTR name, LPCSTR const words[], DWORD count) {
+    if (!name) return false;
+    FOR_LOOP(i, count) {
+        if (G_StringContainsNoCase(name, words[i])) return true;
+    }
+    return false;
+}
+
+static BOOL G_CinematicFunctionName(LPCSTR name) {
+    static LPCSTR const markers[] = {
+        "cinematic", "cutscene", "intro", "outro", "ending", "interlude"
+    };
+    static LPCSTR const helpers[] = {
+        "skip", "time_stop", "timestop", "cheat"
+    };
+
+    if (!name || G_FunctionNameContainsAny(name, helpers, sizeof(helpers) / sizeof(helpers[0]))) {
+        return false;
+    }
+    return G_FunctionNameContainsAny(name, markers, sizeof(markers) / sizeof(markers[0]));
+}
+
+static BOOL G_TriggerLooksCinematic(LPTRIGGER trigger) {
+    /* Classify by action names. Generated condition/helper names frequently
+     * inherit words such as Intro without actually starting a cutscene. */
+    FOR_EACH_LIST(TRIGGERACTION, action, trigger->actions) {
+        if (G_CinematicFunctionName(jass_functionname(action->func))) return true;
+    }
+    return false;
+}
+
+static void G_CheatListCinematics(LPEDICT clent, LPCSTR filter) {
+    DWORD shown = 0;
+
+    if (!level.vm) {
+        G_CheatPrintf(clent, "WC3: no active JASS VM");
+        return;
+    }
+    FOR_LOOP(i, level.num_triggers) {
+        LPTRIGGER trigger = &level.triggers[i];
+        if (!G_TriggerLooksCinematic(trigger)) continue;
+        if (filter && *filter && !G_TriggerMatches(filter, trigger)) continue;
+        G_CheatPrintf(clent, "WC3: cinematic candidate trigger %u %s",
+                (unsigned)i, trigger->disabled ? "disabled" : "enabled");
+        G_CheatPrintTriggerFunctions(clent, trigger);
+        shown++;
+    }
+    if (!shown) {
+        G_CheatPrintf(clent,
+                "WC3: no cinematic trigger candidates%s%s%s; use 'trigger list [filter]' to inspect all map triggers",
+                filter && *filter ? " matching '" : "",
+                filter && *filter ? filter : "",
+                filter && *filter ? "'" : "");
+    }
+}
+
+static BOOL G_ObjectiveFunctionName(LPCSTR name) {
+    static LPCSTR const rejects[] = {
+        "cheat", "defeat", "skip", "cinematic", "cutscene", "intro",
+        "outro", "ending", "interlude", "time_stop", "timestop"
+    };
+    BOOL questish;
+    BOOL completion;
+
+    if (!name || G_FunctionNameContainsAny(name, rejects, sizeof(rejects) / sizeof(rejects[0]))) {
+        return false;
+    }
+    if (G_StringContainsNoCase(name, "victory")) return true;
+
+    questish = G_StringContainsNoCase(name, "quest") || G_StringContainsNoCase(name, "objective");
+    completion = G_StringContainsNoCase(name, "complete") ||
+                 G_StringContainsNoCase(name, "finish") ||
+                 G_StringContainsNoCase(name, "done");
+    return questish && completion;
+}
+
+static BOOL G_TriggerLooksObjective(LPTRIGGER trigger) {
+    FOR_EACH_LIST(TRIGGERACTION, action, trigger->actions) {
+        if (G_ObjectiveFunctionName(jass_functionname(action->func))) return true;
+    }
+    return false;
+}
+
+static void G_CheatListObjectives(LPEDICT clent, LPCSTR filter) {
+    DWORD shown = 0;
+
+    if (!level.vm) {
+        G_CheatPrintf(clent, "WC3: no active JASS VM");
+        return;
+    }
+    FOR_LOOP(i, level.num_triggers) {
+        LPTRIGGER trigger = &level.triggers[i];
+        if (!G_TriggerLooksObjective(trigger)) continue;
+        if (filter && *filter && !G_TriggerMatches(filter, trigger)) continue;
+        G_CheatPrintf(clent, "WC3: objective completion candidate trigger %u %s",
+                (unsigned)i, trigger->disabled ? "disabled" : "enabled");
+        G_CheatPrintTriggerFunctions(clent, trigger);
+        shown++;
+    }
+    if (!shown) {
+        G_CheatPrintf(clent,
+                "WC3: no objective completion trigger candidates%s%s%s; use 'trigger list [filter]' to inspect all map triggers",
+                filter && *filter ? " matching '" : "",
+                filter && *filter ? filter : "",
+                filter && *filter ? "'" : "");
+    }
+}
+
+CLIENTCOMMAND(Objective) {
+    DWORD index;
+    BOOL use_selected = false;
+
+    if (!G_CheatsEnabled()) {
+        G_CheatPrintf(clent, "WC3: cheats are disabled; set sv_cheats 1");
+        return;
+    }
+    if (argc < 2) {
+        G_CheatPrintf(clent, "WC3: usage: objective list [filter] | objective complete <trigger-index> [selected]");
+        return;
+    }
+    if (!strcasecmp(argv[1], "list")) {
+        G_CheatListObjectives(clent, argc >= 3 ? argv[2] : NULL);
+        return;
+    }
+    if (strcasecmp(argv[1], "complete")) {
+        G_CheatPrintf(clent, "WC3: usage: objective list [filter] | objective complete <trigger-index> [selected]");
+        return;
+    }
+    if (argc < 3 || !G_DebugIsNumber(argv[2]) || argv[2][0] == '-') {
+        G_CheatPrintf(clent, "WC3: objective complete requires a non-negative trigger index");
+        return;
+    }
+    if (argc >= 4) {
+        if (strcasecmp(argv[3], "selected")) {
+            G_CheatPrintf(clent, "WC3: optional objective context must be 'selected'");
+            return;
+        }
+        use_selected = true;
+    }
+    index = (DWORD)strtoul(argv[2], NULL, 10);
+    G_CheatFireTrigger(clent, index, use_selected, "completing objective via");
+}
+
+CLIENTCOMMAND(Cinematic) {
+    DWORD index;
+    BOOL use_selected = false;
+
+    if (!G_CheatsEnabled()) {
+        G_CheatPrintf(clent, "WC3: cheats are disabled; set sv_cheats 1");
+        return;
+    }
+    if (argc < 2) {
+        G_CheatPrintf(clent,
+                "WC3: usage: cinematic list [filter] | cinematic play <trigger-index> [selected] | cinematic stop");
+        return;
+    }
+    if (!strcasecmp(argv[1], "list")) {
+        G_CheatListCinematics(clent, argc >= 3 ? argv[2] : NULL);
+        return;
+    }
+    if (!strcasecmp(argv[1], "stop")) {
+        /* Match Escape instead of forcing presentation state back to gameplay.
+         * The map-authored EVENT_PLAYER_END_CINEMATIC handler owns skip flags,
+         * camera/unit cleanup, control restoration, and coroutine termination. */
+        G_PublishEndCinematicForHumans(clent, false);
+        G_CheatPrintf(clent, "WC3: published end-cinematic event for human players");
+        return;
+    }
+    if (strcasecmp(argv[1], "play")) {
+        G_CheatPrintf(clent,
+                "WC3: usage: cinematic list [filter] | cinematic play <trigger-index> [selected] | cinematic stop");
+        return;
+    }
+    if (argc < 3 || !G_DebugIsNumber(argv[2]) || argv[2][0] == '-') {
+        G_CheatPrintf(clent, "WC3: cinematic play requires a non-negative trigger index");
+        return;
+    }
+    if (argc >= 4) {
+        if (strcasecmp(argv[3], "selected")) {
+            G_CheatPrintf(clent, "WC3: optional cinematic context must be 'selected'");
+            return;
+        }
+        use_selected = true;
+    }
+    index = (DWORD)strtoul(argv[2], NULL, 10);
+    G_CheatFireTrigger(clent, index, use_selected, "playing cinematic candidate");
+}
+
+CLIENTCOMMAND(Jass) {
+    if (!G_CheatsEnabled()) {
+        G_CheatPrintf(clent, "WC3: cheats are disabled; set sv_cheats 1");
+        return;
+    }
+    if (!level.vm) {
+        G_CheatPrintf(clent, "WC3: no active JASS VM");
+        return;
+    }
+    if (argc != 2 || !argv[1] || !*argv[1]) {
+        G_CheatPrintf(clent, "WC3: usage: jass <zero-argument-function-name>");
+        return;
+    }
+    G_CheatPrintf(clent, "WC3: starting JASS function %s as a coroutine", argv[1]);
+    jass_callbyname(level.vm, argv[1], true);
 }
 
 static BOOL G_DebugIsNumber(LPCSTR text) {
@@ -1147,6 +1585,10 @@ clientCommand_t clientCommands[] = {
     { "canceltrain", CMD_CancelTrain },
     { "quests", CMD_Quests },
     { "quest", CMD_Quest },
+    { "trigger", CMD_Trigger },
+    { "objective", CMD_Objective },
+    { "cinematic", CMD_Cinematic },
+    { "jass", CMD_Jass },
     { "log", CMD_Log },
     { "hidegameresult", CMD_HideGameResult },
     { "gameresult_restart", CMD_GameResultRestart },

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -71,6 +71,7 @@ FILTER_EDICTS(ENT, G_IsEntitySelected(CLIENT, ENT))
 #define FOR_CONTROLLABLE_SELECTED_UNITS(CLIENT, ENT) \
 FILTER_EDICTS(ENT, G_IsEntitySelected(CLIENT, ENT) && G_UnitCanControl(CLIENT, ENT))
 
+struct jass_function;
 KNOWN_AS(jass_s, JASS);
 KNOWN_AS(gcamerasetup_s, CAMERASETUP);
 KNOWN_AS(gregion_s, REGION);
@@ -1968,6 +1969,8 @@ void jass_close(LPJASS);
 BOOL jass_dofile(LPJASS, LPCSTR);
 BOOL jass_dofilenative(LPJASS, LPCSTR);
 void jass_callbyname(LPJASS, LPCSTR, BOOL);
+LPCSTR jass_functionname(struct jass_function const *);
+void jass_executetrigger(LPJASS, LPTRIGGER, LPEDICT);
 BOOL jass_dobuffer(LPJASS, LPSTR);
 void jass_runevents(LPJASS);
 

--- a/games/warcraft-3/game/tests/t_jass_map.c
+++ b/games/warcraft-3/game/tests/t_jass_map.c
@@ -14,7 +14,9 @@
  *
  * Covered:
  *   Quests   — CreateQuest, QuestSet+IsQuest+ round-trips, QuestCreateItem,
- *              QuestItemSet+IsQuestItem+, multiple quests in one script
+ *              QuestItemSet+IsQuestItem+, quest completion cheats
+ *   Trigger  — direct trigger/JASS/cinematic/objective developer cheats, selected event context
+ *              and in-game console feedback transport
  *   Win      — RemovePlayer(DEFEAT) and RemovePlayer(VICTORY) each publish
  *              exactly the right EVENT_PLAYER_* into level.events
  *   Sanity   — BJassAssert true passes, BJassAssert false is caught
@@ -55,6 +57,30 @@ static void victory_noop_unicast(LPEDICT ent) {
 
 static LPCSTR result_cheats_cvar(LPCSTR name, LPCSTR fallback) {
     return !strcmp(name, "sv_cheats") ? "1" : fallback;
+}
+
+static char cheat_console_text[8192];
+static LONG cheat_console_opcode;
+static DWORD cheat_console_unicasts;
+
+static void cheat_console_capture_write(pfWriteType_t type, void const *value) {
+    if (type == PF_BYTE) {
+        cheat_console_opcode = *(LONG const *)value;
+    } else if (type == PF_STRING && value) {
+        if (cheat_console_text[0]) strlcat(cheat_console_text, "\n", sizeof(cheat_console_text));
+        strlcat(cheat_console_text, (LPCSTR)value, sizeof(cheat_console_text));
+    }
+}
+
+static void cheat_console_capture_unicast(LPEDICT ent) {
+    (void)ent;
+    cheat_console_unicasts++;
+}
+
+static void cheat_console_capture_reset(void) {
+    cheat_console_text[0] = '\0';
+    cheat_console_opcode = -1;
+    cheat_console_unicasts = 0;
 }
 
 /* =========================================================================
@@ -388,6 +414,366 @@ TEST(wc3_jass_map, quest_multiple_items_independent) {
         "  call BJassAssert(not IsQuestItemCompleted(b),  \"item b should be incomplete\")\n"
         "endfunction\n"
     ));
+}
+
+TEST(wc3_jass_map, quest_complete_cheat_marks_quest_and_objectives) {
+    LPCSTR (*old_cvar)(LPCSTR, LPCSTR);
+    LPCSTR command[] = { "quest", "complete", "0" };
+
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  local quest q = CreateQuest()\n"
+        "  local questitem a = QuestCreateItem(q)\n"
+        "  local questitem b = QuestCreateItem(q)\n"
+        "endfunction\n"
+    ));
+    old_cvar = gi.CvarString;
+    gi.CvarString = result_cheats_cvar;
+
+    G_ClientCommand(&g_edicts[0], 3, command);
+
+    T_ASSERT(level.quests[0].completed);
+    T_ASSERT(level.quests[0].items[0].completed);
+    T_ASSERT(level.quests[0].items[1].completed);
+
+    gi.CvarString = old_cvar;
+}
+
+TEST(wc3_jass_map, quest_complete_all_cheat_marks_every_allocated_quest) {
+    LPCSTR (*old_cvar)(LPCSTR, LPCSTR);
+    LPCSTR command[] = { "quest", "complete", "all" };
+
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  local quest q1 = CreateQuest()\n"
+        "  local quest q2 = CreateQuest()\n"
+        "  local questitem item = QuestCreateItem(q2)\n"
+        "endfunction\n"
+    ));
+    old_cvar = gi.CvarString;
+    gi.CvarString = result_cheats_cvar;
+
+    G_ClientCommand(&g_edicts[0], 3, command);
+
+    T_ASSERT(level.quests[0].completed);
+    T_ASSERT(level.quests[1].completed);
+    T_ASSERT(level.quests[1].items[0].completed);
+
+    gi.CvarString = old_cvar;
+}
+
+TEST(wc3_jass_map, cheat_console_feedback_skips_disconnected_client_transport) {
+    LPCSTR (*old_cvar)(LPCSTR, LPCSTR);
+    void (*old_write)(pfWriteType_t, void const *);
+    void (*old_unicast)(LPEDICT);
+    LPCSTR command[] = { "quest", "complete", "all" };
+
+    T_ASSERT(run_test_jass(
+        "function main takes nothing returns nothing\n"
+        "  local quest q = CreateQuest()\n"
+        "endfunction\n"
+    ));
+    old_cvar = gi.CvarString;
+    old_write = gi.Write;
+    old_unicast = gi.unicast;
+    gi.CvarString = result_cheats_cvar;
+    gi.Write = cheat_console_capture_write;
+    gi.unicast = cheat_console_capture_unicast;
+    game.clients[0].connected = false;
+    cheat_console_capture_reset();
+
+    G_ClientCommand(&g_edicts[0], 3, command);
+
+    T_ASSERT(level.quests[0].completed);
+    T_EQ(cheat_console_unicasts, 0);
+    T_EQ(cheat_console_opcode, -1);
+    T_ASSERT(!cheat_console_text[0]);
+
+    gi.CvarString = old_cvar;
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+}
+
+TEST(wc3_jass_map, trigger_fire_cheat_bypasses_disabled_conditions_and_can_supply_selected_context) {
+    LPCSTR (*old_cvar)(LPCSTR, LPCSTR);
+    char index_text[16];
+    LPCSTR command[] = { "trigger", "fire", index_text, "selected" };
+
+    T_ASSERT(run_test_jass(
+        "globals\n"
+        "  quest debugQuest = null\n"
+        "endglobals\n"
+        "function Never takes nothing returns boolean\n"
+        "  return false\n"
+        "endfunction\n"
+        "function DebugComplete takes nothing returns nothing\n"
+        "  if GetTriggerUnit() != null and GetTriggerPlayer() == Player(0) then\n"
+        "    call QuestSetCompleted(debugQuest, true)\n"
+        "  endif\n"
+        "endfunction\n"
+        "function main takes nothing returns nothing\n"
+        "  local trigger t = CreateTrigger()\n"
+        "  set debugQuest = CreateQuest()\n"
+        "  call TriggerAddCondition(t, Condition(function Never))\n"
+        "  call TriggerAddAction(t, function DebugComplete)\n"
+        "  call DisableTrigger(t)\n"
+        "endfunction\n"
+    ));
+    T_ASSERT(level.num_triggers > 0);
+    snprintf(index_text, sizeof(index_text), "%u", (unsigned)(level.num_triggers - 1));
+
+    g_edicts[0].inuse = true;
+    g_edicts[0].health.value = 1.0f;
+    g_edicts[0].s.player = 0;
+    g_edicts[0].selected = 1u << game.clients[0].ps.number;
+
+    old_cvar = gi.CvarString;
+    gi.CvarString = result_cheats_cvar;
+    G_ClientCommand(&g_edicts[0], 4, command);
+    jass_runevents(level.vm);
+
+    T_ASSERT(level.quests[0].completed);
+
+    gi.CvarString = old_cvar;
+}
+
+TEST(wc3_jass_map, cinematic_list_rejects_helpers_and_victory_defeat_triggers) {
+    LPCSTR (*old_cvar)(LPCSTR, LPCSTR);
+    void (*old_write)(pfWriteType_t, void const *);
+    void (*old_unicast)(LPEDICT);
+    LPCSTR command[] = { "cinematic", "list" };
+
+    T_ASSERT(run_test_jass(
+        "function Intro_Cinematic_Actions takes nothing returns nothing\n"
+        "endfunction\n"
+        "function Intro_Cinematic_Skip_Actions takes nothing returns nothing\n"
+        "endfunction\n"
+        "function Intro_Time_Stop_Actions takes nothing returns nothing\n"
+        "endfunction\n"
+        "function End_Cinematic_Actions takes nothing returns nothing\n"
+        "endfunction\n"
+        "function Victory_Cheat_Actions takes nothing returns nothing\n"
+        "endfunction\n"
+        "function Victory_Found_Medivh_Actions takes nothing returns nothing\n"
+        "endfunction\n"
+        "function Defeat_Thrall_Dies_Actions takes nothing returns nothing\n"
+        "endfunction\n"
+        "function main takes nothing returns nothing\n"
+        "  local trigger a = CreateTrigger()\n"
+        "  local trigger b = CreateTrigger()\n"
+        "  local trigger c = CreateTrigger()\n"
+        "  local trigger d = CreateTrigger()\n"
+        "  local trigger e = CreateTrigger()\n"
+        "  local trigger f = CreateTrigger()\n"
+        "  local trigger g = CreateTrigger()\n"
+        "  call TriggerAddAction(a, function Intro_Cinematic_Actions)\n"
+        "  call TriggerAddAction(b, function Intro_Cinematic_Skip_Actions)\n"
+        "  call TriggerAddAction(c, function Intro_Time_Stop_Actions)\n"
+        "  call TriggerAddAction(d, function End_Cinematic_Actions)\n"
+        "  call TriggerAddAction(e, function Victory_Cheat_Actions)\n"
+        "  call TriggerAddAction(f, function Victory_Found_Medivh_Actions)\n"
+        "  call TriggerAddAction(g, function Defeat_Thrall_Dies_Actions)\n"
+        "endfunction\n"
+    ));
+
+    old_cvar = gi.CvarString;
+    old_write = gi.Write;
+    old_unicast = gi.unicast;
+    gi.CvarString = result_cheats_cvar;
+    gi.Write = cheat_console_capture_write;
+    gi.unicast = cheat_console_capture_unicast;
+    game.clients[0].connected = true;
+    cheat_console_capture_reset();
+
+    G_ClientCommand(&g_edicts[0], 2, command);
+
+    T_ASSERT(strstr(cheat_console_text, "Intro_Cinematic_Actions") != NULL);
+    T_ASSERT(strstr(cheat_console_text, "End_Cinematic_Actions") != NULL);
+    T_ASSERT(strstr(cheat_console_text, "Intro_Cinematic_Skip_Actions") == NULL);
+    T_ASSERT(strstr(cheat_console_text, "Intro_Time_Stop_Actions") == NULL);
+    T_ASSERT(strstr(cheat_console_text, "Victory_Cheat_Actions") == NULL);
+    T_ASSERT(strstr(cheat_console_text, "Victory_Found_Medivh_Actions") == NULL);
+    T_ASSERT(strstr(cheat_console_text, "Defeat_Thrall_Dies_Actions") == NULL);
+    T_EQ(cheat_console_opcode, svc_console_print);
+    T_ASSERT(cheat_console_unicasts > 0);
+
+    game.clients[0].connected = false;
+    gi.CvarString = old_cvar;
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+}
+
+TEST(wc3_jass_map, objective_list_finds_real_victory_progression_not_cheat_or_defeat) {
+    LPCSTR (*old_cvar)(LPCSTR, LPCSTR);
+    void (*old_write)(pfWriteType_t, void const *);
+    void (*old_unicast)(LPEDICT);
+    LPCSTR command[] = { "objective", "list" };
+
+    T_ASSERT(run_test_jass(
+        "function Victory_Cheat_Actions takes nothing returns nothing\n"
+        "endfunction\n"
+        "function Victory_Found_Medivh_Actions takes nothing returns nothing\n"
+        "endfunction\n"
+        "function Defeat_Thrall_Dies_Actions takes nothing returns nothing\n"
+        "endfunction\n"
+        "function End_Cinematic_Actions takes nothing returns nothing\n"
+        "endfunction\n"
+        "function main takes nothing returns nothing\n"
+        "  local trigger a = CreateTrigger()\n"
+        "  local trigger b = CreateTrigger()\n"
+        "  local trigger c = CreateTrigger()\n"
+        "  local trigger d = CreateTrigger()\n"
+        "  call TriggerAddAction(a, function Victory_Cheat_Actions)\n"
+        "  call TriggerAddAction(b, function Victory_Found_Medivh_Actions)\n"
+        "  call TriggerAddAction(c, function Defeat_Thrall_Dies_Actions)\n"
+        "  call TriggerAddAction(d, function End_Cinematic_Actions)\n"
+        "endfunction\n"
+    ));
+
+    old_cvar = gi.CvarString;
+    old_write = gi.Write;
+    old_unicast = gi.unicast;
+    gi.CvarString = result_cheats_cvar;
+    gi.Write = cheat_console_capture_write;
+    gi.unicast = cheat_console_capture_unicast;
+    game.clients[0].connected = true;
+    cheat_console_capture_reset();
+
+    G_ClientCommand(&g_edicts[0], 2, command);
+
+    T_ASSERT(strstr(cheat_console_text, "Victory_Found_Medivh_Actions") != NULL);
+    T_ASSERT(strstr(cheat_console_text, "Victory_Cheat_Actions") == NULL);
+    T_ASSERT(strstr(cheat_console_text, "Defeat_Thrall_Dies_Actions") == NULL);
+    T_ASSERT(strstr(cheat_console_text, "End_Cinematic_Actions") == NULL);
+    T_EQ(cheat_console_opcode, svc_console_print);
+    T_ASSERT(cheat_console_unicasts > 0);
+
+    game.clients[0].connected = false;
+    gi.CvarString = old_cvar;
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+}
+
+TEST(wc3_jass_map, objective_complete_executes_completion_trigger) {
+    LPCSTR (*old_cvar)(LPCSTR, LPCSTR);
+    char index_text[16];
+    LPCSTR command[] = { "objective", "complete", index_text };
+
+    T_ASSERT(run_test_jass(
+        "globals\n"
+        "  quest debugQuest = null\n"
+        "endglobals\n"
+        "function Victory_Found_Medivh_Actions takes nothing returns nothing\n"
+        "  call QuestSetCompleted(debugQuest, true)\n"
+        "endfunction\n"
+        "function main takes nothing returns nothing\n"
+        "  local trigger t = CreateTrigger()\n"
+        "  set debugQuest = CreateQuest()\n"
+        "  call TriggerAddAction(t, function Victory_Found_Medivh_Actions)\n"
+        "endfunction\n"
+    ));
+    T_ASSERT(level.num_triggers > 0);
+    snprintf(index_text, sizeof(index_text), "%u", (unsigned)(level.num_triggers - 1));
+
+    old_cvar = gi.CvarString;
+    gi.CvarString = result_cheats_cvar;
+    G_ClientCommand(&g_edicts[0], 3, command);
+    jass_runevents(level.vm);
+
+    T_ASSERT(level.quests[0].completed);
+    gi.CvarString = old_cvar;
+}
+
+TEST(wc3_jass_map, cinematic_play_cheat_executes_authored_trigger_actions) {
+    LPCSTR (*old_cvar)(LPCSTR, LPCSTR);
+    char index_text[16];
+    LPCSTR command[] = { "cinematic", "play", index_text };
+
+    T_ASSERT(run_test_jass(
+        "globals\n"
+        "  quest debugQuest = null\n"
+        "endglobals\n"
+        "function CinematicNever takes nothing returns boolean\n"
+        "  return false\n"
+        "endfunction\n"
+        "function Intro_Cinematic_Actions takes nothing returns nothing\n"
+        "  call QuestSetCompleted(debugQuest, true)\n"
+        "endfunction\n"
+        "function main takes nothing returns nothing\n"
+        "  local trigger t = CreateTrigger()\n"
+        "  set debugQuest = CreateQuest()\n"
+        "  call TriggerAddCondition(t, Condition(function CinematicNever))\n"
+        "  call TriggerAddAction(t, function Intro_Cinematic_Actions)\n"
+        "  call DisableTrigger(t)\n"
+        "endfunction\n"
+    ));
+    T_ASSERT(level.num_triggers > 0);
+    snprintf(index_text, sizeof(index_text), "%u", (unsigned)(level.num_triggers - 1));
+
+    old_cvar = gi.CvarString;
+    gi.CvarString = result_cheats_cvar;
+    G_ClientCommand(&g_edicts[0], 3, command);
+    jass_runevents(level.vm);
+
+    T_ASSERT(level.quests[0].completed);
+
+    gi.CvarString = old_cvar;
+}
+
+TEST(wc3_jass_map, cinematic_stop_cheat_uses_end_cinematic_event_handler) {
+    LPCSTR (*old_cvar)(LPCSTR, LPCSTR);
+    LPCSTR command[] = { "cinematic", "stop" };
+
+    T_ASSERT(run_test_jass(
+        "globals\n"
+        "  quest debugQuest = null\n"
+        "endglobals\n"
+        "function End_Cinematic_Actions takes nothing returns nothing\n"
+        "  call QuestSetCompleted(debugQuest, true)\n"
+        "endfunction\n"
+        "function main takes nothing returns nothing\n"
+        "  local trigger t = CreateTrigger()\n"
+        "  set debugQuest = CreateQuest()\n"
+        "  call TriggerRegisterPlayerEvent(t, Player(0), EVENT_PLAYER_END_CINEMATIC)\n"
+        "  call TriggerAddAction(t, function End_Cinematic_Actions)\n"
+        "endfunction\n"
+    ));
+
+    old_cvar = gi.CvarString;
+    gi.CvarString = result_cheats_cvar;
+    G_ClientCommand(&g_edicts[0], 2, command);
+    G_RunEvents();
+    jass_runevents(level.vm);
+
+    T_ASSERT(level.quests[0].completed);
+
+    gi.CvarString = old_cvar;
+}
+
+TEST(wc3_jass_map, jass_cheat_starts_named_zero_argument_function) {
+    LPCSTR (*old_cvar)(LPCSTR, LPCSTR);
+    LPCSTR command[] = { "jass", "DebugComplete" };
+
+    T_ASSERT(run_test_jass(
+        "globals\n"
+        "  quest debugQuest = null\n"
+        "endglobals\n"
+        "function DebugComplete takes nothing returns nothing\n"
+        "  call QuestSetCompleted(debugQuest, true)\n"
+        "endfunction\n"
+        "function main takes nothing returns nothing\n"
+        "  set debugQuest = CreateQuest()\n"
+        "endfunction\n"
+    ));
+    old_cvar = gi.CvarString;
+    gi.CvarString = result_cheats_cvar;
+
+    G_ClientCommand(&g_edicts[0], 2, command);
+    jass_runevents(level.vm);
+
+    T_ASSERT(level.quests[0].completed);
+
+    gi.CvarString = old_cvar;
 }
 
 /* =========================================================================

--- a/games/warcraft-3/menu/screens/single_player.c
+++ b/games/warcraft-3/menu/screens/single_player.c
@@ -497,7 +497,7 @@ static void SinglePlayer_MarkMissionPlayed(singlePlayerCampaign_t const *campaig
 }
 
 static void SinglePlayer_LaunchMission(singlePlayerCampaign_t const *campaign, DWORD mission_index) {
-    char command[256];
+    char command[MAX_PATHLEN + 7];
     LPCSTR map_path;
 
     if (!campaign || mission_index >= campaign->num_missions) {
@@ -532,7 +532,8 @@ static void SinglePlayer_PopulateMissionList(singlePlayerCampaign_t const *campa
         if (mission->header[0] && mission->name[0]) {
             snprintf(item->name, sizeof(item->name), "%.52s: %.73s", mission->header, mission->name);
         } else {
-            snprintf(item->name, sizeof(item->name), "%s", mission->name[0] ? mission->name : mission->map_path);
+            snprintf(item->name, sizeof(item->name), "%.*s", (int)sizeof(item->name) - 1,
+                     mission->name[0] ? mission->name : mission->map_path);
         }
         snprintf(item->path, sizeof(item->path), "%s", mission->map_path);
         item->flags = i;

--- a/games/warcraft-3/tests/test_client_stubs.c
+++ b/games/warcraft-3/tests/test_client_stubs.c
@@ -24,6 +24,7 @@ COLOR32 test_cursor_tint;
 char test_forwarded_command[128];
 char test_menu_action[32];
 char test_menu_action_arg[128];
+char test_console_message[MAX_CONSOLE_MESSAGE_LEN];
 static PATHSTR test_existing_file;
 static BOX2 test_world_bounds;
 static size2_t test_window_size;
@@ -66,6 +67,13 @@ static bool mock_DrawCursor(float x, float y, COLOR32 tint) {
 
 void V_RenderView(void) {}
 void CON_DrawConsole(void) {}
+void CON_printf(LPCSTR fmt, ...) {
+    va_list args;
+
+    va_start(args, fmt);
+    vsnprintf(test_console_message, sizeof(test_console_message), fmt, args);
+    va_end(args);
+}
 BOOL CL_GameplayInputReady(void) { return false; }
 
 int Cvar_Integer(LPCSTR name, int fallback) {
@@ -126,6 +134,7 @@ void test_client_stubs_init(void) {
     test_forwarded_command[0] = '\0';
     test_menu_action[0] = '\0';
     test_menu_action_arg[0] = '\0';
+    test_console_message[0] = '\0';
     test_existing_file[0] = '\0';
     test_world_bounds = (BOX2){ 0 };
     test_window_size = MAKE(size2_t, 1024, 768);

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -50,6 +50,7 @@ extern COLOR32 test_cursor_tint;
 extern char test_forwarded_command[128];
 extern char test_menu_action[32];
 extern char test_menu_action_arg[128];
+extern char test_console_message[MAX_CONSOLE_MESSAGE_LEN];
 
 static RECT test_scroll_rects[3], test_scroll_uvs[3];
 static LPCTEXTURE test_scroll_tex[3];
@@ -2548,6 +2549,22 @@ TEST(net, active_entity_list_frame_copy_and_map_reset) {
     /* Loading a new map drops the list so fresh baselines repopulate it. */
     CL_BeginLoadingMap("Maps\\Test.w3m");
     T_EQ(cl.num_active, 0);
+}
+
+TEST(net, console_print_message_is_consumed) {
+    BYTE buf[128];
+    sizeBuf_t sb;
+
+    test_client_stubs_init();
+    sb = make_msg_buf(buf, sizeof(buf));
+    MSG_WriteByte(&sb, svc_console_print);
+    MSG_WriteString(&sb, "WC3: objective completion candidate trigger 40 enabled");
+    sb.readcount = 0;
+
+    CL_ParseServerMessage(&sb);
+
+    T_EQ(sb.readcount, sb.cursize);
+    T_STREQ(test_console_message, "WC3: objective completion candidate trigger 40 enabled");
 }
 
 TEST(net, set_selection_rejects_undersized_payload) {


### PR DESCRIPTION
Add a set of `sv_cheats`-gated Warcraft III campaign debugging commands for inspecting and advancing map-authored mission logic without forcing the entire level to end.

Add quest inspection and completion commands:

* `quest list`
* `quest complete <index>`
* `quest complete all`

Quest indices use the same zero-based in-use ordering as the existing `quest <index>` journal command.

Keep quest completion deliberately limited to QUEST and QUESTITEM state. Marking a quest complete does not synthesize a Warcraft trigger event or attempt to reproduce the surrounding campaign logic. Dialogue, spawns, trigger activation, cinematics, and mission results remain controlled by the map script.

Add trigger inspection and direct execution commands:

* `trigger list [filter]`
* `trigger fire <index>`
* `trigger fire <index> selected`

Trigger listing exposes the stable `level.triggers[]` index together with registered conditions, actions, and enabled state.

Direct trigger firing intentionally executes the trigger's registered actions without evaluating its conditions and regardless of whether the trigger is disabled. This provides a low-level way to invoke campaign progression and completion logic before the normal gameplay event occurs.

The optional `selected` argument supplies the current primary selected unit as event-response context, allowing common map code using `GetTriggerUnit()` and unit-derived `GetTriggerPlayer()` to work while leaving unrelated event state unset.

Add named JASS execution:

* `jass <zero-argument-function-name>`

Start the requested map function as a JASS coroutine so generated `Trig_*_Actions` functions can be invoked directly while preserving normal waits, transmissions, and `TriggerSleepAction` behavior.

Add higher-level objective discovery and completion commands:

* `objective list [filter]`
* `objective complete <trigger-index>`
* `objective complete <trigger-index> selected`

Discover likely mission-completion triggers from their registered action function names.

Recognize ordinary Victory actions and quest/objective action names with completion markers such as Complete, Finish, and Done, while excluding obvious Cheat, Defeat, cinematic, intro/outro, skip, and time-stop helpers.

This makes map-authored progression functions such as `Trig_Victory_Found_Medivh_Actions` directly discoverable without mistaking `Trig_Victory_Cheat_Actions` or normal defeat handlers for objectives.

Execute objective completion through the same direct trigger path as `trigger fire`. This preserves the actual map-authored behavior including quest updates, dialogue, spawning, trigger state changes, cinematics, and eventual victory transitions.

Add scripted in-map cinematic commands:

* `cinematic list [filter]`
* `cinematic play <trigger-index>`
* `cinematic play <trigger-index> selected`
* `cinematic stop`

Warcraft III maps do not expose a canonical cinematic trigger table, so discover likely cinematic entry points from registered action names containing strong cutscene markers:

* cinematic
* cutscene
* intro
* outro
* ending
* interlude

Reject common support/helper triggers such as:

* skip handlers
* time-stop helpers
* cheat triggers

Do not classify generic Victory or Defeat triggers as cinematics, since campaign maps frequently use those names for ordinary mission progression and result logic.

This removes observed false positives such as:

* `Trig_Intro_Cinematic_Skip_Actions`
* `Trig_Intro_Time_Stop_Actions`
* `Trig_Victory_Cheat_Actions`
* `Trig_Defeat_Cheat_Actions`
* `Trig_Victory_Found_Medivh_Actions`
* `Trig_Defeat_Thrall_Dies_Actions`

while retaining genuine cutscene entry points such as:

* `Trig_Intro_Cinematic_Actions`
* `Trig_End_Cinematic_Actions`

Run cinematic playback through the real trigger action path so camera movement, transmissions, cinefilters, unit orders, waits, quest changes, and subsequent map logic remain authored by the map rather than being reimplemented in engine-specific code.

Implement `cinematic stop` through Warcraft's existing `EVENT_PLAYER_END_CINEMATIC` path used by Escape. Do not forcibly reset the HUD, camera, user control, or units in the cheat itself. This allows the map's own skip handler to perform its expected cleanup.

Keep these cinematic commands scoped to scripted in-map JASS cutscenes. Prerendered `PlayCinematic` movie playback remains a separate movie decoding and presentation concern.

Add a lightweight server/game-to-client console-print protocol message:

* `svc_console_print`

Parse it on the client through `CON_printf` so campaign debugging command results appear in the in-game OpenRealm console as well as stderr.

Use this path for quest, trigger, objective, cinematic, and JASS command feedback rather than reusing lobby chat or Warcraft HUD messaging.

Add the corresponding standalone client-test `CON_printf` stub and verify that console-print payloads reach the expected client console text.

Also resolve single-player menu truncation warnings by sizing the map launch command buffer for a complete `PATHSTR` and explicitly bounding mission display labels to the destination UI buffer.

Add tests covering:

* completing one quest and its objectives
* completing all allocated quests
* firing a disabled trigger whose condition is false
* selected-unit trigger context
* named zero-argument JASS execution
* cinematic candidate filtering
* objective candidate discovery
* objective completion through authored trigger actions
* cinematic playback
* cinematic stop through an authored end-cinematic handler
* server-to-client console-print transport
* client console-print parsing and text delivery

Document the distinction between quest-state mutation, objective trigger execution, direct trigger/JASS debugging, scripted cinematics, and prerendered movies, together with the new in-game console workflow.