### PR TITLE
wc3: move loading UI into initial layout

### DIFF
--- a/client/cl_main.c
+++ b/client/cl_main.c
@@ -455,10 +455,6 @@ static void CL_UICvarSet(LPCSTR name, LPCSTR value) {
     Cvar_Set(name, value);
 }
 
-FLOAT CL_GetLoadingProgress(void) {
-    return cl.loading_progress;
-}
-
 void CL_SetLoadingProgress(FLOAT progress) {
     if (progress < 0.0f) progress = 0.0f;
     if (progress > 1.0f) progress = 1.0f;
@@ -839,7 +835,6 @@ void CL_Init(void) {
         .Cvar_String = Cvar_String,
         .Cvar_Set = CL_UICvarSet,
         .GetConfigString = CL_GetConfigString,
-        .LoadingProgress = CL_GetLoadingProgress,
         .LAN_RefreshServers = CL_LANRefreshServers,
         .LAN_NumServers = CL_LANNumServers,
         .LAN_Server = CL_LANServer,

--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -242,6 +242,8 @@ void CL_ParseFrame(LPSIZEBUF msg) {
         cls.state = ca_active;
         cl.playerstate.client_ui_state = CLIENT_UI_GAME;
         SCR_EndLoadingPlaque();
+        SAFE_DELETE(cl.layout[LAYER_LOADING], MemFree);
+        SCR_ClearLayoutLayer(LAYER_LOADING);
         CL_SetGameplayInput();
     }
     

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -166,7 +166,8 @@ void SCR_DrawScreenField(DWORD msec) {
         break;
     case ca_connecting:
     case ca_connected:
-        menu.Refresh(cl.time);
+        if (cl.playerstate.client_ui_state == CLIENT_UI_LOADING) SCR_DrawLoadingLayout();
+        else menu.Refresh(cl.time);
         break;
     case ca_active:
         V_RenderView();
@@ -894,6 +895,17 @@ void SCR_LayoutDrawPortrait(LPCUIFRAME frame, LPCRECT screen) {
     re.RenderFrame(&vd);
 }
 
+/* Loading bars are authored as portrait models; the client alone owns their ratio. */
+void SCR_LayoutDrawLoadingBar(LPCUIFRAME frame, LPCRECT screen) {
+    UIFRAME bar = *frame;
+    char anim[16];
+
+    snprintf(anim, sizeof(anim), "#0@%.4f", cl.loading_progress);
+    bar.flags.type = FT_PORTRAIT;
+    bar.text = anim;
+    SCR_LayoutDrawPortrait(&bar, screen);
+}
+
 void SCR_LayoutDrawSprite(LPCUIFRAME frame, LPCRECT screen) {
     LPCMODEL model = cl.models[frame->tex.index];
     LPCSTR anim = (frame->text && *frame->text) ? frame->text : "Stand";
@@ -1208,6 +1220,7 @@ static drawer_t drawers[] = {
     { FT_HIGHLIGHT,      SCR_LayoutDrawHighlight },
     { FT_BACKDROP,       SCR_LayoutDrawBackdrop },
     { FT_SIMPLESTATUSBAR,SCR_LayoutDrawStatusbar },
+    { FT_LOADING_BAR,    SCR_LayoutDrawLoadingBar },
     { FT_COMMANDBUTTON,  SCR_LayoutDrawCommandButton },
     { FT_STRING,         SCR_LayoutDrawString },
     { FT_NAMETAG,        SCR_LayoutDrawNameTag },
@@ -1305,6 +1318,7 @@ void SCR_DrawLayout(void) {
 
     FOR_LOOP(layer, MAX_LAYOUT_LAYERS) {
         DWORD flags = cl.playerstate.uiflags;
+        if (layer == LAYER_LOADING) continue;
         if ((1 << layer) & flags) continue;
         HANDLE layout = layout_layers[layer];
         if (layout) {
@@ -1323,6 +1337,20 @@ void SCR_DrawLayout(void) {
     /* Transient windows are frontmost gameplay UI. The window manager already
      * preserves server-authored z-order, but previously had no screen caller. */
     CL_WindowDraw();
+}
+
+/* The initial layout is a loading-only packet, not a gameplay HUD layer. */
+void SCR_DrawLoadingLayout(void) {
+    HANDLE layout = layout_layers[LAYER_LOADING];
+    RECT root;
+
+    if (!layout) return;
+    layout_current_window = false;
+    layout_current_layer = LAYER_LOADING;
+    SCR_Clear(layout);
+    root = SCR_LayoutSceneRect();
+    SCR_SetLayoutRoot(&root);
+    SCR_LayoutDrawOverlay(layout);
 }
 
 void SCR_SetLayoutLayer(DWORD layer, HANDLE data) {

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -895,8 +895,18 @@ void SCR_LayoutDrawPortrait(LPCUIFRAME frame, LPCRECT screen) {
     re.RenderFrame(&vd);
 }
 
-/* Loading bars are authored as portrait models; the client alone owns their ratio. */
+/* Loading bars are the one client-owned layout value; their art remains server-authored. */
 void SCR_LayoutDrawLoadingBar(LPCUIFRAME frame, LPCRECT screen) {
+    if (frame->tex.index < MAX_IMAGES && cl.pics[frame->tex.index]) {
+        RECT fill = *screen;
+        RECT uv = { 0, 0, 255, 255 };
+        RECT suv;
+        fill.w *= cl.loading_progress;
+        uv.w *= cl.loading_progress;
+        suv = Rect_div(&uv, 0xff);
+        re.DrawImage(cl.pics[frame->tex.index], &fill, &suv, frame->color);
+        return;
+    }
     UIFRAME bar = *frame;
     char anim[16];
 

--- a/client/cl_view.c
+++ b/client/cl_view.c
@@ -459,6 +459,7 @@ static void CL_AddEntities(void) {
 }
 
 void CL_PrepRefresh(void) {
+    if (!cl.layout[LAYER_LOADING]) return;
     if (!*cl.configstrings[CS_WORLD]) {
         world_loaded = false;
         begin_sent = false;

--- a/client/client.h
+++ b/client/client.h
@@ -139,7 +139,6 @@ void CL_SetMenuBindings(void);
 void CL_SetGameplayInput(void);
 void CL_SetGameplayBindings(void);
 void CL_BeginLoadingMap(LPCSTR mapName);
-FLOAT CL_GetLoadingProgress(void);
 void CL_SetLoadingProgress(FLOAT progress);
 
 /* Long-form client music presentation (client/cl_music.c). */

--- a/client/menu.h
+++ b/client/menu.h
@@ -132,7 +132,6 @@ typedef struct {
     LPCSTR (*Cvar_String)(LPCSTR name, LPCSTR fallback);
     void (*Cvar_Set)(LPCSTR name, LPCSTR value);
     LPCSTR (*GetConfigString)(DWORD index);
-    FLOAT (*LoadingProgress)(void); /* normalized client-owned loading progress [0,1] */
     void (*LAN_RefreshServers)(void);
     DWORD (*LAN_NumServers)(void);
     BOOL (*LAN_Server)(DWORD index, menuLanGame_t *out);

--- a/client/ui_layout.h
+++ b/client/ui_layout.h
@@ -34,6 +34,7 @@ BOOL SCR_LayoutHitTest(int x, int y);
 BOOL SCR_LayoutModalActive(void);
 void SCR_LayoutClampSelectionRect(LPRECT rect);
 void SCR_DrawLayout(void);
+void SCR_DrawLoadingLayout(void);
 BOOL SCR_LayoutMouseEvent(menuMouseEvent_t event, int x, int y, int32_t param);
 BOOL SCR_LayoutScrollTextAreaAt(HANDLE layout, LPCVECTOR2 point, int wheel_y);
 FLOAT SCR_LayoutTextAreaMaxScroll(LPCUIFRAME frame);

--- a/common/shared.h
+++ b/common/shared.h
@@ -455,6 +455,7 @@ typedef enum {
     LAYER_GAME_RESULT,
     LAYER_WORLD_HOVER,
     LAYER_UNIT_SHORTCUTS,
+    LAYER_LOADING,
 } UILAYOUTLAYER;
 
 typedef enum {
@@ -857,6 +858,7 @@ typedef enum {
     FT_TOOLTIPTEXT,
     FT_MINIMAP,
     FT_NAMETAG,
+    FT_LOADING_BAR,
 } FRAMETYPE;
 
 #define UIFLAG_SIZE_TO_CONTENT   (1 << 10) // flag bit; derives a composite frame's size from rendered content; used by FT_NAMETAG

--- a/docs/architecture/ui-system.md
+++ b/docs/architecture/ui-system.md
@@ -272,16 +272,15 @@ Game-mode mouse behavior lives in per-game `cl_input_<game>.c` files. Never crea
 
 ## Loading Screen
 
-The loading screen is owned by the UI library and drawn when `playerState_t.client_ui_state == CLIENT_UI_LOADING`, before standalone-screen dispatch. It:
+The loading screen is a server-authored `svc_layout` sent after the initial configstrings and drawn by the client while `playerState_t.client_ui_state == CLIENT_UI_LOADING`. It:
 
-1. Loads `Loading.fdf` frames
-2. Reads map info from `.w3m`/`.w3x` (title, subtitle, custom loading screen model)
-3. Binds frames: `LoadingBackground` (3D portrait), `LoadingBar` (progress), `LoadingTitleText`, `LoadingSubtitleText`, `LoadingText`
-4. Reads normalized client-owned progress through `menuImport_t.LoadingProgress` and drives the WC3 progress MDX as `#0@ratio`
+1. Serializes the authoritative `Loading.fdf` frame tree before `begin`
+2. Includes map-authored title, subtitle, description, and background model
+3. Uses `FT_LOADING_BAR`, whose animation ratio is supplied by client-local registration progress
 
 `CL_PrepRefresh()` advances that value at real registration phase boundaries. The Quake-style plaque remains frozen for ordinary
 frame submission, but `SCR_UpdateLoadingPlaque()` explicitly repaints after a progress change. The value is local client state, not
-a player-state/network field. The loading screen stays visible until the first usable server frame sets
+a player-state/network field. The loading layout stays visible until the first usable server frame sets
 `client_ui_state = CLIENT_UI_GAME`, promotes the client to `ca_active`, and ends the plaque.
 
 ## WC3 vs SC2 vs WoW UI

--- a/docs/games/warcraft-3/architecture/ui-flow.md
+++ b/docs/games/warcraft-3/architecture/ui-flow.md
@@ -45,7 +45,7 @@ Important cvars:
 Loading follows the Quake-style client state split:
 
 1. `CL_BeginLoadingMap()` resets `cl.loading_progress`, sets `playerState_t.client_ui_state = CLIENT_UI_LOADING`, keeps the connection in `ca_connected`, and raises the frozen loading plaque.
-2. The WC3 menu draws the loading screen before standalone-screen dispatch and reads progress through `menuImport_t.LoadingProgress`.
+2. The server sends the map-authored loading `svc_layout` after configstrings; the client draws it before standalone-screen dispatch. `FT_LOADING_BAR` reads client-local progress.
 3. A successful local `SV_Map()` completion advances the local plaque to its first milestone; remote clients skip that listen-server-only milestone. `CL_PrepRefresh()` then loads/registers the world, models, images, sounds, and fonts and advances progress at those real phase boundaries; `SCR_UpdateLoadingPlaque()` explicitly repaints the frozen plaque after each increase.
 4. Once registration is complete, `CL_PrepRefresh()` queues `begin`, closes sound registration, sets `cl.refresh_prepped`, and advances the bar to 1.0.
 5. The first usable server frame then promotes `cls.state` to `ca_active`, changes `client_ui_state` to `CLIENT_UI_GAME`, and calls `SCR_EndLoadingPlaque()`.

--- a/docs/games/warcraft-3/loading-and-assets.md
+++ b/docs/games/warcraft-3/loading-and-assets.md
@@ -81,8 +81,8 @@ do not infer those capabilities from the renderer's map-import lookup.
 Loading progress is client-owned and intentionally coarse. `CL_BeginLoadingMap` resets `cl.loading_progress` to
 zero. `CL_PrepRefresh` advances it monotonically at existing registration boundaries and
 `SCR_UpdateLoadingPlaque` explicitly repaints the otherwise frozen Quake-style loading plaque after each advance.
-The menu module reads the normalized value through `menuImport_t.LoadingProgress`; WC3 maps it directly onto the
-`LoadingProgressBar` MDX sequence using `#0@ratio`. No player-state/network field is involved.
+The initial server payload carries the `Loading.fdf` tree as `svc_layout`; its `FT_LOADING_BAR` maps client-local progress directly
+onto the `LoadingProgressBar` MDX sequence using `#0@ratio`. No player-state/network field is involved.
 
 Current phase values are:
 

--- a/games/starcraft-2/game/g_sc2.c
+++ b/games/starcraft-2/game/g_sc2.c
@@ -773,6 +773,8 @@ static void SC2_ClientBegin(LPEDICT ent) {
     }
 }
 
+static void SC2_ClientLoading(LPEDICT ent) { (void)ent; }
+
 static void SC2_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
     DWORD client_number = SC2_EdictNumber(ent);
     VECTOR2 loc;
@@ -837,6 +839,7 @@ struct game_export *GetGameAPI(struct game_import *import) {
     globals.Shutdown              = SC2_Shutdown;
     globals.RunFrame              = SC2_RunFrame;
     globals.ClientBegin           = SC2_ClientBegin;
+    globals.ClientLoading         = SC2_ClientLoading;
     globals.ClientCommand         = SC2_ClientCommand;
     globals.ClientSetCameraPosition = SC2_ClientSetCameraPosition;
     globals.CanSeeEntity          = SC2_CanSeeEntity;

--- a/games/starcraft-2/game/g_sc2.c
+++ b/games/starcraft-2/game/g_sc2.c
@@ -773,7 +773,18 @@ static void SC2_ClientBegin(LPEDICT ent) {
     }
 }
 
-static void SC2_ClientLoading(LPEDICT ent) { (void)ent; }
+static void SC2_ClientLoading(LPEDICT ent) {
+    uiFrame_t frame = { .number = 1, .size = { 1024.0f, 64.0f }, .color = COLOR32_WHITE,
+                        .flags.type = FT_STRING, .text = "Loading..." };
+    uiLabel_t label = { .font = gi.FontIndex("Assets\\Fonts\\Standard.ttf", 18),
+                        .textalignx = FONT_JUSTIFYCENTER, .textaligny = FONT_JUSTIFYMIDDLE };
+
+    if (!ent) return;
+    SC2_HUD_WriteStart(LAYER_LOADING);
+    frame.buffer.data = &label; frame.buffer.size = sizeof(label);
+    gi.Write(PF_UIFRAME, &frame);
+    SC2_HUD_WriteEnd(ent);
+}
 
 static void SC2_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
     DWORD client_number = SC2_EdictNumber(ent);

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -1799,6 +1799,7 @@ void UI_PrintClasses(void);
 void UI_ClearTemplates(void);
 void UI_ResetHud(void);
 void UI_LoadHud(void);
+void UI_WriteLoadingLayout(LPEDICT);
 void UI_ParseFDF(LPCSTR);
 void UI_ParseFDF_Buffer(LPCSTR, LPSTR);
 void UI_SetAllPoints(LPFRAMEDEF);

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -1056,6 +1056,9 @@ static void G_ClientBegin(LPEDICT edict) {
 #endif
 }
 
+/* Send this before begin; it presents server-authored map data while the client registers media. */
+static void G_ClientLoading(LPEDICT edict) { UI_WriteLoadingLayout(edict); }
+
 /* Look up or register a display name in the packed CS_GENERAL configstring pool.
  * Each configstring stores ENT_NAMES_PER_CS names of ENT_NAME_SLOT_SIZE bytes each.
  * Returns a 1-based packed index (0 = not found / pool full). */
@@ -1127,6 +1130,7 @@ struct game_export *GetGameAPI(struct game_import *import) {
     globals.RunFrame = G_RunFrame;
     globals.ClientCommand = G_ClientCommand;
     globals.ClientSetCameraPosition = G_ClientSetCameraPosition;
+    globals.ClientLoading = G_ClientLoading;
     globals.ClientBegin = G_ClientBegin;
     globals.CanSeeEntity = G_FowPlayerCanSeeEntity;
     globals.CustomizeEntity = G_CustomizeEntity;

--- a/games/warcraft-3/game/generated/loading_screen.h
+++ b/games/warcraft-3/game/generated/loading_screen.h
@@ -2,7 +2,7 @@
 #ifndef LOADINGSCREEN_H
 #define LOADINGSCREEN_H
 
-#include "../menu_local.h"
+#include "../g_local.h"
 
 typedef struct LoadingScreen_s {
     LPFRAMEDEF Loading;

--- a/games/warcraft-3/game/hud/hud.c
+++ b/games/warcraft-3/game/hud/hud.c
@@ -674,6 +674,7 @@ BOOL UI_BuildFrameForWrite(LPCFRAMEDEF frame,
         case FT_MODEL:
         case FT_SPRITE:
         case FT_PORTRAIT:
+        case FT_LOADING_BAR:
             out->tex.index = frame->Portrait.model;
             break;
         default:

--- a/games/warcraft-3/game/hud/hud.c
+++ b/games/warcraft-3/game/hud/hud.c
@@ -810,6 +810,7 @@ void UI_LoadHud(void) {
     UI_LoadHudGameResult();
     UI_LoadHudCinematic();
     UI_LoadHudMessage();
+    UI_LoadHudLoading();
 }
 
 /* FDF host services — game module implementations using gi */
@@ -827,4 +828,6 @@ BZ_HOST_HIDDEN void UI_WireFrameTypeFunctions(LPFRAMEDEF frame) { (void)frame; }
 BZ_HOST_HIDDEN void UI_ClearTheme(void) {}
 
 /* Game module doesn't load 3D models for UI — stub */
-BZ_HOST_HIDDEN DWORD UI_LoadModel(LPCSTR file, BOOL decorate) { (void)file; (void)decorate; return 0; }
+BZ_HOST_HIDDEN DWORD UI_LoadModel(LPCSTR file, BOOL decorate) {
+    return file && *file ? gi.ModelIndex(decorate ? Theme_PlayerString(NULL, file, file) : file) : 0;
+}

--- a/games/warcraft-3/game/hud/hud_loading.c
+++ b/games/warcraft-3/game/hud/hud_loading.c
@@ -1,0 +1,30 @@
+/* Serializes the stock Loading.fdf tree before gameplay UI exists. */
+#include "hud_local.h"
+
+void UI_LoadHudLoading(void) {
+    if (!LoadingScreen_Load(&hud.loading)) {
+        fprintf(stderr, "UI_LoadHudLoading: missing Loading.fdf\n");
+        return;
+    }
+    if (hud.loading.LoadingCustomPanel) UI_SetHidden(hud.loading.LoadingCustomPanel, false);
+    if (hud.loading.LoadingMeleePanel) UI_SetHidden(hud.loading.LoadingMeleePanel, true);
+    if (hud.loading.LoadingBar) {
+        UI_SetPortraitFrameModel(hud.loading.LoadingBar, UI_LoadModel("LoadingProgressBar", true));
+        hud.loading.LoadingBar->Type = FT_LOADING_BAR;
+    }
+}
+
+void UI_WriteLoadingLayout(LPEDICT ent) {
+    LPCMAPINFO info = level.mapinfo;
+
+    if (!ent || !hud.loading.Loading) return;
+    if (hud.loading.LoadingTitleText)
+        UI_SetText(hud.loading.LoadingTitleText, "%s", UI_LevelStringSafe(info ? info->loadingScreenTitle : NULL));
+    if (hud.loading.LoadingSubtitleText)
+        UI_SetText(hud.loading.LoadingSubtitleText, "%s", UI_LevelStringSafe(info ? info->loadingScreenSubtitle : NULL));
+    if (hud.loading.LoadingText)
+        UI_SetText(hud.loading.LoadingText, "%s", UI_LevelStringSafe(info ? info->loadingScreenText : NULL));
+    if (hud.loading.LoadingBackground && info && info->loadingScreenModel && *info->loadingScreenModel)
+        UI_SetPortraitFrameModel(hud.loading.LoadingBackground, gi.ModelIndex(info->loadingScreenModel));
+    UI_WriteLayout(ent, hud.loading.Loading, LAYER_LOADING);
+}

--- a/games/warcraft-3/game/hud/hud_loading.c
+++ b/games/warcraft-3/game/hud/hud_loading.c
@@ -16,15 +16,19 @@ void UI_LoadHudLoading(void) {
 
 void UI_WriteLoadingLayout(LPEDICT ent) {
     LPCMAPINFO info = level.mapinfo;
+    LPCSTR title = info && info->loadingScreenTitle && *info->loadingScreenTitle ? info->loadingScreenTitle :
+                   info ? info->mapName : NULL;
+    LPCSTR background = info && info->loadingScreenModel && *info->loadingScreenModel ? info->loadingScreenModel :
+                        "LoadingMeleeBackground";
 
     if (!ent || !hud.loading.Loading) return;
     if (hud.loading.LoadingTitleText)
-        UI_SetText(hud.loading.LoadingTitleText, "%s", UI_LevelStringSafe(info ? info->loadingScreenTitle : NULL));
+        UI_SetText(hud.loading.LoadingTitleText, "%s", UI_LevelStringSafe(title));
     if (hud.loading.LoadingSubtitleText)
         UI_SetText(hud.loading.LoadingSubtitleText, "%s", UI_LevelStringSafe(info ? info->loadingScreenSubtitle : NULL));
     if (hud.loading.LoadingText)
         UI_SetText(hud.loading.LoadingText, "%s", UI_LevelStringSafe(info ? info->loadingScreenText : NULL));
-    if (hud.loading.LoadingBackground && info && info->loadingScreenModel && *info->loadingScreenModel)
-        UI_SetPortraitFrameModel(hud.loading.LoadingBackground, gi.ModelIndex(info->loadingScreenModel));
+    if (hud.loading.LoadingBackground)
+        UI_SetPortraitFrameModel(hud.loading.LoadingBackground, gi.ModelIndex(background));
     UI_WriteLayout(ent, hud.loading.Loading, LAYER_LOADING);
 }

--- a/games/warcraft-3/game/hud/hud_local.h
+++ b/games/warcraft-3/game/hud/hud_local.h
@@ -18,6 +18,7 @@
 #include "../generated/alliance_dialog.h"
 #include "../generated/game_result_dialog.h"
 #include "../generated/cinematic_panel.h"
+#include "../generated/loading_screen.h"
 
 /* HUD font sizes */
 #define HUD_FONT_SIZE 10
@@ -33,6 +34,7 @@ typedef struct {
 
 /* Process-lifetime HUD bindings. memset(&hud, 0, sizeof(hud)) on map load. */
 typedef struct {
+    LoadingScreen_t loading;
     ConsoleUI_t console;
     ResourceBar_t res;
     UpperButtonBar_t upper;
@@ -99,6 +101,8 @@ DWORD UI_LiveImage(DWORD image);
 DWORD UI_LiveFont(DWORD font);
 void UI_ResetHud(void);
 void UI_LoadHud(void);
+void UI_LoadHudLoading(void);
+void UI_WriteLoadingLayout(LPEDICT ent);
 void UI_LoadHudConsole(void);
 void UI_LoadHudInfoPanel(void);
 void UI_LoadHudQuests(void);

--- a/games/warcraft-3/menu/menu_main.c
+++ b/games/warcraft-3/menu/menu_main.c
@@ -8,8 +8,6 @@
 #include "menu_local.h"
 #include "common/video_modes.h"
 #include "menu_screen.h"
-#include "common/stb_slk.h"
-#include "generated/loading_screen.h"
 
 /* Global import table filled by M_GetAPI */
 menuImport_t menuimport;
@@ -30,7 +28,6 @@ typedef struct {
 static uiState_t ui_state;
 static uiScreen_t *ui_current_screen = NULL;
 static BOOL ui_menu_commands_registered;
-static LoadingScreen_t loading_screen;
 
 /* Some classic/pre-widescreen skin tables expose only one of the paired
  * ConsoleTexture05/06 fields even though both extension tiles are installed.
@@ -96,17 +93,6 @@ static BOOL UI_IsMapCommand(LPCSTR command) {
     return *command != '\0';
 }
 
-typedef struct {
-    PATHSTR map;
-    char title[256];
-    char subtitle[256];
-    char text[1024];
-    DWORD background_model;
-    DWORD background_sequence;
-    DWORD progress_model;
-} uiLoadingState_t;
-
-static uiLoadingState_t loading_state;
 
 static void UI_SetScreen(uiScreen_t *screen) {
     uiScreen_t *previous_screen = ui_current_screen;
@@ -392,93 +378,6 @@ static void UI_ClearScreen(void) {
     UI_SetScreen(NULL);
 }
 
-/* LoadingScreens rows describe the model/sequence; TFT adds an expansion category before the display label. */
-static DWORD UI_LoadCampaignLoadingModel(DWORD background, DWORD *sequence) {
-    static stbIniCache_t data;
-    if (!data.source) Stb_IniCacheLoad(&data, "UI\\WorldEditData.txt");
-    char key[8];
-    PATHSTR model;
-    snprintf(key, sizeof(key), "%02u", (unsigned)background);
-    LPCSTR row = Stb_IniCacheFind(&data, "LoadingScreens", key);
-    if (!UI_ParseLoadingRow(row, sequence, model)) {
-        fprintf(stderr, "UI: invalid LoadingScreens[%s]: %s\n", key, row ? row : "(missing)");
-        return 0;
-    }
-    return UI_LoadModel(model, false);
-}
-
-static DWORD UI_DefaultLoadingModel(void) {
-    return UI_LoadModel("LoadingMeleeBackground", true);
-}
-
-static DWORD UI_CustomLoadingModel(LPCMAPINFO info) {
-    PATHSTR model;
-
-    if (!info || !info->loadingScreenModel || !info->loadingScreenModel[0]) {
-        return 0;
-    }
-    snprintf(model, sizeof(model), "%s", info->loadingScreenModel);
-    UI_SanitizeMapInfoText(model);
-    return model[0] ? UI_LoadModel(model, false) : 0;
-}
-
-static void UI_InitLoadingScreen(void) {
-    LoadingScreen_Load(&loading_screen);
-    if (loading_screen.LoadingCustomPanel) {
-        UI_SetHidden(loading_screen.LoadingCustomPanel, false);
-    }
-    if (loading_screen.LoadingMeleePanel) {
-        UI_SetHidden(loading_screen.LoadingMeleePanel, true);
-    }
-}
-
-static void UI_UpdateLoadingMapInfo(void) {
-    MAPINFO info;
-    LPCSTR map_path = menuimport.Cvar_String("map", "");
-    DWORD model = 0, seq = 0;
-    if (!map_path || !*map_path || !strcmp(loading_state.map, map_path)) return;
-    memset(&info, 0, sizeof(info)); memset(&loading_state, 0, sizeof(loading_state));
-    snprintf(loading_state.map, sizeof(loading_state.map), "%s", map_path);
-    if (UI_ReadMapInfo(map_path, &info)) {
-        UI_ResolveMapInfoString(&info, info.loadingScreenTitle, loading_state.title, sizeof(loading_state.title));
-        if (!loading_state.title[0]) UI_ResolveMapInfoString(&info, info.mapName, loading_state.title, sizeof(loading_state.title));
-        UI_ResolveMapInfoString(&info, info.loadingScreenSubtitle, loading_state.subtitle, sizeof(loading_state.subtitle));
-        UI_ResolveMapInfoString(&info, info.loadingScreenText, loading_state.text, sizeof(loading_state.text));
-        UI_SanitizeMapInfoText(loading_state.title); UI_SanitizeMapInfoText(loading_state.subtitle); UI_SanitizeMapInfoText(loading_state.text);
-        model = UI_CustomLoadingModel(&info);
-        if (!model && info.campaignBackgroundNumber != (DWORD)-1) model = UI_LoadCampaignLoadingModel(info.campaignBackgroundNumber, &seq);
-        UI_FreeMapInfo(&info);
-    }
-    if (!loading_state.title[0]) UI_DefaultMapName(map_path, loading_state.title, sizeof(loading_state.title));
-    loading_state.background_model = model ? model : UI_DefaultLoadingModel();
-    loading_state.background_sequence = seq;
-    loading_state.progress_model = UI_LoadModel("LoadingProgressBar", true);
-}
-
-static void M_DrawLoadingScreen(void) {
-    RECT scene;
-
-    if (!loading_screen.Loading) return;
-    if (loading_screen.LoadingBackground) {
-        snprintf(loading_screen.LoadingBackground->TextStorage, sizeof(loading_screen.LoadingBackground->TextStorage), "#!%u", (unsigned)loading_state.background_sequence);
-        loading_screen.LoadingBackground->Text = loading_screen.LoadingBackground->TextStorage;
-        loading_screen.LoadingBackground->Portrait.model = loading_state.background_model;
-    }
-    if (loading_screen.LoadingBar) {
-        FLOAT progress = menuimport.LoadingProgress ? menuimport.LoadingProgress() : 1.0f;
-        if (progress < 0.0f) progress = 0.0f;
-        if (progress > 1.0f) progress = 1.0f;
-        snprintf(loading_screen.LoadingBar->TextStorage, sizeof(loading_screen.LoadingBar->TextStorage), "#0@%.4f", progress);
-        loading_screen.LoadingBar->Text = loading_screen.LoadingBar->TextStorage;
-        loading_screen.LoadingBar->Portrait.model = loading_state.progress_model;
-    }
-    if (loading_screen.LoadingTitleText) UI_SetTextPointer(loading_screen.LoadingTitleText, loading_state.title);
-    if (loading_screen.LoadingSubtitleText) UI_SetTextPointer(loading_screen.LoadingSubtitleText, loading_state.subtitle);
-    if (loading_screen.LoadingText) UI_SetTextPointer(loading_screen.LoadingText, loading_state.text);
-    scene = UI_GetCenteredSceneRect();
-    UI_DrawFrameInScene(loading_screen.Loading, &scene);
-}
-
 /* Refresh frame state flags before dispatch so draw never asks for mouse position. */
 static void UI_UpdateMouseFrameFlags(LPCFRAMEDEF hit, BOOL clear_pressed) {
     FOR_LOOP(i, MAX_UI_CLASSES) {
@@ -502,7 +401,6 @@ static void UI_UpdateMouseFrameFlags(LPCFRAMEDEF hit, BOOL clear_pressed) {
 
 void M_Init(void) {
     memset(&ui_state, 0, sizeof(ui_state));
-    memset(&loading_state, 0, sizeof(loading_state));
     UI_ResetGlueSceneModels();
     UI_RegisterMenuCommands();
     
@@ -526,8 +424,6 @@ void M_Init(void) {
     UI_ParseFDF("UI\\FrameDef\\Glue\\TeamSetup.fdf");
     UI_ParseFDF("UI\\FrameDef\\Glue\\PlayerSlot.fdf");
     UI_ParseFDF("UI\\FrameDef\\Glue\\GameChatroom.fdf");
-    UI_ParseFDF("UI\\FrameDef\\Glue\\Loading.fdf");
-    UI_InitLoadingScreen();
     
     ui_state.initialized = true;
     ui_state.active = true;
@@ -568,12 +464,6 @@ void M_Refresh(DWORD time) {
     }
 
     ui_state.time = time;
-
-    if (menu_player && menu_player->client_ui_state == CLIENT_UI_LOADING) {
-        UI_UpdateLoadingMapInfo();
-        M_DrawLoadingScreen();
-        return;
-    }
 
     /* Call current screen refresh */
     uiScreen_t *screen = UI_GetCurrentScreen();

--- a/games/warcraft-3/tests/test_menu_fdf.c
+++ b/games/warcraft-3/tests/test_menu_fdf.c
@@ -46,7 +46,6 @@ static int test_campaign_played_mission = -1;
 static VECTOR2 test_mouse_pos;
 static LPCSTR test_map = "";
 static DWORD map_reads, texture_releases;
-static FLOAT test_loading_progress = 1.0f;
 static int fake_image_index(LPCSTR name) {
     captured_model_path = name;
     return (name && *name) ? 456 : 0;
@@ -317,10 +316,6 @@ static void test_cvar_set(LPCSTR name, LPCSTR value) {
     if (name && !strcmp(name, "fs_expansion")) test_fs_expansion = value && atoi(value) != 0;
 }
 
-static FLOAT test_get_loading_progress(void) {
-    return test_loading_progress;
-}
-
 static void load_ui_files(LPCSTR const *file_names, size_t count) {
     menuImport_t saved = menuimport;
 
@@ -361,7 +356,6 @@ static void reset_ui_state(void) {
     captured_glue_changes = 0;
     fake_texture_id = 0;
     texture_releases = map_reads = 0;
-    test_loading_progress = 1.0f;
     menu_player = NULL; test_map = "";
     test_vid_native = -1;
     hover_texture = NULL;
@@ -2698,38 +2692,6 @@ TEST(menu_fdf, deferred_texture_cache_tracks_theme_changes) {
     T_EQ(texture_releases, 1); T_EQ(fake_texture_id, 2);
     T_NOT_NULL(UI_GetTexture(index)); T_EQ(fake_texture_id, 2);
     UI_ClearTheme(); menuimport = saved;
-}
-
-/* A menu launch starts without a startup map cvar; subsequent destinations must invalidate the metadata cache. */
-TEST(menu_fdf, loading_screen_uses_current_destination_and_caches_per_map) {
-    menuImport_t saved = menuimport;
-    PLAYER player = { .client_ui_state = CLIENT_UI_LOADING };
-    reset_ui_state();
-    menuimport.FS_ReadFile = test_fs_read_file; menuimport.FS_FreeFile = test_fs_free_file;
-    menuimport.Cvar_String = test_cvar_string; menuimport.Cmd_ExecuteText = test_cmd_execute_text;
-    menuimport.LoadingProgress = test_get_loading_progress;
-    test_loading_progress = 0.375f;
-    M_Init();
-    menu_player = &player;
-    M_Refresh(0);
-    T_EQ(map_reads, 0);
-    test_map = "Maps\\Campaign\\Human02.w3m";
-    M_Refresh(1);
-    LPFRAMEDEF title = UI_FindFrame("LoadingTitleText");
-    if (require_not_null(title)) {
-        T_STREQ(title->Text, "Human02");
-        T_ASSERT(UI_FindFrame("LoadingBackground")->Portrait.model != 0);
-        T_STREQ(UI_FindFrame("LoadingBar")->Text, "#0@0.3750");
-        T_EQ(map_reads, 1);
-        M_Refresh(2); T_EQ(map_reads, 1);
-        test_map = "Maps\\Campaign\\Orc01.w3m";
-        M_Refresh(3); T_STREQ(title->Text, "Orc01"); T_EQ(map_reads, 2);
-        M_Refresh(4); T_EQ(map_reads, 2);
-        M_Init();
-        M_Refresh(5); T_EQ(map_reads, 3);
-    }
-    menu_player = NULL; test_map = "";
-    M_Shutdown(); menuimport = saved;
 }
 
 TEST(menu_fdf, loading_rows_support_roc_and_tft_schema) {

--- a/games/world-of-warcraft/game/g_ui.c
+++ b/games/world-of-warcraft/game/g_ui.c
@@ -498,6 +498,27 @@ static void UI_WriteColorRect(FLOAT x, FLOAT y, FLOAT w, FLOAT h, COLOR32 color)
     UI_WriteProxyFrame(&frame, NULL, 0);
 }
 
+/* Author the initial loading screen; only the progress value remains client-owned. */
+void UI_WriteLoadingLayout(LPEDICT ent) {
+    uiFrame_t frame = { 0 };
+    uiTextureUV_t uv = { .l = 0, .r = 1, .t = 0, .b = 1, .color = COLOR32_WHITE, .alphamode = BLEND_MODE_ALPHAKEY };
+
+    if (!ent) return;
+    UI_WriteStart(LAYER_LOADING);
+    frame.flags.type = FT_TEXTURE; frame.color = COLOR32_WHITE; frame.tex.index = gi.ImageIndex(wow_loading_texture);
+    UI_SetFrameRect(&frame, 0, 0, VW, VH); UI_WriteProxyFrame(&frame, &uv, sizeof(uv));
+    UI_WriteTextFrame(PX(164), PY(590), PW(696), PH(42), wow_loading_title,
+                      MAKE(COLOR32, 255, 215, 120, 255), FONT_JUSTIFYCENTER);
+    UI_WriteColorRect(PX(164), PY(650), PW(696), PH(12), MAKE(COLOR32, 12, 10, 8, 220));
+    memset(&frame, 0, sizeof(frame));
+    frame.flags.type = FT_LOADING_BAR;
+    frame.tex.index = gi.ImageIndex("Interface\\Glues\\LoadingBar\\Loading-Bar.blp");
+    frame.color = MAKE(COLOR32, 220, 180, 60, 255);
+    UI_SetFrameRect(&frame, PX(166), PY(652), PW(692), PH(8)); UI_WriteProxyFrame(&frame, NULL, 0);
+    UI_WriteEnd();
+    gi.unicast(ent);
+}
+
 /* Solid health/mana bar drawn as two color rects (dark background + colored fill) */
 static void UI_WriteColorBar(FLOAT x, FLOAT y, FLOAT w, FLOAT h,
                              FLOAT value, FLOAT maxvalue,

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -28,8 +28,8 @@ wowClient_t wow_clients[MAX_CLIENTS];
 /* Configstring model indices for spell impact visuals; set during map load. */
 static int wow_firebolt_impact_model = 0;
 static int wow_frostbolt_impact_model = 0;
-static char wow_loading_texture[MAX_PATHLEN] = "Interface\\Glues\\LoadingScreens\\LoadScreenEnviroment.blp";
-static char wow_loading_title[128] = "World of Warcraft";
+char wow_loading_texture[MAX_PATHLEN] = "Interface\\Glues\\LoadingScreens\\LoadScreenEnviroment.blp";
+char wow_loading_title[128] = "World of Warcraft";
 
 /* Pending cross-map teleport: set by Wow_CheckAreaTriggers / warp command before
  * gi.MenuAction("map", ...) fires; consumed once by Wow_SpawnEntities on the new map. */
@@ -2480,7 +2480,7 @@ static void Wow_ClientBegin(LPEDICT ent) {
     UI_WriteWelcomeWindow(ent);
 }
 
-static void Wow_ClientLoading(LPEDICT ent) { (void)ent; }
+static void Wow_ClientLoading(LPEDICT ent) { UI_WriteLoadingLayout(ent); }
 
 struct game_export *GetGameAPI(struct game_import *import) {
     gi = *import;

--- a/games/world-of-warcraft/game/g_wow.c
+++ b/games/world-of-warcraft/game/g_wow.c
@@ -2480,6 +2480,8 @@ static void Wow_ClientBegin(LPEDICT ent) {
     UI_WriteWelcomeWindow(ent);
 }
 
+static void Wow_ClientLoading(LPEDICT ent) { (void)ent; }
+
 struct game_export *GetGameAPI(struct game_import *import) {
     gi = *import;
     (void)gi;
@@ -2490,6 +2492,7 @@ struct game_export *GetGameAPI(struct game_import *import) {
     globals.GetThemeValue = Wow_GetThemeValue;
     globals.ClientCommand = Wow_ClientCommand;
     globals.ClientSetCameraPosition = Wow_ClientSetCameraPosition;
+    globals.ClientLoading = Wow_ClientLoading;
     globals.ClientBegin = Wow_ClientBegin;
     globals.CanSeeEntity = NULL;
     globals.CustomizeEntity = Wow_CustomizeEntity;

--- a/games/world-of-warcraft/game/g_wow_local.h
+++ b/games/world-of-warcraft/game/g_wow_local.h
@@ -7,6 +7,10 @@
 #include "common/ui_constants.h"
 #include "common/stb_dbc.h"
 
+void UI_WriteLoadingLayout(LPEDICT ent);
+extern char wow_loading_texture[MAX_PATHLEN];
+extern char wow_loading_title[128];
+
 typedef struct WOWWEAPON {
     DWORD entry;
     LPCSTR name;

--- a/games/world-of-warcraft/tests/test_wow_abilities.c
+++ b/games/world-of-warcraft/tests/test_wow_abilities.c
@@ -151,6 +151,7 @@ static HANDLE test_read_file(LPCSTR filename, LPDWORD size) {
 void UI_WriteWowHud(LPEDICT ent) { (void)ent; }
 void UI_WriteWowHover(LPEDICT ent) { (void)ent; }
 void UI_WriteWelcomeWindow(LPEDICT ent) { (void)ent; }
+void UI_WriteLoadingLayout(LPEDICT ent) { (void)ent; }
 void UI_HideWindow(LPEDICT ent, LPCSTR window_id) { (void)ent; (void)window_id; }
 
 static struct game_import test_import(void) {

--- a/games/world-of-warcraft/tests/test_wow_entities.c
+++ b/games/world-of-warcraft/tests/test_wow_entities.c
@@ -191,6 +191,7 @@ static void test_error(LPCSTR fmt, ...) {
 void UI_WriteWowHud(LPEDICT ent) { (void)ent; }
 void UI_WriteWowHover(LPEDICT ent) { (void)ent; }
 void UI_WriteWelcomeWindow(LPEDICT ent) { (void)ent; }
+void UI_WriteLoadingLayout(LPEDICT ent) { (void)ent; }
 void UI_HideWindow(LPEDICT ent, LPCSTR window_id) { (void)ent; (void)window_id; }
 
 static struct game_import test_import(void) {

--- a/server/game.h
+++ b/server/game.h
@@ -135,6 +135,7 @@ struct game_export {
     LPCSTR (*GetThemeValue)(LPCSTR filename);
     void (*ClientCommand)(LPEDICT ent, DWORD argc, LPCSTR argv[]);
     void (*ClientSetCameraPosition)(LPEDICT ent, LPCVECTOR2 position);
+    void (*ClientLoading)(LPEDICT ent);
     void (*ClientBegin)(LPEDICT ent);
     BOOL (*CanSeeEntity)(DWORD player, LPCEDICT ent);
     void (*CustomizeEntity)(DWORD player, LPCEDICT ent, LPENTITYSTATE state);

--- a/server/sv_game.c
+++ b/server/sv_game.c
@@ -148,14 +148,12 @@ void PF_Unicast(edict_t *ent) {
     }
     DWORD p = NUM_FOR_EDICT(ent);
     LPCLIENT client = NULL;
-    if (p >= 1 && p <= ge->max_clients && p <= svs.num_clients) {
+    FOR_LOOP(i, svs.num_clients)
+        if (svs.clients[i].edict == ent) { client = &svs.clients[i]; break; }
+    if (!client && p >= 1 && p <= ge->max_clients && p <= svs.num_clients)
         client = svs.clients + (p - 1);
-    } else if (svs.num_clients == 1) {
-        client = svs.clients;
-    } else {
-        SZ_Clear(&sv.multicast);
-        return;
-    }
+    if (!client && svs.num_clients == 1) client = svs.clients;
+    if (!client) { SZ_Clear(&sv.multicast); return; }
     SZ_Write(&client->netchan.message, sv.multicast.data, sv.multicast.cursize);
     SZ_Clear(&sv.multicast);
     Netchan_Transmit(NS_SERVER, &client->netchan);

--- a/server/sv_user.c
+++ b/server/sv_user.c
@@ -48,6 +48,8 @@ void SV_Configstrings_f(LPCLIENT cl, int argc, LPCSTR *argv) {
     MSG_WriteByte(&cl->netchan.message, svc_mirror);
     MSG_WriteString(&cl->netchan.message, "baselines");
     Netchan_Transmit(NS_SERVER, &cl->netchan);
+    if (!cl->edict) cl->edict = EDICT_NUM(SV_ClientPlayerNumber(cl));
+    ge->ClientLoading(cl->edict);
 }
 
 void SV_Baselines_f(LPCLIENT cl, int argc, LPCSTR *argv) {

--- a/server/sv_user.c
+++ b/server/sv_user.c
@@ -32,6 +32,8 @@ void SV_Configstrings_f(LPCLIENT cl, int argc, LPCSTR *argv) {
     (void)argc;
     (void)argv;
 
+    if (!cl->edict) cl->edict = EDICT_NUM(SV_ClientPlayerNumber(cl));
+    ge->ClientLoading(cl->edict);
     FOR_LOOP(i, MAX_CONFIGSTRINGS) {
         if (!*sv.configstrings[i])
             continue;
@@ -48,8 +50,6 @@ void SV_Configstrings_f(LPCLIENT cl, int argc, LPCSTR *argv) {
     MSG_WriteByte(&cl->netchan.message, svc_mirror);
     MSG_WriteString(&cl->netchan.message, "baselines");
     Netchan_Transmit(NS_SERVER, &cl->netchan);
-    if (!cl->edict) cl->edict = EDICT_NUM(SV_ClientPlayerNumber(cl));
-    ge->ClientLoading(cl->edict);
 }
 
 void SV_Baselines_f(LPCLIENT cl, int argc, LPCSTR *argv) {

--- a/shared/test.c
+++ b/shared/test.c
@@ -170,8 +170,8 @@ int Test_Run(const char *pattern) {
         total_asserts += test_asserts;
         if (total_failures != before) failed_tests++;
         ran++;
-        fprintf(stderr, "  %-52s %s\n", t->name,
-                (total_failures == before) ? "PASS" : "FAIL");
+        if (total_failures != before)
+            fprintf(stderr, "  %-52s FAIL\n", t->name);
     }
     test_junit_body = NULL;
     fprintf(stderr, "=== %d/%d assertions passed in %d test(s)",


### PR DESCRIPTION
Moves the Warcraft III loading screen out of libmenu and into the server-authored layout pipeline.\n\n- sends Loading.fdf after initial configstrings and before begin\n- adds the client-owned FT_LOADING_BAR presentation frame\n- keeps progress local to client media registration\n- removes menu loading state and LoadingProgress import\n- retains map-authored loading text/model data in the initial layout\n\nTests:\n- make build -j8\n- make test-menu -j8\n- make openwarcraft3-tests -j8\n- build/bin/openwarcraft3-tests -data build/tests +dedicated 1 +test 'wc3_*'\n\nThe server-network target compiled, but UDP integration tests cannot bind sockets in the sandbox.