### PR TITLE
Restore Smart bridge clicks and shared minimap focus input

### DIFF
--- a/client/cl_input.c
+++ b/client/cl_input.c
@@ -197,6 +197,7 @@ static void CL_EndPan(void) {
 static void CL_SendSmartCommand(float x, float y) {
     DWORD entnum;
     VECTOR3 point;
+    BOOL have_point;
 
     if (!CL_GameplayInputReady()) {
         return;
@@ -204,11 +205,18 @@ static void CL_SendSmartCommand(float x, float y) {
     if (CL_MouseOverGameplayUI()) {
         return;
     }
+    /* Preserve the clicked ground point with an entity hit so walkable bridge
+     * entities can fall back to their ground-move semantics on the server. */
+    have_point = re.TraceLocation(&cl.viewDef, x, y, &point);
     if (re.TraceEntity(&cl.viewDef, x, y, &entnum)) {
         MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
-        SZ_Printf(&cls.netchan.message, CL_OrderQueueModifierDown()
-            ? "smart %d queue" : "smart %d", entnum);
-    } else if (re.TraceLocation(&cl.viewDef, x, y, &point)) {
+        if (have_point)
+            SZ_Printf(&cls.netchan.message, CL_OrderQueueModifierDown()
+                ? "smart %d %d %d queue" : "smart %d %d %d", entnum, (int)point.x, (int)point.y);
+        else
+            SZ_Printf(&cls.netchan.message, CL_OrderQueueModifierDown()
+                ? "smart %d queue" : "smart %d", entnum);
+    } else if (have_point) {
         MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
         SZ_Printf(&cls.netchan.message, CL_OrderQueueModifierDown()
             ? "smartpoint %d %d queue" : "smartpoint %d %d",
@@ -706,14 +714,14 @@ void IN_SelectDown(void) {
         cl.selection.in_progress = false;
         return;
     }
-    if (CL_MouseOverGameplayUI()) return;
-    input.select = true;
-    if (CL_SelectionLimit() == 1) return;
     /* A left-click on the minimap recenters the camera instead of selecting. */
     if (CL_TryMinimapClick(mouse.origin.x, mouse.origin.y)) {
         cl.selection.in_progress = false;
         return;
     }
+    if (CL_MouseOverGameplayUI()) return;
+    input.select = true;
+    if (CL_SelectionLimit() == 1) return;
     cl.selection.in_progress = true;
     cl.selection.rect.x = mouse.origin.x;
     cl.selection.rect.y = mouse.origin.y;
@@ -728,6 +736,7 @@ void IN_SelectDown(void) {
 void IN_SelectUp(void) {
     BOOL held = input.select;
     input.select = false;
+    CL_EndMinimapDrag();
     if (CL_SelectionLimit() == 1) {
         if (!held || !CL_GameplayInputReady() || CL_MouseOverGameplayUI()) return;
         VECTOR2 delta = { mouse.origin.x - input.down.x, mouse.origin.y - input.down.y };
@@ -869,6 +878,79 @@ static bool CL_TestPlane(viewDef_t const *view, float x, float y, LPVECTOR3 poin
     (void)view; (void)x; (void)y;
     pan_plane++; *point = (VECTOR3){ 4, 5, 6 }; return true;
 }
+static bool CL_TestSmartEntity(viewDef_t const *view, float x, float y, LPDWORD number) {
+    (void)view; (void)x; (void)y; *number = 42; return true;
+}
+static bool CL_TestSmartLocation(viewDef_t const *view, float x, float y, LPVECTOR3 point) {
+    (void)view; (void)x; (void)y; *point = (VECTOR3){ 123, 456, 0 }; return true;
+}
+static bool CL_TestNoLocation(viewDef_t const *view, float x, float y, LPVECTOR3 point) {
+    (void)view; (void)x; (void)y; (void)point; return false;
+}
+static bool CL_TestMinimap(float x, float y, LPVECTOR2 point) {
+    (void)x; (void)y; *point = (VECTOR2){ 300, 400 }; return true;
+}
+static size2_t CL_TestWindowSize(void) { return (size2_t){ 1024, 768 }; }
+static void CL_TestUnitUI(DWORD count, menuUnitData_t *units) { (void)count; (void)units; }
+
+TEST(client_input, smart_entity_click_preserves_ground_point) {
+    BYTE data[256];
+    BYTE old_sel[sizeof(cl.selection)];
+    sizeBuf_t old_msg = cls.netchan.message;
+    refExport_t saved = re;
+    menuExport_t old_menu = menu;
+    int old_state = cls.state, old_dest = cls.key_dest;
+    BOOL old_focus = input.focus;
+    char command[128];
+
+    re.TraceEntity = CL_TestSmartEntity; re.TraceLocation = CL_TestSmartLocation;
+    re.GetWindowSize = CL_TestWindowSize;
+    menu.UpdateUnitUI = CL_TestUnitUI;
+    cls.state = ca_active; cls.key_dest = key_game; cl.playerstate.client_ui_state = CLIENT_UI_GAME;
+    memcpy(old_sel, &cl.selection, sizeof(old_sel));
+    input.focus = true; cl.selection.num_selected = 0;
+    SZ_Init(&cls.netchan.message, data, sizeof(data));
+    CL_SendSmartCommand(10, 20);
+    T_EQ(MSG_ReadByte(&cls.netchan.message), clc_stringcmd);
+    MSG_ReadString(&cls.netchan.message, command);
+    T_STREQ(command, "smart 42 123 456");
+    SZ_Init(&cls.netchan.message, data, sizeof(data)); re.TraceLocation = CL_TestNoLocation;
+    CL_SendSmartCommand(10, 20);
+    T_EQ(MSG_ReadByte(&cls.netchan.message), clc_stringcmd);
+    MSG_ReadString(&cls.netchan.message, command);
+    T_STREQ(command, "smart 42");
+    memcpy(&cl.selection, old_sel, sizeof(old_sel));
+    menu = old_menu; re = saved; cls.netchan.message = old_msg;
+    cls.state = old_state; cls.key_dest = old_dest; input.focus = old_focus;
+}
+
+TEST(client_input, minimap_click_precedes_single_selection_ui_block) {
+    BYTE data[256];
+    BYTE old_sel[sizeof(cl.selection)];
+    sizeBuf_t old_msg = cls.netchan.message;
+    refExport_t saved = re;
+    int old_state = cls.state, old_dest = cls.key_dest, old_limit = Cvar_Integer("cl_selection_limit", 64);
+    BOOL old_focus = input.focus;
+    VECTOR3 old_origin = cl.viewDef.camerastate[0].origin;
+    VECTOR2 expected = CL_ClampCameraPosition((VECTOR2){ 300, 400 });
+    memcpy(old_sel, &cl.selection, sizeof(old_sel));
+    re.TraceMinimap = CL_TestMinimap; re.GetWindowSize = CL_TestWindowSize;
+    cls.state = ca_active; cls.key_dest = key_game; cl.playerstate.client_ui_state = CLIENT_UI_GAME;
+    input.focus = true; input.select = false; cl.selection.in_progress = false;
+    Cvar_Set("cl_selection_limit", "1");
+    SZ_Init(&cls.netchan.message, data, sizeof(data));
+    mouse.origin = (VECTOR2){ 10, 20 };
+    IN_SelectDown(); IN_SelectUp();
+    T_FEQ(cl.viewDef.camerastate[0].origin.x, expected.x, 0.001f);
+    T_FEQ(cl.viewDef.camerastate[0].origin.y, expected.y, 0.001f);
+    T_ASSERT(!cl.selection.in_progress);
+    T_EQ(cls.netchan.message.cursize > 0, true);
+    cl.viewDef.camerastate[0].origin = old_origin; cl.viewDef.camerastate[1].origin = old_origin;
+    memcpy(&cl.selection, old_sel, sizeof(old_sel));
+    Cvar_SetValue("cl_selection_limit", old_limit);
+    re = saved; cls.netchan.message = old_msg; cls.state = old_state; cls.key_dest = old_dest; input.focus = old_focus;
+}
+
 TEST(client_input, pan_uses_configured_surface) {
     refExport_t saved = re;
     FLOAT old = Cvar_Value("cl_camera_pan_plane", 0);

--- a/client/cl_input.c
+++ b/client/cl_input.c
@@ -205,8 +205,7 @@ static void CL_SendSmartCommand(float x, float y) {
     if (CL_MouseOverGameplayUI()) {
         return;
     }
-    /* Preserve the clicked ground point with an entity hit so walkable bridge
-     * entities can fall back to their ground-move semantics on the server. */
+    /* Send both trace results; the game owns entity-versus-point order semantics. */
     have_point = re.TraceLocation(&cl.viewDef, x, y, &point);
     if (re.TraceEntity(&cl.viewDef, x, y, &entnum)) {
         MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
@@ -714,7 +713,7 @@ void IN_SelectDown(void) {
         cl.selection.in_progress = false;
         return;
     }
-    /* A left-click on the minimap recenters the camera instead of selecting. */
+    /* Minimap focus precedes world selection and its HUD blocker, regardless of selection capacity. */
     if (CL_TryMinimapClick(mouse.origin.x, mouse.origin.y)) {
         cl.selection.in_progress = false;
         return;
@@ -736,6 +735,7 @@ void IN_SelectDown(void) {
 void IN_SelectUp(void) {
     BOOL held = input.select;
     input.select = false;
+    /* Release the shared drag before either selection path can return. */
     CL_EndMinimapDrag();
     if (CL_SelectionLimit() == 1) {
         if (!held || !CL_GameplayInputReady() || CL_MouseOverGameplayUI()) return;
@@ -746,7 +746,6 @@ void IN_SelectUp(void) {
         CL_ApplySelection(&entnum, hit ? 1 : 0);
         return;
     }
-    CL_EndMinimapDrag();
     if (!CL_GameplayInputReady()) {
         cl.selection.in_progress = false;
         return;
@@ -888,67 +887,100 @@ static bool CL_TestNoLocation(viewDef_t const *view, float x, float y, LPVECTOR3
     (void)view; (void)x; (void)y; (void)point; return false;
 }
 static bool CL_TestMinimap(float x, float y, LPVECTOR2 point) {
-    (void)x; (void)y; *point = (VECTOR2){ 300, 400 }; return true;
+    (void)y; *point = (VECTOR2){ 300, 400 }; return x >= 0;
 }
 static size2_t CL_TestWindowSize(void) { return (size2_t){ 1024, 768 }; }
-static void CL_TestUnitUI(DWORD count, menuUnitData_t *units) { (void)count; (void)units; }
 
+/* Exercise the wire command without letting transient input state leak into later suites. */
 TEST(client_input, smart_entity_click_preserves_ground_point) {
     BYTE data[256];
-    BYTE old_sel[sizeof(cl.selection)];
+    __typeof__(cl.selection) old_sel = cl.selection;
     sizeBuf_t old_msg = cls.netchan.message;
     refExport_t saved = re;
-    menuExport_t old_menu = menu;
-    int old_state = cls.state, old_dest = cls.key_dest;
+    int old_state = cls.state, old_dest = cls.key_dest, old_ui = cl.playerstate.client_ui_state;
     BOOL old_focus = input.focus;
+    SDL_Keymod old_mod = SDL_GetModState();
     char command[128];
 
     re.TraceEntity = CL_TestSmartEntity; re.TraceLocation = CL_TestSmartLocation;
     re.GetWindowSize = CL_TestWindowSize;
-    menu.UpdateUnitUI = CL_TestUnitUI;
     cls.state = ca_active; cls.key_dest = key_game; cl.playerstate.client_ui_state = CLIENT_UI_GAME;
-    memcpy(old_sel, &cl.selection, sizeof(old_sel));
     input.focus = true; cl.selection.num_selected = 0;
-    SZ_Init(&cls.netchan.message, data, sizeof(data));
-    CL_SendSmartCommand(10, 20);
-    T_EQ(MSG_ReadByte(&cls.netchan.message), clc_stringcmd);
-    MSG_ReadString(&cls.netchan.message, command);
-    T_STREQ(command, "smart 42 123 456");
+    FOR_LOOP(i, 2) {
+        SDL_SetModState(i ? KMOD_LSHIFT : KMOD_NONE);
+        SZ_Init(&cls.netchan.message, data, sizeof(data));
+        CL_SendSmartCommand(10, 20);
+        T_EQ(MSG_ReadByte(&cls.netchan.message), clc_stringcmd);
+        MSG_ReadString(&cls.netchan.message, command);
+        T_STREQ(command, i ? "smart 42 123 456 queue" : "smart 42 123 456");
+        T_EQ(cls.netchan.message.readcount, cls.netchan.message.cursize);
+    }
+    SDL_SetModState(KMOD_NONE);
     SZ_Init(&cls.netchan.message, data, sizeof(data)); re.TraceLocation = CL_TestNoLocation;
     CL_SendSmartCommand(10, 20);
     T_EQ(MSG_ReadByte(&cls.netchan.message), clc_stringcmd);
     MSG_ReadString(&cls.netchan.message, command);
     T_STREQ(command, "smart 42");
-    memcpy(&cl.selection, old_sel, sizeof(old_sel));
-    menu = old_menu; re = saved; cls.netchan.message = old_msg;
+    cl.selection = old_sel; re = saved; cls.netchan.message = old_msg;
     cls.state = old_state; cls.key_dest = old_dest; input.focus = old_focus;
+    cl.playerstate.client_ui_state = old_ui; SDL_SetModState(old_mod);
 }
 
-TEST(client_input, minimap_click_precedes_single_selection_ui_block) {
+/* Minimap focus is shared input: selection capacity cannot change its packet or drag lifecycle. */
+TEST(client_input, minimap_focus_and_release_are_selection_independent) {
     BYTE data[256];
-    BYTE old_sel[sizeof(cl.selection)];
+    __typeof__(cl.selection) old_sel = cl.selection;
+    __typeof__(cl.camera_prediction) old_pred = cl.camera_prediction;
+    __typeof__(input) old_input = input;
+    viewDef_t old_view = cl.viewDef;
+    mouseEvent_t old_mouse = mouse;
     sizeBuf_t old_msg = cls.netchan.message;
     refExport_t saved = re;
-    int old_state = cls.state, old_dest = cls.key_dest, old_limit = Cvar_Integer("cl_selection_limit", 64);
-    BOOL old_focus = input.focus;
-    VECTOR3 old_origin = cl.viewDef.camerastate[0].origin;
+    int old_state = cls.state, old_dest = cls.key_dest, old_ui = cl.playerstate.client_ui_state;
+    int old_limit = Cvar_Integer("cl_selection_limit", 64);
     VECTOR2 expected = CL_ClampCameraPosition((VECTOR2){ 300, 400 });
-    memcpy(old_sel, &cl.selection, sizeof(old_sel));
+    INPUTCMD cmd;
+
     re.TraceMinimap = CL_TestMinimap; re.GetWindowSize = CL_TestWindowSize;
     cls.state = ca_active; cls.key_dest = key_game; cl.playerstate.client_ui_state = CLIENT_UI_GAME;
     input.focus = true; input.select = false; cl.selection.in_progress = false;
-    Cvar_Set("cl_selection_limit", "1");
-    SZ_Init(&cls.netchan.message, data, sizeof(data));
     mouse.origin = (VECTOR2){ 10, 20 };
-    IN_SelectDown(); IN_SelectUp();
-    T_FEQ(cl.viewDef.camerastate[0].origin.x, expected.x, 0.001f);
-    T_FEQ(cl.viewDef.camerastate[0].origin.y, expected.y, 0.001f);
-    T_ASSERT(!cl.selection.in_progress);
-    T_EQ(cls.netchan.message.cursize > 0, true);
-    cl.viewDef.camerastate[0].origin = old_origin; cl.viewDef.camerastate[1].origin = old_origin;
-    memcpy(&cl.selection, old_sel, sizeof(old_sel));
+    FOR_LOOP(i, 2) {
+        Cvar_SetValue("cl_selection_limit", i ? 64 : 1);
+        SZ_Init(&cls.netchan.message, data, sizeof(data));
+        IN_SelectDown();
+        T_ASSERT(!input.select && !cl.selection.in_progress);
+        T_EQ(MSG_ReadByte(&cls.netchan.message), clc_input);
+        T_ASSERT(MSG_ReadInput(&cls.netchan.message, &cmd));
+        T_EQ(cmd.action, BZ_INPUT_FOCUS);
+        T_FEQ(cmd.focus.x, expected.x, 0.001f); T_FEQ(cmd.focus.y, expected.y, 0.001f);
+        T_EQ(cls.netchan.message.readcount, cls.netchan.message.cursize);
+        FOR_LOOP(j, 2) {
+            T_FEQ(cl.viewDef.camerastate[j].origin.x, expected.x, 0.001f);
+            T_FEQ(cl.viewDef.camerastate[j].origin.y, expected.y, 0.001f);
+        }
+        SZ_Init(&cls.netchan.message, data, sizeof(data));
+        CL_UpdateMinimapDrag(30, 40);
+        T_EQ(MSG_ReadByte(&cls.netchan.message), clc_input);
+        T_ASSERT(MSG_ReadInput(&cls.netchan.message, &cmd));
+        T_EQ(cmd.action, BZ_INPUT_FOCUS);
+        IN_SelectUp();
+        SZ_Init(&cls.netchan.message, data, sizeof(data));
+        CL_UpdateMinimapDrag(50, 60);
+        T_EQ(cls.netchan.message.cursize, 0);
+        T_ASSERT(!CL_TryMinimapClick(-1, 20));
+        CL_UpdateMinimapDrag(50, 60);
+        T_EQ(cls.netchan.message.cursize, 0);
+        cls.key_dest = key_menu;
+        IN_SelectDown(); IN_SelectUp();
+        T_EQ(cls.netchan.message.cursize, 0);
+        cls.key_dest = key_game;
+    }
+    cl.selection = old_sel; cl.camera_prediction = old_pred; cl.viewDef = old_view;
+    input = old_input; mouse = old_mouse;
     Cvar_SetValue("cl_selection_limit", old_limit);
-    re = saved; cls.netchan.message = old_msg; cls.state = old_state; cls.key_dest = old_dest; input.focus = old_focus;
+    re = saved; cls.netchan.message = old_msg; cls.state = old_state; cls.key_dest = old_dest;
+    cl.playerstate.client_ui_state = old_ui;
 }
 
 TEST(client_input, pan_uses_configured_surface) {

--- a/client/cl_minimap.c
+++ b/client/cl_minimap.c
@@ -127,7 +127,8 @@ void CL_LayoutDrawMinimap(LPCUIFRAME frame, LPCRECT screen) {
 /* Left-click (or click-drag) on the minimap recenters the camera there. */
 BOOL CL_TryMinimapClick(float x, float y) {
     VECTOR2 world;
-    if (!CL_GameplayInputReady() || !re.TraceMinimap || !re.TraceMinimap(x, y, &world)) return false;
+    /* TraceMinimap is mandatory; its result reports whether a minimap was hit. */
+    if (!CL_GameplayInputReady() || !re.TraceMinimap(x, y, &world)) return false;
     minimap_drag_active = true;
     CL_SetCameraPosition(world);
     return true;
@@ -135,7 +136,7 @@ BOOL CL_TryMinimapClick(float x, float y) {
 
 void CL_UpdateMinimapDrag(float x, float y) {
     VECTOR2 world;
-    if (!minimap_drag_active || !re.TraceMinimap || !re.TraceMinimap(x, y, &world)) return;
+    if (!minimap_drag_active || !re.TraceMinimap(x, y, &world)) return;
     CL_SetCameraPosition(world);
 }
 

--- a/docs/architecture/shared-input.md
+++ b/docs/architecture/shared-input.md
@@ -107,6 +107,31 @@ Clicks and group recalls share `cl.selection`. `Wow_SelectEntity` emits the exis
 cycling, interaction, and rejected selections reconcile that cache. Game rules remain authoritative. Group membership
 resets at map boundaries and is not pruned merely because a snapshot cannot currently see a member.
 
+## Minimap and context-click routing
+
+Minimap interaction is shared by every client build, independently of `cl_selection_limit`. `IN_SelectDown`
+checks the minimap before the world-selection HUD blocker; otherwise an authored texture behind the minimap
+can swallow the click. `IN_SelectUp` ends the minimap drag before either single- or multi-selection returns.
+Gameplay/menu/modal ownership still gates entry, and `CL_ResetInput` cancels drags when ownership changes.
+
+`client/cl_minimap.c` calls the mandatory `re.TraceMinimap` export. A false trace result means no minimap hit;
+an absent function pointer is an incomplete renderer API, not an optional feature. The renderer owns screen/world
+conversion and the drawn minimap bounds; the client does not duplicate game layout geometry or inspect game names.
+`CL_SetCameraPosition` predicts focus and writes `clc_input` with `BZ_INPUT_FOCUS`. Server transport delivers that
+typed input to `game_export.ClientInput`. WC3 and SC2 resolve controller focus there; WoW deliberately ignores free
+focus because its camera follows its actor. Availability of a shared minimap does not override that game policy.
+
+Smart entity clicks preserve both available renderer results in the existing `clc_stringcmd` command:
+`smart <entity> <x> <y> [queue]`. Without a point hit the command remains `smart <entity> [queue]`.
+The shared client does not classify bridges/destructables or choose attack versus movement. WC3 resolves its SLK
+walkability and attack rules on the server and uses its existing queued-order/formation path for point movement;
+see [order queues](../games/warcraft-3/order-queue.md). No new game-specific callback or snapshot field is required.
+
+The `client_input` tests decode the focus packet, exercise selection capacities 1 and 64, drag/release, a missed
+minimap trace, menu ownership, and Smart commands with/without traced points and Shift. A bounded diagnostic run
+with `+test 'client_input.*' +com_frame_limit 100` confirmed the focus channel before the old optional-callback
+guards and duplicate release were removed. Investigative logs are not retained in source.
+
 ## Order-marker media
 
 `CS_ORDER_MARKER` (slot 11) carries the server-authored point-order model path. WC3 resolves `TargetPointConfirm`

--- a/docs/games/warcraft-3/order-queue.md
+++ b/docs/games/warcraft-3/order-queue.md
@@ -26,12 +26,14 @@ The client does not mutate a unit queue directly. When Shift is down, it sends t
 
 ```text
 smart 57 queue
+smart 57 1024 768 queue
 smartpoint 1024 768 queue
 select 57 queue
 point 1024 768 queue
 ```
 
-Without Shift, the original command syntax is unchanged.
+Entity Smart clicks may also carry the traced world point as `smart <entity> <x> <y>`. The game normally resolves the entity target exactly as before; the point is only a fallback for an alive walkable destructable whose entity Smart action is rejected. This lets a bridge remain non-attackable by right-click while the same click still becomes formation-aware ground movement to the clicked deck position. Without Shift the corresponding form is `smart 57 1024 768`.
+
 
 `select` and `point` are also used to finish command-card targeting. `menu_t.supports_order_queue` gates the modifier on the server, so only an explicitly queue-capable targeting mode treats Shift as order queuing. Move and Attack set that flag. Other target modes ignore `queue`, preserving their existing lifecycle until their reservation/cost semantics are implemented deliberately.
 

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -616,6 +616,11 @@ CLIENTCOMMAND(Smart) {
         have_click_point = true;
     }
     FOR_CONTROLLABLE_SELECTED_UNITS(client, ent) {
+        /* A queued Smart target is otherwise accepted into the FIFO before
+         * its destructable semantics are evaluated, preventing the clicked
+         * walkable surface from falling back to the queued ground move. */
+        if (queued && have_click_point && G_DestructableIsWalkable(target) &&
+            !G_DestructableAcceptsSmartAttack(ent, target)) continue;
         if (G_IssueUnitTargetOrder(ent, "smart", target, queued, client->ps.number)) {
             if (G_UnitHasRally(ent)) rallied = true;
             issued = true;

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -591,6 +591,8 @@ CLIENTCOMMAND(Smart) {
     BOOL issued = false;
     BOOL rallied = false;
     BOOL queued;
+    BOOL have_click_point = false;
+    VECTOR2 click_point = { 0 };
     DWORD number;
     LPEDICT target;
 
@@ -609,11 +611,25 @@ CLIENTCOMMAND(Smart) {
     }
     target = &globals.edicts[number];
     queued = G_CommandQueueRequested(argc, argv, 2);
+    if (argc >= 4 && strcmp(argv[2], "queue") && strcmp(argv[3], "queue")) {
+        click_point = (VECTOR2){ atoi(argv[2]), atoi(argv[3]) };
+        have_click_point = true;
+    }
     FOR_CONTROLLABLE_SELECTED_UNITS(client, ent) {
         if (G_IssueUnitTargetOrder(ent, "smart", target, queued, client->ps.number)) {
             if (G_UnitHasRally(ent)) rallied = true;
             issued = true;
         }
+    }
+    /* A live walkable destructable is also traversable ground. If its entity
+     * Smart action was rejected, preserve the world point under the cursor and
+     * run the normal formation-aware ground Smart path instead. Keep the
+     * gameplay decision on destructable state rather than presentation flags. */
+    if (!issued && have_click_point && G_DestructableIsWalkable(target)) {
+        BOOL const old_queued = client->menu.order_queued;
+        client->menu.order_queued = queued;
+        issued = move_selectlocation(clent, &click_point);
+        client->menu.order_queued = old_queued;
     }
     if (issued) {
         G_QueueOrderSound(G_GetMainControllableUnit(client));

--- a/games/warcraft-3/game/g_destructable.c
+++ b/games/warcraft-3/game/g_destructable.c
@@ -100,6 +100,11 @@ BOOL G_DestructableIsAttackable(LPCEDICT ent) {
         !(ent->s.flags & EF_NOT_SELECTABLE);
 }
 
+BOOL G_DestructableIsWalkable(LPCEDICT ent) {
+    return G_IsDestructable(ent) && ent->data.DestructableData->walkable &&
+        ent->destructable.placement_solid && !ent->destructable.dead;
+}
+
 /* Warcraft targetflag values from common.j/common.txt.  TARGTYPE is an
  * internal enum, so its ordinal must not be used as the attack-mask bit. */
 static DWORD G_DestructableTargetFlag(TARGTYPE type) {

--- a/games/warcraft-3/game/g_items.c
+++ b/games/warcraft-3/game/g_items.c
@@ -128,7 +128,11 @@ BOOL G_IsItem(LPCEDICT item) {
     if (!item || !item->inuse || !item->class_id) {
         return false;
     }
-    return item->item.in_world || item->item.carrier || item->data.ItemData->file != NULL;
+    /* The item state shares storage with other entity kinds; classify by the
+     * target type before reading it so destructables cannot be mistaken for
+     * items and dereference the wrong data union member. */
+    return item->targtype == TARG_ITEM &&
+        (item->item.in_world || item->item.carrier || (item->data.ItemData && item->data.ItemData->file));
 }
 
 static DWORD G_InventoryRequiredUpgrade(DWORD ability_id) {

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -2128,6 +2128,7 @@ void G_ActivateScriptedDestructable(LPEDICT ent,
                                     DWORD variation);
 BOOL G_IsDestructable(LPCEDICT ent);
 BOOL G_DestructableIsAttackable(LPCEDICT ent);
+BOOL G_DestructableIsWalkable(LPCEDICT ent);
 BOOL G_DestructableCanBeAttackedBy(LPCEDICT attacker, LPCEDICT target);
 BOOL G_DestructableAcceptsSmartAttack(LPCEDICT attacker, LPCEDICT target);
 void G_InitializeDestructablePlacement(LPEDICT ent, LPCDOODAD placement);

--- a/games/warcraft-3/game/tests/t_api.c
+++ b/games/warcraft-3/game/tests/t_api.c
@@ -2579,6 +2579,7 @@ static LPEDICT alloc_inventory_test_unit(void) {
 static LPEDICT alloc_world_test_item(DWORD class_id) {
     LPEDICT item = alloc_test_unit(class_id, 0, 0);
     item->s.model = 1;
+    item->targtype = TARG_ITEM;
     item->item.in_world = true;
     item->item.inventory_slot = -1;
     return item;

--- a/games/warcraft-3/game/tests/t_movement.c
+++ b/games/warcraft-3/game/tests/t_movement.c
@@ -1756,7 +1756,7 @@ TEST(wc3_movement, smart_walkable_debris_keeps_entity_attack_precedence) {
     unit = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0.0f, 0.0f);
     unit->stand = unit_stand;
     unit_stand(unit);
-    unit->attack1.type = ATK_MELEE;
+    unit->attack1.type = ATK_NORMAL;
     unit->attack1.targetsAllowed = 256u; /* debris */
     debris = make_smart_destructable(256.0f, 64.0f, &debris_data, TARG_DEBRIS);
     G_SelectEntity(client, unit);

--- a/games/warcraft-3/game/tests/t_movement.c
+++ b/games/warcraft-3/game/tests/t_movement.c
@@ -1611,6 +1611,166 @@ TEST(wc3_movement, harvest_target_mode_right_click_entity_cancels_without_order)
     gi.unicast = old_unicast;
 }
 
+static LPEDICT make_smart_destructable(FLOAT x, FLOAT y,
+                                        DestructableData_t const *data,
+                                        TARGTYPE targtype) {
+    LPEDICT dest = G_Spawn();
+    dest->class_id = MAKEFOURCC('L','T','0','5');
+    dest->data.DestructableData = data;
+    dest->destructable.initialized = true;
+    dest->destructable.placement_solid = true;
+    dest->health.value = dest->health.max_value = 500.0f;
+    dest->targtype = targtype;
+    dest->s.origin2 = (VECTOR2){ x, y };
+    dest->s.origin.x = x;
+    dest->s.origin.y = y;
+    return dest;
+}
+
+/* Entity picking wins over the terrain trace on a bridge. Preserve that
+ * traced point so rejected bridge Smart attack semantics can still become the
+ * same formation-aware ground move as an ordinary SmartPoint click. */
+TEST(wc3_movement, smart_walkable_bridge_falls_back_to_clicked_ground_point) {
+    static DestructableData_t const bridge_data = {
+        .file = "Doodads/Terrain/WoodBridgeLarge45/WoodBridgeLarge45.mdx",
+        .walkable = true,
+    };
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(LPEDICT) = gi.unicast;
+    LPEDICT clent = &g_edicts[0];
+    LPGAMECLIENT client = clent->client;
+    LPEDICT worker, bridge;
+    char bridge_number[16];
+    LPCSTR command[] = { "smart", bridge_number, "192", "64" };
+
+    setup_test_world();
+    gi.Write = movement_noop_write;
+    gi.unicast = movement_noop_unicast;
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0.0f, 0.0f);
+    worker->collision = 0.0f;
+    worker->stand = unit_stand;
+    unit_stand(worker);
+    bridge = make_smart_destructable(256.0f, 64.0f, &bridge_data, TARG_BRIDGE);
+    G_SelectEntity(client, worker);
+    snprintf(bridge_number, sizeof(bridge_number), "%u", (unsigned)bridge->s.number);
+
+    G_ClientCommand(clent, 4, command);
+
+    T_NOT_NULL(worker->goalentity);
+    T_FEQ(worker->goalentity->s.origin2.x, 192.0f, 0.01f);
+    T_FEQ(worker->goalentity->s.origin2.y, 64.0f, 0.01f);
+    T_ASSERT(worker->goalentity != bridge);
+
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+}
+
+TEST(wc3_movement, smart_nonwalkable_destructable_does_not_fall_back_to_move) {
+    static DestructableData_t const wall_data = {
+        .file = "Doodads/TestWall.mdx",
+        .walkable = false,
+    };
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(LPEDICT) = gi.unicast;
+    LPEDICT clent = &g_edicts[0];
+    LPGAMECLIENT client = clent->client;
+    LPEDICT worker, wall;
+    char wall_number[16];
+    LPCSTR command[] = { "smart", wall_number, "192", "64" };
+
+    setup_test_world();
+    gi.Write = movement_noop_write;
+    gi.unicast = movement_noop_unicast;
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0.0f, 0.0f);
+    worker->stand = unit_stand;
+    unit_stand(worker);
+    wall = make_smart_destructable(256.0f, 64.0f, &wall_data, TARG_WALL);
+    G_SelectEntity(client, worker);
+    snprintf(wall_number, sizeof(wall_number), "%u", (unsigned)wall->s.number);
+
+    G_ClientCommand(clent, 4, command);
+
+    T_NULL(worker->goalentity);
+    T_EQ(G_UnitQueuedOrderCount(worker), 0);
+
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+}
+
+TEST(wc3_movement, shift_smart_walkable_bridge_queues_clicked_ground_point) {
+    static DestructableData_t const bridge_data = {
+        .file = "Doodads/Terrain/WoodBridgeLarge45/WoodBridgeLarge45.mdx",
+        .walkable = true,
+    };
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(LPEDICT) = gi.unicast;
+    LPEDICT clent = &g_edicts[0];
+    LPGAMECLIENT client = clent->client;
+    LPEDICT worker, bridge;
+    VECTOR2 first = { 64.0f, 0.0f };
+    char bridge_number[16];
+    LPCSTR command[] = { "smart", bridge_number, "192", "64", "queue" };
+
+    setup_test_world();
+    gi.Write = movement_noop_write;
+    gi.unicast = movement_noop_unicast;
+    worker = alloc_test_unit(MAKEFOURCC('h','p','e','a'), 0.0f, 0.0f);
+    worker->collision = 0.0f;
+    worker->stand = unit_stand;
+    unit_stand(worker);
+    bridge = make_smart_destructable(256.0f, 64.0f, &bridge_data, TARG_BRIDGE);
+    G_SelectEntity(client, worker);
+    T_ASSERT(G_IssueUnitPointOrder(worker, "move", &first, false,
+                                   client->ps.number, 0.0f));
+    snprintf(bridge_number, sizeof(bridge_number), "%u", (unsigned)bridge->s.number);
+
+    G_ClientCommand(clent, 5, command);
+
+    T_EQ(G_UnitQueuedOrderCount(worker), 1);
+    T_EQ(worker->order_queue.entries[worker->order_queue.head].target_type,
+         UNIT_ORDER_TARGET_POINT);
+    T_STREQ(worker->order_queue.entries[worker->order_queue.head].order, "move");
+    T_FEQ(worker->order_queue.entries[worker->order_queue.head].point.x, 192.0f, 0.01f);
+    T_FEQ(worker->order_queue.entries[worker->order_queue.head].point.y, 64.0f, 0.01f);
+
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+}
+
+TEST(wc3_movement, smart_walkable_debris_keeps_entity_attack_precedence) {
+    static DestructableData_t const debris_data = {
+        .file = "Doodads/TestDebris.mdx",
+        .walkable = true,
+    };
+    void (*old_write)(pfWriteType_t, void const *) = gi.Write;
+    void (*old_unicast)(LPEDICT) = gi.unicast;
+    LPEDICT clent = &g_edicts[0];
+    LPGAMECLIENT client = clent->client;
+    LPEDICT unit, debris;
+    char debris_number[16];
+    LPCSTR command[] = { "smart", debris_number, "192", "64" };
+
+    setup_test_world();
+    gi.Write = movement_noop_write;
+    gi.unicast = movement_noop_unicast;
+    unit = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0.0f, 0.0f);
+    unit->stand = unit_stand;
+    unit_stand(unit);
+    unit->attack1.type = ATK_MELEE;
+    unit->attack1.targetsAllowed = 256u; /* debris */
+    debris = make_smart_destructable(256.0f, 64.0f, &debris_data, TARG_DEBRIS);
+    G_SelectEntity(client, unit);
+    snprintf(debris_number, sizeof(debris_number), "%u", (unsigned)debris->s.number);
+
+    G_ClientCommand(clent, 4, command);
+
+    T_ASSERT(unit->goalentity == debris);
+    T_EQ(G_UnitQueuedOrderCount(unit), 0);
+
+    gi.Write = old_write;
+    gi.unicast = old_unicast;
+}
+
 /* Reissuing Harvest while already full remembers the requested tree but begins
  * return immediately, so no extra over-capacity chop can occur. */
 TEST(wc3_movement, lumber_full_worker_returns_before_new_chop) {

--- a/games/warcraft-3/game/tests/t_unit.c
+++ b/games/warcraft-3/game/tests/t_unit.c
@@ -73,6 +73,7 @@ static LPEDICT make_world_item(DWORD class_id) {
     item->class_id = class_id;
     G_BindEntityData(item);
     item->s.model = 1;
+    item->targtype = TARG_ITEM;
     item->item.in_world = true;
     item->item.inventory_slot = -1;
     return item;


### PR DESCRIPTION
Smart clicks on walkable bridges lost the traced ground point, and minimap clicks could be blocked by the HUD or single-selection path. Preserve entity and point trace results in the existing Smart command, resolve bridge movement through WC3 server rules, and restore shared minimap focus and drag release.

Minimap input is game-independent: the mandatory renderer trace maps screen coordinates, the client sends typed `clc_input / BZ_INPUT_FOCUS`, and each game owns camera policy through `ClientInput`. Remove obsolete optional-callback guards and the duplicate release call. Keep bridge classification, attack precedence, queue handling, and formation movement in the WC3 game module. Document the contract in `docs/architecture/shared-input.md`.

Validation:
- Full `make test` passes, including 1,017 WC3 tests / 23,335 assertions in each edition mode.
- Shared input tests verify exact focus packets, selection capacities 1 and 64, drag/release, missed traces, menu blocking, and Smart point/Shift commands; 69 assertions pass in a bounded in-engine run.
- WC3, WoW, and SC2 build without warnings.
- Bounded RoC and TFT gameplay smoke runs reach the connected game state.
