### PR TITLE
Fix LAN lobby timeouts and remote client loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ endef
 define app_schema
 $(1): $(2) | $$(BIN_DIR) install-share
 	@echo "[$(3)]"
-	@$$(call UNITY,client server common sound,! -name 'stb_vorbis.c') | \
+	@$$(call UNITY,client server common sound $(6),! -name 'stb_vorbis.c') | \
 		$$(CC) $(4) -x c -o $$@ - $$(RPATH) $$(LDFLAGS) $(5)
 endef
 

--- a/client/cl_input.c
+++ b/client/cl_input.c
@@ -955,8 +955,20 @@ TEST(client_input, smart_entity_trace_precedes_ground_trace) {
     cl.playerstate.client_ui_state = old_ui; input.focus = old_focus;
 }
 
+/* A remote client owns its collision world; input tests cannot borrow a previous game-module fixture. */
+static void CL_TestWorldBounds(BOOL set) {
+#ifdef BZ_CLIENT_WORLD
+    extern void CM_SetupTestWorldBounds(LPCBOX2 bounds);
+    BOX2 bounds = { .min = { 0, 0 }, .max = { 1024, 768 } };
+    CM_SetupTestWorldBounds(set ? &bounds : NULL);
+#else
+    (void)set;
+#endif
+}
+
 /* Minimap focus is shared input: selection capacity cannot change its packet or drag lifecycle. */
 TEST(client_input, minimap_focus_and_release_are_selection_independent) {
+    CL_TestWorldBounds(true);
     BYTE data[256];
     __typeof__(cl.selection) old_sel = cl.selection;
     __typeof__(cl.camera_prediction) old_pred = cl.camera_prediction;
@@ -1010,10 +1022,12 @@ TEST(client_input, minimap_focus_and_release_are_selection_independent) {
     Cvar_SetValue("cl_selection_limit", old_limit);
     re = saved; cls.netchan.message = old_msg; cls.state = old_state; cls.key_dest = old_dest;
     cl.playerstate.client_ui_state = old_ui;
+    CL_TestWorldBounds(false);
 }
 
 /* Keep the SDL queue, key binding, layout hit test and command buffer in the regression path. */
 TEST(client_input, minimap_sdl_click_drag_release_over_hud) {
+    CL_TestWorldBounds(true);
     struct client_state *old_cl = MemAlloc(sizeof(cl));
     struct client_static old_cls = cls;
     refExport_t old_re = re;
@@ -1093,6 +1107,7 @@ TEST(client_input, minimap_sdl_click_drag_release_over_hud) {
     if (add_up) Cmd_RemoveCommand("-select");
     Cvar_SetValue("cl_camera_edge_scroll", old_edge); Cvar_SetValue("cl_context_cursor", old_cursor);
     SDL_QuitSubSystem(SDL_INIT_EVENTS);
+    CL_TestWorldBounds(false);
 }
 
 TEST(client_input, pan_uses_configured_surface) {

--- a/client/cl_parse.c
+++ b/client/cl_parse.c
@@ -670,8 +670,8 @@ void CL_MirrorMessage(LPSIZEBUF msg) {
     if (!strcmp(buf, "begin")) {
         return;
     }
-    /* The existing spawn handshake advances only after the full configstring table has arrived. */
-    if (!strcmp(buf, "baselines")) cl.precache_ready = true;
+    /* Paged baselines must finish before registration can queue begin and enable gameplay snapshots. */
+    if (!strcmp(buf, "precache")) { cl.precache_ready = true; return; }
     MSG_WriteByte(&cls.netchan.message, clc_stringcmd);
     MSG_WriteString(&cls.netchan.message, buf);
 }
@@ -961,6 +961,8 @@ void CL_ParseServerMessage(LPSIZEBUF msg) {
     BYTE pack_id = 0;
     while (MSG_Read(msg, &pack_id, 1)) {
         switch (pack_id) {
+            case svc_nop:
+                break;
             case svc_bad:
                 goto done;
             case svc_playerinfo:

--- a/common/common.h
+++ b/common/common.h
@@ -84,6 +84,7 @@ enum svc_ops {
     svc_lobby_chat,              // [byte own] [string text]
     svc_set_selection,           // [byte count] [count * long entity]
     svc_console_print,           // [string text] server/game command feedback for the local console
+    svc_nop,                     // transport keepalive; no payload or presentation change
 };
 
 // client to server

--- a/docs/architecture/network.md
+++ b/docs/architecture/network.md
@@ -156,3 +156,118 @@ a `MSG_WriteDeltaEntity`/`MSG_ReadDeltaEntity` round-trip test in `tests/test_ne
 ## See Also
 
 - [Server-Authored UI Payloads](ui-payloads.md) — `svc_layout` frame payload contract and unsigned size-byte handling
+
+## LAN lobby and startup
+
+Waiting connections receive pending messages or `svc_nop` at a one-second interval, including the listen
+server's loopback client. `ss_lobby` runs transport without advancing the simulation. Keepalives continue
+for `cs_connected` peers while other players are already running the map; cancelling still uses the normal
+disconnect/shutdown path. The client's ordinary timeout remains enabled for a vanished host.
+
+Startup follows Quake II's client-requested configstring and baseline pages. Remote startup messages are
+bounded by `BZ_SIGNON_SIZE` (1400 bytes, leaving UDP/IP header room within a 1500-byte LAN MTU); loopback
+retains the engine message budget. `svc_mirror` asks for the next `configstrings <index>` or `baselines <index>`
+page. The final baseline reply is `precache`, which opens the client registration gate; registration then queues `begin`. Opening that
+gate at the first baseline request would let registration and gameplay overtake the remaining entity pages.
+The early loading presentation still puts its media before the two binary loading-layout configstrings.
+
+`SV_SetConfigString` does not queue live resynchronization while `ss_loading`: every connecting client fetches
+those values through signon. Runtime changes in `ss_game` still mark the slot for broadcast. Broadcasting the
+initial table as well as serving signon pages defeats the packet budget by filling a connected client's pending
+message before its next request.
+
+The September 10 reproduction used two macOS processes and `Maps/(2)PlunderIsle.w3m`. The idle host timed out
+after 10,034 ms without server traffic. The remote configstring reply was 25,395 bytes and failed `sendto`
+with `EMSGSIZE` (40); paging exposed 10,772 bytes of queued initial-table updates already included in that reply. A subsequent remote-only
+world-registration crash resolved to `G_WorldReadFile` calling an uninitialized game import. A listen server
+masks that boundary error because it initializes the game module before client registration.
+
+An instrumented two-process audit of the same ROC map measured the complete configstring reply's table
+at 14,612 bytes, including each entry's opcode, index and string terminator (excluding the early binary loading slots):
+
+| Pool | Entries | Wire bytes |
+|------|--------:|-----------:|
+| Models | 54 | 2,066 |
+| Sounds | 111 | 4,950 |
+| Images | 129 | 7,301 |
+| Font/size pairs | 7 | 173 |
+| World/scope and other metadata | 7 | 122 |
+| Total | 308 | 14,612 |
+
+The original packet decomposes exactly as `10,772 + 14,612 + 11 = 25,395`: queued duplicate updates,
+the table, and `svc_mirror` plus `"baselines"` and its terminator. These are indexed resource names and metadata,
+not asset-file contents. After suppressing loading-time live updates, the audit observed zero pending bytes
+at the first configstring request. The table volume is reasonable for the map's units, creeps, projectiles,
+world models, sound sets and UI, but is not a minimal dependency list:
+
+- Loading preparation registers 2 models, 59 images and 4 font styles (3,780 wire bytes). Its media is sent
+  early and again in the complete table. Native `Loading.fdf` includes `StandardTemplates.fdf`; eagerly
+  indexing these declarations accounts for 3,580 bytes of images, including unused button/scrollbar templates.
+  A future reduction belongs in registration of consumed FDF resources, not filtering arbitrary network entries.
+- Sixteen image entries (914 bytes) resolve to paths also used by other entries. They are distinct raw skin keys
+  or a literal path versus a skin key, not repeated registrations of the same key. `SV_FindIndex` deduplicates
+  raw keys; merging resolved paths would change their independently addressable configstring identity.
+- `CS_WORLD` and `CS_ASSET_SCOPE` legitimately repeat the map path for different consumers; font sizes likewise
+  require distinct entries. The figures above describe this map/edition, not a fixed protocol budget.
+
+To repeat the audit, temporarily log nonempty entries and `SV_ConfigStringWireSize` at the first
+`SV_Configstrings_f` request, excluding `CS_LOADINGSCREEN1/2`, then run the bounded paired reproduction below.
+Inspect raw keys as well as `ge->GetThemeValue` output to distinguish aliases from duplicate registration;
+remove the instrumentation and rebuild afterward.
+
+Reference implementations: [Quake II server sending](https://github.com/id-Software/Quake-2/blob/master/server/sv_send.c)
+(`SV_SendClientMessages`) and [startup commands](https://github.com/id-Software/Quake-2/blob/master/server/sv_user.c)
+(`SV_Configstrings_f`, `SV_Baselines_f`). These lifecycle rules use this engine's existing messages; the raw
+UDP transport is not Quake II's complete sequenced/reliable netchan implementation.
+
+Regression coverage lives in `games/warcraft-3/tests/test_server_net.c` (idle loopback/UDP keepalives,
+loading-time versus runtime updates, complete paged UDP configstrings/baselines) and `tests/test_net.c`
+(the precache gate). `make test-server-net` requires permission to bind local UDP sockets.
+
+WC3 builds `common/world_w3.c` into the executable with `BZ_CLIENT_WORLD`. The engine's `CM_LoadMapFormat`
+therefore uses engine filesystem/allocation functions. The same WPM reader feeds either the client's terrain-cell
+storage (placement previews) or the game's routing buffers; routing jobs and edict-dependent obstacle handling
+remain in `common/routing.c`, compiled only into the game module. `CM_SetupPathMap` and
+`CM_GetPathingFlagsAt` have client implementations for this reason. Do not fix remote registration by initializing
+a local server, skipping WPM data, or guarding NULL game imports. The crash originally traversed
+`CL_PrepRefresh -> CM_LoadMap -> G_WorldReadFile` with `gi.ReadFile == NULL`; compiling only the map-format reader
+without its path-data consumer still reaches `G_WorldMemAlloc` through `CM_ReadPathMap` and crashes.
+
+In-engine input tests must set client collision bounds explicitly: game test-world bounds are not the client world.
+The `client_world` regression checks terrain-cell lookup, replacement, and teardown. `nm build/bin/openwarcraft3`
+should show defined text symbols for `CM_LoadMapFormat`, `CM_SetupPathMap`, and `CM_GetPathingFlagsAt`.
+
+For a bounded two-terminal reproduction, write a host script and start the second terminal during its wait:
+
+```sh
+python3 - <<'PYLAN'
+from pathlib import Path
+Path('/tmp/lan-check.cfg').write_text(
+    'wait\n' * 10 +
+    'lobby_start "Maps/(2)PlunderIsle.w3m"\n'
+    'lobby_config 2 2 PlunderIsle\n'
+    'lobby_slot 0 1 0 1 1 0 0 Host\n'
+    'lobby_slot 1 1 1 0 1 1 1 Open\n' +
+    'wait\n' * 600 + 'map "Maps/(2)PlunderIsle.w3m"\n')
+PYLAN
+build/bin/openwarcraft3 -data 'data/Warcraft III' -roc +set vid_hidden 1 +com_maxfps 30 +com_frame_limit 1500 +exec /tmp/lan-check.cfg
+# Second terminal, after the host prints "Lobby initialized":
+build/bin/openwarcraft3 -data 'data/Warcraft III' -roc -connect 127.0.0.1:27910 +set vid_hidden 1 +com_maxfps 30 +com_frame_limit 1500
+```
+
+Use an installed melee map path on both processes. `127.0.0.1` exercises UDP; `localhost` selects the in-process
+loopback transport. Omit the final `map` command to verify an idle lobby. `+set vid_hidden 1` is required for a
+hidden window; `+vid_hidden 1` alone can be parsed too late to hide it. Mac display access and local socket
+permissions are required even for these hidden runs. Both peers must run the updated binary for `svc_nop` and
+the final `precache` handshake.
+
+Verification on September 10: a bounded idle lobby survived 800 frames at 30 fps (about 26 seconds); the
+PlunderIsle UDP guest and host both sent `begin`, the server called `G_ClientBegin` for players 0 and 1 at distinct
+start locations, and both processes exited normally. `make test` passed 2,927 tests / 61,017 assertions.
+
+For hidden-window gameplay screenshots, set `cl_camera_edge_scroll` to `0`; otherwise the inactive window's
+pointer can pan the camera into unexplored fog. For a command-line guest, also use
+`+set cl_start_menu menu_ingame +screenshot 5`: `CL_Connect` defers the startup command tail until the first
+active frame, so the default queued `menu_main` would otherwise reopen after loading. This CLI-only diagnostic
+setting is unnecessary when joining through the LAN menu. Final engine screenshots confirmed the blue guest
+and red host at their respective bases with terrain, units, fog, and HUD visible.

--- a/docs/games/warcraft-3/loading-and-assets.md
+++ b/docs/games/warcraft-3/loading-and-assets.md
@@ -20,9 +20,9 @@ The initial transport order is:
 1. Loading-phase configstrings: destination, asset scope, models, images, and fonts.
 2. `CS_LOADINGSCREEN1`, then `CS_LOADINGSCREEN2`: receiving the second slot decodes the frame tree, registers
    the preceding media, and repaints immediately.
-3. Full configstrings (excluding the already-sent loading slots), then the existing `svc_mirror "baselines"`
-   handshake transition: permit normal world/model/image/sound registration.
-4. Baselines/player info/`begin`, then the first usable frame activates gameplay.
+3. Full configstring pages (excluding the already-sent loading slots), then baseline pages.
+4. The final `svc_mirror "precache"` permits world/model/image/sound registration; completion queues `begin`,
+   then the first usable frame activates gameplay.
 
 `SV_BuildLoadingConfigstrings` stores the presentation in two consecutive 256-byte **binary** configstrings,
 using the same fixed-size transport convention as `CS_STATUSBAR`. All 512 bytes survive, including embedded NULs
@@ -48,7 +48,7 @@ WC3's background/bar are models, so moving only images earlier is insufficient.
 For a listen server, `SV_Map` establishes the connection and sends these configstrings before `ge->LoadMap`, then
 calls `CL_LoadingFrame`. This limited packet pump invokes no command buffer, client tick, server tick, or gameplay
 callback. `cl.precache_ready` prevents the early layout/`CS_WORLD` from starting bulk registration until the full
-configstring handshake advances to baselines. Dedicated servers skip the presentation pump.
+configstring/baseline handshake reaches `precache`. Dedicated servers skip the presentation pump.
 
 `CS_ASSET_SCOPE` and `re.SetAssetScope` establish map-import resolution before renderer world registration.
 This matters for custom loading MDX models whose companion textures live inside the destination archive.
@@ -251,7 +251,7 @@ between model and image indices.
 
 The shared `net.loading_batch_registers_media_before_full_precache` test verifies that the first binary slot alone
 cannot publish the screen, initial model/image handles become available after the second slot, later world media
-remains deferred, and the existing baselines handshake opens the full-table gate. Corrupt compressed data and partial
+remains deferred, and only the final `precache` reply opens the registration gate. Corrupt compressed data and partial
 binary slots are rejected. `server_net.loading_batch_precedes_world_and_retains_resource_indices` exercises a later
 connection against the retained resource endpoints. Additional server tests verify all 512 binary bytes survive and
 oversized display text shrinks without changing geometry, texture coordinates, or animation directives.
@@ -267,3 +267,5 @@ A bounded console-script run also exercised Human02 → Human02 → Human01, wit
 commands. All three reached `G_ClientBegin`, and early screenshots showed the correct chapter/sequence at zero
 progress, including the same-map reload. Use actual `map` commands in an `exec` config for this check: repeated
 startup `+map` arguments are cvar assignments, so the last value wins instead of scheduling multiple transitions.
+
+LAN loading uses bounded startup pages and an engine-owned client map reader; see [LAN lobby and startup](../../architecture/network.md#lan-lobby-and-startup) for the timeout, UDP-size, and remote-only import-crash fixes.

--- a/games/warcraft-3/common/routing.c
+++ b/games/warcraft-3/common/routing.c
@@ -1524,31 +1524,3 @@ void CM_SetupTestPathmap(DWORD width, DWORD height, BYTE const *cells) {
     CM_SetupPathMap(width, height, cells);
 }
 #endif
-
-#ifndef TOOL_COMMON_NO_MPQ
-void CM_ReadPathMap(HANDLE archive) {
-    HANDLE file;
-    DWORD header, version;
-    DWORD width, height;
-    LPBYTE cells;
-    heatmap_cache_invalidate();
-    if (!SFileOpenFileEx(archive, "war3map.wpm", SFILE_OPEN_FROM_MPQ, &file)) {
-        CM_SetupPathMap(world.map ? world.map->width : 0, world.map ? world.map->height : 0, NULL);
-        return;
-    }
-    SFileReadFile(file, &header, 4, NULL, NULL);
-    SFileReadFile(file, &version, 4, NULL, NULL);
-    SFileReadFile(file, &width, 4, NULL, NULL);
-    SFileReadFile(file, &height, 4, NULL, NULL);
-    if (!width || !height) {
-        SFileCloseFile(file);
-        CM_SetupPathMap(0, 0, NULL);
-        return;
-    }
-    cells = MemAlloc(width * height);
-    SFileReadFile(file, cells, width * height, 0, 0);
-    SFileCloseFile(file);
-    CM_SetupPathMap(width, height, cells);
-    MemFree(cells);
-}
-#endif /* !TOOL_COMMON_NO_MPQ */

--- a/games/warcraft-3/common/world_w3.c
+++ b/games/warcraft-3/common/world_w3.c
@@ -2,6 +2,35 @@
 #include "common/ui_constants.h"
 #include <float.h>
 
+#ifdef BZ_CLIENT_WORLD
+/* The engine needs terrain pathing for placement previews, without game-owned routing jobs or imports. */
+static struct {
+    DWORD width, height;
+    BYTE *cells;
+} cl_path;
+
+/* Keep only client terrain cells; routing work buffers belong to the game module. */
+void CM_SetupPathMap(DWORD width, DWORD height, BYTE const *cells) {
+    SAFE_DELETE(cl_path.cells, MemFree);
+    cl_path.width = width; cl_path.height = height;
+    if (!width || !height) return;
+    cl_path.cells = MemAlloc(width * height);
+    if (cells) memcpy(cl_path.cells, cells, width * height);
+    else memset(cl_path.cells, 0, width * height);
+}
+
+/* Client collision circles add live blockers; this lookup supplies the map's authored terrain flags. */
+BOOL CM_GetPathingFlagsAt(LPCVECTOR2 pos, LPBYTE flags) {
+    if (flags) *flags = 0;
+    if (!pos || !flags || !cl_path.cells) return false;
+    VECTOR2 n = CM_GetNormalizedMapPosition(pos->x, pos->y);
+    int x = (int)floorf(n.x * cl_path.width), y = (int)floorf(n.y * cl_path.height);
+    if (x < 0 || y < 0 || x >= cl_path.width || y >= cl_path.height) return false;
+    *flags = cl_path.cells[x + y * cl_path.width];
+    return true;
+}
+#endif
+
 BOOL CL_GameDefaultCamera(gameCamera_t *camera) {
     if (!camera) return false;
     *camera = (gameCamera_t){
@@ -287,3 +316,50 @@ BOX2 CM_GetWorldBounds(void) {
             .y = (world.map->height - 1) * TILE_SIZE + world.map->center.y,
         });
 }
+
+#ifndef TOOL_COMMON_NO_MPQ
+/* Both worlds read the same WPM bytes; each module owns its path-data consumer. */
+void CM_ReadPathMap(HANDLE archive) {
+    HANDLE file;
+    DWORD header, version;
+    DWORD width, height;
+    LPBYTE cells;
+    if (!SFileOpenFileEx(archive, "war3map.wpm", SFILE_OPEN_FROM_MPQ, &file)) {
+        CM_SetupPathMap(world.map ? world.map->width : 0, world.map ? world.map->height : 0, NULL);
+        return;
+    }
+    SFileReadFile(file, &header, 4, NULL, NULL);
+    SFileReadFile(file, &version, 4, NULL, NULL);
+    SFileReadFile(file, &width, 4, NULL, NULL);
+    SFileReadFile(file, &height, 4, NULL, NULL);
+    if (!width || !height) {
+        SFileCloseFile(file);
+        CM_SetupPathMap(0, 0, NULL);
+        return;
+    }
+    cells = MemAlloc(width * height);
+    SFileReadFile(file, cells, width * height, 0, 0);
+    SFileCloseFile(file);
+    CM_SetupPathMap(width, height, cells);
+    MemFree(cells);
+}
+#endif /* !TOOL_COMMON_NO_MPQ */
+
+#if defined(BZ_CLIENT_WORLD) && defined(BZ_TESTS)
+#include "shared/test.h"
+
+/* Client path queries must use their own cells and replace them cleanly between maps. */
+TEST(client_world, terrain_path_flags_survive_load_replace_and_clear) {
+    BYTE cells[] = { 2, 4, 8, 16 }, flags = 0;
+    CM_SetupTestWorldBounds(&(BOX2){ .min = { 0, 0 }, .max = { 64, 64 } });
+    CM_SetupPathMap(2, 2, cells);
+    T_ASSERT(CM_GetPathingFlagsAt(&(VECTOR2){ 48, 16 }, &flags)); T_EQ(flags, 4);
+    T_ASSERT(CM_GetPathingFlagsAt(&(VECTOR2){ 16, 48 }, &flags)); T_EQ(flags, 8);
+    T_ASSERT(!CM_GetPathingFlagsAt(&(VECTOR2){ 64, 16 }, &flags));
+    CM_SetupPathMap(1, 1, cells);
+    T_ASSERT(CM_GetPathingFlagsAt(&(VECTOR2){ 48, 48 }, &flags)); T_EQ(flags, 2);
+    CM_SetupPathMap(0, 0, NULL);
+    T_ASSERT(!CM_GetPathingFlagsAt(&(VECTOR2){ 16, 16 }, &flags));
+    CM_SetupTestWorldBounds(NULL);
+}
+#endif

--- a/games/warcraft-3/game.mk
+++ b/games/warcraft-3/game.mk
@@ -107,7 +107,8 @@ $(eval $(call src_lib_schema,$(SHEET_LIB),$(WC3_SHEET_DIR)/parser.c $(WC3_SHEET_
 $(eval $(call unity_lib_schema,$(RENDERER_LIB),$(RENDERER_BASE_DEPS) $(call CSRC,renderer $(WC3_DIR)/renderer),renderer,renderer $(WC3_DIR)/renderer,,$(WC3_CFLAGS),common/mpq.c,$(RENDERER_SHARED_LIBS)))
 $(eval $(call unity_lib_schema,$(GAME_LIB),$(GAME_BASE_DEPS) $(JASS_LIB) $(SHEET_LIB) $(WORLD_CORE_SRCS) $(WC3_COMMON_SRCS) $(call CSRC,$(WC3_DIR)/game),game,$(WC3_DIR)/game $(WC3_DIR)/common,! -name 'world_w3.c' ! -name 'routing.c',$(WC3_FDF_CFLAGS),common/mpq.c,-lsheet -lshared -ljass $(LIBS) -lm -lz))
 $(eval $(call unity_lib_schema,$(MENU_LIB),$(UI_BASE_DEPS) $(MENU_HEADERS) common/mpq.c common/mpq.h $(WC3_COMMON_SRCS) $(call CSRC,$(WC3_DIR)/menu),menu,$(WC3_DIR)/menu $(WC3_DIR)/common,! -name 'world_w3.c' ! -name 'routing.c',$(WC3_FDF_CFLAGS),common/mpq.c,-lshared -lsheet -lm -lz))
-$(eval $(call app_schema,$(BINARY),$(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB) $(GAME_LIB) $(RENDERER_LIB) $(MENU_LIB) $(APP_SRCS) $(CLIENT_HEADERS) $(COMMON_HEADERS),openwarcraft3,$(WC3_FDF_CFLAGS),-lsheet -lshared -ljass -lgame -lrenderer -lmenu $(LIBS) $(WC3_FFMPEG_LIBS) -lz))
+# The remote client loads collision data before any game imports exist; compile its format reader into the engine.
+$(eval $(call app_schema,$(BINARY),$(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB) $(GAME_LIB) $(RENDERER_LIB) $(MENU_LIB) $(APP_SRCS) $(WC3_COMMON_SRCS) $(CLIENT_HEADERS) $(COMMON_HEADERS),openwarcraft3,$(WC3_FDF_CFLAGS) -DBZ_CLIENT_WORLD,-lsheet -lshared -ljass -lgame -lrenderer -lmenu $(LIBS) $(WC3_FFMPEG_LIBS) -lz,$(WC3_DIR)/common/world_w3.c))
 
 # ---------------------------------------------------------------------------
 # In-engine tests (see CONTRIBUTING.md)
@@ -124,7 +125,7 @@ GAME_WC3_TEST_LIB := $(LIB_DIR)/libgame-wc3-test$(LIB_EXT)
 WC3_TEST_BINARY   := $(BIN_DIR)/openwarcraft3-tests$(EXE_EXT)
 
 $(eval $(call unity_lib_schema,$(GAME_WC3_TEST_LIB),$(GAME_BASE_DEPS) $(JASS_LIB) $(SHEET_LIB) $(WORLD_CORE_SRCS) $(WC3_COMMON_SRCS) $(call CSRC,$(WC3_DIR)/game),game-wc3-test,$(WC3_DIR)/game $(WC3_DIR)/common,! -name 'world_w3.c' ! -name 'routing.c',$(WC3_FDF_CFLAGS) -DBZ_TESTS,common/mpq.c,-lsheet -lshared -ljass $(LIBS) -lm -lz))
-$(eval $(call app_schema,$(WC3_TEST_BINARY),$(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB) $(GAME_WC3_TEST_LIB) $(RENDERER_LIB) $(MENU_LIB) $(APP_SRCS) $(CLIENT_HEADERS) $(COMMON_HEADERS),openwarcraft3-tests,$(WC3_FDF_CFLAGS) -DBZ_TESTS,-lsheet -lshared -ljass -lgame-wc3-test -lrenderer -lmenu $(LIBS) $(WC3_FFMPEG_LIBS) -lz))
+$(eval $(call app_schema,$(WC3_TEST_BINARY),$(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB) $(GAME_WC3_TEST_LIB) $(RENDERER_LIB) $(MENU_LIB) $(APP_SRCS) $(WC3_COMMON_SRCS) $(CLIENT_HEADERS) $(COMMON_HEADERS),openwarcraft3-tests,$(WC3_FDF_CFLAGS) -DBZ_CLIENT_WORLD -DBZ_TESTS,-lsheet -lshared -ljass -lgame-wc3-test -lrenderer -lmenu $(LIBS) $(WC3_FFMPEG_LIBS) -lz,$(WC3_DIR)/common/world_w3.c))
 
 openwarcraft3-tests: $(WC3_TEST_BINARY)
 
@@ -170,7 +171,7 @@ TEST_JOBS ?= 16
 		test-wow-wmo test-menu test-wc3-engine
 
 $(eval $(call test_schema,test-commands,test-assets $(SHARED_LIB) $(SHEET_LIB),$(TEST_CFLAGS),$(BIN_DIR)/test_commands$(EXE_EXT),tests/test_runner.c $(WC3_TEST_DIR)/test_commands.c client/cl_screenshot.c common/common.c common/cmd.c common/cvar.c common/msg.c common/net.c common/mpq.c,-lsheet -lshared -lm -lz $(NET_LIBS),))
-$(eval $(call test_schema,test-server-net,test-assets $(SHARED_LIB) $(SHEET_LIB),$(TEST_CFLAGS),$(BIN_DIR)/test_server_net$(EXE_EXT),tests/test_runner.c $(WC3_TEST_DIR)/test_server_net.c $(WC3_TEST_DIR)/test_client_stubs.c server/sv_init.c server/sv_lan.c server/sv_main.c server/sv_lobby.c server/sv_send.c server/sv_ents.c server/sv_parse.c common/net.c common/msg.c,-lsheet -lshared -lm -lz $(NET_LIBS),))
+$(eval $(call test_schema,test-server-net,test-assets $(SHARED_LIB) $(SHEET_LIB),$(TEST_CFLAGS),$(BIN_DIR)/test_server_net$(EXE_EXT),tests/test_runner.c $(WC3_TEST_DIR)/test_server_net.c $(WC3_TEST_DIR)/test_client_stubs.c server/sv_init.c server/sv_lan.c server/sv_main.c server/sv_lobby.c server/sv_send.c server/sv_ents.c server/sv_parse.c server/sv_user.c common/net.c common/msg.c,-lsheet -lshared -lm -lz $(NET_LIBS),))
 $(eval $(call test_schema,test-renderer-model,$(SHARED_LIB),$(TEST_CFLAGS) -Wno-unused-function,$(BIN_DIR)/test_renderer_model$(EXE_EXT),tests/test_runner.c tests/test_renderer_model.c renderer/r_model.c $(WC3_DIR)/renderer/mdx/r_mdx_anim.c $(WC3_DIR)/renderer/mdx/r_mdx_interpolation.c $(WC3_DIR)/renderer/mdx/r_mdx_buffer.c $(WC3_DIR)/renderer/mdx/r_mdx_light.c,-lshared -lm $(LIBS),))
 $(eval $(call test_schema,test-renderer-view,$(SHARED_LIB) renderer/r_view.c renderer/r_local.h,$(TEST_CFLAGS),$(BIN_DIR)/test_renderer_view$(EXE_EXT),tests/test_runner.c tests/test_renderer_view.c,-lshared -lm $(LIBS),))
 $(eval $(call test_schema,test-renderer-shadows,$(SHARED_LIB),$(TEST_CFLAGS) -Wno-unused-function -DUSE_SHADOWMAPS,$(BIN_DIR)/test_renderer_shadows$(EXE_EXT),tests/test_runner.c tests/test_renderer_model.c renderer/r_model.c $(WC3_DIR)/renderer/mdx/r_mdx_anim.c $(WC3_DIR)/renderer/mdx/r_mdx_interpolation.c $(WC3_DIR)/renderer/mdx/r_mdx_buffer.c $(WC3_DIR)/renderer/mdx/r_mdx_light.c,-lshared -lm $(LIBS),))

--- a/games/warcraft-3/tests/test_server_net.c
+++ b/games/warcraft-3/tests/test_server_net.c
@@ -111,7 +111,6 @@ TEST(server_net, scheduler_clamps_multi_tick_wall_clock_backlog) {
     T_EQ(SV_ClampSimulationDeadline(180, 100), 100);
 }
 
-void SV_ExecuteUserCommand(LPSIZEBUF msg, LPCLIENT client) { (void)msg; (void)client; }
 void SV_HandleUnitUIRequest(LPCLIENT client, LPSIZEBUF msg) { (void)client; (void)msg; }
 
 static struct game_export test_ge;
@@ -1066,4 +1065,94 @@ TEST(server_net, loading_configstrings_bound_text_without_changing_geometry) {
     number = MSG_ReadEntityBits(&msg, &bits);
     MSG_ReadDeltaUIFrame(&msg, &frame, number, bits);
     T_EQ(frame.flags.type, FT_SPRITE); T_STREQ(frame.text, "#!123");
+}
+
+/* An idle lobby must keep both loopback and UDP peers alive without advancing simulation or rebuilding UI. */
+TEST(server_net, idle_lobby_sends_keepalives_without_simulating) {
+    BYTE buf[MAX_MSGLEN];
+    sizeBuf_t msg = { .data = buf, .maxsize = sizeof(buf) };
+    netadr_t from;
+    NET_Shutdown(); reset_server_state(2);
+    T_ASSERT(bind_server_socket(PORT_SERVER + 20));
+    int sock = open_client_socket();
+    T_ASSERT(sock >= 0);
+    send_connect_oob(sock, PORT_SERVER + 20); pump_server_connects();
+    T_ASSERT(recv_client_connect_oob(sock));
+    fcntl(sock, F_SETFL, fcntl(sock, F_GETFL, 0) & ~O_NONBLOCK);
+    SV_ClientConnect(); drain_client_packets();
+    sv.state = ss_lobby;
+    FOR_LOOP(i, 20) {
+        SV_Frame(1000);
+        T_ASSERT(NET_GetPacket(NS_CLIENT, &from, &msg));
+        T_EQ(msg.cursize, 1); T_EQ(MSG_ReadByte(&msg), svc_nop);
+        T_EQ(recv(sock, buf, sizeof(buf), 0), 1); T_EQ(buf[0], svc_nop);
+        T_EQ(sv.framenum, 0); T_EQ(sv.time, 0); T_EQ(svs.num_clients, 2);
+    }
+    close(sock); NET_Shutdown();
+}
+
+/* Map creation populates the signon table; replaying it as a live multicast bypassed UDP paging. */
+TEST(server_net, loading_configstrings_do_not_queue_duplicate_live_updates) {
+    NET_Shutdown(); reset_server_state(1);
+    sv.state = ss_loading;
+    SV_SetConfigString(CS_MODELS + 1, "Initial.mdx", sizeof("Initial.mdx"));
+    T_ASSERT(sv.syncstrings[CS_MODELS + 1]);
+    sv.state = ss_game;
+    SV_SetConfigString(CS_MODELS + 1, "Changed.mdx", sizeof("Changed.mdx"));
+    T_ASSERT(!sv.syncstrings[CS_MODELS + 1]);
+}
+
+/* Exercise the real command dispatcher over UDP with enough startup data to exceed the old datagram limit. */
+TEST(server_net, udp_signon_pages_preserve_complete_configstrings_and_baselines) {
+    BYTE buf[MAX_MSGLEN];
+    sizeBuf_t msg = { .data = buf, .maxsize = sizeof(buf) };
+    char next[64] = "configstrings";
+    DWORD strings = 0, bases = 0, pages = 0;
+    NET_Shutdown(); reset_server_state(2);
+    T_ASSERT(bind_server_socket(PORT_SERVER + 21));
+    int sock = open_client_socket();
+    T_ASSERT(sock >= 0);
+    struct timeval timeout = { .tv_sec = 1 };
+    T_EQ(setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)), 0);
+    send_connect_oob(sock, PORT_SERVER + 21); pump_server_connects();
+    T_ASSERT(recv_client_connect_oob(sock));
+    fcntl(sock, F_SETFL, fcntl(sock, F_GETFL, 0) & ~O_NONBLOCK);
+    sv.state = ss_game;
+    FOR_LOOP(i, 200) {
+        memset(sv.configstrings[CS_MODELS + i + 1], 'a' + i % 26, MAX_PATHLEN - 1);
+        test_edicts[i].s = (entityState_t){ .number = i, .model = i + 1, .origin = { i, i + 1, i + 2 } };
+    }
+    ge->num_edicts = 200;
+    while (strcmp(next, "precache")) {
+        T_ASSERT(pages++ < 300);
+        SZ_Clear(&msg); msg.readcount = 0;
+        MSG_WriteString(&msg, next);
+        SV_ExecuteUserCommand(&msg, &svs.clients[0]);
+        int size = recv(sock, buf, sizeof(buf), 0);
+        T_ASSERT(size > 0 && size <= BZ_SIGNON_SIZE);
+        if (size <= 0 || size > BZ_SIGNON_SIZE) break;
+        msg.cursize = size; msg.readcount = 0; next[0] = 0;
+        while (msg.readcount < msg.cursize) {
+            int op = MSG_ReadByte(&msg);
+            if (op == svc_configstring) {
+                int index = MSG_ReadShort(&msg);
+                T_EQ(index, CS_MODELS + ++strings);
+                T_STREQ(MSG_ReadString2(&msg), sv.configstrings[index]);
+            } else if (op == svc_spawnbaseline) {
+                DWORD bits;
+                entityState_t ent = { 0 };
+                int num = MSG_ReadEntityBits(&msg, &bits);
+                MSG_ReadDeltaEntity(&msg, &ent, num, bits);
+                T_EQ(num, bases); T_EQ(ent.model, bases + 1); T_FEQ(ent.origin.x, bases, 0.01f);
+                bases++;
+            } else {
+                T_EQ(op, svc_mirror);
+                MSG_ReadStringN(&msg, next, sizeof(next));
+            }
+        }
+        T_ASSERT(next[0]);
+        T_EQ(svs.clients[0].state, cs_connected);
+    }
+    T_EQ(strings, 200); T_EQ(bases, 200); T_ASSERT(pages > 2);
+    close(sock); NET_Shutdown();
 }

--- a/server/server.h
+++ b/server/server.h
@@ -9,6 +9,11 @@
 #define EDICT_NUM(n) ((edict_t *)((LPSTR)ge->edicts + ge->edict_size*(n)))
 #define NUM_FOR_EDICT(e) (DWORD)(((LPSTR)(e)-(LPSTR)ge->edicts) / ge->edict_size)
 
+#define BZ_SIGNON_SIZE 1400 // bytes; fits a 1500-byte LAN MTU with UDP/IP headers; bounds remote startup batches
+
+/* Loopback accepts engine-sized messages; UDP startup must fit an individual datagram. */
+static inline DWORD SV_SignonLimit(struct netchan const *chan) { return chan->remote_address.type == NA_LOOPBACK ? chan->message.maxsize : MIN(chan->message.maxsize, BZ_SIGNON_SIZE); }
+
 KNOWN_AS(client_frame, CLIENTFRAME);
 KNOWN_AS(client, CLIENT);
 
@@ -97,6 +102,7 @@ extern struct server {
     BOOL paused;
     DWORD next_frame_msec; /* real-time deadline for the next simulation frame */
     DWORD pause_msec; /* wall-clock accumulator used only for paused keepalive snapshots */
+    DWORD keepalive; /* real-time deadline for connected clients without gameplay snapshots */
     LPENTITYSTATE baselines;
     WORD loading_end[3]; /* first gameplay index in each loading media pool: models, images, fonts */
     sizeBuf_t multicast;

--- a/server/sv_init.c
+++ b/server/sv_init.c
@@ -326,12 +326,12 @@ void SV_SendLoadingConfigstrings(LPCLIENT cl) {
     FOR_LOOP(i, sizeof(loading_pools) / sizeof(*loading_pools))
         for (DWORD j = 1; j < sv.loading_end[i]; j++) {
             DWORD index = loading_pools[i].base + j;
-            if (cl->netchan.message.cursize + SV_ConfigStringWireSize(index) > cl->netchan.message.maxsize)
+            if (cl->netchan.message.cursize + SV_ConfigStringWireSize(index) > SV_SignonLimit(&cl->netchan))
                 Netchan_Transmit(NS_SERVER, &cl->netchan);
             SV_WriteConfigString(&cl->netchan.message, index);
         }
     FOR_LOOP(i, BZ_LOADING_SCREEN_SLOTS) {
-        if (cl->netchan.message.cursize + SV_ConfigStringWireSize(CS_LOADINGSCREEN1 + i) > cl->netchan.message.maxsize)
+        if (cl->netchan.message.cursize + SV_ConfigStringWireSize(CS_LOADINGSCREEN1 + i) > SV_SignonLimit(&cl->netchan))
             Netchan_Transmit(NS_SERVER, &cl->netchan);
         SV_WriteConfigString(&cl->netchan.message, CS_LOADINGSCREEN1 + i);
     }

--- a/server/sv_main.c
+++ b/server/sv_main.c
@@ -16,6 +16,8 @@ struct game_export *ge;
 struct server sv;
 struct server_static svs;
 
+#define BZ_KEEPALIVE_MSEC 1000 // milliseconds; Quake 2's interval; keeps clients alive while waiting to spawn
+
 BOOL SV_IsActive(void) {
     return svs.initialized && (sv.state == ss_lobby || sv.state == ss_game);
 }
@@ -35,8 +37,8 @@ void SV_SetConfigString(DWORD index, LPCSTR value, DWORD len) {
     if (len > max) len = max;
     memset(sv.configstrings[index], 0, sizeof(sv.configstrings[index]));
     memcpy(sv.configstrings[index], value, len);
-    /* Connected clients otherwise retain the old value because true means that slot was already sent. */
-    sv.syncstrings[index] = false;
+    /* Q2 publishes loading-time values through signon, not a second bulk live update that overflows UDP. */
+    sv.syncstrings[index] = sv.state == ss_loading;
 }
 
 /* Batch bounds must account for fixed binary slots as well as theme-decorated strings. */
@@ -66,7 +68,7 @@ static void SV_SendClientDatagram(LPCLIENT client) {
 /* Flush any un-synced config strings to all clients, then send a per-frame
  * datagram to every spawned client containing the current entity snapshot. */
 static void SV_SendClientMessages(void) {
-    FOR_LOOP(i, MAX_CONFIGSTRINGS) {
+    for (DWORD i = 0; sv.state == ss_game && i < MAX_CONFIGSTRINGS; i++) {
         if (*sv.configstrings[i] && !sv.syncstrings[i]) {
             SV_WriteConfigString(&sv.multicast, i);
             SV_Multicast(&(VECTOR3){0,0,0}, MULTICAST_ALL_R);
@@ -74,10 +76,17 @@ static void SV_SendClientMessages(void) {
     }
     FOR_LOOP(i, svs.num_clients) {
         LPCLIENT client = &svs.clients[i];
-        if (client->state == cs_spawned) {
+        if (client->state == cs_spawned && sv.state == ss_game) {
             SV_SendClientDatagram(client);
+        } else if (client->state == cs_connected || client->state == cs_spawned) {
+            /* Q2 sends pending messages or a one-second keepalive while a client has no gameplay frames. */
+            if (client->netchan.message.cursize || svs.realtime >= sv.keepalive) {
+                if (!client->netchan.message.cursize) MSG_WriteByte(&client->netchan.message, svc_nop);
+                Netchan_Transmit(NS_SERVER, &client->netchan);
+            }
         }
     }
+    if (svs.realtime >= sv.keepalive) sv.keepalive = svs.realtime + BZ_KEEPALIVE_MSEC;
 }
 
 static void SV_ProcessPacket(netadr_t *from, LPSIZEBUF net_message, int r) {
@@ -223,6 +232,8 @@ void SV_Frame(DWORD msec) {
     SV_ReadPackets();
 
     if (sv.state == ss_lobby) {
+        /* An unchanged lobby previously sent nothing and timed out even its own loopback host. */
+        SV_SendClientMessages();
         return;
     }
 

--- a/server/sv_user.c
+++ b/server/sv_user.c
@@ -1,74 +1,60 @@
 #include "server.h"
+#include <stdlib.h>
 
 static DWORD SV_ClientPlayerNumber(LPCLIENT cl) {
     return cl->playernum < MAX_PLAYERS ? cl->playernum : 0;
 }
 
-static void SV_FlushSpawnMessage(LPCLIENT cl, LPCSTR phase, DWORD count) {
-    if (cl->netchan.message.cursize == 0) {
-        return;
+/* Continuation indexes come from the peer; reject malformed requests before indexing server tables. */
+static int SV_SignonStart(int argc, LPCSTR *argv, DWORD count) {
+    if (argc == 1) return 0;
+    char *end;
+    long start = argc == 2 ? strtol(argv[1], &end, 10) : -1;
+    if (start < 0 || start > count || !argv[1][0] || *end) {
+        fprintf(stderr, "SV_SignonStart: invalid %s continuation\n", argv[0]);
+        return -1;
     }
-    if (cl->netchan.message.overflowed) {
-        fprintf(stderr,
-                "SV_%s_f: transmitting overflowed batch count=%u bytes=%u max=%u\n",
-                phase,
-                (unsigned)count,
-                (unsigned)cl->netchan.message.cursize,
-                (unsigned)cl->netchan.message.maxsize);
-    }
-    Netchan_Transmit(NS_SERVER, &cl->netchan);
+    return (int)start;
 }
 
+/* Q2-style request pacing bounds UDP packets and avoids flooding the receiver during registration. */
 void SV_Configstrings_f(LPCLIENT cl, int argc, LPCSTR *argv) {
-    DWORD batch_count = 0;
-
-    (void)argc;
-    (void)argv;
-
+    int start = SV_SignonStart(argc, argv, MAX_CONFIGSTRINGS);
+    DWORD limit = SV_SignonLimit(&cl->netchan);
+    if (cl->state != cs_connected || start < 0) return;
     if (!cl->edict) cl->edict = EDICT_NUM(SV_ClientPlayerNumber(cl));
-    FOR_LOOP(i, MAX_CONFIGSTRINGS) {
-        if (i == CS_LOADINGSCREEN1 || i == CS_LOADINGSCREEN2 || !*sv.configstrings[i])
-            continue;
-        if (cl->netchan.message.cursize + SV_ConfigStringWireSize(i) + 16 >= cl->netchan.message.maxsize) {
-            SV_FlushSpawnMessage(cl, "Configstrings", batch_count);
-            batch_count = 0;
-        }
-        SV_WriteConfigString(&cl->netchan.message, i);
-        batch_count++;
+    for (; start < MAX_CONFIGSTRINGS; start++) {
+        if (start == CS_LOADINGSCREEN1 || start == CS_LOADINGSCREEN2 || !*sv.configstrings[start]) continue;
+        /* The engine buffer is much larger than a UDP datagram; reserve room for the next request too. */
+        if (cl->netchan.message.cursize + SV_ConfigStringWireSize(start) + 32 > limit) break;
+        SV_WriteConfigString(&cl->netchan.message, start);
     }
-    if (cl->netchan.message.cursize + 16 >= cl->netchan.message.maxsize) {
-        SV_FlushSpawnMessage(cl, "Configstrings", batch_count);
-    }
+    char next[32];
+    if (start == MAX_CONFIGSTRINGS) strlcpy(next, "baselines", sizeof(next));
+    else snprintf(next, sizeof(next), "configstrings %d", start);
     MSG_WriteByte(&cl->netchan.message, svc_mirror);
-    MSG_WriteString(&cl->netchan.message, "baselines");
+    MSG_WriteString(&cl->netchan.message, next);
     Netchan_Transmit(NS_SERVER, &cl->netchan);
 }
 
+/* Baselines share the configstring continuation contract, so begin cannot overtake later entity pages. */
 void SV_Baselines_f(LPCLIENT cl, int argc, LPCSTR *argv) {
-    entityState_t nullstate;
-    DWORD batch_count = 0;
-
-    (void)argc;
-    (void)argv;
-
-    memset(&nullstate, 0, sizeof(entityState_t));
-    FOR_LOOP(index, ge->num_edicts) {
-        edict_t *e = EDICT_NUM(index);
-        if (e->svflags & SVF_NOCLIENT)
-            continue;
-        if (cl->netchan.message.cursize + 512 >= cl->netchan.message.maxsize) {
-            SV_FlushSpawnMessage(cl, "Baselines", batch_count);
-            batch_count = 0;
-        }
+    entityState_t empty = { 0 };
+    int start = SV_SignonStart(argc, argv, ge->num_edicts);
+    DWORD limit = SV_SignonLimit(&cl->netchan);
+    if (cl->state != cs_connected || start < 0) return;
+    for (; start < ge->num_edicts; start++) {
+        edict_t *ent = EDICT_NUM(start);
+        if (ent->svflags & SVF_NOCLIENT) continue;
+        if (cl->netchan.message.cursize + 512 + 32 > limit) break;
         MSG_WriteByte(&cl->netchan.message, svc_spawnbaseline);
-        MSG_WriteDeltaEntity(&cl->netchan.message, &nullstate, &e->s, true);
-        batch_count++;
+        MSG_WriteDeltaEntity(&cl->netchan.message, &empty, &ent->s, true);
     }
-    if (cl->netchan.message.cursize + 16 >= cl->netchan.message.maxsize) {
-        SV_FlushSpawnMessage(cl, "Baselines", batch_count);
-    }
+    char next[32];
+    if (start == ge->num_edicts) strlcpy(next, "precache", sizeof(next));
+    else snprintf(next, sizeof(next), "baselines %d", start);
     MSG_WriteByte(&cl->netchan.message, svc_mirror);
-    MSG_WriteString(&cl->netchan.message, "playerinfo");
+    MSG_WriteString(&cl->netchan.message, next);
     Netchan_Transmit(NS_SERVER, &cl->netchan);
 }
 

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -3047,7 +3047,15 @@ TEST(net, loading_batch_registers_media_before_full_precache) {
     MSG_WriteByte(&msg, svc_configstring); MSG_WriteShort(&msg, CS_MODELS + 2); MSG_WriteString(&msg, "World.mdx");
     MSG_WriteByte(&msg, svc_mirror); MSG_WriteString(&msg, "baselines");
     CL_ParseServerMessage(&msg);
-    T_ASSERT(cl.precache_ready); T_NULL(cl.models[2]); T_EQ(test_model_loads, 1);
+    T_ASSERT(!cl.precache_ready); T_NULL(cl.models[2]); T_EQ(test_model_loads, 1);
+    SZ_Clear(&msg); msg.readcount = 0;
+    MSG_WriteByte(&msg, svc_mirror); MSG_WriteString(&msg, "baselines 25");
+    CL_ParseServerMessage(&msg);
+    T_ASSERT(!cl.precache_ready);
+    SZ_Clear(&msg); msg.readcount = 0;
+    MSG_WriteByte(&msg, svc_mirror); MSG_WriteString(&msg, "precache");
+    CL_ParseServerMessage(&msg);
+    T_ASSERT(cl.precache_ready);
     MemFree(cl.layout[LAYER_LOADING]); cl.layout[LAYER_LOADING] = NULL;
     SCR_ClearLayoutLayer(LAYER_LOADING); scr_initialized = old_init;
 }
@@ -3068,4 +3076,20 @@ TEST(net, loading_configstrings_reject_corrupt_and_partial_payloads) {
     MSG_Write(&msg, packed, MAX_PATHLEN - 1);
     CL_ParseServerMessage(&msg);
     T_NULL(cl.layout[LAYER_LOADING]); T_ASSERT(!cl.precache_ready);
+}
+
+/* Transport keepalives must not replace lobby presentation or stop parsing the next message. */
+TEST(net, keepalive_preserves_loading_state_and_continues_packet) {
+    BYTE buf[64];
+    sizeBuf_t msg = make_msg_buf(buf, sizeof(buf));
+    test_client_stubs_init();
+    SZ_Init(&cls.netchan.message, cls.netchan.message_buf, sizeof(cls.netchan.message_buf));
+    cl.loading_progress = 0.4f;
+    MSG_WriteByte(&msg, svc_nop);
+    MSG_WriteByte(&msg, svc_mirror); MSG_WriteString(&msg, "baselines 25");
+    CL_ParseServerMessage(&msg);
+    T_FEQ(cl.loading_progress, 0.4f, 0.001f); T_ASSERT(!cl.precache_ready);
+    cls.netchan.message.readcount = 0;
+    T_EQ(MSG_ReadByte(&cls.netchan.message), clc_stringcmd);
+    T_STREQ(MSG_ReadString2(&cls.netchan.message), "baselines 25");
 }


### PR DESCRIPTION
An idle LAN host disconnected itself after about 10 seconds, and starting a joined game left the remote player on the loading screen. Keep the lobby alive until cancellation and let both host and guest complete startup using Quake II's keepalive and client-requested signon patterns.

- Send pending messages or one-second keepalives to waiting clients without advancing lobby simulation.
- Page remote configstrings and entity baselines within a 1,400-byte budget. Enable asset registration only after the final `precache` reply, and suppress duplicate loading-time configstring broadcasts.
- Compile WC3's client world reader and terrain-pathing consumer into the engine. Remote map registration previously reached uninitialized game imports; listen servers masked the dependency.
- Add regression coverage for lobby keepalives, complete UDP startup transfers, the precache gate, and independent client terrain data. Document the lifecycle and reproduction procedure.

The measured 25,395-byte reply contained 10,772 bytes of duplicate updates, a 14,612-byte table of 308 resource references/metadata entries, and an 11-byte handshake command. The duplicate update is removed. The table still includes unused native UI template declarations; the audit documents that remaining overhead.

Validation:

- `make test`: all 2,927 tests / 61,017 assertions passed.
- Production binary rebuilt successfully after removing diagnostic instrumentation.
- Bounded idle-host run stayed in the lobby beyond the former timeout.
- Two local macOS processes using real UDP loaded `Maps/(2)PlunderIsle.w3m`; both entered gameplay at their own starting locations, verified with engine screenshots.
- `git diff --check` passed.

Both peers need the updated build because the startup handshake changes. This uses the existing UDP transport; full Quake II reliable/sequenced netchan behavior remains outside this change.
