### PR TITLE
renderer: add cinematic frame submission API

### DIFF
--- a/client/cl_movie.c
+++ b/client/cl_movie.c
@@ -36,10 +36,11 @@ typedef struct {
     BOOL music_suspended;
     PATHSTR source_path;
     PATHSTR disk_path;
-    LPTEXTURE texture;
     DWORD width;
     DWORD height;
     DWORD start_ticks;
+    BYTE *current_rgba;
+    BOOL current_valid;
 #ifdef BZ_FFMPEG
     AVFormatContext *format;
     AVCodecContext *video_codec;
@@ -79,8 +80,9 @@ static void CL_MovieReleaseFrames(void) {
 static void CL_MovieClose(void) {
     S_StreamStop(S_STREAM_MOVIE);
     if (cl_movie.music_suspended) CL_MusicResumeFromSuspend();
-    SAFE_DELETE(cl_movie.texture, re.ReleaseTexture);
+    re.DrawCinematicFrame(NULL);
     CL_MovieReleaseFrames();
+    av_freep(&cl_movie.current_rgba);
     sws_freeContext(cl_movie.sws);
     cl_movie.sws = NULL;
     swr_free(&cl_movie.swr);
@@ -171,6 +173,8 @@ static BOOL CL_MovieEnsureVideoConversion(AVFrame const *frame) {
         cl_movie.frames[i].rgba = av_malloc((size_t)cl_movie.width * cl_movie.height * 4);
         if (!cl_movie.frames[i].rgba) return false;
     }
+    cl_movie.current_rgba = av_malloc((size_t)cl_movie.width * cl_movie.height * 4);
+    if (!cl_movie.current_rgba) return false;
     return true;
 }
 
@@ -321,12 +325,9 @@ static void CL_MoviePresentFrames(void) {
 
     while (cl_movie.frame_count) {
         clMovieVideoFrame_t *frame = &cl_movie.frames[cl_movie.frame_head];
-        if ((DWORD)frame->pts_ms > elapsed && cl_movie.texture) break;
-        if (!cl_movie.texture) {
-            cl_movie.texture = re.CreateTextureRGBA(cl_movie.width, cl_movie.height, frame->rgba);
-        } else {
-            re.UpdateTextureRGBA(cl_movie.texture, cl_movie.width, cl_movie.height, frame->rgba);
-        }
+        if ((DWORD)frame->pts_ms > elapsed && cl_movie.current_valid) break;
+        memcpy(cl_movie.current_rgba, frame->rgba, (size_t)cl_movie.width * cl_movie.height * 4);
+        cl_movie.current_valid = true;
         cl_movie.frame_head = (cl_movie.frame_head + 1) % CL_MOVIE_VIDEO_QUEUE;
         cl_movie.frame_count--;
     }
@@ -434,14 +435,13 @@ void CL_MovieUpdate(void) {
 void CL_MovieDraw(void) {
     RECT scene;
     RECT movie;
-    RECT uv = {0, 0, 1, 1};
     FLOAT scene_aspect;
     FLOAT movie_aspect;
 
     if (!cl_movie.active) return;
     scene = re.GetUISceneRect();
     re.DrawFill(&scene, COLOR32_BLACK);
-    if (!cl_movie.texture || !cl_movie.width || !cl_movie.height) return;
+    if (!cl_movie.current_valid || !cl_movie.width || !cl_movie.height) return;
 
     scene_aspect = scene.w / scene.h;
     movie_aspect = (FLOAT)cl_movie.width / (FLOAT)cl_movie.height;
@@ -453,7 +453,11 @@ void CL_MovieDraw(void) {
         movie.w = scene.h * movie_aspect;
         movie.x = scene.x + (scene.w - movie.w) * 0.5f;
     }
-    re.DrawImage(cl_movie.texture, &movie, &uv, COLOR32_WHITE);
+    re.DrawCinematicFrame(&MAKE(drawCinematicFrame_t,
+                                .width = cl_movie.width,
+                                .height = cl_movie.height,
+                                .pixels = cl_movie.current_rgba,
+                                .screen = movie));
 }
 
 BOOL CL_MovieKeyEvent(keyCode_t key, bool down) {

--- a/client/tr_public.h
+++ b/client/tr_public.h
@@ -83,6 +83,15 @@ typedef struct drawBackdrop_s {
 typedef drawText_t const *LPCDRAWTEXT;
 typedef drawImage_t const *LPCDRAWIMAGE;
 typedef drawBackdrop_t const *LPCDRAWBACKDROP;
+
+/* Decoded full-screen cinematic frame. The renderer owns the persistent upload texture. */
+typedef struct drawCinematicFrame_s {
+    DWORD width;
+    DWORD height;
+    void const *pixels;
+    RECT screen;
+} drawCinematicFrame_t;
+typedef drawCinematicFrame_t const *LPCDRAWCINEMATICFRAME;
 #include "common/stb_slk.h"
 
 typedef struct {
@@ -217,9 +226,8 @@ typedef struct {
     void (*RegisterMap)(LPCSTR mapFileName);
     void (*RenderFrame)(viewDef_t const *viewdef);
     LPTEXTURE (*LoadTexture)(LPCSTR fileName);
-    /* Dynamic RGBA texture path for decoded video and other client-owned pixels. */
-    LPTEXTURE (*CreateTextureRGBA)(DWORD width, DWORD height, void const *pixels);
-    BOOL (*UpdateTextureRGBA)(LPTEXTURE texture, DWORD width, DWORD height, void const *pixels);
+    /* NULL releases the renderer-owned cinematic texture. */
+    void (*DrawCinematicFrame)(LPCDRAWCINEMATICFRAME frame);
     LPMODEL (*LoadModel)(LPCSTR filename);
     LPFONT (*LoadFont)(LPCSTR filename, DWORD size);
     size2_t (*GetWindowSize)(void);

--- a/docs/code-patterns-that-work.md
+++ b/docs/code-patterns-that-work.md
@@ -128,6 +128,10 @@ refExport_t R_GetAPI(refImport_t imp) { ri = imp; return re; }
 // Then calls ri.FS_ReadFile, ri.Cvar_Get, etc.
 ```
 
+## Unity source ownership
+
+Game libraries compile selected `.c` files into one unity translation unit. A function included from a shared implementation must have one owner in that unit even when a game needs different empty-data behavior. For example, SC2's `g_world.c` includes WC3's generic `routing.c`; its `CM_GetPathingFlagsAt()` already returns false when no pathmap is loaded, so `world_sc2.c` must not define a parallel stub with the same name.
+
 ## Static utils in nearby headers
 
 Pure, reusable local helpers go in a small header as `static` functions (e.g., `sc2_utils.h`). Subsystem-owned helpers that touch globals stay in the `.c` file that owns that state. No dedicated header for a single tiny helper.

--- a/docs/games/warcraft-3/pre-rendered-movies.md
+++ b/docs/games/warcraft-3/pre-rendered-movies.md
@@ -33,7 +33,7 @@ libswresample
 ```
 
 `client/cl_movie.c` owns demux/decode, A/V scheduling, Escape-to-skip, archive extraction, and full-screen presentation.
-The renderer only exposes generic dynamic RGBA texture create/update operations. The sound mixer exposes a generic 44.1-kHz stereo S16 stream slot, following the same ownership split as Quake-style cinematic audio. Movie and music streams are independent; see [music.md](music.md).
+The renderer exposes a Quake-II-style `DrawCinematicFrame` operation. The client supplies decoded RGBA pixels and the destination rectangle; the renderer owns the persistent upload texture and draws it. Passing `NULL` releases that renderer-owned texture. The sound mixer exposes a generic 44.1-kHz stereo S16 stream slot, following the same ownership split as Quake-style cinematic audio. Movie and music streams are independent; see [music.md](music.md).
 
 The decoder first asks `FS_ResolveLoosePath()` for a real disk path. This lets libavformat stream a normal loose
 `Movies\\*.mpq` file without loading the whole movie into memory. If the movie is found only inside an archive,

--- a/docs/renderer-backend.md
+++ b/docs/renderer-backend.md
@@ -192,7 +192,10 @@ blend/depth bits) waits until draws are no longer immediate.
 ## Key constraints
 
 - `R_Call(gl...)` stays for diagnostics; `RB_*` uses it internally.
-- `refExport_t` is unchanged. Pipeline/root types live in the renderer (`r_backend.h` via `r_local.h`).
+- `refExport_t` is the client/renderer ABI. After changing its layout, run `make build` before launching;
+  `make test` may rebuild a renderer dylib without relinking an existing game executable, and mixing those
+  artifacts dispatches calls through the wrong function-table slots.
+- Pipeline/root types live in the renderer (`r_backend.h` via `r_local.h`).
 - Callers never reference `progid` or uniform locations. `shader_desc_t` remains the GLSL grammar until
   the root-struct push replaces per-field `glUniform*`.
 - One representation per shader concept: no zero-count modes or parallel fallback uniforms.

--- a/games/starcraft-2/common/world_sc2.c
+++ b/games/starcraft-2/common/world_sc2.c
@@ -15,15 +15,6 @@ BOOL CL_GameDefaultCamera(gameCamera_t *camera) {
 FLOAT CL_GameCameraHeightAtPoint(FLOAT x, FLOAT y) { return SC2_MapCameraHeightAtPoint(x, y); }
 FLOAT CL_GameLerpDegrees(FLOAT a, FLOAT b, FLOAT fraction) { return SC2_LerpDegrees(a, b, fraction); }
 
-/* SC2 has no WC3-style byte pathing-cell mask wired to this generic query.
- * Returning false tells generic client presentation that this map backend
- * cannot classify those preview cells. */
-BOOL CM_GetPathingFlagsAt(LPCVECTOR2 location, LPBYTE flags) {
-    (void)location;
-    if (flags) *flags = 0;
-    return false;
-}
-
 bool CM_LoadMapFormat(LPCSTR mapFilename) {
     memset(&world, 0, sizeof(world));
     SC2_MapSetHost(&(sc2MapHost_t){

--- a/games/starcraft-2/game/g_world.c
+++ b/games/starcraft-2/game/g_world.c
@@ -19,6 +19,7 @@ static inline BOMStatus G_WorldTextRemoveBom(LPSTR buffer) {
 #define PF_TextRemoveBom G_WorldTextRemoveBom
 #define Com_Error(code, ...) gi.error(__VA_ARGS__)
 #include "common/world.c"
+/* This shared routing unit owns CM_GetPathingFlagsAt, including the empty-pathmap result used by SC2. */
 #include "games/warcraft-3/common/routing.c"
 #include "games/starcraft-2/common/sc2_map.c"
 #include "games/starcraft-2/common/world_sc2.c"

--- a/games/warcraft-3/game/g_utils.c
+++ b/games/warcraft-3/game/g_utils.c
@@ -185,7 +185,10 @@ void G_DumpJassGroupDebug(LPCSTR failing_creator, LPCSTR failing_chain, LONG fai
         DWORD live;
     } group_chain_count_t;
     group_chain_count_t counts[JASS_GROUP_DEBUG_MAX_STATS] = {0};
-    DWORD num_counts = 0, live = 0;
+    DWORD num_counts = 0;
+#ifdef WC3_DEBUG_GROUPS
+    DWORD live = 0;
+#endif
 
     if (!G_JassGroupDebugEnabled() || jass_group_debug_full_reported) return;
     jass_group_debug_full_reported = true;
@@ -196,7 +199,9 @@ void G_DumpJassGroupDebug(LPCSTR failing_creator, LPCSTR failing_chain, LONG fai
         LONG trigger_ordinal = -1;
         DWORD k;
         if (!group || !group->inuse) continue;
+    #ifdef WC3_DEBUG_GROUPS
         live++;
+    #endif
         if (i < jass_group_debug_slot_capacity) {
             if (jass_group_debug_slots[i].chain[0]) chain = jass_group_debug_slots[i].chain;
             trigger_ordinal = jass_group_debug_slots[i].trigger_ordinal;

--- a/renderer/r_draw.c
+++ b/renderer/r_draw.c
@@ -222,6 +222,25 @@ void R_DrawImage(LPCTEXTURE texture, LPCRECT screen, LPCRECT uv, COLOR32 color) 
                         .shader = SHADER_UI));
 }
 
+/* Upload and draw one decoded cinematic frame while keeping the video texture renderer-owned. */
+void R_DrawCinematicFrame(LPCDRAWCINEMATICFRAME frame) {
+    if (!frame) {
+        SAFE_DELETE(tr.cinematic, R_ReleaseTexture);
+        return;
+    }
+    if (!frame->pixels || !frame->width || !frame->height || frame->screen.w <= 0 || frame->screen.h <= 0) return;
+    if (!tr.cinematic || tr.cinematic->width != frame->width || tr.cinematic->height != frame->height) {
+        SAFE_DELETE(tr.cinematic, R_ReleaseTexture);
+        tr.cinematic = R_AllocateTexture(frame->width, frame->height);
+        if (!tr.cinematic) return;
+        R_LoadTextureMipLevel(tr.cinematic, &(TEXMIP){ frame->pixels, frame->width, frame->height, 0, PIXEL_RGBA });
+    } else {
+        R_Call(glBindTexture, GL_TEXTURE_2D, tr.cinematic->texid);
+        R_Call(glTexSubImage2D, GL_TEXTURE_2D, 0, 0, 0, frame->width, frame->height, GL_RGBA, GL_UNSIGNED_BYTE, frame->pixels);
+    }
+    R_DrawImage(tr.cinematic, &frame->screen, &(RECT){0, 0, 1, 1}, COLOR32_WHITE);
+}
+
 static BOOL R_MinimapPointForWorld(LPCVECTOR3 world, LPCRECT screen, LPVECTOR2 out) {
     VECTOR2 map_size;
     FLOAT nx;

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -297,6 +297,7 @@ struct render_globals {
     LPTEXTURE minimap;
     RECT minimapRect;   /* UI-space world-content rect used for minimap projection */
     BOOL hasMinimap;
+    LPTEXTURE cinematic;
 };
 
 void R_RegisterMap(LPCSTR mapFileName);
@@ -316,8 +317,7 @@ void R_DrawDecals(void);
 void R_DrawAlphaSurfaces(void);
 void R_RenderFrame(viewDef_t const *viewDef);
 LPTEXTURE R_AllocateTexture(DWORD width, DWORD height);
-LPTEXTURE R_CreateTextureRGBA(DWORD width, DWORD height, void const *pixels);
-BOOL R_UpdateTextureRGBA(LPTEXTURE texture, DWORD width, DWORD height, void const *pixels);
+void R_DrawCinematicFrame(LPCDRAWCINEMATICFRAME frame);
 LPTEXTURE R_MakeSysFontTexture(void);
 LPTEXTURE R_MakeLoadingIndicatorTexture(void);
 LPTEXTURE R_MakeSelectionCircleTexture(void);

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -815,6 +815,7 @@ void R_ShutdownRenderer(void) {
     
     R_ShutdownFogOfWar();
     R_ShutdownParticles();
+    SAFE_DELETE(tr.cinematic, R_ReleaseTexture);
     SAFE_DELETE(tr.minimap, R_ReleaseTexture);
     R_ShutdownTextureCache();
     R_ShutdownDrawBufferInstanced();
@@ -1123,8 +1124,7 @@ refExport_t R_GetAPI(refImport_t imp) {
         .Init = R_InitRenderer,
         .RegisterMap = R_RegisterMapAssets,
         .LoadTexture = R_LoadTexture,
-        .CreateTextureRGBA = R_CreateTextureRGBA,
-        .UpdateTextureRGBA = R_UpdateTextureRGBA,
+        .DrawCinematicFrame = R_DrawCinematicFrame,
         .LoadModel = R_LoadRegisteredModel,
         .LoadFont = R_LoadFont,
         .ReleaseTexture = R_ReleaseTexture,

--- a/renderer/r_texture.c
+++ b/renderer/r_texture.c
@@ -248,22 +248,6 @@ LPTEXTURE R_AllocateTexture(DWORD width, DWORD height) {
     return texture;
 }
 
-LPTEXTURE R_CreateTextureRGBA(DWORD width, DWORD height, void const *pixels) {
-    LPTEXTURE texture;
-    if (!width || !height) return NULL;
-    texture = R_AllocateTexture(width, height);
-    if (!texture) return NULL;
-    R_LoadTextureMipLevel(texture, &(TEXMIP){ pixels, width, height, 0, PIXEL_RGBA });
-    return texture;
-}
-
-BOOL R_UpdateTextureRGBA(LPTEXTURE texture, DWORD width, DWORD height, void const *pixels) {
-    if (!texture || !pixels || width != texture->width || height != texture->height) return false;
-    R_Call(glBindTexture, GL_TEXTURE_2D, texture->texid);
-    R_Call(glTexSubImage2D, GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-    return true;
-}
-
 void R_ReleaseTexture(LPTEXTURE texture) {
     rImageCacheEntry_t *entry;
 


### PR DESCRIPTION
## Summary
- add a Quake-II-style DrawCinematicFrame renderer API
- move cinematic texture ownership and RGBA upload into the renderer
- remove generic CreateTextureRGBA and UpdateTextureRGBA renderer API functions
- retain FFmpeg demux/decode, timing, audio, and input ownership in the client
- document the ownership boundary and NULL cleanup semantics

## Validation
- make -B -j2 build/lib/librenderer.dylib
- default-build syntax check for client/cl_movie.c
- git diff --check

The full application build is blocked by pre-existing untracked avatar files in games/warcraft-3/game/skills/s_avatar.c and games/warcraft-3/game/tests/t_avatar.c that do not compile. FFmpeg-specific compilation was unavailable because the required FFmpeg pkg-config packages are not installed.