### PR TITLE
Fix resource delivery to unfinished drop-off buildings

### DIFF
--- a/docs/games/warcraft-3/economy-and-unit-presentation.md
+++ b/docs/games/warcraft-3/economy-and-unit-presentation.md
@@ -62,10 +62,12 @@ For custom abilities whose `AbilityData.slk:code` resolves to the `Artn` Return 
 gold/lumber acceptance flags. This preserves the same capability model for custom drop-off units instead of adding Town Hall or
 Lumber Mill rawcode checks to worker logic.
 
-`S_FindNearestResourceDropoff` scans live, in-use entities owned by the worker's player and chooses the compatible candidate with
-the smallest `Vector2_distance` from the worker. This is geometric distance; it does not pathfind to every candidate and compare
-route lengths. A Human Lumber Mill therefore competes with a Town Hall for lumber return and wins when it is geometrically closer,
-while a Lumber Mill remains ineligible for gold.
+`S_FindNearestResourceDropoff` scans live, in-use, completed entities owned by the worker's player and chooses the compatible
+candidate with the smallest `Vector2_distance` from the worker. `construction.active` structures are not valid return points even if
+their unit data already exposes `Artn`/`Argd`/`Arlm`/`Argl`. This applies equally to lumber-only drop-offs such as War Mills and to
+gold/lumber drop-offs such as Town Halls: workers must ignore them until construction finishes. This is geometric distance; it does
+not pathfind to every candidate and compare route lengths. A completed Human Lumber Mill therefore competes with a completed Town
+Hall for lumber return and wins when it is geometrically closer, while a Lumber Mill remains ineligible for gold.
 
 Return completion is footprint-aware for buildings that expose an authored pathing texture. The worker deposits when its collision radius plus one simulation step reaches the building's no-walk footprint; the older worker+building collision+step test remains the fallback when no path texture is available. This prevents a Peasant carrying gold from stopping at a Town Hall corner while still outside the scalar centre-circle threshold. The return move revalidates its target before each movement/deposit tick. If the selected drop-off dies, is removed, changes owner, or no longer exposes a compatible Return Resources ability, the worker retargets the nearest remaining compatible drop-off. If none exists, the worker stands while preserving the carried resource and carry visual.
 
@@ -520,7 +522,7 @@ make test-wc3-engine WC3_PATTERN='wc3_game.overhead_*'
 The movement suite covers large-footprint mine entry, mine entry through an authored blocking pathing footprint, the complete gold
 deposit/resume cycle, stock capacity 1 under six assigned workers, independent custom mine capacities/durations, non-orderable inside
 miners, finite-gold depletion and partial final trips,
-trained-unit exit placement against static footprints, nearest compatible lumber drop-off selection, explicit Smart-click drop-off return, lumber return through an authored
+trained-unit exit placement against static footprints, nearest compatible lumber drop-off selection, unfinished War Mill/Town Hall drop-off rejection for lumber and gold, explicit Smart-click drop-off return, lumber return through an authored
 blocking Town Hall footprint, rejection of lumber-only drop-offs for gold, drop-off destruction retargeting, exact lethal tree trips with next-tree selection, dead-previous-tree same-forest retargeting, the no-live-tree stop path, capacity clamping, invulnerable-tree rejection, carried-resource gold/lumber visual switching and zero-carry visual clearing,
 non-lethal chops, and both sides of the immobility contract. The in-engine fixture
 `games/warcraft-3/tests/resources-src/Units/UnitUI.slk` supplies `isbldg` for the same metadata lookup used by the game.

--- a/games/warcraft-3/game/skills/s_harvest_lumber.c
+++ b/games/warcraft-3/game/skills/s_harvest_lumber.c
@@ -57,7 +57,10 @@ static DWORD return_resources_mask(LPCSTR ability) {
 BOOL S_CanReturnResourceAt(LPEDICT unit, LPEDICT building, returnResource_t resource) {
     LPCSTR abilities;
 
-    if (!unit || !building || !building->inuse || building->s.player != unit->s.player || M_IsDead(building))
+    /* Unit data exposes Return Resources before construction completes, but
+     * Warcraft keeps that capability unavailable until the structure is finished. */
+    if (!unit || !building || !building->inuse || building->s.player != unit->s.player ||
+        M_IsDead(building) || building->construction.active)
         return false;
     if (!building->data.UnitAbilities || !(abilities = building->data.UnitAbilities->abilList))
         return false;

--- a/games/warcraft-3/game/tests/t_movement.c
+++ b/games/warcraft-3/game/tests/t_movement.c
@@ -2052,6 +2052,54 @@ TEST(wc3_movement, lumber_return_prefers_nearer_lumber_mill) {
     T_FEQ(worker->harvested_lumber, 10.0f, 0.01f);
 }
 
+/* Return Resources is unavailable while a structure is under construction.
+ * An unfinished War Mill must not become a lumber drop-off merely because its
+ * Arlm ability is already present in unit data. */
+TEST(wc3_movement, lumber_return_skips_unfinished_lumber_mill) {
+    LPEDICT worker = make_moving_unit(0.0f, 0.0f);
+    LPEDICT hall = alloc_test_unit(MAKEFOURCC('o','g','r','e'), 500.0f, 0.0f);
+    LPEDICT mill = alloc_test_unit(MAKEFOURCC('o','w','a','r'), 100.0f, 0.0f);
+    hall->s.player = mill->s.player = worker->s.player;
+    make_live_dropoff(hall, &return_gold_lumber_abilities);
+    make_live_dropoff(mill, &return_lumber_abilities);
+    mill->construction.active = true;
+    worker->harvested_lumber = 10;
+    worker->s.renderfx |= RF_HAS_LUMBER;
+
+    T_ASSERT(!S_CanReturnResourceAt(worker, mill, RETURN_RESOURCE_LUMBER));
+    harvest_walkback(worker);
+
+    T_ASSERT(worker->goalentity == hall);
+    T_FEQ(worker->harvested_lumber, 10.0f, 0.01f);
+
+    mill->construction.active = false;
+    T_ASSERT(S_CanReturnResourceAt(worker, mill, RETURN_RESOURCE_LUMBER));
+}
+
+/* The same construction gate applies to gold.  A Town Hall whose Argl data is
+ * already loaded must not receive carried gold until construction completes. */
+TEST(wc3_movement, gold_return_skips_unfinished_town_hall) {
+    LPEDICT worker = make_moving_unit(0.0f, 0.0f);
+    LPEDICT complete_hall = alloc_test_unit(MAKEFOURCC('h','t','o','w'), 500.0f, 0.0f);
+    LPEDICT unfinished_hall = alloc_test_unit(MAKEFOURCC('h','t','o','w'), 100.0f, 0.0f);
+    complete_hall->s.player = unfinished_hall->s.player = worker->s.player;
+    make_live_dropoff(complete_hall, &return_gold_lumber_abilities);
+    make_live_dropoff(unfinished_hall, &return_gold_lumber_abilities);
+    unfinished_hall->construction.active = true;
+    S_SetCarriedResource(worker, RETURN_RESOURCE_GOLD, 10);
+
+    T_ASSERT(!S_CanReturnResourceAt(worker, unfinished_hall, RETURN_RESOURCE_GOLD));
+    T_ASSERT(S_FindNearestResourceDropoff(worker, RETURN_RESOURCE_GOLD) == complete_hall);
+    T_ASSERT(harvest_gold_return_to(worker, S_FindNearestResourceDropoff(worker, RETURN_RESOURCE_GOLD)));
+    T_ASSERT(worker->goalentity == complete_hall);
+    T_EQ(worker->harvested_gold, 10);
+    T_ASSERT(worker->s.renderfx & RF_HAS_GOLD);
+
+    unfinished_hall->construction.active = false;
+    T_ASSERT(S_CanReturnResourceAt(worker, unfinished_hall, RETURN_RESOURCE_GOLD));
+    T_ASSERT(S_FindNearestResourceDropoff(worker, RETURN_RESOURCE_GOLD) == unfinished_hall);
+}
+
 /* If the chosen Lumber Mill dies during the trip, retain the carried lumber
  * and redirect to the nearest remaining compatible return building. */
 TEST(wc3_movement, lumber_return_retargets_after_lumber_mill_dies) {


### PR DESCRIPTION
Prevent workers from treating structures that are still under construction as valid resource drop-off targets.

Return Resources abilities are present in unit data before construction has completed, so the existing capability-based drop-off lookup could select an unfinished building solely because it exposed Artn, Argd, Arlm, or Argl.

This allowed cases such as:
- Peons delivering lumber to an unfinished War Mill.
- Workers delivering gold to an unfinished Town Hall.
- Workers delivering lumber to an unfinished Town Hall.

Make S_CanReturnResourceAt reject buildings with construction.active. Keeping the rule in the shared eligibility helper ensures the same behavior is used by automatic nearest-dropoff selection, explicit resource return orders, Smart/right-click return, and target revalidation while travelling.

Add movement regression coverage proving that:
- a nearer unfinished War Mill is ignored for lumber;
- lumber is instead returned to a farther completed drop-off;
- a nearer unfinished Town Hall is ignored for gold;
- gold is instead returned to a farther completed Town Hall;
- both structures become eligible immediately after construction completes.

Update the WC3 economy documentation to record that Return Resources capabilities are unavailable until construction finishes.