### PR TITLE
wc3: Selection status and order fixes

### DIFF
--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -779,6 +779,16 @@ void SCR_LayoutDrawMultiSelect(LPCUIFRAME frame, LPCRECT scrn) {
     FOR_LOOP(i, ms->numitems) {
         RECT uv = { 0, 0, 1, 1 };
         uiMultiselectItem_t const *item = &ms->items[i];
+        if ((item->flags & UI_MULTISELECT_ITEM_FOCUSED) && ms->focus_highlight) {
+            RECT highlight = {
+                screen.x - screen.w * 0.185f,
+                screen.y - screen.h * 0.10f,
+                screen.w * 1.37f,
+                screen.h * 1.75f
+            };
+            re.DrawImage(cl.pics[ms->focus_highlight], &highlight, &uv,
+                         MAKE(COLOR32, 255, 255, 0, 255));
+        }
         re.DrawImage(cl.pics[item->image], &screen, &uv, frame->color);
         LPCENTITYSTATE ent = &cl.ents[item->entity].current;
         if (ent) {
@@ -813,6 +823,7 @@ void SCR_LayoutDrawPortrait(LPCUIFRAME frame, LPCRECT screen) {
     LPCMODEL port  = cl.portraits[frame->tex.index];
     LPCMODEL model = cl.models[frame->tex.index];
     LPCMODEL draw  = port ? port : model;
+
     if (!draw) return;
 
     LPCSTR anim = (frame->text && *frame->text) ? frame->text : "Portrait";
@@ -1247,6 +1258,10 @@ BOOL SCR_LayoutMouseEvent(menuMouseEvent_t event, int x, int y, int32_t param) {
     if (event == MENU_MOUSE_DOWN) {
         char command[CMDARG_LEN * 2];
         layout_left_down = true;
+        /* Multiselect icons are server-authored gameplay controls. They do not
+         * have an onclick string, so consume the press here and resolve the
+         * concrete entity on release below. */
+        if (hovered_frame && hovered_frame->flags.type == FT_MULTISELECT) return true;
         if (!hovered_frame || layout_held_command[0]) return false;
         SCR_LayoutFormatOnClickCommand(hovered_frame->onclick, command, sizeof(command));
         if (command[0] != '+') return false;
@@ -1282,7 +1297,7 @@ BOOL SCR_LayoutMouseEvent(menuMouseEvent_t event, int x, int y, int32_t param) {
                 if (entity) {
                     MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
                     SZ_Printf(&cls.netchan.message, "focus %u", (unsigned)entity);
-                    return false;
+                    return true;
                 }
                 continue;
             }

--- a/common/shared.h
+++ b/common/shared.h
@@ -920,9 +920,12 @@ typedef struct {
     DWORD endtime;
 } uiBuildQueueItem_t;
 
+#define UI_MULTISELECT_ITEM_FOCUSED (1u << 0)
+
 typedef struct {
     USHORT image;
     USHORT entity;
+    USHORT flags;
 } uiMultiselectItem_t;
 
 typedef struct {
@@ -947,6 +950,7 @@ typedef struct {
 typedef struct {
     RESOURCE hp_bar;
     RESOURCE mana_bar;
+    RESOURCE focus_highlight;
     VECTOR2 offset;
     USHORT numcolumns;
     USHORT numitems;

--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -296,17 +296,25 @@ The selected-unit portrait is one of those runtime-owned frames. Current Warsmas
 `SmashUI/UnitPortrait.fdf`; that file is useful as a parity reference but is not retail MPQ data and must not be loaded by OpenRealm.
 The runtime portrait therefore mirrors its final WC3-space contract directly: the model is `(0.211, 0.4865, 0.0835, 0.085)`, while
 centered `current / max` health and mana strings occupy the strip below it. The strings retain Warsmash's `TextLength 20` contract.
+The portrait remains authored in the same centered `0.8 x 0.6` safe area as `ConsoleUI`. Do not give the portrait layer an
+independent `UIFLAG_EXTEND_WIDESCREEN_X` root. OpenRealm draws `LAYER_PORTRAIT` before `LAYER_CONSOLE`; the later console art contains
+the visible portrait cut-out. Moving only the model to the physical widescreen edge leaves the console in the centered safe area, so
+the valid portrait render is covered by opaque console art and appears completely missing. Gameplay transmissions must use the same
+safe-area coordinates as the normal selected-unit portrait so both remain aligned with the console opening.
+
 Health uses the Warcraft red -> yellow -> green life-ratio gradient and mana is white; units with no mana keep the mana frame but render
-an empty value. These are live snapshot bindings, not static text baked into `LAYER_PORTRAIT`: the server writes the sole-selected
+an empty value. These are live snapshot bindings, not static text baked into `LAYER_PORTRAIT`: the server writes the focused selected
 unit's exact current/max HP and mana to the reserved generic `playerState.stats[18..21]` UI slots each frame, and the client resolves
-`UI_STAT_SELECTION_HEALTH_TEXT` / `UI_STAT_SELECTION_MANA_TEXT` when drawing the already-authored portrait frames. The health colour
-is likewise derived from those current snapshot values. This deliberately avoids retransmitting the complete portrait layout for every
-damage, heal, regeneration, or mana tick and remains independent of the `LAYER_INFOPANEL` presentation cache (important while a
-selected building is showing its build/training queue). A normal gameplay transmission can still replace the portrait layer; once the
-selected-unit portrait is authored again, the same live bindings immediately display the current values.
+`UI_STAT_SELECTION_HEALTH_TEXT` / `UI_STAT_SELECTION_MANA_TEXT` when drawing the already-authored portrait frames. A multiselection
+therefore keeps the focused unit's portrait visible instead of clearing `LAYER_PORTRAIT`, and clicking another subgroup changes the
+portrait and its live stats without altering selection membership. The health colour is likewise derived from those current snapshot
+values. This deliberately avoids retransmitting the complete portrait layout for every damage, heal, regeneration, or mana tick and
+remains independent of the `LAYER_INFOPANEL` presentation cache (important while a selected building is showing its build/training
+queue). A normal gameplay transmission can still replace the portrait layer; once the selected-unit portrait is authored again, the
+same live bindings immediately display the current values.
 
 Holding the selected-unit portrait is also a camera control. The server-authored portrait uses a Quake-style
-`+portraitcamera <entity>` layout command: press recenters on the currently sole-selected unit and installs that unit as the existing
+`+portraitcamera <entity>` layout command: press recenters on the currently focused selected unit and installs that unit as the existing
 camera target controller; release sends the captured `-portraitcamera` command and clears the controller even if the pointer left the
 portrait. `G_RunClients()` then follows the target's current position each simulation frame for the duration of the hold. This reuses
 the same target-controller state as `SetCameraTargetController` rather than adding a second follow-camera implementation.

--- a/docs/games/warcraft-3/selection-and-control.md
+++ b/docs/games/warcraft-3/selection-and-control.md
@@ -55,12 +55,22 @@ focus without changing any selection bits. Focus is transient UI/input state and
 is reset when map-player state is initialized rather than being added to the save
 format.
 
-`FT_MULTISELECT` is one packed frame, but each payload item already carries its
-entity number. `client/cl_scrn.c` therefore hit-tests the authored icon grid using
-the frame rectangle plus `uiMultiselect_t.offset`, sends `focus <entity>` on a
-left-button release over an icon, and treats every icon as gameplay UI so a click
-does not leak through to world selection. The server validates that the entity is
-still selected before accepting the focus change.
+`FT_MULTISELECT` is one packed frame, but each payload item carries its entity
+number and a focused-subgroup flag. `client/cl_scrn.c` hit-tests the authored icon
+grid using the frame rectangle plus `uiMultiselect_t.offset`, consumes both mouse
+edges over an icon, and sends `focus <entity>` on release. The server validates
+that the entity is still selected before accepting the focus change. It then
+rebuilds the full focused-selection presentation (info panel, inventory, portrait,
+and command card), so focus cannot change only the command card while leaving the
+status panel stale.
+
+The focused subgroup follows Warsmash's `RenderUnit.groupsWith()` rule: selected
+units with the same unit type (`class_id` in OpenRealm) are marked focused together.
+The client draws the active skin's `SelectedSubgroupHighlight` behind those icons.
+Selection membership remains unchanged; the concrete clicked unit is still the
+focused unit used by focused-unit commands, inventory, and the persistent unit
+portrait. The portrait remains visible for multiselections and follows focus; its
+live HP/mana bindings follow the same focused entity.
 
 When an entity-target command is active, the same multiselect-icon click is routed
 to `menu.on_entity_selected` instead of changing focus. This preserves the
@@ -73,11 +83,11 @@ order-response selection. The complete selection remains authoritative for
 multi-unit Smart/Move/Attack-style orders. Inventory presentation follows the
 same focused-unit rule; see [Inventory And World Items](inventory-and-items.md).
 
-OpenRealm still does not reproduce Warsmash's type-wide
-`SelectedSubgroupHighlight`, focused/unfocused icon scaling, keyboard subgroup
-cycling, or the Warsmash behavior where clicking the already-focused exact icon
-collapses the group to that one unit. Those are presentation/navigation gaps, not
-reasons to merge inventory state across the group.
+OpenRealm still does not reproduce Warsmash's focused/unfocused icon scaling,
+keyboard subgroup cycling, or the Warsmash behavior where clicking the
+already-focused exact icon collapses the group to that one unit. Those are
+presentation/navigation gaps, not reasons to merge inventory state across the
+group.
 
 ## Relationship Presentation
 
@@ -138,14 +148,14 @@ Selection acknowledgement voices are queued only for controllable selections. Or
 
 ## Selection Lifetime
 
-`G_UpdateClientSelections` runs immediately after `G_FowUpdate` each server frame. It scans the raw per-player selection bits (not `G_IsEntitySelected`, which intentionally hides already-invalid entities), removes any entry that no longer passes `G_UnitCanBeSelected`, then refreshes portrait/info/inventory and command presentation for connected clients.
+`G_UpdateClientSelections` runs immediately after `G_FowUpdate` each server frame. It scans the raw per-player selection bits (not `G_IsEntitySelected`, which intentionally hides already-invalid entities), removes any entry that no longer passes `G_UnitCanBeSelected`, then calls `G_SyncClientSelection()`. That helper mirrors the authoritative surviving entity list with `svc_set_selection` and refreshes portrait/info/inventory plus command presentation. The same helper is used after normal `select` filtering, server-driven Hero/idle-worker shortcuts, and immediate death removal, so the client-side current-selection cache cannot retain entities the server discarded.
 
 Consequences:
 
 - an enemy that leaves active vision stops being selected;
 - a hidden or newly unselectable unit has its stale selection bit removed.
 
-Death has a stronger immediate path in `unit_die`: it sets health to zero, clears all selection bits, sets `EF_NOT_SELECTABLE`, releases any held animation frame, and starts the death animation. The order entry points reject dead units as well, so a corpse cannot be picked or receive a new movement/order that would replace its death animation. `G_ReviveHero` clears `EF_NOT_SELECTABLE` when the persistent Hero edict is revived.
+Death has a stronger immediate path in `unit_die`: it snapshots which players had the unit selected, sets health to zero, clears all selection bits, sets `EF_NOT_SELECTABLE`, releases any held animation frame, and starts the death animation. After death/event bookkeeping it synchronizes every connected affected client. This is necessary because clearing the raw bit before `G_UpdateClientSelections()` means the later revalidation pass cannot discover which client lost membership. The info-panel cache also retains the last non-single selection count so a multiselect that shrinks but remains a multiselect is reserialized instead of leaving the corpse icon behind. The order entry points reject dead units as well, so a corpse cannot be picked or receive a new movement/order that would replace its death animation. `G_ReviveHero` clears `EF_NOT_SELECTABLE` when the persistent Hero edict is revived.
 
 ## Known Gaps
 

--- a/docs/games/warcraft-3/selection-and-control.md
+++ b/docs/games/warcraft-3/selection-and-control.md
@@ -48,12 +48,43 @@ Targeted ability callbacks (`menu.on_entity_selected`) are a separate path: a le
 
 Selection membership and focused-unit presentation are separate state. The server
 retains one focused entity from the current selection; `G_GetMainSelectedUnit()`
-returns that entity while it remains selected, then falls back to the first live
-selected entity if the focus becomes invalid. `G_SelectEntity()` establishes the
-first unit as focus for a new selection, while `G_FocusSelectedUnit()` changes
-focus without changing any selection bits. Focus is transient UI/input state and
-is reset when map-player state is initialized rather than being added to the save
-format.
+returns that entity while it remains selected, then falls back to the first unit
+in canonical Warcraft selection order if the focus becomes invalid.
+`G_SelectEntity()` still establishes an initial focus while membership is being
+built, while the completed `select` command replaces that provisional choice with
+the first canonically ordered unit. `G_FocusSelectedUnit()` changes focus without
+changing any selection bits. Focus is transient UI/input state and is reset when
+map-player state is initialized rather than being added to the save format.
+
+### Multi-selection ordering
+
+`G_GetOrderedSelectedUnits()` is the shared authoritative ordering path used by
+the status panel and default-focus fallback. It reproduces the comparator in
+Warsmash `MeleeUI.selectWidgets()`:
+
+1. `UnitData.slk` `prio` / `UnitData_t.priority`, descending;
+2. `UnitBalance.slk` `level` / `UnitBalance_t.level`, descending;
+3. unit type rawcode, descending in canonical Warcraft `War3ID` byte order.
+
+The third comparison needs an explicit conversion. OpenRealm's `MAKEFOURCC`
+stores the first character in the low byte (`'hfoo'` is little-endian in the
+native integer), while Warsmash `War3ID` stores the first character in the high
+byte before comparing its integer value. Comparing `edict.class_id` directly is
+therefore not equivalent; `G_SelectionRawcodeValue()` converts to canonical
+Warcraft byte order first.
+
+The sort is stable for equal comparator keys. OpenRealm's authoritative selection
+membership is currently only an entity bit per player, so it does not retain the
+original click/rectangle insertion order. Equal unit types therefore preserve the
+server's deterministic edict scan order rather than Warsmash's original input-list
+order. Reproducing that final within-type detail would require retaining selection
+insertion order as additional transient state.
+
+The completed `select` command uses the first sorted unit for both default focus
+and the initial selection acknowledgement sound, matching Warsmash's flow where
+`selectUnits()` chooses `selectedUnits.get(0)` after sorting. Clicking a later
+multiselect portrait may still explicitly focus that unit without reordering the
+panel.
 
 `FT_MULTISELECT` is one packed frame, but each payload item carries its entity
 number and a focused-subgroup flag. `client/cl_scrn.c` hit-tests the authored icon
@@ -166,7 +197,7 @@ The following are deliberately not inferred by the current implementation:
 - invisibility/detection-aware selectability (`IsUnitDetected`/`IsUnitInvisible` coverage is incomplete);
 - Shift-click toggle semantics (Shift-drag addition exists separately);
 - Ctrl-click and double-click same-type expansion;
-- WC3 priority/level/rawcode sorting of the 12 selected entries;
+- exact Warsmash within-identical-type insertion ordering (selection membership currently retains only per-player bits, so stable ties use edict scan order);
 - neutral-shop patron interaction (`Aneu`/`Apit` remains unfinished);
 - data-driven `SelectionCircle` relationship colours;
 - Neutral Passive critter-specific selection response rules;
@@ -183,7 +214,7 @@ Do not bypass these gaps by weakening `G_UnitCanControl` or by restoring owner c
 
 ## Verification
 
-In-engine coverage is in `games/warcraft-3/game/tests/t_api.c` and `t_unit.c` for relationship classification, visible foreign selectability, shared-control authority, dead-unit non-selectability, selection removal, and Hero revival restoring selectability. `t_items.c` additionally covers mixed-selection Smart item pickup with a non-inventory unit first in the selection.
+In-engine coverage is in `games/warcraft-3/game/tests/t_api.c` and `t_unit.c` for relationship classification, visible foreign selectability, shared-control authority, dead-unit non-selectability, selection removal, Hero revival restoring selectability, and Warsmash priority/level/canonical-rawcode multiselect ordering. `t_items.c` additionally covers mixed-selection Smart item pickup with a non-inventory unit first in the selection.
 
 Useful targeted commands after building the test binary:
 
@@ -193,3 +224,4 @@ make test-wc3-engine WC3_PATTERN='wc3_unit.*'
 ```
 
 Runtime verification should also cover an enemy walking from visible terrain into fog, Neutral Passive/Hostile circle colours, and attempting Smart/command-card orders while a foreign unit is selected.
+For multiselect ordering, drag-select a deliberately mixed group (for example a Hero plus several different unit types) and confirm the status-panel icons remain grouped/sorted by priority, level, then rawcode regardless of entity spawn order; the first sorted unit should own the initial command card and selection response.

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -55,6 +55,37 @@ LPEDICT G_GetMainSelectedUnit(LPGAMECLIENT client) {
     return NULL;
 }
 
+
+void G_SyncClientSelection(LPGAMECLIENT client) {
+    LPEDICT clent;
+    DWORD selected[WC3_SELECTION_LIMIT];
+    DWORD count = 0;
+
+    if (!client) return;
+    FOR_SELECTED_UNITS(client, ent) {
+        if (count >= WC3_SELECTION_LIMIT) break;
+        selected[count++] = ent->s.number;
+    }
+
+    if (!client->connected) {
+        G_InvalidateCommands(client);
+        return;
+    }
+    clent = G_GetPlayerEntityByNumber(client->ps.number);
+    if (!clent || clent->client != client) {
+        G_InvalidateCommands(client);
+        return;
+    }
+
+    gi.Write(PF_BYTE, &(LONG){svc_set_selection});
+    gi.Write(PF_BYTE, &(LONG){count});
+    FOR_LOOP(i, count) gi.Write(PF_LONG, &(LONG){selected[i]});
+    gi.unicast(clent);
+
+    Get_Portrait_f(clent);
+    Get_Commands_f(clent);
+}
+
 BOOL G_FocusSelectedUnit(LPGAMECLIENT client, LPEDICT ent) {
     DWORD *focus = G_SelectionFocusSlot(client);
 
@@ -171,7 +202,6 @@ BOOL G_UnitCanControl(LPGAMECLIENT client, LPCEDICT ent) {
 void G_UpdateClientSelections(void) {
     FOR_LOOP(i, game.max_clients) {
         LPGAMECLIENT client = game.clients + i;
-        LPEDICT clent;
         BOOL changed = false;
         DWORD bit = 1 << client->ps.number;
 
@@ -187,13 +217,7 @@ void G_UpdateClientSelections(void) {
         if (!changed) {
             continue;
         }
-        clent = G_GetPlayerEntityByNumber(client->ps.number);
-        if (client->connected && clent && clent->client == client) {
-            Get_Portrait_f(clent);
-            Get_Commands_f(clent);
-        } else {
-            G_InvalidateCommands(client);
-        }
+        G_SyncClientSelection(client);
     }
 }
 
@@ -332,14 +356,11 @@ CLIENTCOMMAND(Select) {
                  * Passive critter response rules remain a separate gap. */
                 G_PlayUISoundForPlayer(clent, "InterfaceClick");
             }
-            /* Selection is authoritative game state; HUD serialization is not
-             * valid until ClientBegin has completed for this player slot. */
-            if (client->connected) {
-                Get_Portrait_f(clent);
-                Get_Commands_f(clent);
-            } else {
-                G_InvalidateCommands(client);
-            }
+            /* Selection is authoritative game state. Mirror the accepted,
+             * server-filtered membership back to the client cache as well as
+             * rebuilding the HUD so the client cannot retain current-selection entries
+             * that the server rejected. */
+            G_SyncClientSelection(client);
         }
     }
 }
@@ -375,9 +396,10 @@ CLIENTCOMMAND(Focus) {
     }
     if (!G_FocusSelectedUnit(client, target)) return;
 
-    /* Selection membership is unchanged. Only focused-unit presentation and
-     * focused-unit commands need to be rebuilt. */
-    G_RefreshInventoryLayer(clent);
+    /* Selection membership is unchanged. Rebuild the full focused-selection
+     * presentation so the multiselect subgroup highlight, inventory, portrait
+     * and command card all move together. */
+    Get_Portrait_f(clent);
     Get_Commands_f(clent);
 }
 

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -18,6 +18,90 @@ static DWORD *G_SelectionFocusSlot(LPGAMECLIENT client) {
     return &selection_focus[index];
 }
 
+static LONG G_SelectionPriority(LPCEDICT ent) {
+    UnitData_t const *data;
+
+    if (!ent) return 0;
+    data = ent->data.UnitData ? ent->data.UnitData : G_UnitData(ent->class_id);
+    return data ? data->priority : 0;
+}
+
+static LONG G_SelectionLevel(LPCEDICT ent) {
+    UnitBalance_t const *balance;
+
+    if (!ent) return 0;
+    balance = ent->data.UnitBalance ? ent->data.UnitBalance : G_UnitBalance(ent->class_id);
+    return balance ? balance->level : 0;
+}
+
+/* OpenRealm's MAKEFOURCC stores the first character in the low byte, while
+ * Warsmash's War3ID value stores it in the high byte.  Selection ordering uses
+ * Warsmash's numeric War3ID tie-break, so compare a canonical byte-swapped
+ * value rather than the native class_id integer. */
+static DWORD G_SelectionRawcodeValue(DWORD class_id) {
+    return ((class_id & 0x000000ffu) << 24) |
+           ((class_id & 0x0000ff00u) << 8) |
+           ((class_id & 0x00ff0000u) >> 8) |
+           ((class_id & 0xff000000u) >> 24);
+}
+
+/* Return < 0 when lhs belongs before rhs in the Warcraft multiselect panel.
+ * Warsmash sorts unit type priority, level, then War3ID descending.  Equal
+ * unit types compare equal so the stable insertion sort below preserves the
+ * authoritative selection scan order for otherwise-identical entries. */
+static LONG G_CompareSelectionOrder(LPCEDICT lhs, LPCEDICT rhs) {
+    LONG left_value;
+    LONG right_value;
+    DWORD left_rawcode;
+    DWORD right_rawcode;
+
+    left_value = G_SelectionPriority(lhs);
+    right_value = G_SelectionPriority(rhs);
+    if (left_value != right_value) return left_value > right_value ? -1 : 1;
+
+    left_value = G_SelectionLevel(lhs);
+    right_value = G_SelectionLevel(rhs);
+    if (left_value != right_value) return left_value > right_value ? -1 : 1;
+
+    left_rawcode = G_SelectionRawcodeValue(lhs ? lhs->class_id : 0);
+    right_rawcode = G_SelectionRawcodeValue(rhs ? rhs->class_id : 0);
+    if (left_rawcode != right_rawcode) return left_rawcode > right_rawcode ? -1 : 1;
+    return 0;
+}
+
+DWORD G_GetOrderedSelectedUnits(LPGAMECLIENT client, LPEDICT *out, DWORD max_out) {
+    DWORD seen = 0;
+
+    if (!client || !out || !max_out) return 0;
+
+    FOR_SELECTED_UNITS(client, ent) {
+        DWORD insert;
+
+        if (seen < max_out) {
+            insert = seen;
+            out[insert] = ent;
+        } else if (G_CompareSelectionOrder(ent, out[max_out - 1]) < 0) {
+            /* Keep the best max_out entries even if malformed/scripted state
+             * ever exceeds the normal 12-unit authoritative selection cap. */
+            insert = max_out - 1;
+            out[insert] = ent;
+        } else {
+            seen++;
+            continue;
+        }
+
+        while (insert > 0 && G_CompareSelectionOrder(out[insert], out[insert - 1]) < 0) {
+            LPEDICT swap = out[insert - 1];
+            out[insert - 1] = out[insert];
+            out[insert] = swap;
+            insert--;
+        }
+        seen++;
+    }
+
+    return MIN(seen, max_out);
+}
+
 static BOOL G_TargetModeActive(LPGAMECLIENT client) {
     return client && (client->menu.on_entity_selected || client->menu.on_location_selected);
 }
@@ -42,14 +126,15 @@ static BOOL G_ParseEntityNumber(LPCSTR text, DWORD *number) {
 
 LPEDICT G_GetMainSelectedUnit(LPGAMECLIENT client) {
     DWORD *focus = G_SelectionFocusSlot(client);
+    LPEDICT ordered[1];
 
     if (focus && *focus > 0 && *focus < globals.num_edicts) {
         LPEDICT ent = &globals.edicts[*focus];
         if (G_IsEntitySelected(client, ent)) return ent;
     }
-    FOR_SELECTED_UNITS(client, ent) {
-        if (focus) *focus = ent->s.number;
-        return ent;
+    if (G_GetOrderedSelectedUnits(client, ordered, sizeof(ordered) / sizeof(ordered[0]))) {
+        if (focus) *focus = ordered[0]->s.number;
+        return ordered[0];
     }
     if (focus) *focus = 0;
     return NULL;
@@ -348,6 +433,17 @@ CLIENTCOMMAND(Select) {
             }
         }
         if (cleared) {
+            LPEDICT ordered[1];
+
+            /* Warsmash chooses the first unit after its priority/level/rawcode
+             * sort as the primary selection.  Use the same unit for default
+             * focus and the initial selection acknowledgement. */
+            if (G_GetOrderedSelectedUnits(client, ordered, sizeof(ordered) / sizeof(ordered[0]))) {
+                G_FocusSelectedUnit(client, ordered[0]);
+                voice = ordered[0];
+            } else {
+                voice = NULL;
+            }
             if (G_UnitCanControl(client, voice)) {
                 G_QueueSelectionSound(voice);
             } else if (voice && voice->s.player != PLAYER_NEUTRAL_PASSIVE) {

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -386,8 +386,10 @@ struct client_s {
         VECTOR2 target_offset;
         BOOL target_inherit_orientation;
     } camera;
-    /* Single-unit info-panel cache. HP/mana are retained here for save-layout
-     * compatibility, but portrait HP/mana now use live player-state bindings. */
+    /* Info-panel cache. For single units entity/xp track static presentation;
+     * HP/mana are retained for save-layout compatibility because live portrait
+     * values now use player-state bindings. With entity==0, hp caches the
+     * non-single selection count (-1 denotes the building queue panel). */
     struct {
         DWORD entity;
         LONG hp;
@@ -1829,6 +1831,7 @@ BOOL G_UnitCanControl(LPGAMECLIENT, LPCEDICT);
 selectionRelation_t G_SelectionRelation(DWORD viewer, LPCEDICT ent);
 LPEDICT G_GetMainControllableUnit(LPGAMECLIENT);
 void G_UpdateClientSelections(void);
+void G_SyncClientSelection(LPGAMECLIENT);
 void G_QueueSelectionSound(LPEDICT);
 void G_ClientCommand(LPEDICT, DWORD, LPCSTR[]);
 void G_ClientSetCameraPosition(LPEDICT, LPCVECTOR2);

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -1821,6 +1821,7 @@ extern int g_treeFallSounds[3];     /* Sound\Destructibles\TreeFall{1,2,3}.wav c
 extern BYTE g_numTreeFallSounds;
 
 // g_command.c
+DWORD G_GetOrderedSelectedUnits(LPGAMECLIENT, LPEDICT *, DWORD);
 void G_SelectEntity(LPGAMECLIENT, LPEDICT);
 void G_DeselectEntity(LPGAMECLIENT, LPEDICT);
 BOOL G_IsEntitySelected(LPGAMECLIENT, LPEDICT);

--- a/games/warcraft-3/game/g_shortcuts.c
+++ b/games/warcraft-3/game/g_shortcuts.c
@@ -106,18 +106,6 @@ static LPEDICT G_GetHeroShortcut(LPGAMECLIENT client, DWORD slot) {
     return NULL;
 }
 
-static void G_SendShortcutSelection(LPEDICT clent, LPEDICT target) {
-    DWORD number;
-
-    if (!clent || !clent->client || !target || !target->inuse ||
-        !clent->client->connected) return;
-    number = (DWORD)(target - globals.edicts);
-    gi.Write(PF_BYTE, &(LONG){svc_set_selection});
-    gi.Write(PF_BYTE, &(LONG){1});
-    gi.Write(PF_LONG, &(LONG){number});
-    gi.unicast(clent);
-}
-
 static BOOL G_SelectShortcutUnit(LPEDICT clent, LPEDICT target) {
     LPGAMECLIENT client;
     DWORD bit;
@@ -133,11 +121,7 @@ static BOOL G_SelectShortcutUnit(LPEDICT clent, LPEDICT target) {
     }
     G_SelectEntity(client, target);
     G_QueueSelectionSound(target);
-    G_SendShortcutSelection(clent, target);
-    if (client->connected) {
-        Get_Portrait_f(clent);
-        Get_Commands_f(clent);
-    }
+    G_SyncClientSelection(client);
     return true;
 }
 

--- a/games/warcraft-3/game/hud/hud.c
+++ b/games/warcraft-3/game/hud/hud.c
@@ -588,10 +588,12 @@ BOOL UI_BuildFrameForWrite(LPCFRAMEDEF frame,
             if (buf.cursize + size > buf.maxsize) { buf.overflowed = true; break; }
             data->hp_bar = frame->Multiselect.HpBar;
             data->mana_bar = frame->Multiselect.ManaBar;
+            data->focus_highlight = 0;
             data->offset = MAKE(VECTOR2, 0.031f, 0.050f);
             data->numcolumns = 6;
             data->numitems = frame->Multiselect.NumItems;
             memcpy(data->items, frame->Multiselect.Items, sizeof(uiMultiselectItem_t) * data->numitems);
+            FOR_LOOP(i, data->numitems) data->items[i].flags = 0;
             buf.cursize += size;
             break;
         }

--- a/games/warcraft-3/game/hud/hud_infopanel.c
+++ b/games/warcraft-3/game/hud/hud_infopanel.c
@@ -888,12 +888,7 @@ void UI_SendInfoPanel(LPEDICT ent, LPEDICT *selected, DWORD count) {
 }
 
 static DWORD SelectedUnits(LPGAMECLIENT client, LPEDICT *out, DWORD max_out) {
-    DWORD count = 0;
-    FOR_SELECTED_UNITS(client, ent) {
-        if (count < max_out) out[count] = ent;
-        count++;
-    }
-    return MIN(count, max_out);
+    return G_GetOrderedSelectedUnits(client, out, max_out);
 }
 
 void Get_Commands_f(LPEDICT ent) {

--- a/games/warcraft-3/game/hud/hud_infopanel.c
+++ b/games/warcraft-3/game/hud/hud_infopanel.c
@@ -811,7 +811,10 @@ void UI_WriteSingleInfo(LPEDICT ent, LPGAMECLIENT viewer) {
                                   is_hero);
 }
 
-void UI_WriteMultiselect(LPEDICT *ents, DWORD count) {
+void UI_WriteMultiselect(LPEDICT *ents, DWORD count, LPGAMECLIENT viewer) {
+    LPEDICT focused = viewer ? G_GetMainSelectedUnit(viewer) : NULL;
+    LPCSTR highlight = Theme_String("SelectedSubgroupHighlight", NULL);
+
     if (count > 12) count = 12;
     DWORD size = sizeof(uiMultiselect_t) + sizeof(uiMultiselectItem_t) * count;
     LPBYTE buffer = gi.MemAlloc(size);
@@ -821,12 +824,17 @@ void UI_WriteMultiselect(LPEDICT *ents, DWORD count) {
     memset(buffer, 0, size);
     multi->hp_bar = gi.ImageIndex("SimpleHpBarConsole");
     multi->mana_bar = gi.ImageIndex("SimpleManaBarConsole");
+    multi->focus_highlight = highlight && *highlight ? gi.ImageIndex(highlight) : 0;
     multi->offset = MAKE(VECTOR2, 0.031f, 0.050f);
     multi->numcolumns = 6;
     multi->numitems = count;
     FOR_LOOP(i, count) {
         multi->items[i].entity = ents[i]->s.number;
         multi->items[i].image = gi.ImageIndex(FindConfigValue(GetClassName(ents[i]->class_id), STR_ART));
+        /* Warsmash highlights the whole selected subgroup: units group by
+         * unit type, even though clicking one icon chooses a concrete focus. */
+        if (focused && ents[i]->class_id == focused->class_id)
+            multi->items[i].flags |= UI_MULTISELECT_ITEM_FOCUSED;
     }
 
     memset(&frame, 0, sizeof(frame));
@@ -854,6 +862,13 @@ void UI_SeedInfoPanelCache(LPEDICT ent, LPEDICT *selected, DWORD count) {
         ent->client->infopanel.xp = (LONG)selected[0]->hero.xp;
     } else {
         ent->client->infopanel.entity = 0;
+        /* HP/mana no longer drive the live portrait bars. Reuse hp as the
+         * non-single selection-count cache so async removals (death/fog/hide)
+         * can invalidate a still-multiselect info panel without changing the
+         * serialized GAMECLIENT layout. -1 distinguishes the build queue. */
+        ent->client->infopanel.hp = count == 1 ? -1 : (LONG)count;
+        ent->client->infopanel.mana = 0;
+        ent->client->infopanel.xp = 0;
     }
 }
 
@@ -866,7 +881,7 @@ void UI_SendInfoPanel(LPEDICT ent, LPEDICT *selected, DWORD count) {
             UI_WriteSingleInfo(selected[0], ent->client);
         }
     } else if (count > 1) {
-        UI_WriteMultiselect(selected, count);
+        UI_WriteMultiselect(selected, count, ent->client);
     }
     UI_WriteEnd(ent);
     UI_SeedInfoPanelCache(ent, selected, count);
@@ -994,15 +1009,18 @@ static void WritePortraitStats(LPEDICT ent) {
 
 void UI_WriteSelectedPortraitLayer(LPEDICT ent) {
     LPEDICT selected[MAX_SELECTED_ENTITIES];
+    LPEDICT focused;
     DWORD count;
 
     if (!ent || !ent->client) return;
     count = SelectedUnits(ent->client, selected, MAX_SELECTED_ENTITIES);
+    focused = count ? G_GetMainSelectedUnit(ent->client) : NULL;
+    if (!focused && count) focused = selected[0];
 
     UI_WriteStart(LAYER_PORTRAIT);
-    if (count == 1) {
-        WritePortraitFrame(selected[0]);
-        WritePortraitStats(selected[0]);
+    if (focused) {
+        WritePortraitFrame(focused);
+        WritePortraitStats(focused);
     }
     UI_WriteEnd(ent);
 }
@@ -1231,9 +1249,13 @@ void G_RefreshInfoPanel(LPEDICT ent) {
 
     if (!ent || !ent->client) return;
     count = SelectedUnits(ent->client, selected, MAX_SELECTED_ENTITIES);
-    UpdateSelectedLiveStats(ent->client, count == 1 ? selected[0] : NULL);
+    UpdateSelectedLiveStats(ent->client, count ? G_GetMainSelectedUnit(ent->client) : NULL);
     if (count != 1) {
-        ent->client->infopanel.entity = 0;
+        if (ent->client->infopanel.entity == 0 &&
+            ent->client->infopanel.hp == (LONG)count) {
+            return;
+        }
+        UI_SendInfoPanel(ent, selected, count);
         return;
     }
 

--- a/games/warcraft-3/game/hud/hud_local.h
+++ b/games/warcraft-3/game/hud/hud_local.h
@@ -130,7 +130,7 @@ void UI_AddCommandButtonExtended(LPCSTR code, BOOL research, DWORD level);
 /* Info panel (hud_infopanel.c) */
 void UI_WriteSingleInfo(LPEDICT ent, LPGAMECLIENT viewer);
 DWORD UI_WriteBuildingQueueShell(LPEDICT ent, LPCSTR action_key);
-void UI_WriteMultiselect(LPEDICT *ents, DWORD count);
+void UI_WriteMultiselect(LPEDICT *ents, DWORD count, LPGAMECLIENT viewer);
 void UI_SeedInfoPanelCache(LPEDICT ent, LPEDICT *selected, DWORD count);
 void UI_SendInfoPanel(LPEDICT ent, LPEDICT *selected, DWORD count);
 void UI_WriteSelectedPortraitLayer(LPEDICT ent);

--- a/games/warcraft-3/game/m_unit.c
+++ b/games/warcraft-3/game/m_unit.c
@@ -117,6 +117,7 @@ void unit_stand(LPEDICT self) {
 
 void unit_die(LPEDICT self, LPEDICT attacker) {
     LPGAMECLIENT owner;
+    DWORD const selected_mask = self ? self->selected : 0;
 
     G_ClearUnitOrderQueue(self);
     G_InvalidateUnitShortcutsForUnit(self);
@@ -170,8 +171,22 @@ void unit_die(LPEDICT self, LPEDICT attacker) {
     if (attacker && attacker != self && attacker->s.player != self->s.player) {
         G_GrantKillXP(self, attacker);
     }
+    /* Corpses stop being selection members immediately. Mirror that server
+     * mutation to each connected client that had this unit selected; otherwise
+     * the packed multiselect layer and local current-selection cache can retain
+     * a dead icon until another explicit selection occurs. */
+    FOR_LOOP(i, game.max_clients) {
+        LPGAMECLIENT client = game.clients + i;
+        if (client->connected && client->ps.number < MAX_PLAYERS &&
+            (selected_mask & (1u << client->ps.number)))
+            G_SyncClientSelection(client);
+    }
+
     owner = G_GetPlayerClientByNumber(self->s.player);
-    if (owner && owner->ps.number == self->s.player) G_InvalidateCommands(owner);
+    if (owner && owner->ps.number == self->s.player &&
+        (!owner->connected || owner->ps.number >= MAX_PLAYERS ||
+         !(selected_mask & (1u << owner->ps.number))))
+        G_InvalidateCommands(owner);
 }
 
 void unit_birth(LPEDICT self) {

--- a/games/warcraft-3/game/tests/t_api.c
+++ b/games/warcraft-3/game/tests/t_api.c
@@ -1580,6 +1580,69 @@ TEST(wc3_api, multiselect_focus_tracks_one_selected_unit_and_falls_back_when_rem
     T_ASSERT(!G_FocusSelectedUnit(client, second));
 }
 
+TEST(wc3_api, multiselect_order_matches_warsmash_priority_level_and_rawcode) {
+    LPGAMECLIENT client = &game.clients[0];
+    LPEDICT low_priority = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);
+    LPEDICT rawcode_foo_first = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 32, 0);
+    LPEDICT rawcode_foo_second = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 64, 0);
+    LPEDICT rawcode_knight = alloc_test_unit(MAKEFOURCC('h','k','n','i'), 96, 0);
+    LPEDICT higher_level = alloc_test_unit(MAKEFOURCC('h','r','i','f'), 128, 0);
+    LPEDICT higher_priority = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 160, 0);
+    UnitData_t low_data = { .priority = 1 };
+    UnitData_t middle_data = { .priority = 5 };
+    UnitData_t high_data = { .priority = 6 };
+    UnitBalance_t low_balance = { .level = 99 };
+    UnitBalance_t middle_balance = { .level = 2 };
+    UnitBalance_t higher_level_balance = { .level = 3 };
+    UnitBalance_t high_balance = { .level = 0 };
+    LPEDICT ordered[6] = { 0 };
+
+    client->ps.number = 0;
+    G_ResetSelectionFocus(client);
+
+    low_priority->data.UnitData = &low_data;
+    low_priority->data.UnitBalance = &low_balance;
+    rawcode_foo_first->data.UnitData = &middle_data;
+    rawcode_foo_first->data.UnitBalance = &middle_balance;
+    rawcode_foo_second->data.UnitData = &middle_data;
+    rawcode_foo_second->data.UnitBalance = &middle_balance;
+    rawcode_knight->data.UnitData = &middle_data;
+    rawcode_knight->data.UnitBalance = &middle_balance;
+    higher_level->data.UnitData = &middle_data;
+    higher_level->data.UnitBalance = &higher_level_balance;
+    higher_priority->data.UnitData = &high_data;
+    higher_priority->data.UnitBalance = &high_balance;
+
+    LPEDICT units[] = {
+        low_priority,
+        rawcode_foo_first,
+        rawcode_foo_second,
+        rawcode_knight,
+        higher_level,
+        higher_priority,
+    };
+    FOR_LOOP(i, sizeof(units) / sizeof(units[0])) {
+        units[i]->s.player = 0;
+        units[i]->svflags |= SVF_MONSTER;
+        G_SelectEntity(client, units[i]);
+    }
+
+    T_EQ(G_GetOrderedSelectedUnits(client, ordered, sizeof(ordered) / sizeof(ordered[0])), 6);
+    T_ASSERT(ordered[0] == higher_priority);
+    T_ASSERT(ordered[1] == higher_level);
+    /* OpenRealm stores FourCC bytes little-endian.  Canonical Warcraft rawcode
+     * ordering still places "hkni" ahead of "hfoo" for the final tie-break. */
+    T_ASSERT(ordered[2] == rawcode_knight);
+    T_ASSERT(ordered[3] == rawcode_foo_first);
+    T_ASSERT(ordered[4] == rawcode_foo_second);
+    T_ASSERT(ordered[5] == low_priority);
+
+    /* When no explicit subgroup focus remains, the same sorted first unit must
+     * own the portrait/command-card fallback rather than edict scan order. */
+    G_ResetSelectionFocus(client);
+    T_ASSERT(G_GetMainSelectedUnit(client) == higher_priority);
+}
+
 TEST(wc3_api, selection_revalidation_clears_hidden_raw_selection_bit) {
     LPGAMECLIENT client = &game.clients[0];
     LPEDICT ent = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0, 0);

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -52,6 +52,92 @@ static LPCSTR give_resources_cheat_cvar(LPCSTR name, LPCSTR fallback) {
     return !strcmp(name, "sv_cheats") ? "1" : fallback;
 }
 
+static DWORD multiselect_capture_count;
+static USHORT multiselect_capture_flags[MAX_SELECTED_ENTITIES];
+static DWORD selection_sync_count;
+static DWORD selection_sync_entities[MAX_SELECTED_ENTITIES];
+static DWORD selection_sync_entity_index;
+static int selection_sync_stage;
+static DWORD portrait_capture_root;
+static DWORD portrait_capture_model;
+static DWORD portrait_capture_parent;
+static DWORD portrait_capture_count;
+static DWORD portrait_capture_text_count;
+static BOOL portrait_capture_root_widescreen;
+static BOOL portrait_capture_child_relative;
+static BOOL portrait_capture_text_relative;
+
+static void portrait_test_write(pfWriteType_t type, void const *data) {
+    LPCUIFRAME frame;
+
+    if (type != PF_UIFRAME || !data) return;
+    frame = data;
+    if (frame->flags.type == FT_SIMPLEFRAME &&
+        (frame->flagsvalue & UIFLAG_EXTEND_WIDESCREEN_X)) {
+        portrait_capture_root = frame->number;
+        portrait_capture_root_widescreen = true;
+    } else if (frame->flags.type == FT_PORTRAIT) {
+        portrait_capture_count++;
+        portrait_capture_model = frame->tex.index;
+        portrait_capture_parent = frame->parent;
+        portrait_capture_child_relative =
+            frame->parent == 0 &&
+            frame->points.x[FPP_MIN].relativeTo == 0 &&
+            frame->points.y[FPP_MIN].relativeTo == 0;
+    } else if (frame->flags.type == FT_STRING &&
+               (frame->stat == UI_STAT_SELECTION_HEALTH_TEXT ||
+                frame->stat == UI_STAT_SELECTION_MANA_TEXT)) {
+        portrait_capture_text_count++;
+        portrait_capture_text_relative |=
+            frame->parent == 0 &&
+            frame->points.x[FPP_MID].relativeTo == 0 &&
+            frame->points.y[FPP_MAX].relativeTo == 0;
+    }
+}
+
+static int portrait_test_font(LPCSTR name, DWORD size) {
+    (void)name;
+    (void)size;
+    return 1;
+}
+
+static void selection_test_write(pfWriteType_t type, void const *data) {
+    if (type == PF_UIFRAME && data) {
+        LPCUIFRAME frame = data;
+        if (frame->flags.type == FT_MULTISELECT && frame->buffer.data &&
+            frame->buffer.size >= sizeof(uiMultiselect_t)) {
+            uiMultiselect_t const *multi = frame->buffer.data;
+            DWORD const available = (frame->buffer.size - sizeof(uiMultiselect_t)) / sizeof(uiMultiselectItem_t);
+            multiselect_capture_count = MIN((DWORD)multi->numitems, available);
+            FOR_LOOP(i, multiselect_capture_count)
+                multiselect_capture_flags[i] = multi->items[i].flags;
+        }
+        return;
+    }
+    if (type == PF_BYTE && data) {
+        LONG const value = *(LONG const *)data;
+        if (selection_sync_stage == 0 && value == svc_set_selection) {
+            selection_sync_stage = 1;
+            selection_sync_count = 0;
+            selection_sync_entity_index = 0;
+            memset(selection_sync_entities, 0, sizeof(selection_sync_entities));
+            return;
+        }
+        if (selection_sync_stage == 1) {
+            selection_sync_count = (DWORD)value;
+            selection_sync_stage = selection_sync_count ? 2 : 3;
+            return;
+        }
+    }
+    if (type == PF_LONG && data && selection_sync_stage == 2 &&
+        selection_sync_entity_index < selection_sync_count) {
+        selection_sync_entities[selection_sync_entity_index++] = (DWORD)*(LONG const *)data;
+        if (selection_sync_entity_index >= selection_sync_count) selection_sync_stage = 3;
+    }
+}
+
+static void selection_test_unicast(LPEDICT ent) { (void)ent; }
+
 TEST(wc3_game, give_resource_cheats_target_issuing_player_without_selection) {
     LPCSTR (*old_cvar)(LPCSTR, LPCSTR) = gi.CvarString;
     LPGAMECLIENT client = &game.clients[0];
@@ -469,6 +555,245 @@ TEST(wc3_game, player_zero_food_ignores_free_edicts) {
     T_EQ(client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP], 6);
     T_EQ(client->ps.stats[PLAYERSTATE_RESOURCE_FOOD_USED], 1);
 }
+TEST(wc3_game, authoritative_selection_sync_mirrors_surviving_server_membership) {
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(LPEDICT) = gi.unicast;
+    LPGAMECLIENT client = &game.clients[0];
+    LPEDICT player = &g_edicts[0];
+    LPEDICT first, second;
+
+    reset_entities();
+    setup_test_world();
+    player->client = client;
+    client->ps.number = 0;
+    client->connected = true;
+    first = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0, 0);
+    second = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 32, 0);
+    first->svflags |= SVF_MONSTER;
+    second->svflags |= SVF_MONSTER;
+    first->s.player = second->s.player = 0;
+    G_SelectEntity(client, first);
+    G_SelectEntity(client, second);
+
+    selection_sync_stage = 0;
+    selection_sync_count = 0;
+    selection_sync_entity_index = 0;
+    gi.Write = selection_test_write;
+    gi.unicast = selection_test_unicast;
+    G_SyncClientSelection(client);
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+
+    T_EQ(selection_sync_count, 2);
+    T_EQ(selection_sync_entity_index, 2);
+    T_EQ(selection_sync_entities[0], first->s.number);
+    T_EQ(selection_sync_entities[1], second->s.number);
+
+    G_DeselectEntity(client, first);
+    selection_sync_stage = 0;
+    selection_sync_count = 0;
+    selection_sync_entity_index = 0;
+    gi.Write = selection_test_write;
+    gi.unicast = selection_test_unicast;
+    G_SyncClientSelection(client);
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+
+    T_EQ(selection_sync_count, 1);
+    T_EQ(selection_sync_entity_index, 1);
+    T_EQ(selection_sync_entities[0], second->s.number);
+}
+
+TEST(wc3_game, multiselect_payload_marks_the_focused_unit_type_subgroup) {
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(LPEDICT) = gi.unicast;
+    LPGAMECLIENT client = &game.clients[0];
+    LPEDICT player = &g_edicts[0];
+    LPEDICT selected[3];
+
+    reset_entities();
+    setup_test_world();
+    player->client = client;
+    client->ps.number = 0;
+    selected[0] = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0, 0);
+    selected[1] = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 32, 0);
+    selected[2] = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 64, 0);
+    FOR_LOOP(i, 3) {
+        selected[i]->svflags |= SVF_MONSTER;
+        selected[i]->s.player = 0;
+        G_SelectEntity(client, selected[i]);
+    }
+
+    multiselect_capture_count = 0;
+    memset(multiselect_capture_flags, 0, sizeof(multiselect_capture_flags));
+    gi.Write = selection_test_write;
+    gi.unicast = selection_test_unicast;
+    UI_SendInfoPanel(player, selected, 3);
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+
+    T_EQ(multiselect_capture_count, 3);
+    T_ASSERT(multiselect_capture_flags[0] & UI_MULTISELECT_ITEM_FOCUSED);
+    T_ASSERT(multiselect_capture_flags[1] & UI_MULTISELECT_ITEM_FOCUSED);
+    T_ASSERT(!(multiselect_capture_flags[2] & UI_MULTISELECT_ITEM_FOCUSED));
+
+    T_ASSERT(G_FocusSelectedUnit(client, selected[2]));
+    multiselect_capture_count = 0;
+    memset(multiselect_capture_flags, 0, sizeof(multiselect_capture_flags));
+    gi.Write = selection_test_write;
+    gi.unicast = selection_test_unicast;
+    UI_SendInfoPanel(player, selected, 3);
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+
+    T_EQ(multiselect_capture_count, 3);
+    T_ASSERT(!(multiselect_capture_flags[0] & UI_MULTISELECT_ITEM_FOCUSED));
+    T_ASSERT(!(multiselect_capture_flags[1] & UI_MULTISELECT_ITEM_FOCUSED));
+    T_ASSERT(multiselect_capture_flags[2] & UI_MULTISELECT_ITEM_FOCUSED);
+}
+
+TEST(wc3_game, multiselect_info_panel_refreshes_when_membership_shrinks) {
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(LPEDICT) = gi.unicast;
+    LPGAMECLIENT client = &game.clients[0];
+    LPEDICT player = &g_edicts[0];
+    LPEDICT units[3];
+
+    reset_entities();
+    setup_test_world();
+    player->client = client;
+    client->ps.number = 0;
+    FOR_LOOP(i, 3) {
+        units[i] = alloc_test_unit(MAKEFOURCC('h','f','o','o'), (FLOAT)(i * 32), 0);
+        units[i]->svflags |= SVF_MONSTER;
+        units[i]->s.player = 0;
+        G_SelectEntity(client, units[i]);
+    }
+
+    gi.Write = selection_test_write;
+    gi.unicast = selection_test_unicast;
+    UI_SendInfoPanel(player, units, 3);
+    T_EQ(client->infopanel.entity, 0);
+    T_EQ(client->infopanel.hp, 3);
+
+    G_DeselectEntity(client, units[1]);
+    multiselect_capture_count = 0;
+    G_RefreshInfoPanel(player);
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+
+    T_EQ(multiselect_capture_count, 2);
+    T_EQ(client->infopanel.entity, 0);
+    T_EQ(client->infopanel.hp, 2);
+}
+
+TEST(wc3_game, multiselect_portrait_uses_focused_unit_and_safe_area_root) {
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(LPEDICT) = gi.unicast;
+    int (*old_font)(LPCSTR, DWORD) = gi.FontIndex;
+    LPGAMECLIENT client = &game.clients[0];
+    LPEDICT player = &g_edicts[0];
+    LPEDICT first, second;
+
+    reset_entities();
+    setup_test_world();
+    player->client = client;
+    client->ps.number = 0;
+    first = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0, 0);
+    second = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 32, 0);
+    first->svflags |= SVF_MONSTER;
+    second->svflags |= SVF_MONSTER;
+    first->s.player = second->s.player = 0;
+    first->s.model = 11;
+    second->s.model = 22;
+    G_SelectEntity(client, first);
+    G_SelectEntity(client, second);
+    T_ASSERT(G_FocusSelectedUnit(client, second));
+
+    portrait_capture_root = 0;
+    portrait_capture_model = 0;
+    portrait_capture_parent = 0;
+    portrait_capture_count = 0;
+    portrait_capture_text_count = 0;
+    portrait_capture_root_widescreen = false;
+    portrait_capture_child_relative = false;
+    portrait_capture_text_relative = false;
+    gi.Write = portrait_test_write;
+    gi.unicast = selection_test_unicast;
+    gi.FontIndex = portrait_test_font;
+    UI_WriteSelectedPortraitLayer(player);
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+    gi.FontIndex = old_font;
+
+    T_ASSERT(!portrait_capture_root_widescreen);
+    T_EQ(portrait_capture_root, 0);
+    T_EQ(portrait_capture_count, 1);
+    T_EQ(portrait_capture_model, 22);
+    T_EQ(portrait_capture_parent, 0);
+    T_ASSERT(portrait_capture_child_relative);
+    T_EQ(portrait_capture_text_count, 2);
+    T_ASSERT(portrait_capture_text_relative);
+
+    G_DeselectEntity(client, first);
+    G_DeselectEntity(client, second);
+    portrait_capture_root = 0;
+    portrait_capture_count = 0;
+    portrait_capture_root_widescreen = false;
+    gi.Write = portrait_test_write;
+    gi.unicast = selection_test_unicast;
+    gi.FontIndex = portrait_test_font;
+    UI_WriteSelectedPortraitLayer(player);
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+    gi.FontIndex = old_font;
+
+    T_ASSERT(!portrait_capture_root_widescreen);
+    T_EQ(portrait_capture_root, 0);
+    T_EQ(portrait_capture_count, 0);
+}
+
+TEST(wc3_game, multiselect_portrait_live_stats_follow_focus) {
+    LPGAMECLIENT client = &game.clients[0];
+    LPEDICT player = &g_edicts[0];
+    LPEDICT first, second;
+
+    reset_entities();
+    setup_test_world();
+    player->client = client;
+    client->ps.number = 0;
+    client->connected = true;
+    first = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0, 0);
+    second = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 32, 0);
+    first->s.player = second->s.player = 0;
+    first->health.value = 111.0f;
+    first->health.max_value = 222.0f;
+    first->mana.value = 12.0f;
+    first->mana.max_value = 34.0f;
+    second->health.value = 333.0f;
+    second->health.max_value = 444.0f;
+    second->mana.value = 55.0f;
+    second->mana.max_value = 66.0f;
+    G_SelectEntity(client, first);
+    G_SelectEntity(client, second);
+    client->infopanel.entity = 0;
+    client->infopanel.hp = 2;
+
+    T_ASSERT(G_FocusSelectedUnit(client, second));
+    G_RefreshInfoPanel(player);
+    T_EQ(client->ps.stats[UI_PLAYERSTAT_SELECTION_HEALTH], 333);
+    T_EQ(client->ps.stats[UI_PLAYERSTAT_SELECTION_MAX_HEALTH], 444);
+    T_EQ(client->ps.stats[UI_PLAYERSTAT_SELECTION_MANA], 55);
+    T_EQ(client->ps.stats[UI_PLAYERSTAT_SELECTION_MAX_MANA], 66);
+
+    T_ASSERT(G_FocusSelectedUnit(client, first));
+    G_RefreshInfoPanel(player);
+    T_EQ(client->ps.stats[UI_PLAYERSTAT_SELECTION_HEALTH], 111);
+    T_EQ(client->ps.stats[UI_PLAYERSTAT_SELECTION_MAX_HEALTH], 222);
+    T_EQ(client->ps.stats[UI_PLAYERSTAT_SELECTION_MANA], 12);
+    T_EQ(client->ps.stats[UI_PLAYERSTAT_SELECTION_MAX_MANA], 34);
+}
+
 TEST(wc3_game, portrait_live_stats_refresh_reserved_connected_client_edict) {
     LPGAMECLIENT client = &game.clients[0];
     LPEDICT player;

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -560,7 +560,7 @@ TEST(wc3_game, authoritative_selection_sync_mirrors_surviving_server_membership)
     void (*old_unicast)(LPEDICT) = gi.unicast;
     LPGAMECLIENT client = &game.clients[0];
     LPEDICT player = &g_edicts[0];
-    LPEDICT first, second;
+    LPEDICT first, second, third;
 
     reset_entities();
     setup_test_world();
@@ -568,12 +568,13 @@ TEST(wc3_game, authoritative_selection_sync_mirrors_surviving_server_membership)
     client->ps.number = 0;
     client->connected = true;
     first = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0, 0);
-    second = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 32, 0);
-    first->svflags |= SVF_MONSTER;
-    second->svflags |= SVF_MONSTER;
-    first->s.player = second->s.player = 0;
+    second = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 32, 0);
+    third = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 64, 0);
+    first->svflags |= SVF_MONSTER; second->svflags |= SVF_MONSTER; third->svflags |= SVF_MONSTER;
+    first->s.player = second->s.player = third->s.player = 0;
     G_SelectEntity(client, first);
     G_SelectEntity(client, second);
+    G_SelectEntity(client, third);
 
     selection_sync_stage = 0;
     selection_sync_count = 0;
@@ -584,10 +585,11 @@ TEST(wc3_game, authoritative_selection_sync_mirrors_surviving_server_membership)
     gi.Write = old_write;
     gi.unicast = old_unicast;
 
-    T_EQ(selection_sync_count, 2);
-    T_EQ(selection_sync_entity_index, 2);
+    T_EQ(selection_sync_count, 3);
+    T_EQ(selection_sync_entity_index, 3);
     T_EQ(selection_sync_entities[0], first->s.number);
     T_EQ(selection_sync_entities[1], second->s.number);
+    T_EQ(selection_sync_entities[2], third->s.number);
 
     G_DeselectEntity(client, first);
     selection_sync_stage = 0;
@@ -599,9 +601,11 @@ TEST(wc3_game, authoritative_selection_sync_mirrors_surviving_server_membership)
     gi.Write = old_write;
     gi.unicast = old_unicast;
 
-    T_EQ(selection_sync_count, 1);
-    T_EQ(selection_sync_entity_index, 1);
+    /* Keep two survivors because this packet test owns no single-unit HUD bindings. */
+    T_EQ(selection_sync_count, 2);
+    T_EQ(selection_sync_entity_index, 2);
     T_EQ(selection_sync_entities[0], second->s.number);
+    T_EQ(selection_sync_entities[1], third->s.number);
 }
 
 TEST(wc3_game, multiselect_payload_marks_the_focused_unit_type_subgroup) {
@@ -693,7 +697,7 @@ TEST(wc3_game, multiselect_portrait_uses_focused_unit_and_safe_area_root) {
     int (*old_font)(LPCSTR, DWORD) = gi.FontIndex;
     LPGAMECLIENT client = &game.clients[0];
     LPEDICT player = &g_edicts[0];
-    LPEDICT first, second;
+    LPEDICT first, second, third;
 
     reset_entities();
     setup_test_world();

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -2291,6 +2291,52 @@ TEST(client_screen, selection_rect_stops_at_bottom_console_command_button) {
     T_FEQ(rect.y + rect.h, 0.41f / UI_BASE_HEIGHT * 768.0f, 1.0f);
 }
 
+TEST(client_screen, multiselect_left_click_is_consumed_and_sends_focus) {
+    BYTE layout_buf[512];
+    BYTE message_buf[256];
+    BYTE multiselect_buf[sizeof(uiMultiselect_t) + sizeof(uiMultiselectItem_t)];
+    char command_buf[128];
+    sizeBuf_t sb = make_msg_buf(layout_buf, sizeof(layout_buf));
+    uiMultiselect_t *multi = (uiMultiselect_t *)multiselect_buf;
+    uiFrame_t empty = {0}, frame = {0};
+
+    test_client_stubs_init();
+    FOR_LOOP(layer, MAX_LAYOUT_LAYERS) SCR_ClearLayoutLayer(layer);
+    SZ_Init(&cls.netchan.message, message_buf, sizeof(message_buf));
+
+    memset(multiselect_buf, 0, sizeof(multiselect_buf));
+    multi->offset = MAKE(VECTOR2, 0.031f, 0.050f);
+    multi->numcolumns = 6;
+    multi->numitems = 1;
+    multi->items[0].entity = 77;
+
+    frame.number = 1;
+    frame.flags.type = FT_MULTISELECT;
+    frame.size.width = 0.20f;
+    frame.size.height = 0.20f;
+    frame.points.x[FPP_MIN].used = 1;
+    frame.points.x[FPP_MIN].targetPos = FPP_MIN;
+    frame.points.y[FPP_MIN].used = 1;
+    frame.points.y[FPP_MIN].targetPos = FPP_MIN;
+
+    MSG_WriteByte(&sb, LAYER_INFOPANEL);
+    MSG_WriteDeltaUIFrame(&sb, &empty, &frame, true);
+    MSG_WriteByte(&sb, sizeof(multiselect_buf));
+    MSG_Write(&sb, multiselect_buf, sizeof(multiselect_buf));
+    MSG_WriteLong(&sb, 0);
+    MSG_WriteShort(&sb, 0);
+    sb.readcount = 0;
+    CL_ParseLayout(&sb);
+
+    T_ASSERT(SCR_LayoutMouseEvent(MENU_MOUSE_DOWN, 10, 10, 1));
+    T_EQ(cls.netchan.message.cursize, 0);
+    T_ASSERT(SCR_LayoutMouseEvent(MENU_MOUSE_UP, 10, 10, 1));
+    cls.netchan.message.readcount = 0;
+    T_EQ(MSG_ReadByte(&cls.netchan.message), clc_stringcmd);
+    MSG_ReadString(&cls.netchan.message, command_buf);
+    T_STREQ(command_buf, "focus 77");
+}
+
 TEST(client_screen, command_button_right_click_sends_secondary_command) {
     BYTE layout_buf[512];
     BYTE message_buf[256];


### PR DESCRIPTION
wc3: Fix multiselect subgroup interaction, selection lifetime, and portrait presentation

Restore Warcraft III multiselect behavior across the status panel, selection
state, and focused-unit portrait presentation.

Consume multiselect status-panel mouse input so subgroup clicks do not leak
through into world selection. Send the clicked entity as the focused unit
and refresh the complete focused presentation so the info panel, inventory,
portrait, and command card remain synchronized.

Represent the focused subgroup by unit type and draw the active skin's
SelectedSubgroupHighlight for every selected unit that belongs to the
focused type.

Keep client selection state synchronized with the authoritative server
selection whenever units are removed or filtered. Reuse the synchronization
path for ordinary selection filtering, Hero and idle-worker shortcuts,
visibility/selectability pruning, and unit death.

Immediately remove dead units from affected selections instead of leaving
stale corpse entries in multiselect groups.

Track non-single selection count in the info-panel cache so changes such as
four selected units becoming three cause the multiselect panel to be
rebuilt even though the selection remains a multiselect.

Keep the selected-unit portrait visible for every non-empty selection by
using the focused/main selected unit instead of requiring exactly one
selected entity.

Make live portrait health and mana follow that same focused unit so changing
subgroups updates the complete portrait presentation coherently.

Keep gameplay portraits in the same centered 0.8 x 0.6 safe-area coordinate
system as ConsoleUI. This preserves alignment with the console portrait
cut-out on widescreen displays and prevents the later console layer from
covering a portrait rendered in an independently extended widescreen
coordinate space.

Use the same safe-area placement for gameplay transmission portraits so
normal selected-unit and talking-head portraits remain aligned.

Add regression coverage for:

* consuming multiselect status-panel clicks;
* sending focused-unit commands;
* focused subgroup highlighting;
* authoritative selection synchronization;
* multiselect refresh after membership shrinks;
* focused-unit portraits during multiselect;
* live portrait health and mana updates;
* safe-area portrait placement.

Update the Warcraft III selection/control and unit-presentation
documentation with the subgroup focus, selection lifetime, and portrait
layout contracts.

Order Warcraft III multi-selection entries using the same unit-type
comparator as Warsmash:

- sort UnitData priority descending
- sort UnitBalance level descending
- sort unit rawcode descending as the final tie-break
- preserve stable ordering for otherwise-equal entries

Convert OpenRealm's little-endian MAKEFOURCC representation to canonical
Warcraft War3ID byte order before the rawcode comparison so the final
tie-break matches Warsmash rather than native class_id integer ordering.

Use the shared ordered-selection path for the status-panel payload and
for default focused-unit fallback. After rebuilding a selection, choose
the first sorted unit as the initial focus and selection acknowledgement
source, matching Warsmash's selectUnits() behavior.

Keep explicit multiselect-icon focus changes and the existing 12-unit WC3
selection limit unchanged.

Add regression coverage for priority, level, canonical rawcode ordering,
stable identical-type ordering, and sorted focus fallback, and document
the remaining subgroup-navigation and within-type insertion-order gaps.