### PR TITLE
wc3: fix Options panel morph animation

### DIFF
--- a/docs/games/warcraft-3/architecture/ui-flow.md
+++ b/docs/games/warcraft-3/architecture/ui-flow.md
@@ -132,9 +132,25 @@ The panel models animate entry and exit through staged geoset visibility/alpha; 
 their action after `Death`; screen controllers do not poll animation completion, keep pending flags, or hide their own frame trees.
 At startup `M_Init` only loads UI resources; the client's post-input `menu_main` command starts the initial transition.
 
-TopLeftPanel and TopRightPanel both author `Options Birth` and `Options Death`; neither authors an Alternate form of those phases.
-The stable Options left panel is `Options Stand Alternate`, while transition phases use the normal `Options Birth` and
-`Options Death` names. `Options Morph Alternate` is a separate authored morph and must not substitute for screen entry.
+The Options layers use different authored transitions. TopRightPanel uses `Options Birth` / `Options Stand` / `Options Death`.
+TopLeftPanel enters with `Options Morph`, holds `Options Stand Alternate`, and exits with `Options Morph Alternate`. Using the
+left layer's `Options Birth` animates the persistent sidebar rather than morphing the Options panel, while invented names such as
+`Options Birth Alternate` miss the sequence table and fall back to sequence zero (`Death`). These names and their 1000/667 ms
+intervals are present in both stock RoC and TFT panel models. Warsmash's current menu leaves Options disabled and has no Options
+transition state to copy.
+
+The right/main panel remains part of the normal `UI_GotoGluePanel` lifecycle. `OptionsMenu_Init` declares the independent left
+tab with `UI_SetGlueTab(UI_GLUE_OPTIONS)` and `OptionsMenu_Shutdown` clears it. The glue scene, not the screen controller, maps
+that declaration to Morph/Stand Alternate/Morph Alternate, so screen code does not micromanage animation phases or timing.
+
+Build with `WC3_DEBUG_GLUE=1` to log each glue phase boundary and any missing MDX sequence that falls back to sequence zero.
+The diagnostics are transition-scoped rather than frame-scoped. Rebuild when toggling the flag, then reproduce Options directly:
+
+```sh
+make -B openwarcraft3 WC3_DEBUG_GLUE=1
+build/bin/openwarcraft3 -data 'data/Warcraft III' +menu_options +com_frame_limit 100
+build/bin/openwarcraft3 -data 'data/Warcraft III' -tft +menu_options +com_frame_limit 100
+```
 
 Campaign background models render their stable `Stand` sequence. Their `Birth` durations vary by race and edition, so they are not
 part of the fixed panel-transition clock. Entering campaign selection waits for `SinglePlayer Death`; returning declares

--- a/games/warcraft-3/game.mk
+++ b/games/warcraft-3/game.mk
@@ -31,6 +31,9 @@ endif
 ifeq ($(WC3_FOW_PACKED_MASK),1)
 WC3_CFLAGS += -DWC3_FOW_PACKED_MASK
 endif
+ifeq ($(WC3_DEBUG_GLUE),1)
+WC3_CFLAGS += -DWC3_DEBUG_GLUE
+endif
 WC3_FDF_CFLAGS := $(WC3_CFLAGS) -DSTB_FDF_IMPLEMENTATION -DSTB_FDF_GLOBALS
 WC3_COMMON_SRCS := $(filter-out $(WC3_DIR)/common/routing.c,$(shell find $(WC3_DIR)/common -name '*.c' 2>/dev/null | sort))
 MENU_HEADERS := $(shell find $(WC3_DIR)/menu -name '*.h' | sort) client/menu.h

--- a/games/warcraft-3/menu/menu_glue_scene.c
+++ b/games/warcraft-3/menu/menu_glue_scene.c
@@ -26,6 +26,7 @@ typedef struct {
     LPCMODEL top_right_panel;
     uiGluePanel_t current;
     uiGluePanel_t target;
+    uiGluePanel_t left_tab;
     uiGluePanelPhase_t phase;
     DWORD phase_start;
     uiGluePanelChanged_f exited;
@@ -38,7 +39,7 @@ static uiGluePanelDef_t const glue_panels[UI_GLUE_PANEL_COUNT] = {
     [UI_GLUE_MAIN_MENU] = { .left = "MainMenu %s", .right = "MainMenu %s" },
     [UI_GLUE_REALM_SELECTION] = { .left = "RealmSelection %s", .right = "RealmSelection %s" },
     [UI_GLUE_SINGLE_PLAYER] = { .left = "SinglePlayer %s", .right = "SinglePlayer %s" },
-    [UI_GLUE_OPTIONS] = { .left = "Options %s Alternate", .right = "Options %s" },
+    [UI_GLUE_OPTIONS] = { .left = "Options %s", .right = "Options %s" },
     [UI_GLUE_SINGLE_PLAYER_SKIRMISH] = { .left = "SinglePlayerSkirmish %s", .right = "SinglePlayerSkirmish %s" },
     [UI_GLUE_MULTIPLAYER_PRE_GAME_CHAT] = { .left = "MultiplayerPreGameChat %s", .right = "MultiplayerPreGameChat %s" },
     [UI_GLUE_BATTLENET_CUSTOM] = { .left = "BattlenetCustom %s", .right = "BattlenetCustom %s" },
@@ -102,6 +103,41 @@ static LPCSTR UI_GluePanelAnimation(LPCSTR format, LPSTR anim, DWORD anim_size) 
     return anim;
 }
 
+static LPCSTR UI_GlueLeftAnimation(uiGluePanelDef_t const *panel, LPSTR anim, DWORD anim_size) {
+    LPCSTR morph;
+    DWORD duration, elapsed;
+
+    if (scene.left_tab != scene.current) return UI_GluePanelAnimation(panel->left, anim, anim_size);
+    morph = scene.phase == UI_GLUE_PANEL_IDLE ? "Stand Alternate" :
+            scene.phase == UI_GLUE_PANEL_EXIT ? "Morph Alternate" : "Morph";
+    snprintf(anim, anim_size, panel->left, morph);
+    if (scene.phase == UI_GLUE_PANEL_IDLE) return anim;
+    duration = durations[scene.phase];
+    elapsed = MIN(M_Time() - scene.phase_start, duration);
+    snprintf(anim + strlen(anim), anim_size - strlen(anim), "@%.4f", (FLOAT)elapsed / (FLOAT)duration);
+    return anim;
+}
+
+#ifdef WC3_DEBUG_GLUE
+/* Log only phase boundaries; animation strings otherwise change every rendered frame. */
+static void UI_GlueDebugPhase(LPCSTR event) {
+    char left[UI_GLUE_ANIM_NAME], right[UI_GLUE_ANIM_NAME];
+    uiGluePanelDef_t const *panel = scene.current ? &glue_panels[scene.current] : NULL;
+
+    if (!panel) {
+        fprintf(stderr, "WC3 glue: %s current=none target=%u phase=%u\n", event,
+                (unsigned)scene.target, (unsigned)scene.phase);
+        return;
+    }
+    UI_GlueLeftAnimation(panel, left, sizeof(left));
+    UI_GluePanelAnimation(panel->right, right, sizeof(right));
+    fprintf(stderr, "WC3 glue: %s current=%u target=%u phase=%s left=\"%s\" right=\"%s\"\n", event,
+            (unsigned)scene.current, (unsigned)scene.target, phases[scene.phase], left, right);
+}
+#else
+#define UI_GlueDebugPhase(EVENT) ((void)0)
+#endif
+
 
 void UI_ResetGlueSceneModels(void) {
     memset(&scene, 0, sizeof(scene));
@@ -149,6 +185,7 @@ void UI_GotoGluePanelTransition(uiGluePanel_t panel, uiGluePanelChanged_f exited
         if (exited) exited();
         scene.exited = NULL;
         scene.changed = changed;
+        UI_GlueDebugPhase("begin");
         return;
     }
     if (panel == scene.current || panel == scene.target) return;
@@ -157,6 +194,33 @@ void UI_GotoGluePanelTransition(uiGluePanel_t panel, uiGluePanelChanged_f exited
     scene.phase_start = M_Time();
     scene.exited = exited;
     scene.changed = changed;
+    UI_GlueDebugPhase("exit");
+}
+
+/* Command-line menu overrides replace the queued default before its first transition completes. */
+void UI_RetargetGluePanel(uiGluePanel_t panel, uiGluePanelChanged_f exited, uiGluePanelChanged_f changed) {
+    if (panel <= UI_GLUE_NONE || panel >= UI_GLUE_PANEL_COUNT) {
+        fprintf(stderr, "UI: unknown glue panel %u\n", (unsigned)panel);
+        return;
+    }
+    scene.current = panel;
+    scene.target = UI_GLUE_NONE;
+    scene.phase = UI_GLUE_PANEL_ENTER;
+    scene.phase_start = M_Time();
+    scene.exited = NULL;
+    scene.changed = changed;
+    if (exited) exited();
+    UI_GlueDebugPhase("retarget");
+}
+
+/* A screen declares its left tab once; the glue scene owns Morph/Stand/return sequencing. */
+void UI_SetGlueTab(uiGluePanel_t panel) {
+    if (panel < UI_GLUE_NONE || panel >= UI_GLUE_PANEL_COUNT) {
+        fprintf(stderr, "UI: unknown glue tab %u\n", (unsigned)panel);
+        return;
+    }
+    scene.left_tab = panel;
+    UI_GlueDebugPhase(panel ? "tab" : "tab-clear");
 }
 
 void UI_CloseGluePanel(uiGluePanelChanged_f changed) {
@@ -172,6 +236,7 @@ void UI_CloseGluePanel(uiGluePanelChanged_f changed) {
     scene.phase = UI_GLUE_PANEL_EXIT;
     scene.phase_start = M_Time();
     scene.changed = changed;
+    UI_GlueDebugPhase("close");
 }
 
 static void UI_GlueFinishExit(void) {
@@ -191,6 +256,7 @@ static void UI_GlueFinishExit(void) {
         if (changed) changed();
     }
     scene.phase_start = M_Time();
+    UI_GlueDebugPhase(scene.current ? "enter" : "closed");
     if (exited) exited();
 }
 
@@ -204,6 +270,7 @@ static void UI_GlueAdvanceTransition(void) {
 
         scene.phase = UI_GLUE_PANEL_IDLE;
         scene.changed = NULL;
+        UI_GlueDebugPhase("idle");
         if (changed) changed();
     }
 }
@@ -239,7 +306,7 @@ void UI_DrawGlueScene(void) {
 
     if (renderer->DrawSprite && scene.top_left_panel) {
         renderer->DrawSprite(scene.top_left_panel,
-                             UI_GluePanelAnimation(panel->left, left_anim, sizeof(left_anim)),
+                             UI_GlueLeftAnimation(panel, left_anim, sizeof(left_anim)),
                              0.0f, UI_BASE_HEIGHT);
     }
     if (renderer->DrawSprite && scene.top_right_panel) {

--- a/games/warcraft-3/menu/menu_local.h
+++ b/games/warcraft-3/menu/menu_local.h
@@ -65,6 +65,8 @@ void UI_PreloadGlueSceneModels(void);
 typedef void (*uiGluePanelChanged_f)(void);
 void UI_GotoGluePanel(uiGluePanel_t panel, uiGluePanelChanged_f changed);
 void UI_GotoGluePanelTransition(uiGluePanel_t panel, uiGluePanelChanged_f exited, uiGluePanelChanged_f changed);
+void UI_RetargetGluePanel(uiGluePanel_t panel, uiGluePanelChanged_f exited, uiGluePanelChanged_f changed);
+void UI_SetGlueTab(uiGluePanel_t panel);
 void UI_CloseGluePanel(uiGluePanelChanged_f changed);
 void UI_DrawGlueScene(void);
 BOOL UI_GetGlueScreenOffset(LPVECTOR2 offset);

--- a/games/warcraft-3/menu/menu_main.c
+++ b/games/warcraft-3/menu/menu_main.c
@@ -160,8 +160,14 @@ static void UI_FinishActionTransition(void) {
 }
 
 static void UI_TransitionToScreen(uiScreen_t *screen) {
-    if (ui_state.transition_screen || ui_state.transition_action) return;
+    /* Late +menu_* commands must be able to replace the default menu_main Birth queued by CL_Init. */
+    if (ui_state.transition_action || ui_state.transition_screen == screen) return;
     if (screen->panel == UI_GLUE_NONE) { UI_SetScreen(screen); return; }
+    if (ui_state.transition_screen) {
+        ui_state.transition_screen = screen;
+        UI_RetargetGluePanel(screen->panel, UI_BeginScreenTransition, UI_FinishScreenTransition);
+        return;
+    }
     ui_state.transition_screen = screen;
     UI_GotoGluePanelTransition(screen->panel, UI_BeginScreenTransition, UI_FinishScreenTransition);
 }

--- a/games/warcraft-3/menu/screens/options_menu.c
+++ b/games/warcraft-3/menu/screens/options_menu.c
@@ -321,6 +321,7 @@ static void OptionsMenu_SetPanel(optionsPanel_t panel) {
 static void OptionsMenu_Init(void) {
     mi.Printf("OptionsMenu_Init\n");
     current_panel = OPTIONS_PANEL_GAMEPLAY;
+    UI_SetGlueTab(UI_GLUE_OPTIONS);
 
     UI_SetOnClick(options_menu.GameplayButton, "menu_options_gameplay");
     UI_SetOnClick(options_menu.VideoButton, "menu_video");
@@ -336,6 +337,7 @@ static void OptionsMenu_Init(void) {
 }
 
 static void OptionsMenu_Shutdown(void) {
+    UI_SetGlueTab(UI_GLUE_NONE);
 }
 
 static void OptionsMenu_Refresh(int msec) {

--- a/games/warcraft-3/renderer/mdx/r_mdx_render.c
+++ b/games/warcraft-3/renderer/mdx/r_mdx_render.c
@@ -161,6 +161,22 @@ static mdxSequence_t const *R_SelectUISequence(mdxModel_t const *mdx, LPCSTR ani
             }
         }
     }
+#ifdef WC3_DEBUG_GLUE
+    if (!seq && anim && *anim && mdx->sequences && mdx->num_sequences > 0) {
+        static char last_missing[sizeof(mdxObjectName_t) + 1];
+        char missing[sizeof(last_missing)];
+        LPCSTR ratio = strchr(anim, '@');
+        size_t len = ratio ? (size_t)(ratio - anim) : strlen(anim);
+
+        len = MIN(len, sizeof(missing) - 1);
+        memcpy(missing, anim, len); missing[len] = '\0';
+        if (strcmp(last_missing, missing)) {
+            fprintf(stderr, "WC3 glue: missing sequence \"%s\"; falling back to sequence 0 \"%s\"\n",
+                    missing, mdx->sequences[0].name);
+            snprintf(last_missing, sizeof(last_missing), "%s", missing);
+        }
+    }
+#endif
     if (!seq && mdx->sequences && mdx->num_sequences > 0) {
         seq = &mdx->sequences[0];
     }

--- a/games/warcraft-3/tests/test_menu_fdf.c
+++ b/games/warcraft-3/tests/test_menu_fdf.c
@@ -2098,14 +2098,14 @@ TEST(menu_fdf, main_menu_realm_select_uses_realm_panel_anim) {
     captured_realm_panel_sprites = 0;
     captured_sprite_calls = 0;
     captured_death_sprites = 0;
-    mainMenuScreen.draw();
+    UI_DrawGlueScene();
     T_EQ(captured_death_sprites, 2);
     M_SetActive(true);
     M_Refresh(M_Time() + 667);
     M_Refresh(M_Time() + 1000);
     captured_stand_sprites = 0;
     captured_realm_panel_sprites = 0;
-    mainMenuScreen.draw();
+    UI_DrawGlueScene();
     T_EQ(captured_stand_sprites, 0);
     T_EQ(captured_realm_panel_sprites, 2);
     mi = saved;
@@ -2168,7 +2168,7 @@ TEST(menu_fdf, initial_glue_panel_finishes_birth_before_opening_screen) {
     mi = saved;
 }
 
-TEST(menu_fdf, options_glue_panel_uses_authored_birth_sequences) {
+TEST(menu_fdf, options_glue_panel_uses_authored_morph_transitions) {
     menuImport_t saved = mi;
     VECTOR2 offset;
 
@@ -2177,9 +2177,11 @@ TEST(menu_fdf, options_glue_panel_uses_authored_birth_sequences) {
     mi.GetRenderer = test_get_renderer;
     UI_ResetGlueSceneModels();
 
-    UI_GotoGluePanel(UI_GLUE_OPTIONS, NULL);
+    UI_GotoGluePanel(UI_GLUE_MAIN_MENU, NULL);
+    UI_RetargetGluePanel(UI_GLUE_OPTIONS, NULL, NULL);
+    UI_SetGlueTab(UI_GLUE_OPTIONS);
     UI_DrawGlueScene();
-    T_STREQ(captured_sprite_anim[0], "Options Birth@0.0000");
+    T_STREQ(captured_sprite_anim[0], "Options Morph@0.0000");
     T_STREQ(captured_sprite_anim[1], "Options Birth@0.0000");
     T_ASSERT(UI_GetGlueScreenOffset(&offset));
     T_FEQ(offset.y, -UI_BASE_HEIGHT, 0.0001f);
@@ -2192,6 +2194,12 @@ TEST(menu_fdf, options_glue_panel_uses_authored_birth_sequences) {
     UI_DrawGlueScene();
     T_STREQ(captured_sprite_anim[0], "Options Stand Alternate");
     T_ASSERT(!UI_GetGlueScreenOffset(&offset));
+
+    UI_GotoGluePanel(UI_GLUE_MAIN_MENU, NULL);
+    captured_sprite_calls = 0;
+    UI_DrawGlueScene();
+    T_STREQ(captured_sprite_anim[0], "Options Morph Alternate@0.0000");
+    T_STREQ(captured_sprite_anim[1], "Options Death@0.0000");
 
     UI_ResetGlueSceneModels();
     mi = saved;
@@ -2239,7 +2247,7 @@ TEST(menu_fdf, main_menu_edition_button_defers_restart_after_death_frame) {
 
     M_MenuCommand(edition->OnClick);
     T_STREQ(captured_command, "");
-    mainMenuScreen.draw();
+    UI_DrawGlueScene();
     T_EQ(captured_death_sprites, 2);
     T_ASSERT(!test_fs_expansion);
     T_STREQ(captured_command, "");


### PR DESCRIPTION
## Summary
- split the Options left tab animation from the right/main glue panel lifecycle
- use the authored `Options Morph` / `Options Stand Alternate` / `Options Morph Alternate` sequence chain
- preserve `Options Birth` / `Options Stand` / `Options Death` for the right panel
- allow `+menu_options` to replace the queued startup Main Menu transition
- add opt-in `WC3_DEBUG_GLUE=1` transition and missing-sequence diagnostics
- document the authoritative ROC/TFT sequence contract and Warsmash reference gap

## Validation
- `make test-menu` (726/726 assertions)
- `make test` (23127/23127 assertions)