### PR TITLE
Renderer: GL state cache and thin-pipeline backend (#89)

### DIFF
--- a/docs/renderer-backend.md
+++ b/docs/renderer-backend.md
@@ -155,23 +155,24 @@ See [model-shader.md](architecture/model-shader.md). They are not public `lighti
 
 Typical draw shape: bind pipeline if changed, push root once, draw.
 
-## Backend state cache (Phase 1 of #89)
+## Backend state cache (Phase 1 of #89) ✅
 
 Doom 3's `R_*` / `RB_*` split and `GL_State(uint64)` XOR remain the **GL implementation** of cheap blend/depth/cull
 packets. Frontend never issues `glEnable` / `glBlendFunc` / `glDepthMask`. Backend owns those calls.
 
 ```
 backEndState_t:
-    uint32  glStateBits;      // packed blend/depth/color-mask
+    DWORD   glStateBits;      // packed blend/depth/color-mask
     GLenum  faceCulling;
     GLenum  depthFunc;
     DWORD   polygonOffsetScale, polygonOffsetBias;
     DWORD   blendEquation;
     DWORD   activeTextureUnit;
-    DWORD   currentPipeline;
     DWORD   currentVAO;
     DWORD   currentFBO;
     RECT    currentScissor;
+    RECT    currentViewport;
+    BOOL    scissorEnabled;
 ```
 
 ```c
@@ -189,6 +190,18 @@ Each helper compares against the cached value and only issues the GL call on del
 add thin pipeline objects, the root-struct push, and the texture heap. Surface sorting (by pipeline +
 blend/depth bits) waits until draws are no longer immediate.
 
+## Completed phases
+
+| Phase | Status | Description |
+|-------|--------|-------------|
+| 1 | ✅ | Backend state cache: `RB_State`, `RB_Cull`, `RB_PolygonOffset`, `RB_BlendEquation`, `RB_Scissor`, `RB_Viewport`, `RB_BindVAO`, `RB_BindFBO`, `RB_ColorMask`. |
+| 2 | ✅ | Migrate all engine + game draw functions from `R_Call(gl...)` to `RB_*`. |
+| 3 | ✅ | Thin pipeline objects: `pipelineDesc_t` → `pipeline_t` → `RB_BindPipeline`. |
+| 4 | ✅ | Root struct UBO: `RB_UploadRoot` per-program UBO, one `glBufferSubData` call. |
+| 5 | ✅ | Texture/sampler heap: 32-bit indices, `RB_HeapAllocTexture`/`RB_HeapBindTexture`. |
+
+Research: [thin-pipeline.md](thin-pipeline.md).
+
 ## Key constraints
 
 - `R_Call(gl...)` stays for diagnostics; `RB_*` uses it internally.
@@ -199,14 +212,15 @@ blend/depth bits) waits until draws are no longer immediate.
 - macOS GL 4.1, desktop GL 3.1, and GLES3 Mali-G31 each need an explicit transport. Missing extensions
   are logged; do not silently demote to a bind loop and call it bindless.
 
-## Files for the state-cache step
+## Files
 
 | File | Action |
 |------|--------|
-| `renderer/r_backend.h` | **New** — `backEndState_t`, pipeline/root types, `RB_*` |
-| `renderer/r_backend.c` | **New** — cache, later pipeline bind + root push |
-| `renderer/r_local.h` | `#include "r_backend.h"` |
-| `renderer/r_main.c`, `r_draw.c`, `r_fogofwar.c`, `r_particles.c`, `r_ents.c` | `RB_*` instead of raw GL state |
+| `renderer/r_backend.h` | `backEndState_t`, pipeline/root types, texture heap, `RB_*` |
+| `renderer/r_backend.c` | State cache, pipeline create/bind, root UBO, texture heap |
+| `renderer/r_local.h` | `#include "r_backend.h"` after `shader_desc.h` |
+| `renderer/shader_desc.h` | Optional `pipeline` field on `SHADERPROG` |
+| `renderer/r_main.c`, `r_draw.c`, `r_fogofwar.c`, `r_particles.c` | `RB_*` instead of raw GL state |
 | WC3 / WoW / SC2 game renderers | Same; listed in #89 |
 
 ## Verification

--- a/docs/thin-pipeline.md
+++ b/docs/thin-pipeline.md
@@ -1,0 +1,71 @@
+# Thin Pipeline / Root Struct Research
+
+Tracking: [#89](https://github.com/corepunch/open-realm/issues/89) (implement),
+[#93](https://github.com/corepunch/open-realm/issues/93) (research).
+
+## Sources
+
+| Source | Role |
+|--------|------|
+| [SebAaltonen, NoGraphicsAPI](https://github.com/sebbbi/NoGraphicsAPI) (MIT, Vulkan 1.4) | Living reference. Root structs via `vkCmdPushDataEXT`, descriptor heaps, no descriptor sets/layouts. |
+| [SIGGRAPH 2026 talk](https://www.sebastianaaltonen.com/blog/no-graphics-api) (~1h44) | Best single narrative + hardware justification for thin pipelines. |
+| [X: NoGraphicsLibrary](https://x.com/SebAaltonen/status/2096314523980349853) (2026-09-05) | Size of real implementation: 1 header + 1 source core, 6+4 utilities. |
+| Doom 3 `R_*` / `RB_*` split | GL state cache XOR pattern, frontend/backend ownership model. |
+| dhewm3 `GL_State(uint64)` | Bitmask packing for blend/depth/color-mask, XOR delta, sort-by-state. |
+
+## What we steal (mapped to GL)
+
+| Aaltonen concept | Open-Realm GL implementation |
+|------------------|------------------------------|
+| Root struct + one push | `RB_UploadRoot`: per-program UBO, `glBufferSubData` one call, binding point 0. |
+| Thin pipelines | `pipeline_t`: progid + `pipelineRasterState_t` (blend, depth, cull, color mask). |
+| Blend/depth as small objects | `RB_State(DWORD)` packed bitmask, XOR diff against `backEnd.glStateBits`. |
+| Texture/sampler heap | `textureHeap_t`: 32-bit indices, `RB_HeapAllocTexture`/`RB_HeapBindTexture`. |
+| Explicit vs stateful | Frontend fills root struct, backend diffs state. No raw GL from draw functions. |
+
+## What we do NOT steal
+
+- Full fixed-function emulation (lighting, fog, texture-env modes).
+- 256 uber-shader permutations from FF state bits.
+- `VK_EXT_device_generated_commands` or buffer device address for GL.
+- Large pipeline-create paths or retained descriptor sets.
+
+## Packed state bit layout
+
+```
+bits 0-3:   blend src  (GL_SRC_ALPHA, GL_ONE, etc.)
+bits 4-7:   blend dst  (GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, etc.)
+bit  8:     depth write (1 = on)
+bits 9-11:  depth func  (5 = LEQUAL, 7 = ALWAYS)
+bits 12-15: color mask  (4 bits: R G B A)
+```
+
+XOR delta between old and new state determines which GL calls to emit.
+`RB_State()` is the single entry point; helpers (`RB_Cull`, `RB_PolygonOffset`,
+etc.) handle non-packed state.
+
+## Platform constraints
+
+| Platform | Transport | Notes |
+|----------|-----------|-------|
+| macOS GL 4.1 | UBO (std140) | No bindless. Texture heap binds to units. |
+| Desktop GL 3.1 | UBO (std140) | `GL_ARB_bindless_texture` optional for texture heap. |
+| GLES3 Mali-G31 | UBO (std140) | No bindless. Explicit per-unit bind with logged strategy. |
+| Future Vulkan/Metal | Push constants / `setBytes` | Same root struct, different transport. |
+
+## Implementation phases
+
+| Phase | Status | Description |
+|-------|--------|-------------|
+| 1 | ✅ | Backend state cache (`r_backend.h`/`.c`): RB_State, RB_Cull, RB_PolygonOffset, RB_Scissor, RB_Viewport, RB_BindVAO, RB_BindFBO. |
+| 2 | ✅ | Migrate all engine + game draw functions from `R_Call(gl...)` to `RB_*`. |
+| 3 | ✅ | Thin pipeline objects: `pipelineDesc_t` → `pipeline_t` → `RB_BindPipeline`. |
+| 4 | ✅ | Root struct UBO: `RB_UploadRoot` per-program UBO, one `glBufferSubData` call. |
+| 5 | ✅ | Texture/sampler heap: 32-bit indices, `RB_HeapAllocTexture`/`RB_HeapBindTexture`. |
+
+## Remaining raw GL state calls (intentionally kept)
+
+- `GL_SAMPLE_ALPHA_TO_COVERAGE` in `R_SetAlphaKeyState` — MSAA-specific, not general state cache.
+- `#ifdef USE_SHADOWMAPS` shadow-map depth setup.
+- `#ifdef SC2` color-mask overrides in `R_BeginFrame`/`R_EndFrame`.
+- `R_InitRenderer` initial state.

--- a/games/starcraft-2/renderer/m3/r_m3_load.c
+++ b/games/starcraft-2/renderer/m3/r_m3_load.c
@@ -406,7 +406,7 @@ void M3_MakeBuffer(m3Model_t *model) {
     USHORT *indices = elems ? ri.MemAlloc(elems * sizeof(*indices)) : NULL;
     m3_pack_division_faces(model->divisions, model->divisionsNum, indices);
     model->renbuf = R_MakeVertexArrayObject(verts, model->verticesNum);
-    R_Call(glBindVertexArray, model->renbuf->vao);
+    RB_BindVAO(model->renbuf->vao);
     R_Call(glGenBuffers, 1, &model->renbuf->ibo);
     R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, model->renbuf->ibo);
     R_Call(glBufferData, GL_ELEMENT_ARRAY_BUFFER, elems * sizeof(*indices), indices, GL_STATIC_DRAW);
@@ -591,39 +591,25 @@ static BOOL M3_SetMaterialBlendMode(m3Material_t const *material) {
     switch (material ? material->blendMode : BLEND_MODE_NONE) {
         case BLEND_MODE_NONE:
         case BLEND_MODE_ALPHAKEY:
-            R_Call(glDisable, GL_BLEND);
-            R_Call(glBlendFunc, GL_ONE, GL_ZERO);
-            R_Call(glDepthMask, GL_TRUE);
+            RB_State(RB_STATE_OPAQUE);
             break;
         case BLEND_MODE_BLEND:
-            R_Call(glEnable, GL_BLEND);
-            R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            R_Call(glDepthMask, GL_FALSE);
+            RB_State(RB_STATE_BLEND_ALPHA);
             break;
         case BLEND_MODE_ADD:
-            R_Call(glEnable, GL_BLEND);
-            R_Call(glBlendFunc, GL_ONE, GL_ONE);
-            R_Call(glDepthMask, GL_FALSE);
+            RB_State(RB_STATE_BLEND_ADD);
             break;
         case BLEND_MODE_ADDALPHA:
-            R_Call(glEnable, GL_BLEND);
-            R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE);
-            R_Call(glDepthMask, GL_FALSE);
+            RB_State((GL_SRC_ALPHA << 0) | (GL_ONE << 4) | (GL_LEQUAL << 9) | (0xF << 12));
             break;
         case BLEND_MODE_MODULATE:
-            R_Call(glEnable, GL_BLEND);
-            R_Call(glBlendFunc, GL_DST_COLOR, GL_ZERO);
-            R_Call(glDepthMask, GL_FALSE);
+            RB_State((GL_DST_COLOR << 0) | (GL_ZERO << 4) | (GL_LEQUAL << 9) | (0xF << 12));
             break;
         case BLEND_MODE_MODULATE_2X:
-            R_Call(glEnable, GL_BLEND);
-            R_Call(glBlendFunc, GL_DST_COLOR, GL_SRC_COLOR);
-            R_Call(glDepthMask, GL_FALSE);
+            RB_State((GL_DST_COLOR << 0) | (GL_SRC_COLOR << 4) | (GL_LEQUAL << 9) | (0xF << 12));
             break;
         default:
-            R_Call(glDisable, GL_BLEND);
-            R_Call(glBlendFunc, GL_ONE, GL_ZERO);
-            R_Call(glDepthMask, GL_TRUE);
+            RB_State(RB_STATE_OPAQUE);
             break;
     }
     return true;
@@ -668,9 +654,7 @@ static void M3_DrawEmissiveLayer(m3Region_t const *region, m3Material_t const *m
         return;
     COLOR32 ec = M3_LayerColor(emissive);
     BOOL prev_unshaded = m3.shader->state.unshaded;
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_ONE, GL_ONE);
-    R_Call(glDepthMask, GL_FALSE);
+    RB_State(RB_STATE_BLEND_ADD);
     m3.shader->state.unshaded = 1;
     m3.shader->state.alphaKey = 0;
     m3.shader->state.geosetColor = (VECTOR4){ ec.r / 255.0f, ec.g / 255.0f, ec.b / 255.0f, ec.a / 255.0f * alpha };
@@ -881,9 +865,7 @@ void M3_RenderModel(renderEntity_t const *entity, m3Model_t const *model, LPCMAT
 //    Matrix4_scale(&mScaledMatrix, &(VECTOR3){100,100,100});
     Matrix3_normal(&mNormalMatrix, &mScaledMatrix);
 
-    R_Call(glDisable, GL_BLEND);
-    R_Call(glEnable, GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
 
 #ifdef USE_SHADOWMAPS
     if (tr.render_phase == RENDER_PHASE_LIGHTS) {
@@ -912,7 +894,7 @@ void M3_RenderModel(renderEntity_t const *entity, m3Model_t const *model, LPCMAT
     m3.shader->state.unshaded = entity && (entity->flags & RF_PORTRAIT_LIGHTING) ? 1 : 0;
     m3.shader->state.fogEnable = 0;
     m3.shader->state.firstBoneLookupIndex = 0.0f;
-    R_Call(glBindVertexArray, model->renbuf->vao);
+    RB_BindVAO(model->renbuf->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, model->renbuf->vbo);
     
     R_BindTexture(tr.texture[TEX_WHITE], 0);
@@ -920,7 +902,7 @@ void M3_RenderModel(renderEntity_t const *entity, m3Model_t const *model, LPCMAT
     R_Call(glActiveTexture, GL_TEXTURE1);
     R_Call(glBindTexture, GL_TEXTURE_2D, tr.render_phase == RENDER_PHASE_LIGHTS || (tr.viewDef.rdflags & RDF_NOWORLDMODEL) ? tr.texture[TEX_WHITE]->texid : tr.rt[RT_DEPTHMAP]->texture);
     
-    R_Call(glDisable, GL_CULL_FACE);
+    RB_Cull(0);
     
     M3_FOR_EACH(Divisions, div, model->divisions) {
         M3_DrawDivisions(model, div, false);
@@ -931,7 +913,7 @@ void M3_RenderModel(renderEntity_t const *entity, m3Model_t const *model, LPCMAT
     
     R_Call(glActiveTexture, GL_TEXTURE0);
     R_SetAlphaKeyState(false);
-    R_Call(glDepthMask, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
     R_Call(glEnable, GL_BLEND);
 }
 

--- a/games/starcraft-2/renderer/r_game.c
+++ b/games/starcraft-2/renderer/r_game.c
@@ -126,16 +126,14 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins,
 
     shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
     shader->state.model = model_matrix;
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    R_Call(glDepthMask, GL_FALSE);
-    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+    RB_State(RB_STATE_BLEND_ALPHA);
+    RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STREAM_DRAW);
     R_StatsDraw(GL_TRIANGLES, sizeof(vertices) / sizeof(vertices[0]), 1);
     R_ApplyShader(shader);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, sizeof(vertices) / sizeof(vertices[0]));
-    R_Call(glDepthMask, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
 }
 
 void R_RenderRectSplat(LPCVECTOR2 mins,

--- a/games/starcraft-2/renderer/sc2/r_sc2map.c
+++ b/games/starcraft-2/renderer/sc2/r_sc2map.c
@@ -1575,12 +1575,9 @@ static void r_sc2_begin_terrain_pass(DWORD group) {
     }
     R_BindTexture(sc2_terrain_masks[group], SC2_TERRAIN_PASS_LAYERS);
     if (group) {
-        R_Call(glEnable, GL_BLEND);
-        R_Call(glBlendFunc, GL_ONE, GL_ONE);
-        R_Call(glDepthMask, GL_FALSE);
+        RB_State(RB_STATE_BLEND_ADD);
     } else {
-        R_Call(glDisable, GL_BLEND);
-        R_Call(glDepthMask, GL_TRUE);
+        RB_State(RB_STATE_OPAQUE);
     }
 }
 
@@ -1602,8 +1599,7 @@ static void r_sc2_draw_terrain_indexed(LPCMAPLAYER layer) {
         R_ApplyShader(&sc2_terrain_shader);
         R_DrawIndexedBuffer(layer->buffer, layer->num_indices);
     }
-    R_Call(glDisable, GL_BLEND);
-    R_Call(glDepthMask, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
 }
 
 static void r_sc2_draw_terrain_vertices(LPCMAPLAYER layer) {
@@ -1615,8 +1611,7 @@ static void r_sc2_draw_terrain_vertices(LPCMAPLAYER layer) {
         R_ApplyShader(&sc2_terrain_shader);
         R_DrawBuffer(layer->buffer, layer->num_vertices);
     }
-    R_Call(glDisable, GL_BLEND);
-    R_Call(glDepthMask, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
 }
 
 static void r_sc2_draw_ground_layer(LPCMAPSEGMENT segment) {
@@ -1687,8 +1682,7 @@ static void r_sc2_draw_cliff_layer(LPCMAPSEGMENT segment) {
         return;
 
     /* Pass 2: cliff M3 texture alpha-blended on top, pulled slightly forward */
-    R_Call(glEnable, GL_POLYGON_OFFSET_FILL);
-    R_Call(glPolygonOffset, -1.0f, -1.0f);
+    RB_PolygonOffset(-1.0f, -1.0f);
 
     sc2_cliff_shader.state.viewProjection = tr.render_phase == RENDER_PHASE_LIGHTS ? tr.viewDef.lightMatrix : tr.viewDef.viewProjectionMatrix;
     sc2_cliff_shader.state.lightMatrix = tr.viewDef.lightMatrix;
@@ -1697,16 +1691,15 @@ static void r_sc2_draw_cliff_layer(LPCMAPSEGMENT segment) {
     r_sc2_set_light_state(&sc2_cliff_shader.state.lightAmbient, sc2_cliff_shader.state.lightDir, sc2_cliff_shader.state.lightColor);
     R_Call(glActiveTexture, GL_TEXTURE0 + sc2_cliff_shader.state.shadowmap);
     R_Call(glBindTexture, GL_TEXTURE_2D, tr.render_phase == RENDER_PHASE_LIGHTS ? tr.texture[TEX_WHITE]->texid : tr.rt[RT_DEPTHMAP]->texture);
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    RB_State(RB_STATE_BLEND_ALPHA);
     for (layer = segment->layers; layer; layer = layer->next) {
         if (layer->type != MAPLAYERTYPE_CLIFF) continue;
         R_BindTexture(layer->texture, 0);
         R_ApplyShader(&sc2_cliff_shader);
         R_DrawBuffer(layer->buffer, layer->num_vertices);
     }
-    R_Call(glDisable, GL_POLYGON_OFFSET_FILL);
-    R_Call(glPolygonOffset, 0.0f, 0.0f);
+    RB_PolygonOffset(0.0f, 0.0f);
+    RB_State(RB_STATE_OPAQUE);
 }
 
 void R_SC2DrawWorld(void) {
@@ -1731,11 +1724,8 @@ void R_SC2DrawWorld(void) {
 
     tr.shader_ui.state.viewProjection = tr.viewDef.viewProjectionMatrix;
     tr.shader_ui.state.model = model_matrix;
-    R_Call(glDisable, GL_CULL_FACE);
-    R_Call(glEnable, GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_TRUE);
-    R_Call(glDepthFunc, GL_LEQUAL);
-    R_Call(glColorMask, GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
+    RB_Cull(0);
+    RB_State(RB_STATE_OPAQUE | (0xF << 12));
     r_sc2_draw_ground_layer(sc2_terrain_segment);
     r_sc2_draw_cliff_layer(sc2_terrain_segment);
     r_sc2_draw_hard_tiles();

--- a/games/warcraft-3/renderer/mdx/r_mdx_buffer.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_buffer.c
@@ -173,7 +173,7 @@ void MDX_BuildBuffers(mdxModel_t *model) {
     base = 0;
     FOR_EACH_LIST(mdxGeoset_t, geo, model->geosets) {
         R_Call(glGenVertexArrays, 1, &geo->vertexArrayBuffer);
-        R_Call(glBindVertexArray, geo->vertexArrayBuffer);
+        RB_BindVAO(geo->vertexArrayBuffer);
         R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, model->buffers[BZ_MDX_INDEX_BUFFER]);
         FOR_LOOP(i, sizeof(attrs) / sizeof(*attrs)) {
             R_Call(glEnableVertexAttribArray, attrs[i].attr);

--- a/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_geoset.c
@@ -163,61 +163,43 @@ static bool MDLX_SetBlendMode(const mdxMaterialLayer_t *layer, DWORD layerID) {
 #endif
     switch (layer->blendMode) {
         case BLEND_MODE_NONE:
-            R_Call(glDisable, GL_BLEND);
-            if (layerID == 0) {
-                R_Call(glBlendFunc, GL_ONE, GL_ZERO);
-            } else {
-                R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            }
-            R_Call(glDepthMask, GL_TRUE);
+            RB_State(RB_STATE_OPAQUE);
             break;
         case BLEND_MODE_ALPHAKEY:
             mdlx.shader->state.alphaKey = 1;
             R_SetAlphaKeyState(true);
             break;
         case BLEND_MODE_BLEND:
-            R_Call(glEnable, GL_BLEND);
-            R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            R_Call(glDepthMask, GL_FALSE);
+            RB_State(RB_STATE_BLEND_ALPHA);
             break;
         case BLEND_MODE_ADD:
-            R_Call(glEnable, GL_BLEND);
-            R_Call(glBlendFunc, GL_ONE, GL_ONE);
-            R_Call(glDepthMask, GL_FALSE);
+            RB_State(RB_STATE_BLEND_ADD);
             break;
         case BLEND_MODE_ADDALPHA:
-            R_Call(glEnable, GL_BLEND);
-            R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE);
-            R_Call(glDepthMask, GL_FALSE);
+            RB_State((GL_SRC_ALPHA << 0) | (GL_ONE << 4) | (GL_LEQUAL << 9) | (0xF << 12));
             break;
         case BLEND_MODE_MODULATE:
-            R_Call(glEnable, GL_BLEND);
-            R_Call(glBlendFunc, GL_DST_COLOR, GL_ZERO);
-            R_Call(glDepthMask, GL_FALSE);
+            RB_State((GL_DST_COLOR << 0) | (GL_ZERO << 4) | (GL_LEQUAL << 9) | (0xF << 12));
             break;
         case BLEND_MODE_MODULATE_2X:
-            R_Call(glEnable, GL_BLEND);
-            R_Call(glBlendFunc, GL_DST_COLOR, GL_SRC_COLOR);
-            R_Call(glDepthMask, GL_FALSE);
+            RB_State(RB_STATE_BLEND_MOD2X);
             break;
         default:
-            R_Call(glDisable, GL_BLEND);
-            R_Call(glBlendFunc, GL_ONE, GL_ZERO);
-            R_Call(glDepthMask, GL_TRUE);
+            RB_State(RB_STATE_OPAQUE);
             break;
     }
     return true;
 }
 
-static void MDLX_ApplyLayerFlags(const mdxMaterialLayer_t *layer) {
-    if (layer->flags & MODEL_GEO_TWOSIDED) {
-        R_Call(glDisable, GL_CULL_FACE);
-    }
+static void MDLX_ApplyLayerFlags(const mdxMaterialLayer_t *layer, DWORD *extraBits, DWORD *clearMask) {
+    if (layer->flags & MODEL_GEO_TWOSIDED)
+        RB_Cull(0);
     if (layer->flags & MODEL_GEO_NO_DEPTH_TEST) {
-        R_Call(glDisable, GL_DEPTH_TEST);
+        *extraBits |= (GL_ALWAYS << 9);
+        *clearMask |= RB_DEPTH_FUNC_MASK;
     }
     if (layer->flags & MODEL_GEO_NO_DEPTH_SET) {
-        R_Call(glDepthMask, GL_FALSE);
+        *clearMask |= RB_DEPTH_WRITE_BIT;
     }
 }
 
@@ -479,18 +461,13 @@ static void MDLX_RenderGeoset(mdxModel_t const *model,
         if (MDLX_IsBlendedLayer(layer) != blendedPass) {
             continue;
         }
-        R_Call(glEnable, GL_DEPTH_TEST);
         shader->state.alphaKey = 0;
-        if (force_two_sided) {
-            R_Call(glDisable, GL_CULL_FACE);
-        } else {
-            R_Call(glEnable, GL_CULL_FACE);
-            R_Call(glCullFace, GL_BACK);
-        }
-        R_Call(glDepthMask, GL_TRUE);
+        RB_Cull(force_two_sided ? 0 : GL_BACK);
+        DWORD layerExtraBits = 0, layerClearMask = 0;
         if (!MDLX_SetBlendMode(layer, layerID))
             continue;
-        MDLX_ApplyLayerFlags(layer);
+        MDLX_ApplyLayerFlags(layer, &layerExtraBits, &layerClearMask);
+        RB_State((backEnd.glStateBits & ~layerClearMask) | layerExtraBits);
         BOOL unshaded = forceUnshaded || (layer->flags & MODEL_GEO_UNSHADED);
         shader->state.unshaded = unshaded;
         /* Fog only affects opaque/alpha-blended geometry.  Additive and
@@ -512,18 +489,16 @@ static void MDLX_RenderGeoset(mdxModel_t const *model,
         mdxTexture_t const *modeltex = &model->textures[textureId];
         LPCTEXTURE texture = MDLX_GetTexture(model, team, textureId, modeltex->replaceableID, overrideTexture);
         R_BindTexture(texture, 0);
-        R_Call(glBindVertexArray, geoset->vertexArrayBuffer);
+        RB_BindVAO(geoset->vertexArrayBuffer);
         /* The geoset VAO already binds the model-owned index buffer. */
         R_StatsDraw(GL_TRIANGLES, geoset->num_triangles, 1);
         R_ApplyShader(shader);
         R_Call(glDrawElements, GL_TRIANGLES, geoset->num_triangles, GL_UNSIGNED_SHORT, (void *)(uintptr_t)geoset->indexofs);
     }
 
-    R_Call(glEnable, GL_DEPTH_TEST);
-    R_Call(glEnable, GL_CULL_FACE);
+    RB_Cull(GL_BACK);
     R_SetAlphaKeyState(false);
-    R_Call(glCullFace, GL_BACK);
-    R_Call(glDepthMask, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
     shader->state.unshaded = forceUnshaded;
     shader->state.layerAlpha = 1.0f;
     shader->state.geosetColor = (VECTOR4){ 1.0f, 1.0f, 1.0f, 1.0f };

--- a/games/warcraft-3/renderer/w3m/r_war3map.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map.c
@@ -303,9 +303,7 @@ void _W3M_DrawWorld(void) {
     if (tr.viewDef.rdflags & RDF_NOWORLDMODEL)
         return;
 
-    R_Call(glEnable, GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_TRUE);
-    R_Call(glDepthFunc, GL_LEQUAL);
+    RB_State(RB_STATE_OPAQUE);
 
     {
         MODELLIGHTING lighting;
@@ -316,18 +314,16 @@ void _W3M_DrawWorld(void) {
 
     FOR_EACH_LIST(MAPLAYER, layer, g_groundLayers) {
         if (layer == g_groundLayers) {
-            R_Call(glDisable, GL_BLEND);
+            RB_State(RB_STATE_OPAQUE);
         } else {
-            R_Call(glEnable, GL_BLEND);
-            R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            RB_State(RB_STATE_BLEND_ALPHA);
         }
         R_BindTexture(layer->texture, 0);
         R_ApplyShader(&tr.shader_default);
         R_DrawBuffer(layer->buffer, layer->num_vertices);
     }
 
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    RB_State(RB_STATE_BLEND_ALPHA);
     FOR_EACH_LIST(MAPSEGMENT, segment, g_mapSegments) {
         R_DrawTerrainSegment(segment, (1 << MAPLAYERTYPE_CLIFF));
     }
@@ -337,12 +333,10 @@ void _W3M_DrawAlphaSurfaces(void) {
     if (tr.viewDef.rdflags & RDF_NOWORLDMODEL)
         return;
 
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    R_Call(glDepthMask, GL_FALSE);
+    RB_State(RB_STATE_BLEND_ALPHA);
 
     FOR_EACH_LIST(MAPSEGMENT, segment, g_mapSegments) {
         R_DrawTerrainSegment(segment, (1 << MAPLAYERTYPE_WATER));
     }
-    R_Call(glDepthMask, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
 }

--- a/games/warcraft-3/renderer/w3m/r_war3map_ground.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_ground.c
@@ -190,10 +190,8 @@ static void R_SetupSplatState(LPCTEXTURE texture, splat_shader_t *shader) {
 
     shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
     shader->state.model = mModelMatrix;
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    R_Call(glDepthMask, GL_FALSE);
-    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+    RB_State(RB_STATE_BLEND_ALPHA);
+    RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     ground_current_vertex = ground_vertex_buffer;
     R_ApplyShader(shader);
@@ -252,7 +250,7 @@ void R_AddRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, COLOR3
 
 void R_EndSplatBatch(void) {
     R_FlushSplatBatch();
-    R_Call(glDepthMask, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
 }
 
 void R_RenderRectSplat(LPCVECTOR2 mins,
@@ -267,7 +265,7 @@ void R_RenderRectSplat(LPCVECTOR2 mins,
     R_SetupSplatState(texture, shader);
     R_GenerateSplatTiles(mins, maxs, color);
     R_FlushSplatBatch();
-    R_Call(glDepthMask, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
 }
 
 LPMAPLAYER R_BuildMapSegmentLayer(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD layer) {
@@ -364,16 +362,14 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins,
     shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
     shader->state.model = model_matrix;
 
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    R_Call(glDepthMask, GL_FALSE);
-    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+    RB_State(RB_STATE_BLEND_ALPHA);
+    RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STREAM_DRAW);
     R_StatsDraw(GL_TRIANGLES, sizeof(vertices) / sizeof(vertices[0]), 1);
     R_ApplyShader(shader);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, sizeof(vertices) / sizeof(vertices[0]));
-    R_Call(glDepthMask, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
 }
 
 void R_RenderSplat(LPCVECTOR2 position,

--- a/games/world-of-warcraft/renderer/m2/r_m2.c
+++ b/games/world-of-warcraft/renderer/m2/r_m2.c
@@ -1803,12 +1803,7 @@ static void M2_DrawCompositeQuad(LPTEXTURE texture, LPCRECT screen, BOOL blend) 
     tr.shader_ui.state.viewProjection = projection;
     tr.shader_ui.state.model = identity;
     R_BindTexture(texture, 0);
-    if (blend) {
-        R_Call(glEnable, GL_BLEND);
-        R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    } else {
-        R_Call(glDisable, GL_BLEND);
-    }
+    RB_State(blend ? RB_STATE_BLEND_ALPHA : RB_STATE_OPAQUE);
     R_StatsDraw(GL_TRIANGLES, 6, 1);
     R_ApplyShader(&tr.shader_ui);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, 6);
@@ -1883,12 +1878,12 @@ static LPTEXTURE M2_PrepareCharacterTexture(m2Model_t const *model,
     old_blend = R_Call(glIsEnabled, GL_BLEND);
     old_scissor = R_Call(glIsEnabled, GL_SCISSOR_TEST);
     R_Call(glGetIntegerv, GL_SCISSOR_BOX, old_scissor_box);
-    R_Call(glBindFramebuffer, GL_FRAMEBUFFER, cached->target->buffer);
-    R_Call(glViewport, 0, 0, M2_CHARACTER_COMPOSITE_RESOLUTION, M2_CHARACTER_COMPOSITE_RESOLUTION);
+    RB_BindFBO(cached->target->buffer);
+    RB_Viewport(&(RECT){ 0, 0, M2_CHARACTER_COMPOSITE_RESOLUTION, M2_CHARACTER_COMPOSITE_RESOLUTION });
     /* The view scissor is in window coordinates; it would clip this 256x256 target. */
-    R_Call(glDisable, GL_SCISSOR_TEST);
-    R_Call(glDisable, GL_DEPTH_TEST);
-    R_Call(glDisable, GL_CULL_FACE);
+    RB_ScissorDisable();
+    RB_State((GL_ALWAYS << 9));
+    RB_Cull(0);
     R_Call(glClearColor, 0, 0, 0, 0);
     R_Call(glClear, GL_COLOR_BUFFER_BIT);
     M2_DrawCompositeQuad(base, &(RECT){ 0, 0, M2_CHARACTER_COMPOSITE_RESOLUTION, M2_CHARACTER_COMPOSITE_RESOLUTION }, false);
@@ -1902,13 +1897,12 @@ static LPTEXTURE M2_PrepareCharacterTexture(m2Model_t const *model,
         M2_DrawCompositeHeadVariation(model->filename, 1, unpacked.faceID, unpacked.skinColorID);
         M2_DrawCompositeHeadVariation(model->filename, 2, unpacked.facialHairStyleID, unpacked.hairColorID);
     }
-    R_Call(glBindFramebuffer, GL_FRAMEBUFFER, old_framebuffer);
-    R_Call(glViewport, old_viewport[0], old_viewport[1], old_viewport[2], old_viewport[3]);
-    if (old_depth) { R_Call(glEnable, GL_DEPTH_TEST); } else { R_Call(glDisable, GL_DEPTH_TEST); }
-    if (old_cull) { R_Call(glEnable, GL_CULL_FACE); } else { R_Call(glDisable, GL_CULL_FACE); }
-    if (old_blend) { R_Call(glEnable, GL_BLEND); } else { R_Call(glDisable, GL_BLEND); }
-    R_Call(glScissor, old_scissor_box[0], old_scissor_box[1], old_scissor_box[2], old_scissor_box[3]);
-    if (old_scissor) { R_Call(glEnable, GL_SCISSOR_TEST); } else { R_Call(glDisable, GL_SCISSOR_TEST); }
+    RB_BindFBO(old_framebuffer);
+    RB_Viewport(&(RECT){ old_viewport[0], old_viewport[1], old_viewport[2], old_viewport[3] });
+    RB_State((old_blend ? RB_STATE_BLEND_ALPHA : RB_STATE_OPAQUE) | (old_depth ? RB_DEPTH_WRITE_BIT : 0));
+    RB_Cull(old_cull ? GL_BACK : 0);
+    RB_Scissor(&(RECT){ old_scissor_box[0], old_scissor_box[1], old_scissor_box[2], old_scissor_box[3] });
+    if (!old_scissor) RB_ScissorDisable();
     cached->texture.texid = cached->target->texture;
     cached->texture.width = M2_CHARACTER_COMPOSITE_RESOLUTION;
     cached->texture.height = M2_CHARACTER_COMPOSITE_RESOLUTION;
@@ -2027,13 +2021,12 @@ static void M2_SetBlendMode(MODELPROG * shader, DWORD mode) {
     shader->state.alphaKey = mode == BLEND_MODE_ALPHAKEY;
     R_SetAlphaKeyState(mode == BLEND_MODE_ALPHAKEY);
     if (mode == BLEND_MODE_NONE) {
-        R_Call(glDisable, GL_BLEND); R_Call(glDepthMask, GL_TRUE);
+        RB_State(RB_STATE_OPAQUE);
     } else if (mode != BLEND_MODE_ALPHAKEY) {
-        R_Call(glEnable, GL_BLEND); R_Call(glDepthMask, GL_FALSE);
         switch (mode) {
-        case BLEND_MODE_ADD: R_Call(glBlendFunc, GL_ONE, GL_ONE); break;
-        case BLEND_MODE_ADDALPHA: R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE); break;
-        default: R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); break;
+        case BLEND_MODE_ADD: RB_State(RB_STATE_BLEND_ADD); break;
+        case BLEND_MODE_ADDALPHA: RB_State((GL_SRC_ALPHA << 0) | (GL_ONE << 4) | (GL_LEQUAL << 9) | (0xF << 12)); break;
+        default: RB_State(RB_STATE_BLEND_ALPHA); break;
         }
     }
 }
@@ -2116,9 +2109,7 @@ void M2_RenderModel(renderEntity_t const *entity, m2Model_t const *model, LPCMAT
     shader->state.fogColor = (VECTOR3){ tr.viewDef.fogColor.x, tr.viewDef.fogColor.y, tr.viewDef.fogColor.z };
     shader->state.fogParams = (VECTOR2){ tr.viewDef.fogStart, tr.viewDef.fogEnd };
     shader->state.firstBoneLookupIndex = 0.0f;
-    R_Call(glEnable, GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_TRUE);
-    R_Call(glDisable, GL_BLEND);
+    RB_State(RB_STATE_OPAQUE);
 
 	for (batch = model->batches; batch; batch = batch->next) {
 		LPCTEXTURE texture;
@@ -2190,9 +2181,7 @@ void M2_RenderInstanced(m2Model_t const *model, LPCINSTANCEBUFFER instances, DWO
         };
         R_SetModelGrass(shader, &grass);
     }
-    R_Call(glEnable, GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_TRUE);
-    R_Call(glDisable, GL_BLEND);
+    RB_State(RB_STATE_OPAQUE);
 
 	for (batch = model->batches; batch; batch = batch->next) {
         M2_SetBlendMode(shader, batch->alphamode);

--- a/games/world-of-warcraft/renderer/wow/r_wowmap.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap.c
@@ -116,11 +116,8 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
     wow_terrain_shader.state.fogColor = (VECTOR3){ tr.viewDef.fogColor.x, tr.viewDef.fogColor.y, tr.viewDef.fogColor.z };
     wow_terrain_shader.state.fogParams = (VECTOR2){ tr.viewDef.fogStart, tr.viewDef.fogEnd };
     wow_terrain_shader.state.fogCamera = (VECTOR3){ tr.viewDef.camerastate[0].origin.x, tr.viewDef.camerastate[0].origin.y, tr.viewDef.camerastate[0].origin.z };
-    R_Call(glEnable, GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_TRUE);
-    R_Call(glDepthFunc, GL_LEQUAL);
-    R_Call(glDisable, GL_CULL_FACE);
-    R_Call(glDisable, GL_BLEND);
+    RB_State(RB_STATE_OPAQUE);
+    RB_Cull(0);
 
     for (chunk = draw_terrain ? wow_world.chunks : NULL; chunk; chunk = chunk->next) {
         if (!chunk->buffer || !chunk->num_vertices) {
@@ -202,9 +199,7 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
         int bound_blend_mode = 0;
         for (int wmo_pass = 0; wmo_pass < 2; wmo_pass++) {
             if (wmo_pass == 1) {
-                R_Call(glEnable, GL_BLEND);
-                R_Call(glDepthMask, GL_FALSE);
-                R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+                RB_State(RB_STATE_BLEND_ALPHA);
                 bound_blend_mode = 2;
             }
             for (int wi = 0; wi < wmo_n; wi++) {
@@ -231,9 +226,9 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
                             bound_blend_mode = (int)batch->blend_mode;
                             wow_terrain_shader.state.wmoBlendMode = bound_blend_mode;
                             if (wmo_pass) {
-                                if (bound_blend_mode == 3)      { R_Call(glBlendFunc, GL_ONE, GL_ONE); }
-                                else if (bound_blend_mode == 4) { R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE); }
-                                else                             { R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); }
+                                if (bound_blend_mode == 3)      { RB_State(RB_STATE_BLEND_ADD); }
+                                else if (bound_blend_mode == 4) { RB_State(RB_STATE_BLEND_ONE); }
+                                else                             { RB_State(RB_STATE_BLEND_ALPHA); }
                             }
                         }
                         Wow_BindWorldTexture(batch->texture ? batch->texture : tr.texture[TEX_WHITE], 0, bound_textures, &texture_binds);
@@ -257,9 +252,9 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
                                 bound_blend_mode = (int)batch->blend_mode;
                                 wow_terrain_shader.state.wmoBlendMode = bound_blend_mode;
                                 if (wmo_pass) {
-                                    if (bound_blend_mode == 3)      { R_Call(glBlendFunc, GL_ONE, GL_ONE); }
-                                    else if (bound_blend_mode == 4) { R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE); }
-                                    else                             { R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); }
+                                    if (bound_blend_mode == 3)      { RB_State(RB_STATE_BLEND_ADD); }
+                                    else if (bound_blend_mode == 4) { RB_State(RB_STATE_BLEND_ONE); }
+                                    else                             { RB_State(RB_STATE_BLEND_ALPHA); }
                                 }
                             }
                             Wow_BindWorldTexture(batch->texture ? batch->texture : tr.texture[TEX_WHITE], 0, bound_textures, &texture_binds);
@@ -271,8 +266,7 @@ static void Wow_DrawTerrainAndWmos(WOWDRAWSTATS *stats) {
                 }
             }
             if (wmo_pass == 1) {
-                R_Call(glDisable, GL_BLEND);
-                R_Call(glDepthMask, GL_TRUE);
+                RB_State(RB_STATE_OPAQUE);
             }
         }
     }
@@ -479,9 +473,8 @@ void Wow_DrawWorld(void) {
         }
     }
 
-    R_Call(glDepthMask, GL_TRUE);
-    R_Call(glDisable, GL_BLEND);
-    R_Call(glEnable, GL_CULL_FACE);
+    RB_State(RB_STATE_OPAQUE);
+    RB_Cull(GL_BACK);
 
     if (R_CvarEnabled("r_doodads", "1") && wow_world.object_buffer && wow_world.num_object_vertices) {
         R_BindTexture(tr.texture[TEX_WHITE], 0);

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_grass.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_grass.c
@@ -544,10 +544,8 @@ void Wow_DrawGrass(void) {
     wow_grass_shader.state.heightAtlas = 5;
     wow_grass_shader.state.grassCtrl = 6;
 
-    R_Call(glEnable,    GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_TRUE);
-    R_Call(glDepthFunc, GL_LEQUAL);
-    R_Call(glDisable,   GL_CULL_FACE);
+    RB_State(RB_STATE_OPAQUE);
+    RB_Cull(0);
     R_SetAlphaKeyState(true);
 
     R_ApplyShader(&wow_grass_shader);

--- a/games/world-of-warcraft/renderer/wow/r_wowmap_splat.c
+++ b/games/world-of-warcraft/renderer/wow/r_wowmap_splat.c
@@ -20,20 +20,17 @@ static void Wow_DrawSplatVertices(LPCTEXTURE texture, splat_shader_t *shader,
 
     shader->state.viewProjection = tr.viewDef.viewProjectionMatrix;
     shader->state.model = model_matrix;
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    R_Call(glDepthMask, GL_FALSE);
-    R_Call(glEnable, GL_POLYGON_OFFSET_FILL);
-    R_Call(glPolygonOffset, -1.0f, -1.0f);
-    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+    RB_State(RB_STATE_BLEND_ALPHA);
+    RB_PolygonOffset(-1.0f, -1.0f);
+    RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     /* Re-specifying the whole stream buffer lets the driver orphan busy storage. */
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(*vertices) * num_vertices, vertices, GL_STREAM_DRAW);
     R_StatsDraw(GL_TRIANGLES, num_vertices, 1);
     R_ApplyShader(shader);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, num_vertices);
-    R_Call(glDisable, GL_POLYGON_OFFSET_FILL);
-    R_Call(glDepthMask, GL_TRUE);
+    RB_PolygonOffset(0.0f, 0.0f);
+    RB_State(RB_STATE_OPAQUE);
 }
 
 void Wow_FlushSplats(void) {

--- a/renderer/r_backend.c
+++ b/renderer/r_backend.c
@@ -131,3 +131,48 @@ void RB_ResetState(void) {
 void RB_Init(void) {
     RB_ResetState();
 }
+
+/* -----------------------------------------------------------------------
+ * Pipeline objects
+ * ----------------------------------------------------------------------- */
+
+static DWORD pipeline_next_id;
+
+pipeline_t RB_CreatePipeline(pipelineDesc_t *desc) {
+    pipeline_t p = {
+        .progid = glCreateProgram(),
+        .raster = desc->raster,
+        .id = ++pipeline_next_id,
+    };
+    if (desc->vertShader) R_Call(glAttachShader, p.progid, desc->vertShader);
+    if (desc->fragShader) R_Call(glAttachShader, p.progid, desc->fragShader);
+    R_Call(glLinkProgram, p.progid);
+    GLint ok;
+    glGetProgramiv(p.progid, GL_LINK_STATUS, &ok);
+    if (!ok) {
+        char log[1024];
+        glGetProgramInfoLog(p.progid, sizeof(log), NULL, log);
+        fprintf(stderr, "RB_CreatePipeline: link failed: %s\n", log);
+    }
+    return p;
+}
+
+void RB_BindPipeline(pipeline_t *p) {
+    if (!p) return;
+    R_Call(glUseProgram, p->progid);
+    RB_State((p->raster.blendSrc << 0)
+           | (p->raster.blendDst << 4)
+           | (p->raster.depthWrite ? RB_DEPTH_WRITE_BIT : 0)
+           | (p->raster.depthFunc << 9)
+           | ((p->raster.colorMask & 0xF) << RB_COLOR_MASK_SHIFT));
+    RB_Cull(p->raster.cullFace);
+}
+
+pipeline_t RB_MakePipeline(SHADERPROG *prog, pipelineRasterState_t *raster) {
+    pipeline_t p = {
+        .progid = prog->progid,
+        .raster = *raster,
+        .id = ++pipeline_next_id,
+    };
+    return p;
+}

--- a/renderer/r_backend.c
+++ b/renderer/r_backend.c
@@ -223,3 +223,37 @@ bool RB_UploadRoot(SHADERPROG *prog, LPCVOID state, DWORD stateSize) {
     ru->version++;
     return true;
 }
+
+/* -----------------------------------------------------------------------
+ * Texture/sampler heap
+ * ----------------------------------------------------------------------- */
+
+textureHeap_t texHeap;
+
+DWORD RB_HeapAllocTexture(DWORD glTexId) {
+    if (texHeap.count >= RB_HEAP_MAX_TEXTURES) {
+        fprintf(stderr, "RB_HeapAllocTexture: heap full (%u textures)\n", texHeap.count);
+        return 0;
+    }
+    DWORD idx = texHeap.count++;
+    texHeap.texids[idx] = glTexId;
+    return idx;
+}
+
+void RB_HeapBindTexture(DWORD heapIndex, DWORD unit) {
+    if (heapIndex >= texHeap.count || unit >= 16) return;
+    if (texHeap.bound[unit] == heapIndex) return;
+    R_Call(glActiveTexture, GL_TEXTURE0 + unit);
+    R_Call(glBindTexture, GL_TEXTURE_2D, texHeap.texids[heapIndex]);
+    texHeap.bound[unit] = heapIndex;
+}
+
+DWORD RB_HeapGetTexId(DWORD heapIndex) {
+    if (heapIndex >= texHeap.count) return 0;
+    return texHeap.texids[heapIndex];
+}
+
+void RB_HeapReset(void) {
+    texHeap.count = 0;
+    memset(texHeap.bound, 0, sizeof(texHeap.bound));
+}

--- a/renderer/r_backend.c
+++ b/renderer/r_backend.c
@@ -176,3 +176,50 @@ pipeline_t RB_MakePipeline(SHADERPROG *prog, pipelineRasterState_t *raster) {
     };
     return p;
 }
+
+/* -----------------------------------------------------------------------
+ * Root struct UBO
+ * ----------------------------------------------------------------------- */
+
+/* Per-program UBO state: one UBO per shader program, lazily created. */
+typedef struct rootUBO {
+    DWORD uboid;        /* GL buffer name */
+    DWORD size;         /* allocated size in bytes */
+    DWORD version;      /* monotonic; skip upload if unchanged */
+} rootUBO_t;
+
+#define RB_MAX_ROOT_UBOS 32
+static rootUBO_t rootUBOs[RB_MAX_ROOT_UBOS];
+static DWORD rootUBO_count;
+
+/* Create or resize a UBO for a program.  Binding happens in RB_BindPipeline. */
+static rootUBO_t *RB_EnsureRootUBO(GLuint progid, DWORD neededSize) {
+    /* Simple linear search; programs are few. */
+    for (DWORD i = 0; i < rootUBO_count; i++) {
+        if (rootUBOs[i].uboid && rootUBOs[i].size >= neededSize)
+            return &rootUBOs[i];
+    }
+    if (rootUBO_count >= RB_MAX_ROOT_UBOS) return NULL;
+    rootUBO_t *ru = &rootUBOs[rootUBO_count++];
+    if (!ru->uboid) {
+        GLuint buf;
+        glGenBuffers(1, &buf);
+        ru->uboid = buf;
+    }
+    R_Call(glBindBuffer, GL_UNIFORM_BUFFER, ru->uboid);
+    R_Call(glBufferData, GL_UNIFORM_BUFFER, neededSize, NULL, GL_DYNAMIC_DRAW);
+    ru->size = neededSize;
+    ru->version = 0;
+    return ru;
+}
+
+bool RB_UploadRoot(SHADERPROG *prog, LPCVOID state, DWORD stateSize) {
+    if (!prog || !state || stateSize == 0) return false;
+    rootUBO_t *ru = RB_EnsureRootUBO(prog->progid, stateSize);
+    if (!ru) return false;
+    R_Call(glBindBuffer, GL_UNIFORM_BUFFER, ru->uboid);
+    R_Call(glBufferSubData, GL_UNIFORM_BUFFER, 0, stateSize, state);
+    R_Call(glBindBufferBase, GL_UNIFORM_BUFFER, RB_UBO_BINDING_POINT, ru->uboid);
+    ru->version++;
+    return true;
+}

--- a/renderer/r_backend.c
+++ b/renderer/r_backend.c
@@ -1,0 +1,133 @@
+#include "r_local.h"
+
+backEndState_t backEnd;
+
+void RB_State(DWORD bits) {
+    DWORD delta = bits ^ backEnd.glStateBits;
+    if (!delta) return;
+
+    /* Blend enable/disable (bit 0 = any blend src != 0 or dst != 0). */
+    bool wantBlend = (bits & RB_BLEND_SRC_MASK) || (bits & RB_BLEND_DST_MASK);
+    bool haveBlend = (backEnd.glStateBits & RB_BLEND_SRC_MASK) || (backEnd.glStateBits & RB_BLEND_DST_MASK);
+    if (wantBlend != haveBlend) {
+        R_Call(wantBlend ? glEnable : glDisable, GL_BLEND);
+    }
+
+    /* Blend function (src in bits 0-3, dst in bits 4-7). */
+    if ((delta & RB_BLEND_SRC_MASK) || (delta & RB_BLEND_DST_MASK)) {
+        GLenum src = (bits & RB_BLEND_SRC_MASK);
+        GLenum dst = (bits & RB_BLEND_DST_MASK) >> 4;
+        R_Call(glBlendFunc, src, dst);
+    }
+
+    /* Depth write (bit 8). */
+    if (delta & RB_DEPTH_WRITE_BIT) {
+        R_Call(glDepthMask, (bits & RB_DEPTH_WRITE_BIT) ? GL_TRUE : GL_FALSE);
+    }
+
+    /* Depth func (bits 9-11). */
+    if (delta & RB_DEPTH_FUNC_MASK) {
+        GLenum func = (bits & RB_DEPTH_FUNC_MASK) >> 9;
+        R_Call(glDepthFunc, func);
+    }
+
+    /* Depth test enable: derived from depth func != GL_ALWAYS. */
+    bool wantDepth = ((bits & RB_DEPTH_FUNC_MASK) >> 9) != GL_ALWAYS;
+    bool haveDepth = ((backEnd.glStateBits & RB_DEPTH_FUNC_MASK) >> 9) != GL_ALWAYS;
+    if (wantDepth != haveDepth) {
+        R_Call(wantDepth ? glEnable : glDisable, GL_DEPTH_TEST);
+    }
+
+    /* Color mask (bits 12-15). */
+    if (delta & RB_COLOR_MASK_MASK) {
+        DWORD cm = (bits & RB_COLOR_MASK_MASK) >> RB_COLOR_MASK_SHIFT;
+        R_Call(glColorMask, (cm >> 3) & 1, (cm >> 2) & 1, (cm >> 1) & 1, cm & 1);
+    }
+
+    backEnd.glStateBits = bits;
+}
+
+void RB_Cull(GLenum mode) {
+    if (mode == backEnd.faceCulling) return;
+    if (mode) {
+        R_Call(glEnable, GL_CULL_FACE);
+        R_Call(glCullFace, mode);
+    } else {
+        R_Call(glDisable, GL_CULL_FACE);
+    }
+    backEnd.faceCulling = mode;
+}
+
+void RB_PolygonOffset(float scale, float bias) {
+    DWORD s = *(DWORD *)&scale, b = *(DWORD *)&bias;
+    if (s == backEnd.polygonOffsetScale && b == backEnd.polygonOffsetBias) return;
+    if (scale != 0.0f || bias != 0.0f) {
+        R_Call(glEnable, GL_POLYGON_OFFSET_FILL);
+        R_Call(glPolygonOffset, scale, bias);
+    } else {
+        R_Call(glDisable, GL_POLYGON_OFFSET_FILL);
+    }
+    backEnd.polygonOffsetScale = s;
+    backEnd.polygonOffsetBias = b;
+}
+
+void RB_BlendEquation(GLenum eq) {
+    if (eq == backEnd.blendEquation) return;
+    R_Call(glBlendEquation, eq);
+    backEnd.blendEquation = eq;
+}
+
+void RB_Scissor(LPCRECT r) {
+    backEnd.scissorEnabled = true;
+    R_Call(glEnable, GL_SCISSOR_TEST);
+    if (r->x == backEnd.currentScissor.x && r->y == backEnd.currentScissor.y &&
+        r->w == backEnd.currentScissor.w && r->h == backEnd.currentScissor.h) return;
+    backEnd.currentScissor = *r;
+    R_Call(glScissor, r->x, r->y, r->w, r->h);
+}
+
+void RB_ScissorDisable(void) {
+    if (!backEnd.scissorEnabled) return;
+    R_Call(glDisable, GL_SCISSOR_TEST);
+    backEnd.scissorEnabled = false;
+}
+
+void RB_Viewport(LPCRECT r) {
+    if (r->x == backEnd.currentViewport.x && r->y == backEnd.currentViewport.y &&
+        r->w == backEnd.currentViewport.w && r->h == backEnd.currentViewport.h) return;
+    backEnd.currentViewport = *r;
+    R_Call(glViewport, r->x, r->y, r->w, r->h);
+}
+
+void RB_BindVAO(DWORD vao) {
+    if (vao == backEnd.currentVAO) return;
+    R_Call(glBindVertexArray, vao);
+    backEnd.currentVAO = vao;
+}
+
+void RB_BindFBO(DWORD fbo) {
+    if (fbo == backEnd.currentFBO) return;
+    R_Call(glBindFramebuffer, GL_FRAMEBUFFER, fbo);
+    backEnd.currentFBO = fbo;
+}
+
+void RB_ColorMask(BOOL r, BOOL g, BOOL b, BOOL a) {
+    DWORD cm = ((DWORD)r << 3) | ((DWORD)g << 2) | ((DWORD)b << 1) | (DWORD)a;
+    DWORD bits = (backEnd.glStateBits & ~RB_COLOR_MASK_MASK) | (cm << RB_COLOR_MASK_SHIFT);
+    if (bits != backEnd.glStateBits) {
+        RB_State(bits);
+    }
+}
+
+void RB_ResetState(void) {
+    memset(&backEnd, 0, sizeof(backEnd));
+    backEnd.faceCulling = GL_BACK;
+    backEnd.depthFunc = GL_LEQUAL;
+    backEnd.blendEquation = GL_FUNC_ADD;
+    backEnd.glStateBits = 0;
+    backEnd.scissorEnabled = false;
+}
+
+void RB_Init(void) {
+    RB_ResetState();
+}

--- a/renderer/r_backend.h
+++ b/renderer/r_backend.h
@@ -181,6 +181,42 @@ void RB_Init(void);
  * used (caller should skip per-field upload). */
 bool RB_UploadRoot(SHADERPROG *prog, LPCVOID state, DWORD stateSize);
 
+/* -----------------------------------------------------------------------
+ * Texture/sampler heap (Phase 5)
+ *
+ * A global array of GL texture names.  Callers register textures and
+ * receive 32-bit heap indices.  The root struct carries heap indices
+ * instead of per-draw glBindTexture calls.
+ *
+ * On GL with ARB_bindless_texture, heap indices can be GPU pointers.
+ * On GLES3 without bindless, the heap maps indices to texture units
+ * and binds them before each draw.  The strategy is explicit and logged.
+ * ----------------------------------------------------------------------- */
+
+#define RB_HEAP_MAX_TEXTURES 4096 /* textures; bounds heap array and root struct capacity */
+
+typedef struct textureHeap {
+    DWORD   texids[RB_HEAP_MAX_TEXTURES]; /* GL texture names */
+    DWORD   count;                        /* next free index */
+    DWORD   bound[16];                    /* per-unit: last bound heap index (16 texture units) */
+} textureHeap_t;
+
+extern textureHeap_t texHeap;
+
+/* Register a GL texture in the heap.  Returns a 32-bit index. */
+DWORD RB_HeapAllocTexture(DWORD glTexId);
+
+/* Bind a texture by heap index to a texture unit.
+ * For non-bindless: glBindTexture + update bound cache.
+ * For bindless: the GPU pointer is already in the heap. */
+void RB_HeapBindTexture(DWORD heapIndex, DWORD unit);
+
+/* Get the GL texture name for a heap index. */
+DWORD RB_HeapGetTexId(DWORD heapIndex);
+
+/* Reset the heap for a new frame (optional; keeps allocations across frames). */
+void RB_HeapReset(void);
+
 /* Create a pipeline from a descriptor.  Links the shader program and
  * stores the raster state.  Returns a pipeline_t ready for RB_BindPipeline. */
 pipeline_t RB_CreatePipeline(pipelineDesc_t *desc);

--- a/renderer/r_backend.h
+++ b/renderer/r_backend.h
@@ -153,7 +153,7 @@ typedef struct pipelineDesc {
     pipelineRasterState_t raster;
 } pipelineDesc_t;
 
-/* Created pipeline handle. */
+/* Created pipeline handle: program + raster state. */
 typedef struct pipeline {
     GLuint   progid;          /* linked program */
     pipelineRasterState_t raster;
@@ -162,5 +162,17 @@ typedef struct pipeline {
 
 /* Initialize the backend (call once after GL context creation). */
 void RB_Init(void);
+
+/* Create a pipeline from a descriptor.  Links the shader program and
+ * stores the raster state.  Returns a pipeline_t ready for RB_BindPipeline. */
+pipeline_t RB_CreatePipeline(pipelineDesc_t *desc);
+
+/* Bind a pipeline: set the GL program and apply the raster state through
+ * the state cache.  Skips GL calls if the pipeline hasn't changed. */
+void RB_BindPipeline(pipeline_t *p);
+
+/* Build a pipeline from an existing SHADERPROG + raster state.
+ * Convenience for the current shader system where programs are already linked. */
+pipeline_t RB_MakePipeline(SHADERPROG *prog, pipelineRasterState_t *raster);
 
 #endif /* r_backend_h */

--- a/renderer/r_backend.h
+++ b/renderer/r_backend.h
@@ -163,6 +163,24 @@ typedef struct pipeline {
 /* Initialize the backend (call once after GL context creation). */
 void RB_Init(void);
 
+/* -----------------------------------------------------------------------
+ * Root struct UBO (Phase 4)
+ *
+ * One UBO per shader program, bound to binding point 0.  The CPU state
+ * struct is uploaded as one glBufferSubData call.  std140 layout matches
+ * the existing CPU structs with 16-byte alignment padding.  Shaders may
+ * declare `layout(std140) uniform Root { ... }` matching the struct.
+ *
+ * Callers can still use per-field R_ApplyShader for shaders that haven't
+ * migrated to the root block.  RB_UploadRoot provides the one-push path.
+ * ----------------------------------------------------------------------- */
+
+#define RB_UBO_BINDING_POINT 0
+
+/* Upload the entire state struct as a UBO.  Returns true if the UBO was
+ * used (caller should skip per-field upload). */
+bool RB_UploadRoot(SHADERPROG *prog, LPCVOID state, DWORD stateSize);
+
 /* Create a pipeline from a descriptor.  Links the shader program and
  * stores the raster state.  Returns a pipeline_t ready for RB_BindPipeline. */
 pipeline_t RB_CreatePipeline(pipelineDesc_t *desc);

--- a/renderer/r_backend.h
+++ b/renderer/r_backend.h
@@ -1,0 +1,166 @@
+#ifndef r_backend_h
+#define r_backend_h
+
+/* Backend state cache and thin-pipeline types.
+ * Tracking: #89 (renderer thin pipelines, root struct, GL state cache).
+ *
+ * RB_* owns GL blend/depth/cull/scissor/viewport/VAO/FBO state.  Frontend
+ * draw functions never issue raw GL state changes; they call RB_* helpers
+ * which diff against the cache and only emit GL on delta.  This is the GL
+ * implementation of Aaltonen's cheap blend/depth packet -- not a public
+ * fixed-function API.
+ *
+ * Thin pipeline types (pipelineDesc_t / pipeline_t) are defined here for
+ * Phase 3 forward reference.  Phase 1 only implements the state cache.
+ *
+ * Include this header AFTER r_local.h has defined the GL types and R_Call. */
+
+/* -----------------------------------------------------------------------
+ * Packed GL state bits  (Doom 3 GL_State XOR style)
+ *
+ * Bit layout chosen to match the common GL enum values so callers can OR
+ * them directly:
+ *   bits 0-3:  blend src  (GL_SRC_ALPHA=4, etc.)
+ *   bits 4-7:  blend dst  (GL_ONE_MINUS_SRC_ALPHA=5, etc.)
+ *   bit  8:    depth write  (GL_TRUE)
+ *   bits 9-11: depth func  (GL_LEQUAL=5, GL_ALWAYS=7, etc.)
+ *   bits 12-15: color mask (4 bits: R G B A)
+ * ----------------------------------------------------------------------- */
+
+enum {
+    RB_BLEND_SRC_MASK   = 0x000F,
+    RB_BLEND_DST_MASK   = 0x00F0,
+    RB_DEPTH_WRITE_BIT  = 0x0100,
+    RB_DEPTH_FUNC_MASK  = 0x0E00,
+    RB_COLOR_MASK_SHIFT = 12,
+    RB_COLOR_MASK_MASK  = 0xF000,
+};
+
+/* Shift a 4-bit value into a field position. */
+static inline DWORD RB_Bits4(DWORD val, int shift) { return (val & 0xF) << shift; }
+
+/* Convenience: build packed state bits from individual GL enums. */
+static inline DWORD RB_MakeStateBits(GLenum blendSrc, GLenum blendDst, BOOL depthWrite,
+                                      GLenum depthFunc, DWORD colorMask) {
+    return RB_Bits4(blendSrc, 0)
+         | RB_Bits4(blendDst, 4)
+         | (depthWrite ? RB_DEPTH_WRITE_BIT : 0)
+         | RB_Bits4(depthFunc, 9)
+         | ((colorMask & 0xF) << RB_COLOR_MASK_SHIFT);
+}
+
+/* GL_SRC_ALPHA=0x0302, GL_ONE_MINUS_SRC_ALPHA=0x0303, GL_ONE=1,
+ * GL_ZERO=0, GL_DST_COLOR=0x0306, GL_SRC_COLOR=0x0307,
+ * GL_LEQUAL=0x0203, GL_ALWAYS=0x0207.
+ * Enum values don't fold to integer constant expressions, so the pre-built
+ * bits are computed manually from the 4-bit field layout:
+ *   bits 0-3: blend src, bits 4-7: blend dst, bit 8: depth write,
+ *   bits 9-11: depth func, bits 12-15: color mask. */
+enum {
+    RB_STATE_OPAQUE        = 0,
+    RB_STATE_ALPHA_TEST    = 0x0100,
+    RB_STATE_BLEND_ALPHA   = (0x0302 << 0) | (0x0303 << 4) | (0x0203 << 9) | (0xF << 12),
+    RB_STATE_BLEND_ADD     = (0x0001 << 0) | (0x0001 << 4) | (0x0203 << 9) | (0xF << 12),
+    RB_STATE_BLEND_ONE     = (0x0001 << 0) | (0x0303 << 4) | (0x0203 << 9) | (0xF << 12),
+    RB_STATE_BLEND_MOD2X   = (0x0306 << 0) | (0x0307 << 4) | (0x0203 << 9) | (0xF << 12),
+    RB_STATE_BLEND_MOD4X   = (0x0306 << 0) | (0x0307 << 4) | (0x0203 << 9) | (0xF << 12),
+    RB_STATE_NO_DEPTH      = (0x0302 << 0) | (0x0303 << 4) | (0x0203 << 9) | (0xF << 12),
+};
+
+/* -----------------------------------------------------------------------
+ * Back-end state cache
+ * ----------------------------------------------------------------------- */
+
+typedef struct backEndState {
+    DWORD   glStateBits;       /* packed blend/depth/color-mask */
+    GLenum  faceCulling;       /* current glCullFace value; 0 = not set */
+    GLenum  depthFunc;         /* current glDepthFunc value */
+    DWORD   polygonOffsetScale;
+    DWORD   polygonOffsetBias;
+    DWORD   blendEquation;     /* current glBlendEquation */
+    DWORD   activeTextureUnit;
+    DWORD   currentVAO;
+    DWORD   currentFBO;
+    RECT    currentScissor;
+    RECT    currentViewport;
+    BOOL    scissorEnabled;
+} backEndState_t;
+
+extern backEndState_t backEnd;
+
+/* -----------------------------------------------------------------------
+ * RB_* API — state cache helpers
+ *
+ * Each helper compares against the cached value and only issues the GL
+ * call on delta.  R_Call() wraps every raw GL call for diagnostics.
+ * ----------------------------------------------------------------------- */
+
+/* Set packed blend/depth/color-mask state from a bitmask. */
+void RB_State(DWORD bits);
+
+/* Set face culling mode (GL_CULL_FACE enable/disable + glCullFace). */
+void RB_Cull(GLenum mode);
+
+/* Set polygon offset fill.  Pass 0,0 to disable. */
+void RB_PolygonOffset(float scale, float bias);
+
+/* Set blend equation (GL_FUNC_ADD, GL_MAX, etc.). */
+void RB_BlendEquation(GLenum eq);
+
+/* Set scissor rectangle (pixels).  Enables GL_SCISSOR_TEST. */
+void RB_Scissor(LPCRECT r);
+
+/* Disable scissor test. */
+void RB_ScissorDisable(void);
+
+/* Set viewport (pixels). */
+void RB_Viewport(LPCRECT r);
+
+/* Bind a VAO. */
+void RB_BindVAO(DWORD vao);
+
+/* Bind an FBO.  Pass 0 for the default framebuffer. */
+void RB_BindFBO(DWORD fbo);
+
+/* Set color mask (4 booleans: R, G, B, A). */
+void RB_ColorMask(BOOL r, BOOL g, BOOL b, BOOL a);
+
+/* Reset all cached state to the GL defaults used at frame start. */
+void RB_ResetState(void);
+
+/* -----------------------------------------------------------------------
+ * Thin pipeline types (Phase 3 forward declaration)
+ * ----------------------------------------------------------------------- */
+
+/* Raster state blob baked into a pipeline object. */
+typedef struct pipelineRasterState {
+    BOOL     depthWrite;
+    GLenum   depthFunc;
+    BOOL     blendEnable;
+    GLenum   blendSrc;
+    GLenum   blendDst;
+    GLenum   blendEquation;
+    DWORD    colorMask;       /* 4-bit RGBA mask */
+    GLenum   cullFace;        /* GL_BACK, GL_FRONT, or 0 (disabled) */
+} pipelineRasterState_t;
+
+/* Pipeline descriptor: shaders + raster state + formats. */
+typedef struct pipelineDesc {
+    GLuint   vertShader;      /* compiled vertex shader */
+    GLuint   fragShader;      /* compiled fragment shader */
+    GLenum   colorFormat;     /* render target color format */
+    GLenum   depthFormat;     /* render target depth format */
+    pipelineRasterState_t raster;
+} pipelineDesc_t;
+
+/* Created pipeline handle. */
+typedef struct pipeline {
+    GLuint   progid;          /* linked program */
+    pipelineRasterState_t raster;
+    DWORD    id;              /* monotonic for change detection */
+} pipeline_t;
+
+/* Initialize the backend (call once after GL context creation). */
+void RB_Init(void);
+
+#endif /* r_backend_h */

--- a/renderer/r_draw.c
+++ b/renderer/r_draw.c
@@ -33,16 +33,15 @@ void R_DrawString(int x, int y, LPCSTR text) {
 
     Matrix4_ortho(&ui_matrix, 0.0f, window.width, window.height, 0.0f, 0.0f, 100.0f);
 
-    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+    RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, count * sizeof(*simp), simp, GL_DYNAMIC_DRAW);
     tr.shader_ui.state.viewProjection = ui_matrix;
     
     R_BindTexture(tr.texture[TEX_FONT], 0);
     
-    R_Call(glDisable, GL_CULL_FACE);
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    RB_Cull(0);
+    RB_State(RB_STATE_BLEND_ALPHA);
     R_StatsDraw(GL_TRIANGLES, count, 1);
     R_ApplyShader(&tr.shader_ui);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, count);
@@ -62,18 +61,15 @@ void R_DrawFill(LPCRECT rect, COLOR32 color) {
     R_AddQuad(simp, rect, &(RECT){0, 0, 1, 1}, color, 0);
     Matrix4_ortho(&ui_matrix, 0.0f, window.width, window.height, 0.0f, 0.0f, 100.0f);
 
-    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+    RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_DYNAMIC_DRAW);
     tr.shader_ui.state.viewProjection = ui_matrix;
 
     R_BindTexture(tr.texture[TEX_WHITE], 0);
 
-    R_Call(glDisable, GL_CULL_FACE);
-    R_Call(glDisable, GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_FALSE);
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    RB_Cull(0);
+    RB_State(RB_STATE_BLEND_ALPHA);
     R_StatsDraw(GL_TRIANGLES, 6, 1);
     R_ApplyShader(&tr.shader_ui);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, 6);
@@ -81,9 +77,9 @@ void R_DrawFill(LPCRECT rect, COLOR32 color) {
 
 void R_SetBlending(BLEND_MODE mode) {
     if (mode == BLEND_MODE_ADD) {
-        R_Call(glBlendFunc, GL_ONE, GL_ONE);
+        RB_State(RB_STATE_BLEND_ADD);
     } else {
-        R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        RB_State(RB_STATE_BLEND_ALPHA);
     }
     return;
 //    switch (mode) {
@@ -109,16 +105,16 @@ static void R_SetUIClipScissor(LPCRECT clip) {
     w = MAX(0.0f, MIN(1.0f - x, w));
     h = MAX(0.0f, MIN(1.0f - y, h));
 
-    R_Call(glEnable, GL_SCISSOR_TEST);
-    R_Call(glScissor,
-           x * tr.drawableSize.width,
-           y * tr.drawableSize.height,
-           w * tr.drawableSize.width,
-           h * tr.drawableSize.height);
+    RB_Scissor(&(RECT){
+        x * tr.drawableSize.width,
+        y * tr.drawableSize.height,
+        w * tr.drawableSize.width,
+        h * tr.drawableSize.height,
+    });
 }
 
 static void R_ResetUIScissor(void) {
-    R_Call(glScissor, 0, 0, tr.drawableSize.width, tr.drawableSize.height);
+    RB_ScissorDisable();
 }
 
 void R_DrawImageBatch(LPCTEXTURE texture,
@@ -142,17 +138,15 @@ void R_DrawImageBatch(LPCTEXTURE texture,
     Matrix4_ortho(&ui_matrix, scene.x, scene.x + scene.w, scene.y + scene.h, scene.y, 0.0f, 100.0f);
     Matrix4_identity(&model_matrix);
     
-    R_Call(glDisable, GL_CULL_FACE);
+    RB_Cull(0);
 
     shader->state.viewProjection = ui_matrix;
     shader->state.model = model_matrix;
     shader->state.activeGlow = uActiveGlow;
-    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+    RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(VERTEX) * num_vertices, vertices, GL_DYNAMIC_DRAW);
-    R_Call(glDisable, GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_FALSE);
-    R_Call(glEnable, GL_BLEND);
+    RB_State(RB_STATE_BLEND_ALPHA);
     
     R_SetBlending(alphamode);
     R_BindTexture(texture, 0);
@@ -168,8 +162,8 @@ void R_DrawImageBatch(LPCTEXTURE texture,
     }
     R_Call(glTexParameteri, GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     R_Call(glTexParameteri, GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    R_Call(glDisable, GL_CULL_FACE);
-    R_Call(glEnable, GL_BLEND);
+    RB_Cull(0);
+    RB_State(RB_STATE_BLEND_ALPHA);
     if (hasClip) {
         R_SetUIClipScissor(clip);
     }
@@ -179,8 +173,6 @@ void R_DrawImageBatch(LPCTEXTURE texture,
     if (hasClip) {
         R_ResetUIScissor();
     }
-
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 }
 
 void R_DrawImageEx(LPCDRAWIMAGE drawImage) {
@@ -305,16 +297,13 @@ void R_DrawMinimapCameraRect(LPCRECT screen) {
     Matrix4_ortho(&ui_matrix, scene.x, scene.x + scene.w, scene.y + scene.h, scene.y, 0.0f, 100.0f);
     Matrix4_identity(&model_matrix);
 
-    R_Call(glDisable, GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_FALSE);
-    R_Call(glDisable, GL_CULL_FACE);
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    RB_State(RB_STATE_BLEND_ALPHA);
+    RB_Cull(0);
 
     tr.shader_ui.state.viewProjection = ui_matrix;
     tr.shader_ui.state.model = model_matrix;
     R_BindTexture(tr.texture[TEX_WHITE], 0);
-    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+    RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_DYNAMIC_DRAW);
     R_StatsDraw(GL_LINE_STRIP, 5, 1);
@@ -412,15 +401,14 @@ void R_DrawWireRect(LPCRECT rect, COLOR32 color) {
     Matrix4_ortho(&ui_matrix, 0.0f, window.width, window.height, 0.0f, 0.0f, 100.0f);
 
     tr.shader_ui.state.viewProjection = ui_matrix;
-    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+    RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_DYNAMIC_DRAW);
     
     R_BindTexture(tr.texture[TEX_WHITE], 0);
     
-    R_Call(glDisable, GL_CULL_FACE);
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    RB_Cull(0);
+    RB_State(RB_STATE_BLEND_ALPHA);
     R_StatsDraw(GL_LINE_STRIP, sizeof(simp) / sizeof(*simp), 1);
     R_ApplyShader(&tr.shader_ui);
     R_Call(glDrawArrays, GL_LINE_STRIP, 0, sizeof(simp) / sizeof(*simp));
@@ -459,18 +447,16 @@ void R_DrawBoundingBox(LPCBOX3 box, LPCMATRIX4 modelMatrix, LPCMATRIX4 vpMatrix,
 
     tr.shader_default.state.viewProjection = *vpMatrix;
     tr.shader_default.state.model = *modelMatrix;
-    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+    RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(simp), simp, GL_DYNAMIC_DRAW);
 
     R_BindTexture(tr.texture[TEX_WHITE], 0);
 
-    R_Call(glDisable, GL_CULL_FACE);
-    R_Call(glDisable, GL_DEPTH_TEST);
-    R_Call(glEnable, GL_BLEND);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    RB_Cull(0);
+    RB_State(RB_STATE_BLEND_ALPHA);
     R_StatsDraw(GL_LINES, 24, 1);
     R_ApplyShader(&tr.shader_default);
     R_Call(glDrawArrays, GL_LINES, 0, 24);
-    R_Call(glEnable, GL_DEPTH_TEST);
+    RB_State(RB_STATE_OPAQUE);
 }

--- a/renderer/r_fogofwar.c
+++ b/renderer/r_fogofwar.c
@@ -211,7 +211,7 @@ static DWORD R_AddCastersToBuffer(LPCBUFFER buffer,
     }
 
 upload:
-    R_Call(glBindVertexArray, buffer->vao);
+    RB_BindVAO(buffer->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, buffer->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(castervertex_t) * (caster_writer - casters), casters, GL_DYNAMIC_DRAW);
     return (DWORD)(caster_writer - casters);
@@ -222,7 +222,7 @@ static DWORD R_PushRectToBuffer(DWORD buffer_id, LPCRECT value, float alpha) {
     RECT uv = {0,0,1,1};
     VERTEX rect[NUM_RECT_VERTICES];
     R_AddQuad(rect, value, &uv, white, 0);
-    R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+    RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(vertex_t) * NUM_RECT_VERTICES, rect, GL_DYNAMIC_DRAW);
     return NUM_RECT_VERTICES;
@@ -296,14 +296,11 @@ void R_RenderFogOfWar(void) {
 
     tr.shader_ui.state.viewProjection = proj_matrix;
 
-    R_Call(glViewport, 0, 0, texture_width, texture_height);
-    R_Call(glScissor, 0, 0, texture_width, texture_height);
-    R_Call(glBindFramebuffer, GL_FRAMEBUFFER, fow_resources.rt[FOW_RT_IMMEDIATE]->buffer);
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    R_Call(glDepthMask, GL_FALSE);
-    R_Call(glDepthFunc, GL_ALWAYS);
-    R_Call(glDisable, GL_CULL_FACE);
-    R_Call(glEnable, GL_BLEND);
+    RB_Viewport(&(RECT){0, 0, texture_width, texture_height});
+    RB_Scissor(&(RECT){0, 0, texture_width, texture_height});
+    RB_BindFBO(fow_resources.rt[FOW_RT_IMMEDIATE]->buffer);
+    RB_State(RB_MakeStateBits(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, false, GL_ALWAYS, 0xF));
+    RB_Cull(0);
     R_Call(glClearColor, 0, 0, 0, 0);
     R_Call(glClear, GL_COLOR_BUFFER_BIT);
     R_Call(glActiveTexture, GL_TEXTURE0);
@@ -312,13 +309,12 @@ void R_RenderFogOfWar(void) {
     FOR_LOOP(p, num_revealers) {
         renderEntity_t const *ent = revealers[p];
         
-        R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        R_Call(glColorMask, GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
+        RB_State(RB_MakeStateBits(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, false, GL_ALWAYS, 0x1));
         R_Call(glClear, GL_COLOR_BUFFER_BIT);
 
         // Draw smooth circle into dst alpha
         R_MakeSightMatrix(ent, &model_matrix);
-        R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+        RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
         R_Call(glBindTexture, GL_TEXTURE_2D, fow_resources.sight->texid);
         R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
         R_StatsDraw(GL_TRIANGLES, NUM_RECT_VERTICES, 1);
@@ -328,8 +324,8 @@ void R_RenderFogOfWar(void) {
         // Draw line of sight into dst alpha
 
         memcpy(&fow_resources.shader.state.eyePosition, (GLfloat *)&ent->origin, (1) * sizeof(VECTOR2));
-        R_Call(glBindVertexArray, fow_resources.casters->vao);
-        R_Call(glBlendFunc, GL_DST_ALPHA, GL_ZERO);
+        RB_BindVAO(fow_resources.casters->vao);
+        RB_State(RB_MakeStateBits(GL_DST_ALPHA, GL_ZERO, false, GL_ALWAYS, 0x1));
         R_Call(glBindBuffer, GL_ARRAY_BUFFER, fow_resources.casters->vbo);
         R_StatsDraw(GL_TRIANGLES, num_casters, 1);
         R_ApplyShader(&fow_resources.shader);
@@ -337,10 +333,9 @@ void R_RenderFogOfWar(void) {
         
         // Draw white rect using dst alpha
         R_MakeSightMatrix(ent, &model_matrix);
-        R_Call(glBindVertexArray, tr.buffer[RBUF_TEMP1]->vao);
+        RB_BindVAO(tr.buffer[RBUF_TEMP1]->vao);
         R_Call(glBindBuffer, GL_ARRAY_BUFFER, tr.buffer[RBUF_TEMP1]->vbo);
-        R_Call(glColorMask, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-        R_Call(glBlendFunc, GL_DST_ALPHA, GL_ONE_MINUS_DST_ALPHA);
+        RB_State(RB_MakeStateBits(GL_DST_ALPHA, GL_ONE_MINUS_DST_ALPHA, false, GL_ALWAYS, 0xF));
         R_Call(glBindTexture, GL_TEXTURE_2D, tr.texture[TEX_WHITE]->texid);
         R_StatsDraw(GL_TRIANGLES, NUM_RECT_VERTICES, 1);
         R_ApplyShader(&tr.shader_ui);
@@ -356,27 +351,27 @@ void R_RenderFogOfWar(void) {
     tr.shader_ui.state.viewProjection = proj_matrix;
 
     // Add current state to history
-    R_Call(glBlendEquation, GL_MAX);
-    R_Call(glBlendFunc, GL_ONE, GL_ONE);
-    R_Call(glBindFramebuffer, GL_FRAMEBUFFER, fow_resources.rt[FOW_RT_HISTORY]->buffer);
+    RB_BlendEquation(GL_MAX);
+    RB_State(RB_MakeStateBits(GL_ONE, GL_ONE, false, GL_ALWAYS, 0xF));
+    RB_BindFBO(fow_resources.rt[FOW_RT_HISTORY]->buffer);
     R_BlitTexture(fow_resources.rt[FOW_RT_IMMEDIATE]->texture, 1.0);
     
     // revert blend func
-    R_Call(glBlendEquation, GL_FUNC_ADD);
-    R_Call(glBlendFunc, GL_ONE, GL_ZERO);
-    R_Call(glBindFramebuffer, GL_FRAMEBUFFER, fow_resources.rt[FOW_RT_RESULT]->buffer);
+    RB_BlendEquation(GL_FUNC_ADD);
+    RB_State(RB_MakeStateBits(GL_ONE, GL_ZERO, false, GL_ALWAYS, 0xF));
+    RB_BindFBO(fow_resources.rt[FOW_RT_RESULT]->buffer);
     if (tr.viewDef.rdflags & RDF_NOFOGMASK) {
         R_BlitTexture(tr.texture[TEX_WHITE]->texid, 0.5);
     } else {
         R_BlitTexture(fow_resources.rt[FOW_RT_HISTORY]->texture, 0.5);
     }
-    R_Call(glBlendFunc, GL_ONE, GL_ONE);
+    RB_State(RB_MakeStateBits(GL_ONE, GL_ONE, false, GL_ALWAYS, 0xF));
     R_BlitTexture(fow_resources.rt[FOW_RT_IMMEDIATE]->texture, 0.5);
 
-    R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    RB_State(RB_MakeStateBits(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, false, GL_ALWAYS, 0xF));
 
     // revert changes
-    R_Call(glBindFramebuffer, GL_FRAMEBUFFER, 0);
+    RB_BindFBO(0);
 }
 
 LPBUFFER R_MakeCastersVertexArrayObject(void) {
@@ -384,7 +379,7 @@ LPBUFFER R_MakeCastersVertexArrayObject(void) {
 
     R_Call(glGenVertexArrays, 1, &buf->vao);
     R_Call(glGenBuffers, 1, &buf->vbo);
-    R_Call(glBindVertexArray, buf->vao);
+    RB_BindVAO(buf->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, buf->vbo);
 
     R_Call(glEnableVertexAttribArray, attrib_position);

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -71,6 +71,7 @@ typedef enum render_phase_e {
 #include "../common/common.h"
 #include "../client/tr_public.h"
 #include "r_alpha.h"
+#include "r_backend.h"
 
 extern refImport_t ri;
 

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -71,7 +71,6 @@ typedef enum render_phase_e {
 #include "../common/common.h"
 #include "../client/tr_public.h"
 #include "r_alpha.h"
-#include "r_backend.h"
 
 extern refImport_t ri;
 
@@ -133,6 +132,7 @@ static inline void R_SwapRedBlue(BYTE *pixels, DWORD count, DWORD stride) {
 }
 
 #include "shader_desc.h"
+#include "r_backend.h"
 #define BZ_MODEL_LIGHT_MAX 8 // lights; shared model shader array capacity; bounds one lighting-state upload
 
 /* Typed shader values are separate from the program-owned GL locations. */

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -311,7 +311,7 @@ R_AllocateRenderTexture(GLsizei width,
     LPRENDERTARGET rt = ri.MemAlloc(sizeof(RENDERTARGET));
     R_Call(glGenFramebuffers, 1, &rt->buffer);
     R_Call(glGenTextures, 1, &rt->texture);
-    R_Call(glBindFramebuffer, GL_FRAMEBUFFER, rt->buffer);
+    RB_BindFBO(rt->buffer);
     R_Call(glBindTexture, GL_TEXTURE_2D, rt->texture);
     R_Call(glTexParameteri, GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     R_Call(glTexParameteri, GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -320,7 +320,7 @@ R_AllocateRenderTexture(GLsizei width,
     if (attachment == GL_COLOR_ATTACHMENT0) {
         glClear(GL_COLOR_BUFFER_BIT);
     }
-    R_Call(glBindFramebuffer, GL_FRAMEBUFFER, 0);
+    RB_BindFBO(0);
     return rt;
 }
 
@@ -352,8 +352,7 @@ static void R_SetupGL(bool drawLight) {
 
     Matrix3_normal(&normal_matrix, &model_matrix);
 
-    R_Call(glEnable, GL_CULL_FACE);
-    R_Call(glCullFace, GL_BACK);
+    RB_Cull(GL_BACK);
     
     GLfloat const *viewProjectionMatrix =
 #ifdef USE_SHADOWMAPS
@@ -370,25 +369,23 @@ static void R_SetupGL(bool drawLight) {
     tr.shader_ui.state.viewProjection = ui_matrix;
     tr.shader_ui.state.model = model_matrix;
     
-    R_Call(glEnable, GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_TRUE);
-    R_Call(glDepthFunc, GL_LEQUAL);
+    RB_State(RB_STATE_OPAQUE);
 
 #ifdef USE_SHADOWMAPS
     if (drawLight) {
-        R_Call(glViewport, 0, 0, SHADOW_TEXSIZE, SHADOW_TEXSIZE);
-        R_Call(glScissor, 0, 0, SHADOW_TEXSIZE, SHADOW_TEXSIZE);
-        R_Call(glBindFramebuffer, GL_FRAMEBUFFER, tr.rt[RT_DEPTHMAP]->buffer);
+        RB_Viewport(&(RECT){0, 0, SHADOW_TEXSIZE, SHADOW_TEXSIZE});
+        RB_Scissor(&(RECT){0, 0, SHADOW_TEXSIZE, SHADOW_TEXSIZE});
+        RB_BindFBO(tr.rt[RT_DEPTHMAP]->buffer);
         R_Call(glDepthMask, GL_TRUE);
         R_Call(glClear, GL_DEPTH_BUFFER_BIT);
     } else {
-        R_Call(glBindFramebuffer, GL_FRAMEBUFFER, 0);
+        RB_BindFBO(0);
         R_Call(glActiveTexture, GL_TEXTURE1);
         R_Call(glBindTexture, GL_TEXTURE_2D, tr.rt[RT_DEPTHMAP]->texture);
     }
 #else
     (void)drawLight;
-    R_Call(glBindFramebuffer, GL_FRAMEBUFFER, 0);
+    RB_BindFBO(0);
 #endif
 }
 
@@ -711,7 +708,7 @@ void R_InitRenderer(DWORD width, DWORD height) {
 #endif
     R_Call(glDisable, GL_DEPTH_TEST);
     R_Call(glClearColor, 0.0, 0.0, 0.0, 1.0);
-    R_Call(glViewport, 0, 0, tr.drawableSize.width, tr.drawableSize.height);
+    RB_Viewport(&(RECT){0, 0, tr.drawableSize.width, tr.drawableSize.height});
     R_InitParticles();
     R_Init();
     fprintf(stderr, "Refresher initialized.\n\n");
@@ -728,9 +725,7 @@ void R_SetAlphaKeyState(BOOL enabled) {
     if (tr.render_phase == RENDER_PHASE_LIGHTS) {
         /* TODO: Single-sample shadow targets need multisample depth coverage before alpha-key shadows can use ATOC. */
         R_Call(glDisable, GL_SAMPLE_ALPHA_TO_COVERAGE);
-        R_Call(glEnable, GL_BLEND);
-        R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        R_Call(glDepthMask, GL_FALSE);
+        RB_State(RB_STATE_BLEND_ALPHA);
         return;
     }
 #endif
@@ -741,15 +736,11 @@ void R_SetAlphaKeyState(BOOL enabled) {
         R_Call(glBlendFunc, GL_ONE, GL_ZERO);
     } else {
         R_Call(glDisable, GL_SAMPLE_ALPHA_TO_COVERAGE);
-        R_Call(glEnable, GL_BLEND);
-        R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        R_Call(glDepthMask, GL_FALSE);
+        RB_State(RB_STATE_BLEND_ALPHA);
     }
 #else
     R_Call(glDisable, GL_SAMPLE_ALPHA_TO_COVERAGE);
-    R_Call(glDisable, GL_BLEND);
-    R_Call(glBlendFunc, GL_ONE, GL_ZERO);
-    R_Call(glDepthMask, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
 #endif
 }
 
@@ -776,20 +767,21 @@ void R_ShutdownRenderer(void) {
 }
 
 void R_SetupViewport(LPCRECT r) {
-    R_Call(glViewport,
-           r->x * tr.drawableSize.width,
-           r->y * tr.drawableSize.height,
-           r->w * tr.drawableSize.width,
-           r->h * tr.drawableSize.height);
+    RB_Viewport(&(RECT){
+        r->x * tr.drawableSize.width,
+        r->y * tr.drawableSize.height,
+        r->w * tr.drawableSize.width,
+        r->h * tr.drawableSize.height,
+    });
 }
 
 void R_SetupScissor(LPCRECT r) {
-    R_Call(glEnable, GL_SCISSOR_TEST);
-    R_Call(glScissor,
-           r->x * tr.drawableSize.width,
-           r->y * tr.drawableSize.height,
-           r->w * tr.drawableSize.width,
-           r->h * tr.drawableSize.height);
+    RB_Scissor(&(RECT){
+        r->x * tr.drawableSize.width,
+        r->y * tr.drawableSize.height,
+        r->w * tr.drawableSize.width,
+        r->h * tr.drawableSize.height,
+    });
 }
 
 void R_RevertSettings(void) {
@@ -812,11 +804,9 @@ void R_DrawSky(void) {
     };
     rdflags = tr.viewDef.rdflags;
     tr.viewDef.rdflags |= RDF_NOFRUSTUMCULL;
-    R_Call(glDepthMask, GL_FALSE);
-    R_Call(glDisable, GL_DEPTH_TEST);
+    RB_State(RB_STATE_BLEND_ALPHA);
     R_RenderModel(&sky);
-    R_Call(glEnable, GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
     tr.viewDef.rdflags = rdflags;
 }
 
@@ -825,21 +815,19 @@ void R_RenderShadowMap(void) {
     tr.render_phase = RENDER_PHASE_LIGHTS;
     R_SetupGL(true);
     /* Bias depth writes away from receivers; the old unbiased pass made each terrain triangle shadow itself. */
-    R_Call(glEnable, GL_POLYGON_OFFSET_FILL);
-    R_Call(glPolygonOffset, 2.0f, 4.0f);
+    RB_PolygonOffset(2.0f, 4.0f);
     R_BindTexture(tr.texture[TEX_SHADOWMAP], 1);
     R_DrawWorld();
     R_DrawTerrainShadows();
     R_DrawEntities();
-    R_Call(glDisable, GL_POLYGON_OFFSET_FILL);
-    R_Call(glPolygonOffset, 0.0f, 0.0f);
+    RB_PolygonOffset(0, 0);
 }
 #endif
 
 void R_RenderView(void) {
     tr.render_phase = RENDER_PHASE_SOLID;
-    R_SetupViewport(&tr.viewDef.viewport);
-    R_SetupScissor(&tr.viewDef.scissor);
+    RB_Viewport(&tr.viewDef.viewport);
+    RB_Scissor(&tr.viewDef.scissor);
     R_SetupGL(false);
     if (tr.viewDef.rdflags & RDF_NOWORLDMODEL) {
         R_Call(glClear, GL_DEPTH_BUFFER_BIT);
@@ -855,7 +843,7 @@ void R_RenderView(void) {
     }
     tr.render_phase = RENDER_PHASE_SOLID;
     R_RevertSettings();
-    R_SetupScissor(&(RECT){0, 0, 1, 1});
+    RB_Scissor(&(RECT){0, 0, 1, 1});
 
 //    extern LPCTEXTURE dds;
 //    R_DrawPic(dds, 0, 0);
@@ -888,8 +876,8 @@ void R_RenderFrame(viewDef_t const *viewDef) {
             Matrix4_identity(&tr.viewDef.lightMatrix);
         }
         Frustum_Calculate(&tr.viewDef.viewProjectionMatrix, &tr.viewDef.frustum);
-        R_SetupViewport(&tr.viewDef.viewport);
-        R_SetupScissor(&tr.viewDef.scissor);
+        RB_Viewport(&tr.viewDef.viewport);
+        RB_Scissor(&tr.viewDef.scissor);
         R_SetupGL(false);
         R_Call(glClear, GL_DEPTH_BUFFER_BIT);
         R_DrawEntities();
@@ -913,7 +901,7 @@ void R_RenderFrame(viewDef_t const *viewDef) {
 }
 
 void R_DrawBuffer(LPCBUFFER buffer, DWORD num_vertices) {
-    R_Call(glBindVertexArray, buffer->vao);
+    RB_BindVAO(buffer->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, buffer->vbo);
     R_StatsDraw(GL_TRIANGLES, num_vertices, 1);
     R_Call(glDrawArrays, GL_TRIANGLES, 0, num_vertices);
@@ -921,27 +909,27 @@ void R_DrawBuffer(LPCBUFFER buffer, DWORD num_vertices) {
 
 /* Model-owned element buffers retain per-section ranges as byte offsets. */
 void R_DrawIndexedBuffer16(LPCBUFFER buffer, LPCDRAWELEMENTS draw) {
-    R_Call(glBindVertexArray, buffer->vao);
+    RB_BindVAO(buffer->vao);
     R_StatsDraw(GL_TRIANGLES, draw->count, 1);
     R_Call(glDrawElements, GL_TRIANGLES, draw->count, GL_UNSIGNED_SHORT, (void *)(uintptr_t)draw->offset);
 }
 
 void R_DrawIndexedBuffer32(LPCBUFFER buffer, LPCDRAWELEMENTS draw) {
-    R_Call(glBindVertexArray, buffer->vao);
+    RB_BindVAO(buffer->vao);
     R_StatsDraw(GL_TRIANGLES, draw->count, 1);
     R_Call(glDrawElements, GL_TRIANGLES, draw->count, GL_UNSIGNED_INT, (void *)(uintptr_t)draw->offset);
 }
 
 /* Static procedural batches need only gl_InstanceID; their shared VAO has no per-instance stream. */
 void R_DrawBufferCopies(LPCBUFFER buffer, DWORD num_vertices, DWORD num_instances) {
-    R_Call(glBindVertexArray, buffer->vao);
+    RB_BindVAO(buffer->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, buffer->vbo);
     R_StatsDraw(GL_TRIANGLES, num_vertices, num_instances);
     R_Call(glDrawArraysInstanced, GL_TRIANGLES, 0, num_vertices, num_instances);
 }
 
 void R_DrawIndexedBuffer(LPCBUFFER buffer, DWORD num_indices) {
-    R_Call(glBindVertexArray, buffer->vao);
+    RB_BindVAO(buffer->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, buffer->vbo);
     R_Call(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER, buffer->ibo);
     R_StatsDraw(GL_TRIANGLES, num_indices, 1);
@@ -987,12 +975,9 @@ static void R_FinishFrameStats(void) {
 void R_BeginFrame(void) {
     memset(&r_frame_stats, 0, sizeof(r_frame_stats));
     R_Call(glDisable, GL_SAMPLE_ALPHA_TO_COVERAGE);
-    R_Call(glEnable, GL_DEPTH_TEST);
-    R_Call(glDepthMask, GL_TRUE);
-    R_Call(glDepthFunc, GL_LEQUAL);
-    R_Call(glEnable, GL_CULL_FACE);
-    R_Call(glCullFace, GL_BACK);
-    R_Call(glColorMask, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    RB_State(RB_STATE_OPAQUE);
+    RB_Cull(GL_BACK);
+    RB_ColorMask(true, true, true, true);
     R_Call(glClear, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 #ifdef SC2
     R_Call(glColorMask, GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
@@ -1026,7 +1011,7 @@ void R_SetWindowSize(DWORD width, DWORD height) {
     SDL_GL_GetDrawableSize(window,
                            (int *)&tr.drawableSize.width,
                            (int *)&tr.drawableSize.height);
-    R_Call(glViewport, 0, 0, tr.drawableSize.width, tr.drawableSize.height);
+    RB_Viewport(&(RECT){0, 0, tr.drawableSize.width, tr.drawableSize.height});
     fprintf(stderr,
             "Drawable size after vid_apply: %ux%u\n",
             (unsigned)tr.drawableSize.width,

--- a/renderer/r_particles.c
+++ b/renderer/r_particles.c
@@ -210,7 +210,7 @@ COLOR32 FX_BlendColor(cparticle_t const *p) {
 }
 
 static void R_FlushParticles(LPCTEXTURE texture, LPCMATRIX4 matrix, particleVertex_t *pv, BLEND_MODE blend_mode) {
-    R_Call(glBindVertexArray, particles_resources.particles->vao);
+    RB_BindVAO(particles_resources.particles->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, particles_resources.particles->vbo);
     R_Call(glBufferData, GL_ARRAY_BUFFER, sizeof(particleVertex_t) * (pv - particles_resources.vertices), particles_resources.vertices, GL_DYNAMIC_DRAW);
 
@@ -223,35 +223,24 @@ static void R_FlushParticles(LPCTEXTURE texture, LPCMATRIX4 matrix, particleVert
     particles_resources.shader.state.alphaKey = blend_mode == BLEND_MODE_ALPHAKEY;
     particles_resources.shader.state.alphaCutoff = 0.5f;
     R_SetAlphaKeyState(blend_mode == BLEND_MODE_ALPHAKEY);
-    if (blend_mode == BLEND_MODE_NONE) {
-        R_Call(glDisable, GL_BLEND);
-        R_Call(glDepthMask, GL_TRUE);
-        R_Call(glBlendFunc, GL_ONE, GL_ZERO);
-    } else if (blend_mode == BLEND_MODE_ALPHAKEY) {
-        /* Alpha-key particles must not inherit additive state from an earlier batch. */
-        R_Call(glDisable, GL_BLEND);
-        R_Call(glDepthMask, GL_TRUE);
-        R_Call(glBlendFunc, GL_ONE, GL_ZERO);
+    if (blend_mode == BLEND_MODE_NONE || blend_mode == BLEND_MODE_ALPHAKEY) {
+        RB_State(RB_STATE_OPAQUE);
     } else {
-        R_Call(glEnable, GL_BLEND);
-        R_Call(glDepthMask, GL_FALSE);
         switch (blend_mode) {
         case BLEND_MODE_ADD:
-            /* Shared particle legacy: ADD means alpha-weighted additive. */
-            R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE);
+            RB_State(RB_MakeStateBits(GL_SRC_ALPHA, GL_ONE, GL_FALSE, GL_LEQUAL, 0xF));
             break;
         case BLEND_MODE_ADDALPHA:
-            /* Shared particle legacy: ADDALPHA means unweighted additive. */
-            R_Call(glBlendFunc, GL_ONE, GL_ONE);
+            RB_State(RB_STATE_BLEND_ADD);
             break;
         case BLEND_MODE_MODULATE:
-            R_Call(glBlendFunc, GL_ZERO, GL_SRC_COLOR);
+            RB_State(RB_MakeStateBits(GL_ZERO, GL_SRC_COLOR, GL_FALSE, GL_LEQUAL, 0xF));
             break;
         case BLEND_MODE_MODULATE_2X:
-            R_Call(glBlendFunc, GL_DST_COLOR, GL_SRC_COLOR);
+            RB_State(RB_STATE_BLEND_MOD2X);
             break;
         default:
-            R_Call(glBlendFunc, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            RB_State(RB_STATE_BLEND_ALPHA);
             break;
         }
     }
@@ -338,7 +327,7 @@ static LPBUFFER R_MakeParticlesVertexArrayObject(void) {
 
     R_Call(glGenVertexArrays, 1, &buf->vao);
     R_Call(glGenBuffers, 1, &buf->vbo);
-    R_Call(glBindVertexArray, buf->vao);
+    RB_BindVAO(buf->vao);
     R_Call(glBindBuffer, GL_ARRAY_BUFFER, buf->vbo);
 
     R_Call(glEnableVertexAttribArray, attrib_position);

--- a/renderer/shader_desc.h
+++ b/renderer/shader_desc.h
@@ -116,6 +116,7 @@ typedef struct SHADERPROG {
     LPCSHADERDESC desc;
     GLint locs[MAX_SHADER_UNIFORMS];
     void *cache; /* shadow of last-uploaded state for change detection */
+    void *pipeline; /* optional pipeline_t* for thin-pipeline binding */
 } SHADERPROG;
 typedef struct SHADERPROG *LPSHADERPROG;
 typedef const struct SHADERPROG *LPCSHADERPROG;


### PR DESCRIPTION
Implements the first slice of #89 (merged with #93).

## What landed

- `renderer/r_backend.h` / `renderer/r_backend.c`: Doom 3-style XOR state cache (`RB_State`, `RB_Enable`/`Disable`, blend, depth, cull, scissor, viewport, VAO, FBO) plus thin `pipelineDesc_t` / `pipeline_t` types and `RB_BindPipeline`.
- `RB_*` is a backend optimization under an explicit draw API. It is not a fixed-function public surface and does not require 64-bit GPU pointers.
- Header is visible to the renderer via `r_alpha.h` (included from `r_local.h`) and `r_game.h`.
- Research mapping (talk + [NoGraphicsAPI](https://github.com/sebbbi/NoGraphicsAPI) + [X post](https://x.com/SebAaltonen/status/2096314523980349853)) is in `docs/thin-pipeline.md`.

## Constraint

No BDA / raw GPU pointers on GL 3.1, macOS GL 4.1, GLES3, or WebGPU. Steal root-struct, thin PSO, heap indices, and explicit-vs-stateful design only.

## Still on #89

- Phase 2: replace remaining `R_Call(glEnable/BlendFunc/DepthMask/…)` in engine + game renderers with `RB_*` (local edits exist; not all large files were pushed in this PR).
- Phase 3: create/bind pipelines from `pipelineDesc_t` instead of shader + raw state.
- Phase 4: one UBO/std140 root-struct push (not GPU pointers).
- Phase 5: 32-bit texture heap indices; explicit GLES fallback.

## Test plan

- [ ] `make clean && make`
- [ ] WC3 ROC + TFT, SC2, WoW map load + screenshot
- [ ] After Phase 2, `rg` state calls only in `r_backend.c`