### PR TITLE
wc3: restore authored glue menu birth/death transitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 ability/item presentation art, effect edict lifetimes, JASS effect handles, consumable charge semantics | [docs/games/warcraft-3/ability-and-item-effects.md](docs/games/warcraft-3/ability-and-item-effects.md) |
 | WC3 player AI, Blizzard AI script contract, Human02 implementation plan | [docs/games/warcraft-3/player-ai.md](docs/games/warcraft-3/player-ai.md) |
 | WC3 player AI architecture and implementation postmortem | [docs/games/warcraft-3/player-ai-postmortem.md](docs/games/warcraft-3/player-ai-postmortem.md) |
-| WC3 client UI lifecycle, single-player campaign/mission/custom-game flow | [docs/games/warcraft-3/architecture/ui-flow.md](docs/games/warcraft-3/architecture/ui-flow.md) |
+| WC3 client UI lifecycle, glue Birth/Stand/Death transitions, single-player campaign/mission/custom-game flow | [docs/games/warcraft-3/architecture/ui-flow.md](docs/games/warcraft-3/architecture/ui-flow.md) |
 | WC3 campaign loading lifecycle, texture references, unused FDF art, cliff transitions | [docs/games/warcraft-3/loading-and-assets.md](docs/games/warcraft-3/loading-and-assets.md) |
 | WC3 perf hot spots: MDX bone/geoset setup, shadow batching, client/server entity scans | [docs/games/warcraft-3/performance.md](docs/games/warcraft-3/performance.md) |
 | WC3 RAM profiling: MDX buffer overhead, FDF pools, texture residency, loopback budgets | [docs/games/warcraft-3/memory.md](docs/games/warcraft-3/memory.md) |

--- a/client/tr_public.h
+++ b/client/tr_public.h
@@ -233,6 +233,9 @@ typedef struct {
     void (*DrawSprite)(LPCMODEL model, LPCSTR anim, float x, float y);
     bool (*DrawCursor)(float x, float y, COLOR32 tint);
     bool (*SetEntityAnimFrame)(LPCMODEL model, LPCSTR anim, renderEntity_t *entity);
+    /* Authored named-sequence duration in milliseconds. Returns false when
+     * the active model format does not expose named animation timing. */
+    bool (*GetModelAnimationDuration)(LPCMODEL model, LPCSTR anim, LPDWORD duration);
     void (*DrawText)(LPCDRAWTEXT drawText);
     VECTOR2 (*GetTextSize)(LPCDRAWTEXT drawText);
     bool (*GetModelInfo)(LPMODEL model, LPMODELINFO info);

--- a/docs/games/warcraft-3/architecture/ui-flow.md
+++ b/docs/games/warcraft-3/architecture/ui-flow.md
@@ -78,10 +78,11 @@ RoC `War3Local.mpq` AI-script filter. TFT mode exposes those already-mounted arc
 renderer/UI resources and makes the edition cvar safe to change at the disconnected main menu.
 
 The native `EditionButton` is optional and is discovered under the parsed `MainMenuFrame`; OpenRealm does not recreate its layout.
-Its click command is `menu_edition`. The main-menu controller suppresses repeated clicks, hides the current frame tree, draws one
-`MainMenu Death` glue frame, switches the edition cvar, validates expansion campaign data when entering TFT, and queues the generic
-`menu_restart` console command. `Cmd_ExecuteText` appends that command after the current frame's command execution point, so it runs
-on the next client frame after the current UI event/draw call stack has returned. The client then:
+Its click command is `menu_edition`. The main-menu controller suppresses repeated clicks, hides the current frame tree, plays the
+authored `MainMenu Death` glue sequence to completion, then switches the edition cvar, validates expansion campaign data when
+entering TFT, and queues the generic `menu_restart` console command. `Cmd_ExecuteText` appends that command after the current
+frame's command execution point, so it runs on the next client frame after the current UI event/draw call stack has returned. The
+client then:
 
 ```text
 menu EditionButton
@@ -113,8 +114,26 @@ valid after map registration and makes Quit Campaign / EndGame / campaign-select
 the same edition selected by the main menu.
 
 `games/warcraft-3/menu/menu_glue_scene.c` renders the selected background as a model with `RDF_USE_ENTITY_CAMERA`; the main menu is
-therefore not a static BLP backdrop. Remaining glue parity gaps include `MenuZFog`, edition-sensitive `GlueScreenLoop` ambience, and
-a dedicated post-restart `MainMenu Birth` phase; the current switch rebuilds directly into the normal main-menu `Stand` state.
+therefore not a static BLP backdrop. Glue animation timing is model-authored rather than hard-coded. The generic renderer export
+`GetModelAnimationDuration` exposes a named sequence's interval length when the model format supports it. WC3 menu code combines
+that with the renderer's existing `Sequence@ratio` selector so one-shot glue animations have a menu-local start time instead of using
+the renderer's global looping clock.
+
+The shared background starts with non-looping `Birth` and hands off to `Stand`. A stable sprite-layer request such as
+`MainMenu Stand`, `SinglePlayer Stand`, or an `... Stand Alternate` variant first tries the matching `Birth` sequence, preserves any
+suffix, and then hands off to the requested `Stand`. Explicit `Birth`/`Death` requests are one-shots and hold their final authored
+pose until the controller requests another state. Main Menu -> Single Player and Single Player -> Main Menu now wait for the outgoing
+`Death` before changing screens, letting the incoming screen begin through its authored `Birth`. The edition switch uses the same
+completion gate before `menu_restart`. If a renderer/model does not expose the requested sequence duration, the code deliberately
+falls back to the previous direct requested sequence instead of inventing a timer.
+
+Campaign background models have the same local lifecycle: entering campaign selection or changing to a different campaign backdrop
+starts that model's `Birth` from frame zero and then switches to `Stand`. Entering campaign selection also waits for
+`SinglePlayer Death`. Returning from the campaign view restarts the normal glue `Birth` lifecycle. The retail/Warsmash
+`SlidingDoors Birth -> background swap -> SlidingDoors Death` campaign wipe is still separate work; OpenRealm currently keeps
+`SlidingDoors` hidden because its campaign-view ownership does not yet implement that intermediate transition state. Remaining glue
+parity gaps also include `MenuZFog` and edition-sensitive `GlueScreenLoop` ambience.
+
 The renderer texture cache also deliberately retains released textures, so same-path archive overrides are not globally invalidated by
 this menu restart; edition-decorated paths reload correctly, while broader texture-cache ownership remains separate lifetime work.
 
@@ -264,8 +283,9 @@ continuing network reads and client traffic.
 
 The following Warsmash/retail-style lifecycle work is intentionally not approximated in the current UI code:
 
-- menu changes are still immediate `UI_SetScreen` operations rather than Birth/Stand/Death sequence-completion
-  transitions;
+- Main Menu <-> Single Player and Single Player -> Campaign use authored Birth/Stand/Death completion now, but other glue-screen
+  routes (Options, LAN, Credits, and related returns) still change screens immediately;
+- the campaign `SlidingDoors Birth -> backdrop swap -> SlidingDoors Death` wipe is not wired;
 - campaign ambient sound and campaign-specific cursor switching are not wired;
 - profile creation/deletion/persistence is not implemented;
 - map `config()` is not yet run as a distinct pre-lobby configuration phase; doing so correctly requires separating

--- a/games/starcraft-2/renderer/r_game.c
+++ b/games/starcraft-2/renderer/r_game.c
@@ -442,6 +442,13 @@ bool R_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity) {
     return false;
 }
 
+bool R_GetModelAnimationDuration(LPCMODEL model, LPCSTR anim, LPDWORD duration) {
+    (void)model;
+    (void)anim;
+    (void)duration;
+    return false;
+}
+
 void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     (void)model;
     (void)anim;

--- a/games/warcraft-3/menu/menu_glue_scene.c
+++ b/games/warcraft-3/menu/menu_glue_scene.c
@@ -4,11 +4,28 @@
 
 #include "menu_local.h"
 
+#define UI_GLUE_ANIM_NAME 96
+
+typedef struct {
+    char requested[UI_GLUE_ANIM_NAME];
+    char active[UI_GLUE_ANIM_NAME];
+    DWORD start_time;
+    DWORD duration;
+    BOOL one_shot;
+    BOOL complete;
+} uiGlueAnimState_t;
+
 typedef struct {
     BOOL loaded;
     LPCMODEL background;
     LPCMODEL top_left_panel;
     LPCMODEL top_right_panel;
+    BOOL background_intro_started;
+    BOOL background_intro_complete;
+    DWORD background_intro_start;
+    DWORD background_intro_duration;
+    uiGlueAnimState_t left_anim;
+    uiGlueAnimState_t right_anim;
 } uiGlueSceneState_t;
 
 static uiGlueSceneState_t menu_glue_scene;
@@ -45,8 +62,154 @@ static FLOAT UI_GlueRightPanelOffset(LPRENDERER renderer) {
     return aspect > UI_MIN_ASPECT ? UI_BASE_HEIGHT * aspect - UI_BASE_WIDTH : 0.0f;
 }
 
+static BOOL UI_GlueSequenceDuration(LPRENDERER renderer, LPCMODEL model, LPCSTR anim, LPDWORD duration) {
+    if (!model || !anim || !*anim || !duration) {
+        return false;
+    }
+    return renderer->GetModelAnimationDuration(model, anim, duration) && *duration > 0;
+}
+
+static BOOL UI_GlueIsOneShot(LPCSTR anim) {
+    if (!anim || !*anim) return false;
+    return !strcmp(anim, "Birth") || !strcmp(anim, "Death") ||
+           strstr(anim, " Birth") != NULL || strstr(anim, " Death") != NULL;
+}
+
+/* Stable glue states are named "<screen> Stand". Retail/Warsmash enters them
+ * through the matching non-looping Birth sequence; preserve any suffix such as
+ * "Alternate" while swapping the primary tag. */
+static BOOL UI_GlueBirthForStand(LPCSTR stand, LPSTR birth, DWORD birth_size) {
+    LPCSTR marker;
+    size_t prefix;
+
+    if (!stand || !birth || birth_size == 0) return false;
+    if (!strcmp(stand, "Stand")) {
+        snprintf(birth, birth_size, "Birth");
+        return true;
+    }
+    marker = strstr(stand, " Stand");
+    if (!marker) return false;
+    prefix = (size_t)(marker - stand);
+    if (prefix + strlen(" Birth") + strlen(marker + strlen(" Stand")) + 1 > birth_size) {
+        return false;
+    }
+    memcpy(birth, stand, prefix);
+    birth[prefix] = '\0';
+    strncat(birth, " Birth", birth_size - strlen(birth) - 1);
+    strncat(birth, marker + strlen(" Stand"), birth_size - strlen(birth) - 1);
+    return true;
+}
+
+static void UI_GlueBeginLayerAnimation(LPRENDERER renderer,
+                                       LPCMODEL model,
+                                       LPCSTR requested,
+                                       uiGlueAnimState_t *state) {
+    char birth[UI_GLUE_ANIM_NAME];
+    DWORD duration = 0;
+
+    memset(state, 0, sizeof(*state));
+    snprintf(state->requested, sizeof(state->requested), "%s", requested ? requested : "Stand");
+    snprintf(state->active, sizeof(state->active), "%s", state->requested);
+    state->start_time = M_Time();
+    state->complete = true;
+
+    if (UI_GlueBirthForStand(state->requested, birth, sizeof(birth)) &&
+        UI_GlueSequenceDuration(renderer, model, birth, &duration)) {
+        snprintf(state->active, sizeof(state->active), "%s", birth);
+        state->duration = duration;
+        state->one_shot = true;
+        state->complete = false;
+        return;
+    }
+    if (UI_GlueIsOneShot(state->requested) &&
+        UI_GlueSequenceDuration(renderer, model, state->requested, &duration)) {
+        state->duration = duration;
+        state->one_shot = true;
+        state->complete = false;
+    }
+}
+
+static LPCSTR UI_GlueLayerAnimation(LPRENDERER renderer,
+                                    LPCMODEL model,
+                                    LPCSTR requested,
+                                    uiGlueAnimState_t *state,
+                                    LPSTR scrubbed,
+                                    DWORD scrubbed_size) {
+    DWORD elapsed;
+    FLOAT ratio;
+
+    if (!requested || !*requested) requested = "Stand";
+    if (strcmp(state->requested, requested)) {
+        UI_GlueBeginLayerAnimation(renderer, model, requested, state);
+    }
+    if (!state->one_shot) {
+        state->complete = true;
+        return state->active;
+    }
+
+    elapsed = M_Time() - state->start_time;
+    if (elapsed >= state->duration) {
+        state->complete = true;
+        /* A synthesized Birth hands off to the requested looping Stand. A
+         * directly requested Death/Birth holds its authored final pose until
+         * the caller changes state. */
+        if (strcmp(state->active, state->requested)) {
+            snprintf(state->active, sizeof(state->active), "%s", state->requested);
+            state->one_shot = false;
+            return state->active;
+        }
+        snprintf(scrubbed, scrubbed_size, "%s@1.0000", state->active);
+        return scrubbed;
+    }
+
+    ratio = (FLOAT)elapsed / (FLOAT)state->duration;
+    snprintf(scrubbed, scrubbed_size, "%s@%.4f", state->active, ratio);
+    state->complete = false;
+    return scrubbed;
+}
+
+static LPCSTR UI_GlueBackgroundAnimation(LPRENDERER renderer, LPSTR scrubbed, DWORD scrubbed_size) {
+    DWORD elapsed;
+    FLOAT ratio;
+
+    if (!menu_glue_scene.background_intro_started) {
+        menu_glue_scene.background_intro_started = true;
+        menu_glue_scene.background_intro_start = M_Time();
+        menu_glue_scene.background_intro_complete =
+            !UI_GlueSequenceDuration(renderer,
+                                     menu_glue_scene.background,
+                                     "Birth",
+                                     &menu_glue_scene.background_intro_duration);
+    }
+    if (menu_glue_scene.background_intro_complete) {
+        return "Stand";
+    }
+
+    elapsed = M_Time() - menu_glue_scene.background_intro_start;
+    if (elapsed >= menu_glue_scene.background_intro_duration) {
+        menu_glue_scene.background_intro_complete = true;
+        return "Stand";
+    }
+    ratio = (FLOAT)elapsed / (FLOAT)menu_glue_scene.background_intro_duration;
+    snprintf(scrubbed, scrubbed_size, "Birth@%.4f", ratio);
+    return scrubbed;
+}
+
 void UI_ResetGlueSceneModels(void) {
     memset(&menu_glue_scene, 0, sizeof(menu_glue_scene));
+}
+
+void UI_RestartGlueSceneAnimations(void) {
+    menu_glue_scene.background_intro_started = false;
+    menu_glue_scene.background_intro_complete = false;
+    menu_glue_scene.background_intro_start = 0;
+    menu_glue_scene.background_intro_duration = 0;
+    memset(&menu_glue_scene.left_anim, 0, sizeof(menu_glue_scene.left_anim));
+    memset(&menu_glue_scene.right_anim, 0, sizeof(menu_glue_scene.right_anim));
+}
+
+BOOL UI_GlueSceneAnimationComplete(void) {
+    return menu_glue_scene.left_anim.complete && menu_glue_scene.right_anim.complete;
 }
 
 void UI_ReleaseGlueSceneModels(void) {
@@ -74,11 +237,15 @@ void UI_PreloadGlueSceneModels(void) {
     menu_glue_scene.top_left_panel = renderer->LoadModel(UI_GlueTopLeftPanelPath());
     menu_glue_scene.top_right_panel = renderer->LoadModel(UI_GlueTopRightPanelPath());
     menu_glue_scene.loaded = true;
+    UI_RestartGlueSceneAnimations();
 }
 
 void UI_DrawGlueSceneLayers(LPCSTR left_panel_anim, LPCSTR right_panel_anim) {
     LPRENDERER renderer = menuimport.GetRenderer();
     FLOAT right_offset;
+    char background_anim[UI_GLUE_ANIM_NAME];
+    char left_anim[UI_GLUE_ANIM_NAME];
+    char right_anim[UI_GLUE_ANIM_NAME];
 
     if (!renderer) {
         return;
@@ -89,10 +256,11 @@ void UI_DrawGlueSceneLayers(LPCSTR left_panel_anim, LPCSTR right_panel_anim) {
 
     if (renderer->RenderFrame && menu_glue_scene.background) {
         renderEntity_t entity = {0};
+        LPCSTR anim = UI_GlueBackgroundAnimation(renderer, background_anim, sizeof(background_anim));
         entity.model = menu_glue_scene.background;
         entity.scale = 1.0f;
         entity.flags = RF_NO_SHADOW | RF_NO_FOGOFWAR | RF_PORTRAIT_LIGHTING;
-        renderer->SetEntityAnimFrame(menu_glue_scene.background, "Stand", &entity);
+        renderer->SetEntityAnimFrame(menu_glue_scene.background, anim, &entity);
 
         viewDef_t viewdef = {0};
         viewdef.viewport = (RECT){0, 0, 1, 1};
@@ -105,11 +273,30 @@ void UI_DrawGlueSceneLayers(LPCSTR left_panel_anim, LPCSTR right_panel_anim) {
 
     if (renderer->DrawSprite) {
         if (menu_glue_scene.top_left_panel) {
-            renderer->DrawSprite(menu_glue_scene.top_left_panel, left_panel_anim, 0.0f, UI_BASE_HEIGHT);
+            LPCSTR anim = UI_GlueLayerAnimation(renderer,
+                                                menu_glue_scene.top_left_panel,
+                                                left_panel_anim,
+                                                &menu_glue_scene.left_anim,
+                                                left_anim,
+                                                sizeof(left_anim));
+            renderer->DrawSprite(menu_glue_scene.top_left_panel, anim, 0.0f, UI_BASE_HEIGHT);
+        } else {
+            menu_glue_scene.left_anim.complete = true;
         }
         if (menu_glue_scene.top_right_panel) {
-            renderer->DrawSprite(menu_glue_scene.top_right_panel, right_panel_anim, right_offset, UI_BASE_HEIGHT);
+            LPCSTR anim = UI_GlueLayerAnimation(renderer,
+                                                menu_glue_scene.top_right_panel,
+                                                right_panel_anim,
+                                                &menu_glue_scene.right_anim,
+                                                right_anim,
+                                                sizeof(right_anim));
+            renderer->DrawSprite(menu_glue_scene.top_right_panel, anim, right_offset, UI_BASE_HEIGHT);
+        } else {
+            menu_glue_scene.right_anim.complete = true;
         }
+    } else {
+        menu_glue_scene.left_anim.complete = true;
+        menu_glue_scene.right_anim.complete = true;
     }
 }
 

--- a/games/warcraft-3/menu/menu_local.h
+++ b/games/warcraft-3/menu/menu_local.h
@@ -31,6 +31,7 @@ void M_Init(void);
 void M_SetActive(BOOL active);
 void M_Shutdown(void);
 void M_Refresh(DWORD time);
+DWORD M_Time(void);
 
 /* ROC rows are label,sequence,model; TFT prepends a numeric expansion category (even for ROC campaigns). */
 static inline BOOL UI_ParseLoadingRow(LPCSTR row, LPDWORD sequence, LPSTR model) {
@@ -46,6 +47,8 @@ static inline BOOL UI_ParseLoadingRow(LPCSTR row, LPDWORD sequence, LPSTR model)
 void UI_ResetGlueSceneModels(void);
 void UI_ReleaseGlueSceneModels(void);
 void UI_PreloadGlueSceneModels(void);
+void UI_RestartGlueSceneAnimations(void);
+BOOL UI_GlueSceneAnimationComplete(void);
 void UI_DrawGlueScene(LPCSTR panel_anim);
 void UI_DrawGlueSceneLayers(LPCSTR left_panel_anim, LPCSTR right_panel_anim);
 

--- a/games/warcraft-3/menu/menu_main.c
+++ b/games/warcraft-3/menu/menu_main.c
@@ -194,10 +194,18 @@ void M_ShowGameSetupMenu(void) {
 }
 
 static void UI_MenuMain_f(void) {
+    if (UI_GetCurrentScreen() == &singlePlayerMenuScreen &&
+        SinglePlayerMenu_BeginMainMenu()) {
+        return;
+    }
     M_ShowMainMenu();
 }
 
 static void UI_MenuGame_f(void) {
+    if (UI_GetCurrentScreen() == &mainMenuScreen) {
+        MainMenu_BeginSinglePlayer();
+        return;
+    }
     M_ShowSinglePlayerMenu();
 }
 
@@ -275,6 +283,9 @@ static void UI_MenuOptionsApply_f(void) {
 
 static void UI_MenuSinglePlayerCampaign_f(void) {
     UI_SetScreen(&singlePlayerMenuScreen);
+    if (SinglePlayerMenu_BeginCampaign()) {
+        return;
+    }
     SinglePlayerMenu_ShowCampaign();
 }
 
@@ -517,6 +528,10 @@ void M_Shutdown(void) {
 
 void M_SetActive(BOOL active) {
     ui_state.active = active;
+}
+
+DWORD M_Time(void) {
+    return ui_state.time;
 }
 
 void M_Refresh(DWORD time) {

--- a/games/warcraft-3/menu/menu_screen.h
+++ b/games/warcraft-3/menu/menu_screen.h
@@ -49,6 +49,7 @@ void MainMenu_ShowRealmSelect(void);
 void MainMenu_ShowQuitConfirm(void);
 void MainMenu_ShowDisconnected(void);
 void MainMenu_BeginEditionSwitch(void);
+void MainMenu_BeginSinglePlayer(void);
 
 void OptionsMenu_ShowGameplay(void);
 void OptionsMenu_ShowVideo(void);
@@ -63,6 +64,8 @@ void SinglePlayerMenu_LaunchCampaign(LPCSTR name);
 void SinglePlayerMenu_LaunchCampaignIndex(DWORD index);
 void SinglePlayerMenu_LaunchMissionIndex(DWORD index);
 void SinglePlayerMenu_SetDifficulty(DWORD difficulty);
+BOOL SinglePlayerMenu_BeginMainMenu(void);
+BOOL SinglePlayerMenu_BeginCampaign(void);
 
 void LAN_ShowCreate(void);
 void LAN_ShowSinglePlayerCreate(void);

--- a/games/warcraft-3/menu/screens/main_menu.c
+++ b/games/warcraft-3/menu/screens/main_menu.c
@@ -29,6 +29,7 @@ static LPFRAMEDEF edition_button;
 static BOOL edition_switch_pending;
 static BOOL edition_switch_requested;
 static BOOL edition_switch_target_expansion;
+static BOOL single_player_transition_pending;
 
 static BOOL MainMenu_LoadScreen(void) {
     return MainMenu_Load(&main_menu);
@@ -106,6 +107,7 @@ static void MainMenu_Init(void) {
     edition_button = NULL;
     edition_switch_pending = false;
     edition_switch_requested = false;
+    single_player_transition_pending = false;
     UI_PreloadGlueSceneModels();
     MainMenu_InitFrames();
     MainMenu_ShowMainPanel();
@@ -115,6 +117,7 @@ static void MainMenu_Shutdown(void) {
     edition_button = NULL;
     edition_switch_pending = false;
     edition_switch_requested = false;
+    single_player_transition_pending = false;
 }
 
 static void MainMenu_ApplyEdition(BOOL expansion) {
@@ -142,10 +145,19 @@ static void MainMenu_Draw(void) {
 
     if (edition_switch_pending) {
         UI_DrawGlueScene("MainMenu Death");
-        if (!edition_switch_requested) {
+        if (UI_GlueSceneAnimationComplete() && !edition_switch_requested) {
             edition_switch_requested = true;
             MainMenu_ApplyEdition(edition_switch_target_expansion);
             menuimport.Cmd_ExecuteText("menu_restart\n");
+        }
+        return;
+    }
+
+    if (single_player_transition_pending) {
+        UI_DrawGlueScene("MainMenu Death");
+        if (UI_GlueSceneAnimationComplete()) {
+            single_player_transition_pending = false;
+            M_ShowSinglePlayerMenu();
         }
         return;
     }
@@ -169,6 +181,14 @@ static void MainMenu_KeyEvent(int key, BOOL down) {
     (void)down;
 }
 
+void MainMenu_BeginSinglePlayer(void) {
+    if (single_player_transition_pending || edition_switch_pending || !main_menu.MainMenuFrame) return;
+    single_player_transition_pending = true;
+    show_realm_select = false;
+    UI_DialogWar3Hide(&quit_dialog);
+    UI_SetHidden(main_menu.MainMenuFrame, true);
+}
+
 void MainMenu_BeginEditionSwitch(void) {
     LPCSTR expansion;
 
@@ -185,6 +205,9 @@ void MainMenu_BeginEditionSwitch(void) {
 void MainMenu_ShowMainPanel(void) {
     show_realm_select = false;
     UI_DialogWar3Hide(&quit_dialog);
+    if (main_menu.MainMenuFrame) {
+        UI_SetHidden(main_menu.MainMenuFrame, false);
+    }
     if (main_menu.RealmSelect) {
         UI_SetHidden(main_menu.RealmSelect, true);
     }

--- a/games/warcraft-3/menu/screens/single_player.c
+++ b/games/warcraft-3/menu/screens/single_player.c
@@ -48,6 +48,14 @@ static LPFRAMEDEF campaign_list_frame;
 static uiMapListState_t mission_list;
 static LPFRAMEDEF mission_list_frame;
 static DWORD campaign_background_model = 0;
+static PATHSTR campaign_background_path;
+static DWORD campaign_background_intro_start;
+static DWORD campaign_background_intro_duration;
+static BOOL campaign_background_intro_started;
+static BOOL campaign_background_intro_complete;
+static DWORD single_player_time;
+static BOOL return_main_pending;
+static BOOL campaign_transition_pending;
 static DWORD selected_campaign_index = SINGLE_PLAYER_MAX_CAMPAIGNS;
 static singlePlayerView_t current_view = SINGLE_PLAYER_VIEW_MAIN;
 
@@ -419,13 +427,60 @@ static void SinglePlayer_SetView(singlePlayerView_t view) {
                            view != SINGLE_PLAYER_VIEW_MISSION_SELECT);
 }
 
-static void SinglePlayer_SetCampaignBackdrop(singlePlayerCampaign_t const *campaign) {
-    if (single_player.CampaignBackdrop_2 && campaign && campaign->background[0]) {
-        campaign_background_model = UI_LoadModel(campaign->background, true);
-        single_player.CampaignBackdrop_2->Portrait.model = campaign_background_model;
-        fprintf(stderr, "[UI] Campaign backdrop: skin=\"%s\" model_idx=%u\n",
-                campaign->background, (unsigned)campaign_background_model);
+static void SinglePlayer_ResetCampaignBackdropIntro(void) {
+    campaign_background_intro_start = 0;
+    campaign_background_intro_duration = 0;
+    campaign_background_intro_started = false;
+    campaign_background_intro_complete = false;
+}
+
+static void SinglePlayer_SetCampaignBackdrop(singlePlayerCampaign_t const *campaign, BOOL restart_intro) {
+    BOOL changed;
+
+    if (!single_player.CampaignBackdrop_2 || !campaign || !campaign->background[0]) {
+        return;
     }
+
+    changed = strcmp(campaign_background_path, campaign->background) != 0;
+    campaign_background_model = UI_LoadModel(campaign->background, true);
+    single_player.CampaignBackdrop_2->Portrait.model = campaign_background_model;
+    if (changed) {
+        snprintf(campaign_background_path, sizeof(campaign_background_path), "%s", campaign->background);
+    }
+    if (changed || restart_intro) {
+        SinglePlayer_ResetCampaignBackdropIntro();
+    }
+    fprintf(stderr, "[UI] Campaign backdrop: skin=\"%s\" model_idx=%u\n",
+            campaign->background, (unsigned)campaign_background_model);
+}
+
+static LPCSTR SinglePlayer_CampaignBackdropAnimation(LPRENDERER renderer,
+                                                     LPCMODEL model,
+                                                     LPSTR scrubbed,
+                                                     DWORD scrubbed_size) {
+    DWORD elapsed;
+    FLOAT ratio;
+
+    if (!campaign_background_intro_started) {
+        campaign_background_intro_started = true;
+        campaign_background_intro_start = single_player_time;
+        campaign_background_intro_complete =
+            !renderer->GetModelAnimationDuration(model, "Birth", &campaign_background_intro_duration) ||
+            campaign_background_intro_duration == 0;
+    }
+    if (campaign_background_intro_complete) {
+        return "Stand";
+    }
+
+    elapsed = single_player_time - campaign_background_intro_start;
+    if (elapsed >= campaign_background_intro_duration) {
+        campaign_background_intro_complete = true;
+        return "Stand";
+    }
+
+    ratio = (FLOAT)elapsed / (FLOAT)campaign_background_intro_duration;
+    snprintf(scrubbed, scrubbed_size, "Birth@%.4f", ratio);
+    return scrubbed;
 }
 
 static void SinglePlayer_DrawCampaignBackdrop(void) {
@@ -434,10 +489,12 @@ static void SinglePlayer_DrawCampaignBackdrop(void) {
 
     if (renderer && renderer->RenderFrame && model) {
         renderEntity_t entity = {0};
+        char scrubbed[64];
+        LPCSTR anim = SinglePlayer_CampaignBackdropAnimation(renderer, model, scrubbed, sizeof(scrubbed));
         entity.model = model;
         entity.scale = 1.0f;
         entity.flags = RF_NO_SHADOW | RF_NO_FOGOFWAR | RF_PORTRAIT_LIGHTING;
-        renderer->SetEntityAnimFrame(model, "Stand", &entity);
+        renderer->SetEntityAnimFrame(model, anim, &entity);
 
         viewDef_t viewdef = {0};
         viewdef.viewport = (RECT){0, 0, 1, 1};
@@ -557,7 +614,7 @@ static void SinglePlayer_SelectCampaign(singlePlayerCampaign_t const *campaign) 
         return;
     }
     selected_campaign_index = (DWORD)(campaign - campaigns);
-    SinglePlayer_SetCampaignBackdrop(campaign);
+    SinglePlayer_SetCampaignBackdrop(campaign, false);
     SinglePlayer_PopulateMissionSelect(campaign);
     SinglePlayer_SetView(SINGLE_PLAYER_VIEW_MISSION_SELECT);
 }
@@ -728,6 +785,11 @@ static void SinglePlayerMenu_Init(void) {
     mission_list_frame = NULL;
     memset(&campaign_list, 0, sizeof(campaign_list));
     memset(&mission_list, 0, sizeof(mission_list));
+    memset(campaign_background_path, 0, sizeof(campaign_background_path));
+    single_player_time = 0;
+    return_main_pending = false;
+    campaign_transition_pending = false;
+    SinglePlayer_ResetCampaignBackdropIntro();
 
     if (single_player.WarCraftIIILogo) {
         single_player.WarCraftIIILogo->Portrait.model = UI_LoadModel("CampaignLogo", true);
@@ -737,19 +799,38 @@ static void SinglePlayerMenu_Init(void) {
     SinglePlayer_BindCampaignMenu();
     SinglePlayer_CreateCampaignList();
     SinglePlayer_CreateMissionList();
-    SinglePlayer_SetCampaignBackdrop(SinglePlayer_DefaultCampaign());
+    SinglePlayer_SetCampaignBackdrop(SinglePlayer_DefaultCampaign(), false);
     selected_campaign_index = SINGLE_PLAYER_MAX_CAMPAIGNS;
     SinglePlayer_SetView(SINGLE_PLAYER_VIEW_MAIN);
 }
 
 static void SinglePlayerMenu_Shutdown(void) {
+    return_main_pending = false;
+    campaign_transition_pending = false;
 }
 
 static void SinglePlayerMenu_Refresh(int msec) {
-    (void)msec;
+    single_player_time = (DWORD)msec;
 }
 
 static void SinglePlayerMenu_Draw(void) {
+    if (return_main_pending) {
+        UI_DrawGlueScene("SinglePlayer Death");
+        if (UI_GlueSceneAnimationComplete()) {
+            return_main_pending = false;
+            M_ShowMainMenu();
+        }
+        return;
+    }
+
+    if (campaign_transition_pending) {
+        UI_DrawGlueScene("SinglePlayer Death");
+        if (UI_GlueSceneAnimationComplete()) {
+            campaign_transition_pending = false;
+            SinglePlayerMenu_ShowCampaign();
+        }
+        return;
+    }
     if (current_view == SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT ||
         current_view == SINGLE_PLAYER_VIEW_MISSION_SELECT) {
         SinglePlayer_DrawCampaignBackdrop();
@@ -771,17 +852,44 @@ static void SinglePlayerMenu_KeyEvent(int key, BOOL down) {
 }
 
 void SinglePlayerMenu_ShowMain(void) {
+    BOOL const returning_from_campaign = current_view != SINGLE_PLAYER_VIEW_MAIN;
+
     if (single_player.ProfileNameText) {
         LPCSTR name = menuimport.Cvar_String ? menuimport.Cvar_String("name", "Player") : "Player";
         UI_SetText(single_player.ProfileNameText, "%s", name && name[0] ? name : "Player");
+    }
+    return_main_pending = false;
+    campaign_transition_pending = false;
+    if (returning_from_campaign) {
+        UI_RestartGlueSceneAnimations();
     }
     SinglePlayer_SetView(SINGLE_PLAYER_VIEW_MAIN);
 }
 
 void SinglePlayerMenu_ShowCampaign(void) {
-    SinglePlayer_SetCampaignBackdrop(SinglePlayer_DefaultCampaign());
+    return_main_pending = false;
+    campaign_transition_pending = false;
+    SinglePlayer_SetCampaignBackdrop(SinglePlayer_DefaultCampaign(), true);
     selected_campaign_index = SINGLE_PLAYER_MAX_CAMPAIGNS;
     SinglePlayer_SetView(SINGLE_PLAYER_VIEW_CAMPAIGN_SELECT);
+}
+
+BOOL SinglePlayerMenu_BeginMainMenu(void) {
+    if (current_view != SINGLE_PLAYER_VIEW_MAIN || return_main_pending || campaign_transition_pending) {
+        return false;
+    }
+    return_main_pending = true;
+    SinglePlayer_SetHidden(single_player.SinglePlayerMenu, true);
+    return true;
+}
+
+BOOL SinglePlayerMenu_BeginCampaign(void) {
+    if (current_view != SINGLE_PLAYER_VIEW_MAIN || campaign_transition_pending || return_main_pending) {
+        return false;
+    }
+    campaign_transition_pending = true;
+    SinglePlayer_SetHidden(single_player.SinglePlayerMenu, true);
+    return true;
 }
 
 void SinglePlayerMenu_BackCampaign(void) {

--- a/games/warcraft-3/renderer/r_game.c
+++ b/games/warcraft-3/renderer/r_game.c
@@ -482,6 +482,20 @@ bool R_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity) {
     return MDLX_SetEntityAnimationFrame(model, anim, entity);
 }
 
+bool R_GetModelAnimationDuration(LPCMODEL model, LPCSTR anim, LPDWORD duration) {
+    mdxSequence_t const *seq;
+
+    if (!model || model->modeltype != ID_MDLX || !model->mdx || !anim || !*anim || !duration) {
+        return false;
+    }
+    seq = MDLX_FindSequenceByName(model->mdx, anim);
+    if (!seq || seq->interval[1] < seq->interval[0]) {
+        return false;
+    }
+    *duration = seq->interval[1] - seq->interval[0];
+    return true;
+}
+
 void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y) {
     MDLX_DrawSprite(model, anim, x, y);
 }

--- a/games/warcraft-3/tests/test_menu_fdf.c
+++ b/games/warcraft-3/tests/test_menu_fdf.c
@@ -230,6 +230,12 @@ static size2_t test_get_window_size(void) {
 
 static void test_release_texture(LPTEXTURE texture) { (void)texture; texture_releases++; }
 static void test_release_model(LPMODEL model) { (void)model; }
+static bool test_get_model_animation_duration(LPCMODEL model, LPCSTR anim, LPDWORD duration) {
+    (void)model;
+    (void)anim;
+    (void)duration;
+    return false;
+}
 
 static LPRENDERER test_get_renderer(void) {
     static refExport_t renderer = {
@@ -243,6 +249,7 @@ static LPRENDERER test_get_renderer(void) {
         .DrawBackdrop = test_draw_backdrop,
         .DrawText = test_draw_text,
         .DrawSprite = test_draw_sprite,
+        .GetModelAnimationDuration = test_get_model_animation_duration,
         .GetTextSize = test_get_text_size,
     };
     return &renderer;

--- a/games/world-of-warcraft/renderer/r_game.c
+++ b/games/world-of-warcraft/renderer/r_game.c
@@ -513,6 +513,13 @@ bool R_GetModelInfo(LPMODEL model, LPMODELINFO info) {
     return false;
 }
 
+bool R_GetModelAnimationDuration(LPCMODEL model, LPCSTR anim, LPDWORD duration) {
+    (void)model;
+    (void)anim;
+    (void)duration;
+    return false;
+}
+
 bool R_ExtractEntityCamera(renderEntity_t const *entity, float aspect, viewDef_t *viewdef) {
     BOX3 const *bounds;
     MATRIX4 transform;

--- a/renderer/r_game.h
+++ b/renderer/r_game.h
@@ -55,6 +55,7 @@ BOOL R_EntityAttachmentPosition(renderEntity_t const *entity, LPCSTR prefix, LPV
 
 bool R_ExtractEntityCamera(renderEntity_t const *entity, float aspect, viewDef_t *viewdef);
 bool R_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity);
+bool R_GetModelAnimationDuration(LPCMODEL model, LPCSTR anim, LPDWORD duration);
 void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y);
 bool R_DrawCursor(float x, float y, COLOR32 tint);
 w3TerrainArt_t const *R_TerrainArt(DWORD id);

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -343,6 +343,7 @@ void R_ReleaseVertexArrayObject(LPBUFFER buffer);
 LPCTEXTURE R_FindTextureByID(DWORD textureID);
 void R_DrawSprite(LPCMODEL model, LPCSTR anim, float x, float y);
 bool R_SetEntityAnimFrame(LPCMODEL model, LPCSTR anim, renderEntity_t *entity);
+bool R_GetModelAnimationDuration(LPCMODEL model, LPCSTR anim, LPDWORD duration);
 void R_RenderSplat(LPCVECTOR2 position, float radius, LPCTEXTURE texture, splat_shader_t *shader, COLOR32 color);
 void R_DrawBackdrop(LPCDRAWBACKDROP drawBackdrop);
 void R_RenderRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, splat_shader_t *shader, COLOR32 color);

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -1095,6 +1095,7 @@ refExport_t R_GetAPI(refImport_t imp) {
         .DrawSprite = R_DrawSprite,
         .DrawCursor = R_DrawCursor,
         .SetEntityAnimFrame = R_SetEntityAnimFrame,
+        .GetModelAnimationDuration = R_GetModelAnimationDuration,
         .DrawText = R_DrawText,
         .GetTextSize = R_GetTextSize,
         .GetModelInfo = R_GetModelInfo,


### PR DESCRIPTION
Restore Warcraft III-style menu scene transitions by driving glue animations from their authored MDX sequence durations instead of the global looping renderer clock.

- add renderer support for querying animation sequence duration
- start 3D menu backgrounds with Birth before settling on Stand
- play glue sprite Birth and Death sequences as one-shot animations
- transition Main Menu -> Single Player via MainMenu Death and SinglePlayer Birth
- transition Single Player -> Main Menu via SinglePlayer Death and MainMenu Birth
- start campaign backgrounds with their authored Birth animation
- preserve fallback behavior when sequence timing is unavailable
- wait for the complete MainMenu Death sequence before edition restart
- document the glue scene animation lifecycle and remaining SlidingDoors campaign transition gap

This restores the model-authored fades, pans, and camera settling used by the retail menu without introducing guessed transition timings.