### PR TITLE
Restore WC3 loading screens and minimap camera outline

### DIFF
--- a/client/cl_input.c
+++ b/client/cl_input.c
@@ -868,6 +868,7 @@ void CL_InitInput(void) {
 
 #ifdef BZ_TESTS
 #include "shared/test.h"
+void CL_ParseLayout(LPSIZEBUF msg);
 static DWORD pan_terrain, pan_plane;
 static bool CL_TestTerrain(viewDef_t const *view, float x, float y, LPVECTOR3 point) {
     (void)view; (void)x; (void)y;
@@ -887,7 +888,7 @@ static bool CL_TestNoLocation(viewDef_t const *view, float x, float y, LPVECTOR3
     (void)view; (void)x; (void)y; (void)point; return false;
 }
 static bool CL_TestMinimap(float x, float y, LPVECTOR2 point) {
-    (void)y; *point = (VECTOR2){ 300, 400 }; return x >= 0;
+    (void)y; *point = (VECTOR2){ 300, 400 }; return x >= 0 && x <= 100 && y >= 0 && y <= 100;
 }
 static size2_t CL_TestWindowSize(void) { return (size2_t){ 1024, 768 }; }
 
@@ -981,6 +982,89 @@ TEST(client_input, minimap_focus_and_release_are_selection_independent) {
     Cvar_SetValue("cl_selection_limit", old_limit);
     re = saved; cls.netchan.message = old_msg; cls.state = old_state; cls.key_dest = old_dest;
     cl.playerstate.client_ui_state = old_ui;
+}
+
+/* Keep the SDL queue, key binding, layout hit test and command buffer in the regression path. */
+TEST(client_input, minimap_sdl_click_drag_release_over_hud) {
+    struct client_state *old_cl = MemAlloc(sizeof(cl));
+    struct client_static old_cls = cls;
+    refExport_t old_re = re;
+    __typeof__(input) old_input = input;
+    mouseEvent_t old_mouse = mouse;
+    SDL_Keymod old_mod = SDL_GetModState();
+    UINAME binding;
+    BYTE data[512], packet[512];
+    sizeBuf_t msg;
+    UIFRAME empty = { 0 }, frame = { .number = 1, .flags.type = FT_TEXTURE,
+        .size = { UI_BASE_WIDTH, UI_BASE_HEIGHT }, .tooltip = "Minimap" };
+    SDL_Event event = { .button = { .type = SDL_MOUSEBUTTONDOWN, .button = SDL_BUTTON_LEFT, .x = 10, .y = 20 } };
+    FLOAT old_edge = Cvar_Value("cl_camera_edge_scroll", 0), old_cursor = Cvar_Value("cl_context_cursor", 0);
+    BOOL add_down = !Cmd_Exists("+select"), add_up = !Cmd_Exists("-select");
+    INPUTCMD cmd = { 0 };
+
+    memcpy(old_cl, &cl, sizeof(cl));
+    strlcpy(binding, Key_GetBinding(K_MOUSE1, 0), sizeof(binding));
+    T_EQ(SDL_InitSubSystem(SDL_INIT_EVENTS), 0);
+    if (add_down) Cmd_AddCommand("+select", IN_SelectDown);
+    if (add_up) Cmd_AddCommand("-select", IN_SelectUp);
+    Key_SetBinding(K_MOUSE1, 0, "+select"); SDL_SetModState(KMOD_NONE);
+    Cvar_Set("cl_camera_edge_scroll", "0"); Cvar_Set("cl_context_cursor", "0");
+    memset(&cl, 0, sizeof(cl)); input = (__typeof__(input)){ .focus = true };
+    cls.state = ca_active; cls.key_dest = key_game; cl.playerstate.client_ui_state = CLIENT_UI_GAME;
+    re.TraceMinimap = CL_TestMinimap; re.GetWindowSize = CL_TestWindowSize;
+    FOR_LOOP(i, MAX_LAYOUT_LAYERS) SCR_ClearLayoutLayer(i);
+    SZ_Init(&msg, packet, sizeof(packet));
+    MSG_WriteByte(&msg, LAYER_CONSOLE);
+    MSG_WriteDeltaUIFrame(&msg, &empty, &frame, true); MSG_WriteByte(&msg, 0);
+    MSG_WriteLong(&msg, 0); MSG_WriteShort(&msg, 0);
+    CL_ParseLayout(&msg);
+    T_ASSERT(SCR_LayoutHitTest(10, 20));
+    SZ_Init(&cls.netchan.message, data, sizeof(data));
+    T_EQ(SDL_PushEvent(&event), 1); CL_Input(); Cbuf_Execute();
+    T_EQ(MSG_ReadByte(&cls.netchan.message), clc_input);
+    T_ASSERT(MSG_ReadInput(&cls.netchan.message, &cmd)); T_EQ(cmd.action, BZ_INPUT_FOCUS);
+    VECTOR2 expected = CL_ClampCameraPosition((VECTOR2){ 300, 400 });
+    T_FEQ(cmd.focus.x, expected.x, 0.001f); T_FEQ(cmd.focus.y, expected.y, 0.001f);
+    T_ASSERT(!input.select && !cl.selection.in_progress);
+    T_EQ(cls.netchan.message.readcount, cls.netchan.message.cursize);
+
+    event = (SDL_Event){ .motion = { .type = SDL_MOUSEMOTION, .x = 30, .y = 40 } };
+    SZ_Init(&cls.netchan.message, data, sizeof(data));
+    T_EQ(SDL_PushEvent(&event), 1); CL_Input(); Cbuf_Execute();
+    T_EQ(MSG_ReadByte(&cls.netchan.message), clc_input);
+    T_ASSERT(MSG_ReadInput(&cls.netchan.message, &cmd)); T_EQ(cmd.action, BZ_INPUT_FOCUS);
+    T_EQ(cls.netchan.message.readcount, cls.netchan.message.cursize);
+    event = (SDL_Event){ .button = { .type = SDL_MOUSEBUTTONUP, .button = SDL_BUTTON_LEFT, .x = 30, .y = 40 } };
+    T_EQ(SDL_PushEvent(&event), 1); CL_Input(); Cbuf_Execute();
+    SZ_Init(&cls.netchan.message, data, sizeof(data));
+    event = (SDL_Event){ .motion = { .type = SDL_MOUSEMOTION, .x = 50, .y = 60 } };
+    T_EQ(SDL_PushEvent(&event), 1); CL_Input(); Cbuf_Execute();
+    T_EQ(cls.netchan.message.cursize, 0);
+
+    /* Other HUD pixels must not become world selection or camera focus. */
+    event = (SDL_Event){ .button = { .type = SDL_MOUSEBUTTONDOWN, .button = SDL_BUTTON_LEFT, .x = 500, .y = 100 } };
+    T_ASSERT(SCR_LayoutHitTest(500, 100));
+    T_EQ(SDL_PushEvent(&event), 1); CL_Input(); Cbuf_Execute();
+    event.type = SDL_MOUSEBUTTONUP;
+    T_EQ(SDL_PushEvent(&event), 1); CL_Input(); Cbuf_Execute();
+    T_EQ(cls.netchan.message.cursize, 0); T_ASSERT(!cl.selection.in_progress);
+
+    /* A real modal layout must still prevent the same bound click from moving the camera. */
+    SCR_SetLayoutLayer(LAYER_GAME_RESULT, cl.layout[LAYER_CONSOLE]);
+    event = (SDL_Event){ .button = { .type = SDL_MOUSEBUTTONDOWN, .button = SDL_BUTTON_LEFT, .x = 10, .y = 20 } };
+    T_ASSERT(SCR_LayoutModalActive());
+    T_EQ(SDL_PushEvent(&event), 1); CL_Input(); Cbuf_Execute();
+    event.type = SDL_MOUSEBUTTONUP;
+    T_EQ(SDL_PushEvent(&event), 1); CL_Input(); Cbuf_Execute();
+    T_EQ(cls.netchan.message.cursize, 0);
+    MemFree(cl.layout[LAYER_CONSOLE]);
+    cl = *old_cl; MemFree(old_cl); cls = old_cls; re = old_re; input = old_input; mouse = old_mouse;
+    FOR_LOOP(i, MAX_LAYOUT_LAYERS) SCR_SetLayoutLayer(i, cl.layout[i]);
+    Key_SetBinding(K_MOUSE1, 0, binding); SDL_SetModState(old_mod);
+    if (add_down) Cmd_RemoveCommand("+select");
+    if (add_up) Cmd_RemoveCommand("-select");
+    Cvar_SetValue("cl_camera_edge_scroll", old_edge); Cvar_SetValue("cl_context_cursor", old_cursor);
+    SDL_QuitSubSystem(SDL_INIT_EVENTS);
 }
 
 TEST(client_input, pan_uses_configured_surface) {

--- a/client/cl_layout.c
+++ b/client/cl_layout.c
@@ -149,6 +149,10 @@ BOOL SCR_LayoutContextValue(DWORD stat, LPFLOAT value) {
     LPCENTITYSTATE ent;
 
     if (!value) return false;
+    if (stat == UI_STAT_LOADING_PROGRESS) {
+        *value = cl.loading_progress;
+        return true;
+    }
     if (stat == UI_STAT_SELECTION_TIMED_STATUS) {
         *value = cl.playerstate.stats[UI_PLAYERSTAT_SELECTION_TIMED_STATUS] / (FLOAT)USHRT_MAX;
         return true;

--- a/client/cl_scrn.c
+++ b/client/cl_scrn.c
@@ -897,23 +897,12 @@ void SCR_LayoutDrawPortrait(LPCUIFRAME frame, LPCRECT screen) {
 
 /* Loading bars are the one client-owned layout value; their art remains server-authored. */
 void SCR_LayoutDrawLoadingBar(LPCUIFRAME frame, LPCRECT screen) {
-    if (frame->tex.index < MAX_IMAGES && cl.pics[frame->tex.index]) {
-        RECT fill = *screen;
-        RECT uv = { 0, 0, 255, 255 };
-        RECT suv;
-        fill.w *= cl.loading_progress;
-        uv.w *= cl.loading_progress;
-        suv = Rect_div(&uv, 0xff);
-        re.DrawImage(cl.pics[frame->tex.index], &fill, &suv, frame->color);
-        return;
-    }
-    UIFRAME bar = *frame;
-    char anim[16];
-
-    snprintf(anim, sizeof(anim), "#0@%.4f", cl.loading_progress);
-    bar.flags.type = FT_PORTRAIT;
-    bar.text = anim;
-    SCR_LayoutDrawPortrait(&bar, screen);
+    RECT fill = *screen, uv = { 0, 0, 255, 255 };
+    fill.w *= cl.loading_progress;
+    uv.w *= cl.loading_progress;
+    RECT suv = Rect_div(&uv, 0xff);
+    /* This frame declares an image. Model and image indices are independent namespaces. */
+    re.DrawImage(SCR_LayoutPic(frame->tex.index), &fill, &suv, frame->color);
 }
 
 void SCR_LayoutDrawSprite(LPCUIFRAME frame, LPCRECT screen) {
@@ -921,6 +910,7 @@ void SCR_LayoutDrawSprite(LPCUIFRAME frame, LPCRECT screen) {
     LPCSTR anim = (frame->text && *frame->text) ? frame->text : "Stand";
     char sequence_anim[96];
     char phased_anim[96];
+    FLOAT phase = 0.0f;
 
     /* Some server-authored sprites need one replicated stat for their
      * normalized animation phase and another for the authored sequence.  The
@@ -941,13 +931,13 @@ void SCR_LayoutDrawSprite(LPCUIFRAME frame, LPCRECT screen) {
         anim = sequence_anim;
     }
 
-    /* A server-authored numeric stat on a SPRITE is a normalized animation
-     * phase. This keeps the frame tree static while snapshot state drives the
-     * model locally each render frame. The game chooses the stat and model. */
-    if (frame->stat > 0 && frame->stat < MAX_STATS) {
+    /* Sprite phase uses either a normalized snapshot stat or a generic local binding.
+     * Loading sprites previously lost their geometry when converted into portrait bars. */
+    if (SCR_LayoutContextValue(frame->stat, &phase) || (frame->stat > 0 && frame->stat < MAX_STATS)) {
         LPCSTR marker = strchr(anim, '@');
         size_t base_len = marker ? (size_t)(marker - anim) : strlen(anim);
-        FLOAT phase = (FLOAT)cl.playerstate.stats[frame->stat] / (FLOAT)UINT16_MAX;
+        if (frame->stat > 0 && frame->stat < MAX_STATS)
+            phase = (FLOAT)cl.playerstate.stats[frame->stat] / (FLOAT)UINT16_MAX;
 
         if (base_len > sizeof(phased_anim) - 16) base_len = sizeof(phased_anim) - 16;
         snprintf(phased_anim, sizeof(phased_anim), "%.*s@%.6f", (int)base_len, anim, phase);

--- a/common/shared.h
+++ b/common/shared.h
@@ -497,6 +497,7 @@ typedef enum {
     /* uiFrame_t.stat is NFT_BYTE on the wire. Keep generic special bindings
      * inside the reserved high-byte range and below 251 so the established
      * selection/context bindings retain their values. */
+    UI_STAT_LOADING_PROGRESS = 249, /* client-local normalized resource registration progress */
     UI_STAT_SELECTION_TIMED_STATUS = 250, /* statusbar binding; reads normalized selected-unit timer player stat */
     UI_STAT_SELECTION_HEALTH_TEXT = 251,
     UI_STAT_SELECTION_MANA_TEXT,

--- a/docs/architecture/shared-input.md
+++ b/docs/architecture/shared-input.md
@@ -166,3 +166,18 @@ assessment; remaining menu/session/renderer coupling is outside this input chang
 
 See also: [client camera](client.md), [runtime config](runtime.md), and
 [control groups](../games/warcraft-3/control-groups.md).
+
+### Minimap diagnostic boundary
+
+When a click appears ineffective, trace `IN_SelectDown` → `CL_TryMinimapClick` → `clc_input/BZ_INPUT_FOCUS` →
+`G_ClientInput` → the next `vieworigin` snapshot before changing input dispatch. `Key_Event` queues the binding
+before `SCR_LayoutMouseEvent` runs, so a later layout-event return alone does not prove that `+select` was lost.
+A September 9 bounded Human02 replay on `4045cd0c` confirmed a minimap hit, `no_control=0`, and the same focus
+coordinates in the returned server snapshot. That revision's normal focused gameplay click could not reproduce
+an input-order failure. Also check window focus, modal ownership, cinematic state, and the active MOUSE1 binding.
+
+Regression coverage: `client_input.minimap_sdl_click_drag_release_over_hud` pushes SDL button/motion events
+through `CL_Input`, the MOUSE1 binding, layout handling and `Cbuf_Execute`. It checks focus packets, drag/release,
+non-minimap HUD clicks and modal blocking. `wc3_api.controller_focus_updates_camera_and_respects_control`
+checks server application, camera-target release, bounds clamping and scripted ownership. Temporarily moving
+the HUD blocker ahead of `CL_TryMinimapClick` makes the SDL regression fail.

--- a/docs/architecture/ui-system.md
+++ b/docs/architecture/ui-system.md
@@ -272,11 +272,12 @@ Game-mode mouse behavior lives in per-game `cl_input_<game>.c` files. Never crea
 
 ## Loading Screen
 
-The loading screen is a server-authored `svc_layout` sent after the initial configstrings and drawn by the client while `playerState_t.client_ui_state == CLIENT_UI_LOADING`. It:
+The loading screen is a server-authored `svc_layout` sent before the initial configstrings and drawn by the client while `playerState_t.client_ui_state == CLIENT_UI_LOADING`. It:
 
 1. Serializes the authoritative `Loading.fdf` frame tree before `begin`
 2. Includes map-authored title, subtitle, description, and background model
-3. Uses `FT_LOADING_BAR`, whose animation ratio is supplied by client-local registration progress
+3. Keeps WC3 MDX art as `FT_SPRITE` with `UI_STAT_LOADING_PROGRESS`; texture bars use `FT_LOADING_BAR`.
+   Both consume client-local registration progress without guessing resource type from a numeric index.
 
 `CL_PrepRefresh()` advances that value at real registration phase boundaries. The Quake-style plaque remains frozen for ordinary
 frame submission, but `SCR_UpdateLoadingPlaque()` explicitly repaints after a progress change. The value is local client state, not

--- a/docs/games/warcraft-3/alerts-and-minimap-pings.md
+++ b/docs/games/warcraft-3/alerts-and-minimap-pings.md
@@ -54,6 +54,25 @@ For rectangular Warcraft maps, world-space minimap content must **not** be stret
 
 `MDLX_DrawSpriteTinted()` temporarily replaces `tr.viewDef`. Because minimap pings are drawn after the world, it must restore the previous `tr.viewDef` after its sprite pass; otherwise a post-world sprite can corrupt renderer state expected by subsequent HUD/overlay work.
 
+### Camera outline and portrait view ownership
+
+`R_DrawMinimapCameraRect()` projects the gameplay viewport corners onto the ground plane. It skips views marked
+`RDF_NOWORLDMODEL` or `RDF_NOFRUSTUMCULL`. The selected-unit portrait can render before the minimap, so
+`R_RenderFrame()` in `renderer/r_view.c` must restore the previous `tr.viewDef` after a no-world scene, including
+the entity-camera early return. World renders retain their new view for later HUD consumers.
+
+A bounded Human02 trace confirmed the missing outline was caused by the portrait leaving flags `0x2d` and its small
+viewport in `tr.viewDef`; the minimap returned before projecting any corners. Minimap clicks still moved the camera.
+Restoring the world view produced flags zero and four projected corners, with the outline visible under both ROC and
+TFT archives. `git blame` traces the entity-camera early return to `b6349c392`; GL viewport restoration alone did not
+restore the renderer's camera state.
+
+`make test-renderer-view` exercises the production frame function with mocked game/GPU passes: authored portrait
+cameras, missing model cameras, empty entity-camera scenes, ordinary no-world scenes, and subsequent world frames.
+Removing view restoration makes all four no-world cases fail. For visual verification, load Human02 with a bounded
+frame limit, skip its intro via `cinematic stop` after connection with cheats enabled, and capture the HUD with a unit
+selected. See [renderer view ownership](../../renderer-backend.md#view-ownership).
+
 ## Recent Alert History And Space
 
 The generic minimap client keeps the latest eight positions from packets carrying `MINIMAP_PING_REMEMBER`. New entries are inserted newest-first and evict the oldest when full.

--- a/docs/games/warcraft-3/loading-and-assets.md
+++ b/docs/games/warcraft-3/loading-and-assets.md
@@ -4,17 +4,32 @@ For measured menu/loading resource residency and reclamation priorities, see [WC
 
 ## Loading-screen ownership
 
-`CL_BeginLoadingMap` publishes the resolved destination in the session-only `map` cvar **before**
-`SCR_BeginLoadingPlaque` freezes a frame. This covers console launches, menu selections, game menu actions,
-and incoming `CS_WORLD`. The client owns loading state; only `CL_PrepRefresh` promotes it to `ca_active`.
-The WC3 UI reads the current destination and caches metadata per path, not per UI lifetime.
-Loading plaques are non-interactive: `SCR_DrawCursor` suppresses both the game-authored cursor and the native SDL cursor while `CLIENT_UI_LOADING` is active, then the existing cursor-state handoff restores the configured cursor automatically when loading ends.
+`CL_BeginLoadingMap` publishes the resolved destination and freezes a non-interactive loading plaque.
+The client remains `ca_connected` while registering assets; the first usable server frame activates it once
+`CL_PrepRefresh` has completed. `SCR_DrawCursor` hides both the native and authored cursors during loading.
 
-`UI_UpdateLoadingMapInfo` reads the nested map MPQ's `war3map.w3i` and `war3map.wts` through
-`UI_ReadMapInfo`. Custom loading models take precedence; otherwise the campaign background number indexes
-`UI/WorldEditData.txt`'s `LoadingScreens` section (model plus sequence). Maps without an authored background
-use the existing `LoadingMeleeBackground` skin entry. Geometry and text fields come from native
-`UI/FrameDef/Glue/Loading.fdf` and its generated binding.
+The game binds native `UI/FrameDef/Glue/Loading.fdf` in `UI_LoadHudLoading`. During the initial handshake,
+`SV_Configstrings_f` calls `ClientLoading` before sending the media table. `UI_WriteLoadingLayout` reads
+`level.mapinfo` and resolves WTS text through `UI_LevelStringSafe`. A custom W3I loading model takes precedence;
+otherwise the campaign background number selects a model and sequence from `UI/WorldEditData.txt`'s
+`LoadingScreens` section. Maps without either use the decorated `LoadingMeleeBackground` skin entry.
+
+Both background and progress bar retain the FDF's `FT_SPRITE` type. The background uses `#!sequence` for native
+screen-space geometry. The zero-size bar uses `#0` plus `UI_STAT_LOADING_PROGRESS`, a client-local normalized
+binding, so `SCR_LayoutDrawSprite` supplies `#0@ratio`. No player-state field or network layout size changes.
+`FT_LOADING_BAR` is the image-bar contract used by WoW; an image and a model may have the same numeric index.
+
+### September 7 initial-layout regression
+
+Commit `aa5f89f73` moved the loading screen from the menu to the initial server layout but lost campaign-row
+resolution and changed native sprites into portraits. A bounded Human02 trace confirmed background number `3`
+was registered as nonexistent `LoadingMeleeBackground.mdx`, while the bar's portrait viewport was zero-sized.
+Once images registered, the same model index (`1`) selected an unrelated image. Restoring native sprite types,
+the ROC/TFT row parser, and an explicit progress binding fixes all three without changing FDF geometry.
+
+The server-layout lifecycle still publishes the screen only after synchronous `SV_Map` finishes, and its resources
+become available during client registration. It cannot display destination artwork during the earlier server-load
+phase; providing that requires a separate earlier publication lifecycle. Do not fabricate progress for that phase.
 
 ### June 28 regression
 
@@ -28,11 +43,12 @@ TFT has an additional independent schema difference: ROC `LoadingScreens` rows a
 under TFT archives. Fixed ROC indices interpreted HumanX01's sequence `6` as a filename. `UI_ParseLoadingRow`
 consumes the optional numeric category and validates the sequence/model fields; malformed rows log their key.
 
-Preserve the loading-state draw check before standalone-screen dispatch: `menu_ingame` is queued asynchronously, so loading must remain authoritative even after the glue screen is released.
+In that menu-owned implementation, the loading-state draw check had to precede standalone-screen dispatch because
+`menu_ingame` is queued asynchronously. The initial-layout path now dispatches loading from `SCR_DrawScreenField`.
 
-### FDF registry isolation
+### Historical menu FDF registry isolation
 
-`libmenu` and `libgame` intentionally have separate `stb_fdf` frame registries.  The parser implementation functions are hidden per shared library, and the `frames[]` backing store must be hidden as well.  On ELF/Linux, exporting `frames` allows normal symbol interposition to alias the two registries even though each library defines its own copy.  `G_LoadMap -> UI_ResetHud -> UI_ClearTemplates` then clears/reuses the menu's live `Loading`/`LoadingBar` slots during `SV_Map`; cached non-NULL loading-frame pointers survive but no longer describe the loading sprites, so later progress updates reach `M_DrawLoadingScreen` without reaching the MDX renderer.
+`libmenu` and `libgame` intentionally have separate `stb_fdf` frame registries.  The parser implementation functions are hidden per shared library, and the `frames[]` backing store must be hidden as well.  On ELF/Linux, exporting `frames` allows normal symbol interposition to alias the two registries even though each library defines its own copy.  `G_LoadMap -> UI_ResetHud -> UI_ClearTemplates` then clears/reuses the menu's live `Loading`/`LoadingBar` slots during `SV_Map`; cached non-NULL loading-frame pointers survive but no longer describe the loading sprites, so later progress updates reach the old `M_DrawLoadingScreen` without reaching the MDX renderer.
 
 A characteristic failure is that the initial loading sprite renders before `SV_Map`, while later progress values change without reaching the MDX sprite renderer. Verify registry isolation before changing progress math or swap/present code.
 
@@ -81,8 +97,8 @@ do not infer those capabilities from the renderer's map-import lookup.
 Loading progress is client-owned and intentionally coarse. `CL_BeginLoadingMap` resets `cl.loading_progress` to
 zero. `CL_PrepRefresh` advances it monotonically at existing registration boundaries and
 `SCR_UpdateLoadingPlaque` explicitly repaints the otherwise frozen Quake-style loading plaque after each advance.
-The initial server payload carries the `Loading.fdf` tree as `svc_layout`; its `FT_LOADING_BAR` maps client-local progress directly
-onto the `LoadingProgressBar` MDX sequence using `#0@ratio`. No player-state/network field is involved.
+The initial server payload carries the `Loading.fdf` tree as `svc_layout`; its `FT_SPRITE` bar binds
+`UI_STAT_LOADING_PROGRESS` to the `LoadingProgressBar` MDX sequence using `#0@ratio`. No player-state/network field is involved.
 
 Current phase values are:
 
@@ -153,9 +169,16 @@ Use `+com_frame_limit 100` for bounded runs; engine screenshots appear under `sc
 
 Regression tests cover texture extension lookup and exact-file precedence, SLK replacement sentinels,
 ROC/TFT loading-row schemas, rotated/equal-height/diagonal cliff edges, unused FDF art, lazy texture cache hits/misses and theme changes,
-and loading destination/cache invalidation including UI reinitialization. The loading-cache unit test uses
-existing metadata-less map fixtures to exercise the melee/default path; campaign artwork needs ROC/TFT
-runtime verification against real archives.
+and native loading-sprite serialization, client progress binding, and separate model/image namespaces.
+Campaign artwork needs ROC/TFT runtime verification against real archives. Use explicit `-roc` and `-tft`
+when a saved `fs_expansion` setting might override the default.
 
 See also [UI authoring](../../ui-authoring.md), [scene workflow](../../rendering-scene-workflow.md),
 and [filesystem loading](../../fs-loading-architecture.md).
+
+The `wc3_loading.initial_layout_resolves_campaign_custom_and_melee_art` test uses `tests.mpq`'s native
+`Loading.fdf`, skin keys and `WorldEditData.txt` rows. It calls the production loader and writer, then inspects
+emitted sprites, model configstrings, title/subtitle/body, sequence and progress binding. Cases cover ROC and
+TFT row schemas, custom-model precedence, and default skin decoration. Restoring the pre-fix
+`hud_loading.c` makes this test fail. The client drawing tests additionally check progress 0/0.5/1 and collisions
+between model and image indices.

--- a/docs/renderer-backend.md
+++ b/docs/renderer-backend.md
@@ -33,6 +33,14 @@ Consequences:
 - State changes between consecutive identical surfaces are never skipped.
 - Game-specific renderers (WC3, SC2, WoW) duplicate the same boilerplate.
 
+## View ownership
+
+`R_RenderFrame()` (`renderer/r_view.c`) leaves the latest world view in `tr.viewDef` for HUD projection consumers.
+Scenes carrying `RDF_NOWORLDMODEL` borrow that state only for their render and restore the complete prior view on
+both the entity-camera and general rendering paths. Resetting GL viewport/scissor state is a separate operation.
+This preserves the gameplay projection, frustum, viewport, flags, and lighting across portrait draws. The regression
+and runtime evidence are documented in [WC3 minimap camera outlines](games/warcraft-3/alerts-and-minimap-pings.md#camera-outline-and-portrait-view-ownership).
+
 ## Alpha-key coverage contract
 
 The shared renderer requests the compile-time `MSAA=0/2/4/8` sample count before creating the SDL

--- a/games/warcraft-3/game.mk
+++ b/games/warcraft-3/game.mk
@@ -165,13 +165,14 @@ TEST_JOBS ?= 16
 	@TEST_JUNIT="$(TEST_JUNIT_DIR)/test-core.xml" TEST_JUNIT_SUITE="test-core" $(BIN_DIR)/test_openwarcraft3$(EXE_EXT)
 	@# Run independent suites concurrently while preserving recursive-make failure propagation.
 	@$(MAKE) -j$(TEST_JOBS) test-commands test-jass-build test-galaxy test-server-net \
-		test-renderer-model test-renderer-shadows test-sc2 test-wow-appearance \
+		test-renderer-model test-renderer-view test-renderer-shadows test-sc2 test-wow-appearance \
 		test-wow-engine test-wow-game test-wow-entities test-wow-abilities test-wow-menu \
 		test-wow-wmo test-menu test-wc3-engine
 
 $(eval $(call test_schema,test-commands,test-assets $(SHARED_LIB) $(SHEET_LIB),$(TEST_CFLAGS),$(BIN_DIR)/test_commands$(EXE_EXT),tests/test_runner.c $(WC3_TEST_DIR)/test_commands.c client/cl_screenshot.c common/common.c common/cmd.c common/cvar.c common/msg.c common/net.c common/mpq.c,-lsheet -lshared -lm -lz $(NET_LIBS),))
 $(eval $(call test_schema,test-server-net,test-assets $(SHARED_LIB) $(SHEET_LIB),$(TEST_CFLAGS),$(BIN_DIR)/test_server_net$(EXE_EXT),tests/test_runner.c $(WC3_TEST_DIR)/test_server_net.c $(WC3_TEST_DIR)/test_client_stubs.c server/sv_init.c server/sv_lan.c server/sv_main.c server/sv_lobby.c server/sv_send.c server/sv_ents.c server/sv_parse.c common/net.c common/msg.c,-lsheet -lshared -lm $(NET_LIBS),))
 $(eval $(call test_schema,test-renderer-model,$(SHARED_LIB),$(TEST_CFLAGS) -Wno-unused-function,$(BIN_DIR)/test_renderer_model$(EXE_EXT),tests/test_runner.c tests/test_renderer_model.c renderer/r_model.c $(WC3_DIR)/renderer/mdx/r_mdx_anim.c $(WC3_DIR)/renderer/mdx/r_mdx_interpolation.c $(WC3_DIR)/renderer/mdx/r_mdx_buffer.c $(WC3_DIR)/renderer/mdx/r_mdx_light.c,-lshared -lm $(LIBS),))
+$(eval $(call test_schema,test-renderer-view,$(SHARED_LIB) renderer/r_view.c renderer/r_local.h,$(TEST_CFLAGS),$(BIN_DIR)/test_renderer_view$(EXE_EXT),tests/test_runner.c tests/test_renderer_view.c,-lshared -lm $(LIBS),))
 $(eval $(call test_schema,test-renderer-shadows,$(SHARED_LIB),$(TEST_CFLAGS) -Wno-unused-function -DUSE_SHADOWMAPS,$(BIN_DIR)/test_renderer_shadows$(EXE_EXT),tests/test_runner.c tests/test_renderer_model.c renderer/r_model.c $(WC3_DIR)/renderer/mdx/r_mdx_anim.c $(WC3_DIR)/renderer/mdx/r_mdx_interpolation.c $(WC3_DIR)/renderer/mdx/r_mdx_buffer.c $(WC3_DIR)/renderer/mdx/r_mdx_light.c,-lshared -lm $(LIBS),))
 $(eval $(call test_schema,test-galaxy,$(SHARED_LIB) $(JASS_LIB),$(TEST_CFLAGS) -DBZ_TESTS,$(BIN_DIR)/test_galaxy$(EXE_EXT),tests/test_runner.c tests/test_galaxy.c games/starcraft-2/game/galaxy/galaxy_host.c,-lshared -ljass -lm,))
 $(eval $(call test_schema,test-menu,test-assets $(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB),$(TEST_MENU_CFLAGS),$(BIN_DIR)/test_openwarcraft3_ui$(EXE_EXT),tests/test_runner.c $(TEST_UI_SRCS) common/mpq.c common/cmd.c common/common.c common/cvar.c common/msg.c common/net.c $(call CSRC,$(WC3_DIR)/menu),-lsheet -lshared -ljass -lm -lz $(NET_LIBS),))
@@ -261,5 +262,5 @@ $(ZIP_FILE):
 	curl -L -o $(ZIP_FILE) $(ZIP_URL)
 
 WC3_PHONY := wc3-build jass-tool jass sheet renderer game menu openwarcraft3 run run-demo run-map test \
-	test-commands test-server-net test-renderer-model test-renderer-shadows test-galaxy test-menu test-mpq-compat test-assets test-render-golden \
+	test-commands test-server-net test-renderer-model test-renderer-view test-renderer-shadows test-galaxy test-menu test-mpq-compat test-assets test-render-golden \
 	update-render-golden openwarcraft3-tests test-wc3-engine download

--- a/games/warcraft-3/game/hud/hud_loading.c
+++ b/games/warcraft-3/game/hud/hud_loading.c
@@ -1,6 +1,7 @@
 /* Serializes the stock Loading.fdf tree before gameplay UI exists. */
 #include "hud_local.h"
 
+/* The native zero-size loading bar gets its geometry from its MDX, not a portrait viewport. */
 void UI_LoadHudLoading(void) {
     if (!LoadingScreen_Load(&hud.loading)) {
         fprintf(stderr, "UI_LoadHudLoading: missing Loading.fdf\n");
@@ -9,17 +10,18 @@ void UI_LoadHudLoading(void) {
     if (hud.loading.LoadingCustomPanel) UI_SetHidden(hud.loading.LoadingCustomPanel, false);
     if (hud.loading.LoadingMeleePanel) UI_SetHidden(hud.loading.LoadingMeleePanel, true);
     if (hud.loading.LoadingBar) {
-        UI_SetPortraitFrameModel(hud.loading.LoadingBar, UI_LoadModel("LoadingProgressBar", true));
-        hud.loading.LoadingBar->Type = FT_LOADING_BAR;
+        hud.loading.LoadingBar->Portrait.model = UI_LoadModel("LoadingProgressBar", true);
+        hud.loading.LoadingBar->Stat = UI_STAT_LOADING_PROGRESS;
+        UI_SetText(hud.loading.LoadingBar, "#0");
     }
 }
 
+/* Resolve W3I presentation before SV_Configstrings_f publishes the initial media table. */
 void UI_WriteLoadingLayout(LPEDICT ent) {
     LPCMAPINFO info = level.mapinfo;
     LPCSTR title = info && info->loadingScreenTitle && *info->loadingScreenTitle ? info->loadingScreenTitle :
                    info ? info->mapName : NULL;
-    LPCSTR background = info && info->loadingScreenModel && *info->loadingScreenModel ? info->loadingScreenModel :
-                        "LoadingMeleeBackground";
+    DWORD model = 0, seq = 0;
 
     if (!ent || !hud.loading.Loading) return;
     if (hud.loading.LoadingTitleText)
@@ -28,7 +30,25 @@ void UI_WriteLoadingLayout(LPEDICT ent) {
         UI_SetText(hud.loading.LoadingSubtitleText, "%s", UI_LevelStringSafe(info ? info->loadingScreenSubtitle : NULL));
     if (hud.loading.LoadingText)
         UI_SetText(hud.loading.LoadingText, "%s", UI_LevelStringSafe(info ? info->loadingScreenText : NULL));
-    if (hud.loading.LoadingBackground)
-        UI_SetPortraitFrameModel(hud.loading.LoadingBackground, gi.ModelIndex(background));
+    /* Loading.fdf authors screen-space sprites; portrait conversion discarded their native geometry. */
+    if (info && info->loadingScreenModel && *info->loadingScreenModel) {
+        model = UI_LoadModel(info->loadingScreenModel, false);
+    } else if (info && info->campaignBackgroundNumber != (DWORD)-1) {
+        stbIniCache_t data = { 0 };
+        PATHSTR path;
+        char key[16];
+        Stb_IniCacheLoad(&data, "UI\\WorldEditData.txt");
+        snprintf(key, sizeof(key), "%02u", (unsigned)info->campaignBackgroundNumber);
+        LPCSTR row = Stb_IniCacheFind(&data, "LoadingScreens", key);
+        if (UI_ParseLoadingRow(row, &seq, path)) model = UI_LoadModel(path, false);
+        else fprintf(stderr, "UI_WriteLoadingLayout: invalid LoadingScreens[%s]: %s\n", key, row ? row : "(missing)");
+        Stb_IniCacheFree(&data);
+    } else {
+        model = UI_LoadModel("LoadingMeleeBackground", true);
+    }
+    if (hud.loading.LoadingBackground) {
+        hud.loading.LoadingBackground->Portrait.model = model;
+        UI_SetText(hud.loading.LoadingBackground, "#!%u", (unsigned)seq);
+    }
     UI_WriteLayout(ent, hud.loading.Loading, LAYER_LOADING);
 }

--- a/games/warcraft-3/game/hud/hud_utils.h
+++ b/games/warcraft-3/game/hud/hud_utils.h
@@ -1,6 +1,16 @@
 #ifndef hud_utils_h
 #define hud_utils_h
 
+/* ROC rows are label,sequence,model; TFT prepends a numeric expansion category (even for ROC campaigns). */
+static inline BOOL UI_ParseLoadingRow(LPCSTR row, LPDWORD sequence, LPSTR model) {
+    int offset = 0;
+    *sequence = 0; model[0] = 0;
+    if (!row) return false;
+    sscanf(row, "%*u,%n", &offset);
+    /* The old fixed column indices read TFT's sequence as a filename; 255 bounds the PATHSTR output. */
+    return sscanf(row + offset, "%*[^,],%u,%255[^,\r\n]", sequence, model) == 2;
+}
+
 /* Keep generated FDF frames and later proxy frames in one monotonically increasing wire namespace. */
 static DWORD UI_NextProxyFrameNumber(DWORD next, DWORD written) { return MAX(next, written + 1); }
 static BOOL UI_HasSecondAttack(UnitWeapons_t const *weapons) {

--- a/games/warcraft-3/game/tests/t_api.c
+++ b/games/warcraft-3/game/tests/t_api.c
@@ -3103,4 +3103,24 @@ TEST(wc3_api, controller_input_preserves_scripted_ownership) {
     gc->no_control = old_ctrl;
 }
 
+/* Minimap focus must reach the server camera, clear unit tracking, and respect scripted control. */
+TEST(wc3_api, controller_focus_updates_camera_and_respects_control) {
+    LPGAMECLIENT gc = &game.clients[0];
+    INPUTCMD cmd = { .action = BZ_INPUT_FOCUS, .focus = { 300, 400 } };
+    level.camera_bounds = (BOX2){ .min = { 0, 0 }, .max = { 512, 512 } };
+    gc->camera.state.position = (VECTOR2){ 10, 20 };
+    gc->camera.target_controller = &g_edicts[2];
+    gc->no_control = true;
+    globals.ClientInput(&g_edicts[0], &cmd);
+    T_FEQ(gc->camera.state.position.x, 10, 0.001f); T_FEQ(gc->camera.state.position.y, 20, 0.001f);
+    T_NOT_NULL(gc->camera.target_controller);
+    gc->no_control = false;
+    globals.ClientInput(&g_edicts[0], &cmd);
+    T_FEQ(gc->camera.state.position.x, 300, 0.001f); T_FEQ(gc->camera.state.position.y, 400, 0.001f);
+    T_NULL(gc->camera.target_controller); T_EQ(gc->camera.start_time, gc->camera.end_time);
+    cmd.focus = (VECTOR2){ -100, 700 };
+    globals.ClientInput(&g_edicts[0], &cmd);
+    T_FEQ(gc->camera.state.position.x, 0, 0.001f); T_FEQ(gc->camera.state.position.y, 512, 0.001f);
+}
+
 #endif /* BZ_TESTS */

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -969,6 +969,42 @@ TEST(wc3_game, portrait_live_stats_refresh_reserved_connected_client_edict) {
     T_EQ(client->ps.stats[UI_PLAYERSTAT_SELECTION_MANA], 21);
 }
 
+TEST(wc3_game, loading_rows_support_roc_and_tft_schema) {
+    static const struct { LPCSTR row, model; DWORD seq; BOOL valid; } cases[] = {
+        { "WESTRING_LOADINGSCREEN_HUMAN01,0,UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdl",
+          "UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdl", 0, true },
+        { "1,WESTRING_LOADINGSCREEN_HUMANX01,6,UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronExpansionBackground.mdl",
+          "UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronExpansionBackground.mdl", 6, true },
+        { "0,WESTRING_LOADINGSCREEN_HUMAN02,1,UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdl",
+          "UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdl", 1, true },
+        { NULL, "", 0, false }, { "", "", 0, false },
+        { "WESTRING_LOADINGSCREEN_HUMAN01", "", 0, false },
+        { "1,WESTRING_LOADINGSCREEN_HUMANX01,6,", "", 6, false },
+    };
+    FOR_LOOP(i, sizeof(cases) / sizeof(cases[0])) {
+        PATHSTR model; DWORD seq;
+        T_EQ(UI_ParseLoadingRow(cases[i].row, &seq, model), cases[i].valid);
+        if (cases[i].valid) { T_STREQ(model, cases[i].model); T_EQ(seq, cases[i].seq); }
+    }
+}
+
+/* Author native sprites through the same serializer used during the initial client handshake. */
+TEST(wc3_game, loading_layout_preserves_sprite_geometry_and_progress_binding) {
+    FRAMEDEF bar = { .Type = FT_SPRITE, .Stat = UI_STAT_LOADING_PROGRESS, .Portrait.model = 17, .Text = "#0" };
+    FRAMEDEF back = { .Type = FT_SPRITE, .Portrait.model = 18, .Text = "#!6" };
+    uiFrame_t wire = { 0 };
+    BYTE data[128];
+    char text[128];
+
+    UI_ResetFrameWriteList();
+    T_ASSERT(UI_BuildFrameForWrite(&bar, &wire, data, sizeof(data), text, sizeof(text)));
+    T_EQ(wire.flags.type, FT_SPRITE); T_EQ(wire.tex.index, 17);
+    T_EQ(wire.stat, UI_STAT_LOADING_PROGRESS); T_STREQ(wire.text, "#0");
+    T_FEQ(wire.size.width, 0, 0.00001f); T_FEQ(wire.size.height, 0, 0.00001f);
+    T_ASSERT(UI_BuildFrameForWrite(&back, &wire, data, sizeof(data), text, sizeof(text)));
+    T_EQ(wire.flags.type, FT_SPRITE); T_EQ(wire.tex.index, 18); T_STREQ(wire.text, "#!6");
+}
+
 TEST(wc3_game, hud_portrait_model_uses_serialized_field) {
     FRAMEDEF frame = { 0 };
     UI_SetPortraitFrameModel(&frame, 42);

--- a/games/warcraft-3/game/tests/t_loading.c
+++ b/games/warcraft-3/game/tests/t_loading.c
@@ -1,0 +1,79 @@
+/* Loading must survive the real FDF loader and the initial-layout serialization path. */
+#ifdef BZ_TESTS
+#include "shared/test.h"
+#include "../hud/hud_local.h"
+
+typedef struct {
+    DWORD sprites, bar, back, texts, sent, bytes;
+    LONG opcode, layer;
+    UIFRAME progress;
+    char anim[32];
+} LOADCAP;
+static LOADCAP loadcap;
+
+/* Capture what a connecting client receives, rather than inspecting manually constructed frames. */
+static void loading_write(pfWriteType_t type, void const *data) {
+    if (type == PF_BYTE) {
+        if (!loadcap.bytes++) loadcap.opcode = *(LONG const *)data;
+        else loadcap.layer = *(LONG const *)data;
+    }
+    if (type != PF_UIFRAME) return;
+    LPCUIFRAME frame = data;
+    if (frame->flags.type == FT_SPRITE) {
+        loadcap.sprites++;
+        if (frame->stat == UI_STAT_LOADING_PROGRESS) {
+            loadcap.bar = frame->tex.index;
+            loadcap.progress = *frame;
+            T_STREQ(frame->text, "#0");
+        } else {
+            loadcap.back = frame->tex.index;
+            strlcpy(loadcap.anim, frame->text, sizeof(loadcap.anim));
+        }
+    }
+    if (frame->flags.type == FT_TEXT && frame->text) {
+        if (!strcmp(frame->text, "Chapter")) loadcap.texts |= 1;
+        if (!strcmp(frame->text, "Subtitle")) loadcap.texts |= 2;
+        if (!strcmp(frame->text, "Description")) loadcap.texts |= 4;
+    }
+}
+
+static void loading_unicast(LPEDICT ent) { (void)ent; loadcap.sent++; }
+
+/* tests.mpq carries the native FDF plus ROC/TFT WorldEditData rows and decorated skin keys. */
+TEST(wc3_loading, initial_layout_resolves_campaign_custom_and_melee_art) {
+    static const struct { DWORD row; LPSTR custom; LPCSTR model, anim; } cases[] = {
+        { 0, NULL, "UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdx", "#!0" },
+        { 1, NULL, "UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronExpansionBackground.mdx", "#!6" },
+        { 1, "war3mapImported\\LoadingScreen.mdx", "war3mapImported\\LoadingScreen.mdx", "#!0" },
+        { (DWORD)-1, NULL, "UI\\Glues\\Loading\\Multiplayer\\Load-Multiplayer-Random.mdx", "#!0" },
+    };
+    __typeof__(gi.Write) old_write = gi.Write;
+    __typeof__(gi.unicast) old_send = gi.unicast;
+    LPCMAPINFO old_info = level.mapinfo;
+    MAPINFO info = { .mapName = "Chapter", .loadingScreenTitle = "Chapter",
+                    .loadingScreenSubtitle = "Subtitle", .loadingScreenText = "Description" };
+
+    UI_ResetHud(); UI_LoadHudLoading();
+    T_NOT_NULL(hud.loading.Loading); T_NOT_NULL(hud.loading.LoadingBar);
+    T_NOT_NULL(hud.loading.LoadingBackground);
+    if (!hud.loading.Loading || !hud.loading.LoadingBar || !hud.loading.LoadingBackground) return;
+    gi.Write = loading_write; gi.unicast = loading_unicast; level.mapinfo = &info;
+    FOR_LOOP(i, sizeof(cases) / sizeof(cases[0])) {
+        info.campaignBackgroundNumber = cases[i].row;
+        info.loadingScreenModel = cases[i].custom;
+        /* Empty title must resolve the authored map name; custom art must override the campaign row. */
+        info.loadingScreenTitle = i == 3 ? "" : "Chapter";
+        memset(&loadcap, 0, sizeof(loadcap));
+        UI_WriteLoadingLayout(g_edicts);
+        T_EQ(loadcap.opcode, svc_layout); T_EQ(loadcap.layer, LAYER_LOADING); T_EQ(loadcap.sent, 1);
+        T_EQ(loadcap.sprites, 2); T_NE(loadcap.bar, 0); T_NE(loadcap.back, 0); T_EQ(loadcap.texts, 7);
+        T_STREQ(gi.GetConfigstring(CS_MODELS + loadcap.back), cases[i].model);
+        T_STREQ(gi.GetConfigstring(CS_MODELS + loadcap.bar), "UI\\Glues\\Loading\\LoadBar\\LoadBar.mdx");
+        T_STREQ(loadcap.anim, cases[i].anim);
+        T_FEQ(loadcap.progress.size.width, 0, 0.00001f); T_FEQ(loadcap.progress.size.height, 0, 0.00001f);
+        T_EQ(loadcap.progress.points.y[FPP_MAX].offset, (SHORT)(0.0025f * UI_FRAMEPOINT_SCALE));
+    }
+    gi.Write = old_write; gi.unicast = old_send; level.mapinfo = old_info;
+    UI_ResetHud();
+}
+#endif

--- a/games/warcraft-3/menu/menu_local.h
+++ b/games/warcraft-3/menu/menu_local.h
@@ -35,16 +35,6 @@ DWORD M_Time(void);
 void M_TransitionToAction(void (*action)(void));
 BOOL M_IsTransitioning(void);
 
-/* ROC rows are label,sequence,model; TFT prepends a numeric expansion category (even for ROC campaigns). */
-static inline BOOL UI_ParseLoadingRow(LPCSTR row, LPDWORD sequence, LPSTR model) {
-    int offset = 0;
-    *sequence = 0; model[0] = 0;
-    if (!row) return false;
-    sscanf(row, "%*u,%n", &offset);
-    /* The old fixed column indices read TFT's sequence as a filename; 255 bounds the PATHSTR output. */
-    return sscanf(row + offset, "%*[^,],%u,%255[^,\r\n]", sequence, model) == 2;
-}
-
 /* scene.c */
 typedef enum {
     UI_GLUE_NONE,

--- a/games/warcraft-3/tests/resources-src/TestUI/FrameDef/GlobalStrings.fdf
+++ b/games/warcraft-3/tests/resources-src/TestUI/FrameDef/GlobalStrings.fdf
@@ -1,3 +1,4 @@
 StringList {
+    LOADING_LOADING "L O A D I N G",
     CONFIRM_EXIT_MESSAGE "Are you sure you want to exit?",
 }

--- a/games/warcraft-3/tests/resources-src/UI/WorldEditData.txt
+++ b/games/warcraft-3/tests/resources-src/UI/WorldEditData.txt
@@ -1,0 +1,3 @@
+[LoadingScreens]
+00=WESTRING_LOADINGSCREEN_HUMAN01,0,UI\Glues\Loading\Backgrounds\Campaigns\LordaeronBackground.mdl
+01=1,WESTRING_LOADINGSCREEN_HUMANX01,6,UI\Glues\Loading\Backgrounds\Campaigns\LordaeronExpansionBackground.mdl

--- a/games/warcraft-3/tests/resources-src/UI/war3skins.txt
+++ b/games/warcraft-3/tests/resources-src/UI/war3skins.txt
@@ -1,4 +1,6 @@
 [Default]
+LoadingProgressBar=UI\Glues\Loading\LoadBar\LoadBar.mdl
+LoadingMeleeBackground=UI\Glues\Loading\Multiplayer\Load-Multiplayer-Random.mdl
 TargetPointConfirm=UI\Feedback\Confirmation\Confirmation.mdl
 ConsoleInventoryCoverTexture=TestUI\Textures\default-inventory-cover.blp
 ConsoleInventoryNoCapacity=TestUI\Textures\default-inventory-no-capacity.blp

--- a/games/warcraft-3/tests/test_menu_fdf.c
+++ b/games/warcraft-3/tests/test_menu_fdf.c
@@ -3296,24 +3296,6 @@ TEST(menu_fdf, deferred_texture_cache_tracks_theme_changes) {
     UI_ClearTheme(); mi = saved;
 }
 
-TEST(menu_fdf, loading_rows_support_roc_and_tft_schema) {
-    static const struct { LPCSTR row, model; DWORD seq; BOOL valid; } cases[] = {
-        { "WESTRING_LOADINGSCREEN_HUMAN01,0,UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdl",
-          "UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdl", 0, true },
-        { "1,WESTRING_LOADINGSCREEN_HUMANX01,6,UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronExpansionBackground.mdl",
-          "UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronExpansionBackground.mdl", 6, true },
-        { "0,WESTRING_LOADINGSCREEN_HUMAN02,1,UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdl",
-          "UI\\Glues\\Loading\\Backgrounds\\Campaigns\\LordaeronBackground.mdl", 1, true },
-        { NULL, "", 0, false }, { "", "", 0, false },
-        { "WESTRING_LOADINGSCREEN_HUMAN01", "", 0, false },
-        { "1,WESTRING_LOADINGSCREEN_HUMANX01,6,", "", 6, false },
-    };
-    FOR_LOOP(i, sizeof(cases) / sizeof(cases[0])) {
-        PATHSTR model; DWORD seq;
-        T_EQ(UI_ParseLoadingRow(cases[i].row, &seq, model), cases[i].valid);
-        if (cases[i].valid) { T_STREQ(model, cases[i].model); T_EQ(seq, cases[i].seq); }
-    }
-}
 
 TEST(menu_fdf, exported_image_resolver_uses_local_player_skin) {
     menuImport_t saved = mi;

--- a/renderer/r_local.h
+++ b/renderer/r_local.h
@@ -372,6 +372,7 @@ SPRITEPROG *R_SpriteShader(SHADERTYPE type);
 void R_RenderShadowMap(void);
 #endif
 void R_RenderView(void);
+void R_SetupGL(bool drawLight);
 void R_SetupViewport(LPCRECT r);
 void R_SetupScissor(LPCRECT r);
 void R_RevertSettings(void);

--- a/renderer/r_main.c
+++ b/renderer/r_main.c
@@ -340,7 +340,7 @@ void R_ReleaseRenderTexture(LPRENDERTARGET rt) {
     ri.MemFree(rt);
 }
 
-static void R_SetupGL(bool drawLight) {
+void R_SetupGL(bool drawLight) {
     size2_t const window = R_GetWindowSize();
     
     MATRIX4 model_matrix;
@@ -910,58 +910,6 @@ void R_RenderView(void) {
 
 //    extern LPCTEXTURE dds;
 //    R_DrawPic(dds, 0, 0);
-}
-
-void R_RenderFrame(viewDef_t const *viewDef) {
-    tr.viewDef = *viewDef;
-
-    /* UI scene and portrait callers zero-initialise their viewDef, leaving
-     * time == 0, which would freeze model animations (MDLX_SetEntityAnimationFrame
-     * uses tr.viewDef.time to compute the current frame).  Fall back to the
-     * wall clock so the menu background and portraits animate. */
-    if (tr.viewDef.time == 0) {
-        tr.viewDef.time = SDL_GetTicks();
-    }
-    R_SetupEnvironmentLighting();
-    R_ConformGroundSurfaces(&tr.viewDef);
-
-    if (!tr.viewDef.scissor.w && !tr.viewDef.scissor.h) {
-        tr.viewDef.scissor = (RECT){0, 0, 1, 1};
-    }
-
-    if ((tr.viewDef.rdflags & RDF_USE_ENTITY_CAMERA) && tr.viewDef.num_entities > 0) {
-        renderEntity_t const *entity = &tr.viewDef.entities[0];
-        float aspect = (tr.viewDef.viewport.w * tr.drawableSize.width) > 0.0f
-            ? (tr.viewDef.viewport.w * tr.drawableSize.width) / (tr.viewDef.viewport.h * tr.drawableSize.height)
-            : 1.0f;
-        if (!R_ExtractEntityCamera(entity, aspect, &tr.viewDef)) {
-            Matrix4_identity(&tr.viewDef.viewProjectionMatrix);
-            Matrix4_identity(&tr.viewDef.textureMatrix);
-            Matrix4_identity(&tr.viewDef.lightMatrix);
-        }
-        Frustum_Calculate(&tr.viewDef.viewProjectionMatrix, &tr.viewDef.frustum);
-        R_SetupViewport(&tr.viewDef.viewport);
-        R_SetupScissor(&tr.viewDef.scissor);
-        R_SetupGL(false);
-        R_Call(glClear, GL_DEPTH_BUFFER_BIT);
-        R_DrawEntities();
-        R_RevertSettings();
-        return;
-    }
-
-    Frustum_Calculate(&tr.viewDef.viewProjectionMatrix, &tr.viewDef.frustum);
-
-    R_RenderFogOfWar();
-    R_Call(glActiveTexture, GL_TEXTURE2);
-    R_Call(glBindTexture, GL_TEXTURE_2D, R_GetFogOfWarTexture());
-    R_Call(glActiveTexture, GL_TEXTURE0);
-#ifdef USE_SHADOWMAPS
-    /* Layout-provided model cameras have no world shadow pass either. */
-    if (!(tr.viewDef.rdflags & (RDF_USE_ENTITY_CAMERA | RDF_NOWORLDMODEL))) {
-        R_RenderShadowMap();
-    }
-#endif
-    R_RenderView();
 }
 
 void R_DrawBuffer(LPCBUFFER buffer, DWORD num_vertices) {

--- a/renderer/r_view.c
+++ b/renderer/r_view.c
@@ -1,0 +1,58 @@
+#include "r_local.h"
+#include "r_game.h"
+
+/* UI scenes borrow the renderer view; retaining a portrait hid the later minimap camera outline. */
+void R_RenderFrame(viewDef_t const *viewDef) {
+    viewDef_t saved = tr.viewDef;
+    tr.viewDef = *viewDef;
+
+    /* UI scene and portrait callers zero-initialise their viewDef, leaving
+     * time == 0, which would freeze model animations (MDLX_SetEntityAnimationFrame
+     * uses tr.viewDef.time to compute the current frame).  Fall back to the
+     * wall clock so the menu background and portraits animate. */
+    if (tr.viewDef.time == 0) {
+        tr.viewDef.time = SDL_GetTicks();
+    }
+    R_SetupEnvironmentLighting();
+    R_ConformGroundSurfaces(&tr.viewDef);
+
+    if (!tr.viewDef.scissor.w && !tr.viewDef.scissor.h) {
+        tr.viewDef.scissor = (RECT){0, 0, 1, 1};
+    }
+
+    if ((tr.viewDef.rdflags & RDF_USE_ENTITY_CAMERA) && tr.viewDef.num_entities > 0) {
+        renderEntity_t const *entity = &tr.viewDef.entities[0];
+        float aspect = (tr.viewDef.viewport.w * tr.drawableSize.width) > 0.0f
+            ? (tr.viewDef.viewport.w * tr.drawableSize.width) / (tr.viewDef.viewport.h * tr.drawableSize.height)
+            : 1.0f;
+        if (!R_ExtractEntityCamera(entity, aspect, &tr.viewDef)) {
+            Matrix4_identity(&tr.viewDef.viewProjectionMatrix);
+            Matrix4_identity(&tr.viewDef.textureMatrix);
+            Matrix4_identity(&tr.viewDef.lightMatrix);
+        }
+        Frustum_Calculate(&tr.viewDef.viewProjectionMatrix, &tr.viewDef.frustum);
+        R_SetupViewport(&tr.viewDef.viewport);
+        R_SetupScissor(&tr.viewDef.scissor);
+        R_SetupGL(false);
+        R_Call(glClear, GL_DEPTH_BUFFER_BIT);
+        R_DrawEntities();
+        R_RevertSettings();
+        if (viewDef->rdflags & RDF_NOWORLDMODEL) tr.viewDef = saved;
+        return;
+    }
+
+    Frustum_Calculate(&tr.viewDef.viewProjectionMatrix, &tr.viewDef.frustum);
+
+    R_RenderFogOfWar();
+    R_Call(glActiveTexture, GL_TEXTURE2);
+    R_Call(glBindTexture, GL_TEXTURE_2D, R_GetFogOfWarTexture());
+    R_Call(glActiveTexture, GL_TEXTURE0);
+#ifdef USE_SHADOWMAPS
+    /* Layout-provided model cameras have no world shadow pass either. */
+    if (!(tr.viewDef.rdflags & (RDF_USE_ENTITY_CAMERA | RDF_NOWORLDMODEL))) {
+        R_RenderShadowMap();
+    }
+#endif
+    R_RenderView();
+    if (viewDef->rdflags & RDF_NOWORLDMODEL) tr.viewDef = saved;
+}

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -40,6 +40,7 @@ void SCR_LayoutDrawStatusbar(LPCUIFRAME frame, LPCRECT screen);
 void SCR_LayoutDrawTextArea(LPCUIFRAME frame, LPCRECT screen);
 void SCR_LayoutDrawListBox(LPCUIFRAME frame, LPCRECT screen);
 void SCR_LayoutDrawSprite(LPCUIFRAME frame, LPCRECT screen);
+void SCR_LayoutDrawLoadingBar(LPCUIFRAME frame, LPCRECT screen);
 void SCR_LayoutClampSelectionRect(LPRECT rect);
 BOOL SCR_LayoutModalActive(void);
 void SCR_UpdateScreen(DWORD msec);
@@ -1755,6 +1756,46 @@ TEST(client_layout, sprite_numeric_stat_drives_normalized_animation_phase) {
     T_EQ(test_sprite_draws, 1);
     T_EQ(sscanf(test_sprite_anim, "#0@%f", &ratio), 1);
     T_FEQ(ratio, 32768.0f / (FLOAT)UINT16_MAX, 0.00001f);
+}
+
+/* An image with the same numeric index must not capture a model-backed loading sprite. */
+TEST(client_layout, loading_sprite_uses_client_progress_and_model_namespace) {
+    uiFrame_t frame = { .flags = { .type = FT_SPRITE }, .tex = { .index = 1 },
+                        .stat = UI_STAT_LOADING_PROGRESS, .text = "#0" };
+    RECT screen = MAKE(RECT, 0.0f, 0.6f, 0.0f, 0.0f);
+    FLOAT ratio;
+
+    test_client_stubs_init();
+    cl.models[1] = (LPMODEL)(uintptr_t)1;
+    cl.pics[1] = (LPTEXTURE)(uintptr_t)2;
+    re.DrawSprite = capture_sprite;
+    FOR_LOOP(i, 3) {
+        cl.loading_progress = i * 0.5f;
+        test_sprite_draws = 0;
+        SCR_LayoutDrawSprite(&frame, &screen);
+        T_EQ(test_sprite_draws, 1);
+        T_EQ(sscanf(test_sprite_anim, "#0@%f", &ratio), 1);
+        T_FEQ(ratio, cl.loading_progress, 0.00001f);
+    }
+    frame.stat = 0; frame.text = "#!6";
+    SCR_LayoutDrawSprite(&frame, &screen);
+    T_STREQ(test_sprite_anim, "#!6");
+}
+
+/* Image loading bars retain their explicit texture contract even when a model shares the index. */
+TEST(client_layout, loading_image_uses_texture_namespace) {
+    uiFrame_t frame = { .flags = { .type = FT_LOADING_BAR }, .tex = { .index = 1 } };
+    RECT screen = MAKE(RECT, 0, 0, 0.4f, 0.1f);
+
+    test_client_stubs_init();
+    cl.models[1] = (LPMODEL)(uintptr_t)1;
+    cl.pics[1] = (LPTEXTURE)(uintptr_t)2;
+    cl.loading_progress = 0.25f;
+    test_scroll_draws = 0; re.DrawImage = capture_scroll_image;
+    SCR_LayoutDrawLoadingBar(&frame, &screen);
+    T_EQ(test_scroll_draws, 1); T_ASSERT(test_scroll_tex[0] == cl.pics[1]);
+    T_FEQ(test_scroll_rects[0].w, 0.1f, 0.00001f);
+    T_FEQ(test_scroll_uvs[0].w, 0.25f, 0.00001f);
 }
 
 TEST(client_layout, sprite_sequence_can_be_selected_by_second_stat) {

--- a/tests/test_renderer_view.c
+++ b/tests/test_renderer_view.c
@@ -1,0 +1,75 @@
+#include "test.h"
+#include "renderer/r_local.h"
+#include "renderer/r_game.h"
+
+struct render_globals tr;
+static viewDef_t drawn;
+static BOOL camera;
+static int entities, scenes;
+
+/* Exercise production view ownership while replacing only game/GPU passes. */
+#undef R_Call
+#define R_Call(func, ...) ((void)0)
+#include "renderer/r_view.c"
+
+void R_SetupEnvironmentLighting(void) {}
+void R_ConformGroundSurfaces(viewDef_t *view) { (void)view; }
+void R_SetupViewport(LPCRECT rect) { (void)rect; }
+void R_SetupScissor(LPCRECT rect) { (void)rect; }
+void R_SetupGL(bool light) { (void)light; }
+void R_RevertSettings(void) {}
+void R_RenderFogOfWar(void) {}
+DWORD R_GetFogOfWarTexture(void) { return 0; }
+void R_DrawEntities(void) { drawn = tr.viewDef; entities++; }
+void R_RenderView(void) { drawn = tr.viewDef; scenes++; }
+
+/* A model camera changes the projection as well as the portrait viewport/flags. */
+bool R_ExtractEntityCamera(renderEntity_t const *ent, float aspect, viewDef_t *view) {
+    (void)ent; (void)aspect;
+    Matrix4_identity(&view->viewProjectionMatrix);
+    return camera;
+}
+
+/* HUD consumers must still see the world camera after every kind of no-world scene. */
+TEST(renderer_view, portrait_preserves_world_camera) {
+    renderEntity_t ent = {0};
+    viewDef_t world = { .time = 1234, .viewport = {0, 0.22f, 1, 0.76f} };
+    viewDef_t portrait = { .time = 5678, .viewport = {0.32f, 0.04f, 0.08f, 0.14f}, .entities = &ent };
+    Matrix4_identity(&world.viewProjectionMatrix);
+    world.viewProjectionMatrix.v[0] = 2;
+    R_RenderFrame(&world);
+    viewDef_t saved = tr.viewDef;
+    FOR_LOOP(i, 4) {
+        portrait.rdflags = RDF_NOWORLDMODEL | RDF_NOFRUSTUMCULL;
+        if (i < 3) portrait.rdflags |= RDF_USE_ENTITY_CAMERA;
+        portrait.num_entities = i < 2 ? 1 : 0;
+        camera = i == 0;
+        entities = scenes = 0;
+        R_RenderFrame(&portrait);
+        T_EQ(entities, i < 2 ? 1 : 0);
+        T_EQ(scenes, i < 2 ? 0 : 1);
+        T_EQ(drawn.rdflags, portrait.rdflags);
+        T_FEQ(drawn.viewport.w, portrait.viewport.w, 0.0001f);
+        T_EQ(drawn.time, portrait.time);
+        T_EQ(memcmp(&tr.viewDef, &saved, sizeof(saved)), 0);
+    }
+}
+
+/* A new world render must replace the previous camera, including entity-camera views. */
+TEST(renderer_view, world_camera_advances) {
+    renderEntity_t ent = {0};
+    FOR_LOOP(i, 2) {
+        viewDef_t world = { .time = 1234 + i, .viewport = {0, 0.22f, 1, 0.76f}, .entities = &ent, .num_entities = 1 };
+        world.rdflags = i ? RDF_USE_ENTITY_CAMERA : 0;
+        Matrix4_identity(&world.viewProjectionMatrix);
+        tr.viewDef = (viewDef_t){ .time = 100, .rdflags = RDF_NOWORLDMODEL };
+        camera = true;
+        entities = scenes = 0;
+        R_RenderFrame(&world);
+        T_EQ(entities, i ? 1 : 0);
+        T_EQ(scenes, i ? 0 : 1);
+        T_EQ(tr.viewDef.time, world.time);
+        T_EQ(tr.viewDef.rdflags, world.rdflags);
+        T_EQ(memcmp(&tr.viewDef, &drawn, sizeof(drawn)), 0);
+    }
+}


### PR DESCRIPTION
Campaign loading became blank after aa5f89f73 moved it into the initial server layout: campaign artwork lookup was lost, native screen-space sprites became portraits, and the progress model index could select an unrelated image. Restore ROC/TFT campaign lookup and native Loading.fdf sprites, with a client-local progress binding that keeps model and image resources distinct.

The minimap camera outline also disappeared because the selected-unit portrait left its camera and no-world flags in the renderer's current view. Restore the prior view after no-world scenes on both rendering paths, so the minimap projects the gameplay camera again. Move the frame entry point into r_view.c to exercise its actual control flow independently of the GPU.

Regression coverage includes native loading-screen authoring through the fixture MPQ, model/image namespace separation, minimap SDL click/drag/release and modal blocking, server camera focus/clamping, and preservation of the gameplay view across four portrait/UI cases. Ordinary world frames must still replace the current view.

Validation:
- `make test` passed, including ROC and TFT in-engine suites and the new `test-renderer-view` target.
- Restoring the old loading writer breaks its regression test; moving HUD blocking ahead of minimap dispatch breaks the SDL test; removing view restoration breaks all four no-world view cases.
- Bounded ROC/TFT runtime captures verified loading artwork and the minimap outline with a selected-unit portrait.
- WC3, SC2, and WoW built successfully; bounded SC2 gameplay and WoW character-create scenes exercised the shared renderer.

Destination loading artwork still becomes available after synchronous server map loading under the current initial-layout lifecycle.
