### PR TITLE
server: prevent map-load stalls from fast-forwarding simulation

### DIFF
--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -452,11 +452,12 @@ void V_RenderView(void) {
     cl.viewDef.fow_generation = cl.fow.generation;
     if (!world_loaded || cls.state != ca_active) {
         VECTOR3 target = { 0, 0, 90 };
+        DWORD const elapsed = lastTime && cl.time >= lastTime ? cl.time - lastTime : 0;
 
         cl.viewDef.viewport = (RECT) { 0, 0, 1, 1 };
         cl.viewDef.scissor = (RECT) { 0, 0, 1, 1 };
         cl.viewDef.time = cl.time;
-        cl.viewDef.deltaTime = cl.time - lastTime;
+        cl.viewDef.deltaTime = elapsed;
         cl.viewDef.rdflags = RDF_NOWORLDMODEL | RDF_NOFRUSTUMCULL | RDF_NOFOG;
     cl.viewDef.player = cl.playerstate.number;
     cl.viewDef.hover_entity = cl.hover_entity;

--- a/client/client.h
+++ b/client/client.h
@@ -189,7 +189,19 @@ void Matrix4_getCameraMatrix(LPMATRIX4 output);
 /* Paused views retain the last scene and render time. Zero delta is required
  * because model renderers emit effects while submitting cached entities. */
 static inline BOOL V_AdvanceSceneTime(viewDef_t *view, DWORD now, LPDWORD last, BOOL paused) {
-    DWORD elapsed = *last ? now - *last : 0;
+    DWORD elapsed;
+
+    /* Map/session time restarts from zero. A persistent renderer clock must
+     * treat that as a new epoch instead of unsigned-wrap advancing effects by
+     * roughly 2^32 milliseconds in one frame. */
+    if (*last && now < *last) {
+        *last = now;
+        view->time = now;
+        view->deltaTime = 0;
+        return !paused;
+    }
+
+    elapsed = *last ? now - *last : 0;
     *last = now;
     if (paused) { view->deltaTime = 0; return false; }
     view->time = view->time ? view->time + elapsed : now;

--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -100,6 +100,8 @@ WoW still replaces look-at Z from the local player entity (`WOW_CAMERA_EYE_HEIGH
 
 The client keeps two snapshots per entity: `prev` and `current`. `CL_PrepRefresh` blends between them using a fraction derived from `cl.time` and the server frame interval, producing smooth motion even when the client render rate exceeds the server tick rate.
 
+`V_RenderView` keeps a presentation-only scene clock across frames so paused views can submit cached entities with `deltaTime = 0`. Map/session server time can restart from zero while the process and renderer remain alive, so `V_AdvanceSceneTime` treats `now < last` as a new render epoch: it resets `view.time` to `now` and emits zero delta for that frame. The non-active preview path applies the same non-wrapping elapsed-time rule. Never subtract a retained `DWORD` scene timestamp from a newly reset map clock without this epoch check; unsigned wrap otherwise looks like roughly `2^32` milliseconds and can burst particles/animations/effects for one frame. The regression is covered by `net.scene_time_rewind_starts_a_new_render_epoch`.
+
 ## Console and HUD
 
 `cl_console.c` maintains an in-game console that can be toggled with the tilde key. `cl_scrn.c` coordinates frame presentation and the UI draw pass.

--- a/docs/architecture/server.md
+++ b/docs/architecture/server.md
@@ -25,6 +25,8 @@ void SV_Frame(DWORD msec) {
     }
     if (svs.realtime < sv.next_frame_msec)
         return;          // not yet time for a new game frame
+    sv.next_frame_msec = SV_ClampSimulationDeadline(
+        svs.realtime, sv.next_frame_msec);
     SV_RunGameFrame();   // 1. advance simulation
     sv.next_frame_msec += FRAMETIME;
     SV_SendClientMessages(); // 2. send snapshots to clients
@@ -32,6 +34,12 @@ void SV_Frame(DWORD msec) {
 ```
 
 This fixed-step approach decouples the simulation rate from the render rate and makes replay and deterministic simulation practical. `SV_SetPaused()` gates only simulation advancement; transport stays active, and resuming rebases `sv.next_frame_msec` so paused wall-clock time is not simulated as catch-up work. Warcraft III pause policy is documented in [Pause And Modal UI](../games/warcraft-3/pause-and-modal-ui.md).
+
+`SV_Frame` executes at most one simulation step per outer-loop call. Before that step it applies `SV_ClampSimulationDeadline`: normal sub-tick lateness is preserved, but if the simulation deadline is more than one `FRAMETIME` behind wall time the deadline is rebased to the current `svs.realtime`. This follows Quake II's server policy of never allowing a multi-tick wall-clock stall to become a long burst of catch-up simulation. It is especially important for the local-client architecture because synchronous map loading and renderer/resource registration can block the outer loop for seconds. That wall time is loading latency, not simulation work, and must not later be replayed as consecutive 100 ms game ticks at render-loop speed.
+
+A September 2026 WC3 campaign trace confirmed the failure mode directly: multi-second map-load stalls left the server several seconds overdue; at a ~15–16 ms render-loop cadence, each subsequent outer iteration advanced the fixed simulation by 100 ms until the backlog drained, making JASS/camera time run roughly six times faster than wall time. The deadline clamp removes that debt while preserving ordinary scheduler jitter. The regression is covered by `server_net.scheduler_clamps_multi_tick_wall_clock_backlog`. See [WC3 Cinematics](../games/warcraft-3/cinematics.md) for the campaign symptom.
+
+Reference behavior: id Software Quake II `server/sv_main.c`, `SV_RunGameFrame`, clamps server realtime when the simulation falls behind so the engine does not replay an arbitrarily large backlog after a stall.
 
 ### 1. SV_ReadPackets
 

--- a/docs/games/warcraft-3/cinematics.md
+++ b/docs/games/warcraft-3/cinematics.md
@@ -63,6 +63,13 @@ Camera and transmission natives should not grow permanent investigative tracing;
 
 ### Common Issues
 
+**Opening cinematic runs too fast after a mission/map load:**
+The authored JASS waits and camera durations can be correct while the whole opening still fast-forwards if the generic server scheduler carries wall-clock loading time forward as simulation debt. `SV_Frame` advances at most one 100 ms game step per outer-loop call; without a backlog clamp, a multi-second synchronous map/resource load can leave `sv.next_frame_msec` seconds behind `svs.realtime`. At a high render rate the following outer-loop iterations then each advance 100 ms of JASS/camera time only ~15–16 ms apart until the debt drains. This was confirmed on Prologue01 on both an initial load and a same-process restart; `skip_cutscene` remained disabled and `TriggerSleepAction` retained the authored durations.
+
+The fix belongs in the generic server scheduler, not the WC3 cinematic natives: `SV_ClampSimulationDeadline` rebases deadlines that are more than one fixed tick overdue before `SV_RunGameFrame`, discarding loading latency while preserving ordinary sub-tick lateness. See [Server Architecture](../../architecture/server.md) and `server_net.scheduler_clamps_multi_tick_wall_clock_backlog`.
+
+A same-process restart also resets map/server time while the client renderer survives. `V_AdvanceSceneTime` therefore treats a backwards scene timestamp as a new render epoch and forces `deltaTime = 0` for that frame; otherwise unsigned `DWORD` subtraction can produce a near-`2^32` ms effect delta. This is a separate one-frame restart hazard, covered by `net.scene_time_rewind_starts_a_new_render_epoch` and documented in [Client Architecture](../../architecture/client.md).
+
 **Mismatched player numbers in SetCinematicScene/EndCinematicScene:**
 `currentplayer` is the `GetLocalPlayer()` presentation selector, not the owner
 of the unit that fired an event. Event ownership belongs in

--- a/games/warcraft-3/tests/test_server_net.c
+++ b/games/warcraft-3/tests/test_server_net.c
@@ -100,6 +100,13 @@ TEST(server_net, pause_publishes_client_render_state) {
     T_ASSERT(!sv.paused); T_EQ(Cvar_Integer("paused", 1), 0);
 }
 
+TEST(server_net, scheduler_clamps_multi_tick_wall_clock_backlog) {
+    T_EQ(SV_ClampSimulationDeadline(3602, 0), 3602);
+    T_EQ(SV_ClampSimulationDeadline(220, 100), 220);
+    T_EQ(SV_ClampSimulationDeadline(200, 100), 100);
+    T_EQ(SV_ClampSimulationDeadline(180, 100), 100);
+}
+
 void SV_ExecuteUserCommand(LPSIZEBUF msg, LPCLIENT client) { (void)msg; (void)client; }
 void SV_HandleUnitUIRequest(LPCLIENT client, LPSIZEBUF msg) { (void)client; (void)msg; }
 

--- a/server/server.h
+++ b/server/server.h
@@ -102,6 +102,18 @@ extern struct server {
     BYTE multicast_buf[MAX_MSGLEN];
 } sv;
 
+/* Match Quake II's "never get more than one tic behind" scheduler policy.
+ * A long blocking client/map-loading hitch is wall-clock time, not simulation
+ * work that should later be replayed at render-loop speed. Preserve normal
+ * sub-tick lateness, but rebase a deadline that is more than one fixed step
+ * overdue before running the next game frame. */
+static inline DWORD SV_ClampSimulationDeadline(DWORD realtime, DWORD deadline) {
+    if (realtime >= deadline && realtime - deadline > FRAMETIME) {
+        return realtime;
+    }
+    return deadline;
+}
+
 extern struct game_export *ge;
 
 // sv_init.c

--- a/server/sv_main.c
+++ b/server/sv_main.c
@@ -229,6 +229,7 @@ void SV_Frame(DWORD msec) {
         return;
     }
 
+    sv.next_frame_msec = SV_ClampSimulationDeadline(svs.realtime, sv.next_frame_msec);
     SV_RunGameFrame();
     sv.next_frame_msec += FRAMETIME;
     SV_SendClientMessages();

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -264,6 +264,14 @@ TEST(net, paused_scene_time_reuses_cached_world_without_effect_delta) {
     T_EQ(view.time, 1100); T_EQ(view.deltaTime, 100); T_EQ(last, 1200);
 }
 
+TEST(net, scene_time_rewind_starts_a_new_render_epoch) {
+    viewDef_t view = { .time = 22316, .deltaTime = 16 };
+    DWORD last = 22316;
+
+    T_ASSERT(V_AdvanceSceneTime(&view, 400, &last, false));
+    T_EQ(view.time, 400); T_EQ(view.deltaTime, 0); T_EQ(last, 400);
+}
+
 
 /* Authored cursors use the same recipient-relative hover relationship as the
  * world ring: enemies tint red, neutral/passive targets yellow, and friendly


### PR DESCRIPTION
Clamp multi-tick server scheduler backlog after blocking load work so wall-clock loading time is not replayed as accelerated simulation.

Also treat client scene-time rewinds across map restarts as a new render epoch to avoid unsigned delta overflow, and add regression coverage and architecture documentation for both timing issues.