### PR TITLE
fix(wc3): close Human02Interlude terrain holes

### DIFF
--- a/docs/games/warcraft-3/architecture/map-renderer.md
+++ b/docs/games/warcraft-3/architecture/map-renderer.md
@@ -114,7 +114,11 @@ For each tile the four corner vertices are examined. Their relative height diffe
 | 1 | `B` | `H` |
 | 2 | `C` | `X` |
 
-Corner order is `[SW, NW, SE, NE]` (stored in `remap[] = {3,1,0,2}`). The resulting string like `"AABB"` selects the correct model variant.
+Corner order is `[SW, NW, NE, SE]` (`r_cliff_corners[] = {3,1,0,2}`), while `GetTileVertices` stores
+`[NE, NW, SE, SW]`. The resulting string like `"AABB"` selects the correct model variant.
+
+`R_CliffTexture` selects the first authored cliff index in this same configuration order. W3E index 15 marks a
+non-cliff corner, not a texture layer. Checking only SW discards legitimate faces whose other corners identify the cliff.
 
 ### Ground Override
 
@@ -122,7 +126,49 @@ When a cliff tile is built, the renderer overwrites the `ground` index of all fo
 
 ### Ramp Placement
 
-For ramp tiles the model is translated by ±`TILE_SIZE` in X or Y depending on which side has the lower terrain. The axis is chosen by comparing the model's bounding-box extents: if the model is wider in X the ramp runs east–west and the X offset is adjusted; otherwise it runs north–south and Y is adjusted.
+The base MDX translation is `((x+1)*TILE_SIZE, y*TILE_SIZE)`. `R_CliffRampOffset` extends the two-cell model
+into the low-side neighbour that the ground baker intentionally omits. The longer bounding-box axis identifies the ramp axis.
+East–west MDX models occupy local X `[-256,0]`: west-high ramps add 128 to X, east-high ramps keep the base X.
+North–south models occupy local Y `[0,256]`: north-high ramps subtract 128 from Y, south-high ramps keep the base Y.
+The two axes are not interchangeable: applying the Y adjustment rule to X leaves every E/W ramp one cell west.
+
+### Human02Interlude terrain-hole regression
+
+`Maps/Campaign/Human02Interlude.w3m` is a standalone cinematic map and can be launched directly; completing Human02 with
+the `win` cheat reaches the same map. The inspected local ROC data has 97x65 vertices, tileset X, 9 ground textures,
+2 cliff textures, tile size 128, and world offset `(-7168,-3072)`. Coordinates below are zero-based SW cell coordinates.
+
+Targeted logs at ground rejection and cliff-model baking identified two independent geometry omissions:
+
+- 73 of 2,284 cliff cells had SW cliff index 15 and were rejected by every cliff layer despite valid indices at other corners.
+  Examples: `(10,29)` AACA and `(65,35)` ABBA use cliff 1; `(75,25)` CCAC and `(77,9)` BBBA use cliff 0.
+- The screenshot's courtyard holes remained after fixing that selection. E/W ramp models at `(36,33)` HAAL,
+  `(36,34)` AHLA, and `(36,36)/(36,37)/(36,41)/(36,42)` HBAL/BHLA were baked across columns 35–36 instead of 36–37.
+  The ground baker correctly skipped low-side cells `(37,33)`, `(37,34)`, `(37,36)`, `(37,37)`, `(37,41)`, `(37,42)`;
+  the misplaced meshes never covered them. The foreground pair starts at world `(-2432,1536)` and `(-2432,1664)`;
+  the background pair starts at `(-2432,2176)` and `(-2432,2304)`.
+
+The HBAL MDX vertices confirm X endpoints -256 (high) and 0 (low), with the midpoint at -128. For `(36,36)`,
+the old translation was `(37,36)` tiles and bounds `[35,37] x [36,37]`; the correct translation is `(38,36)` and
+bounds `[36,38] x [36,37]`. This is placement, not inverted normals or flipped UVs. Drawing the skipped cliff ground
+does not repair the ramp holes. The incorrect X rule dates to `62e559a76` (2023), not the recent ramp-classification change.
+
+Windowed, bounded visual check (the built-in screenshot captures only the game drawable):
+
+```sh
+make -j8 build test-renderer-model
+build/bin/openwarcraft3 -data 'data/Warcraft III' +set vid_fullscreen 0 +set vid_native 0 +set vid_mode 4 +set skip_cutscene 1 +com_frame_limit 230 +map 'Maps/Campaign/Human02Interlude.w3m' +screenshot 180
+```
+
+Inspect the generated `screenshots/shot*.jpg` at the courtyard close-up: the foreground and background ramp edges must be
+continuous, without black/sky-coloured gaps. Cinematic timing can vary; adjust the capture frame if necessary.
+`renderer_terrain.cliff_texture_skips_non_cliff_corners` covers corner priority/sentinel handling, and
+`renderer_terrain.ramp_footprints_cover_the_low_neighbour` checks the sampled ramp levels and all four directions without
+requiring retail MPQ data. Camera behavior is a separate issue; see [cinematics](../cinematics.md).
+
+Verification: temporarily restoring only the old X placement reproduced the reported black/sky-coloured holes in the
+same courtyard view and failed 10 footprint assertions. Restoring the fix removed those holes in the matching windowed
+capture; all 2,833 assertions in the 75 renderer-model tests passed. Investigative logs were removed afterward.
 
 ### Height Snapping
 

--- a/docs/games/warcraft-3/architecture/map-renderer.md
+++ b/docs/games/warcraft-3/architecture/map-renderer.md
@@ -114,23 +114,56 @@ For each tile the four corner vertices are examined. Their relative height diffe
 | 1 | `B` | `H` |
 | 2 | `C` | `X` |
 
-Corner order is `[SW, NW, NE, SE]` (`r_cliff_corners[] = {3,1,0,2}`), while `GetTileVertices` stores
+Corner order is `[NW, NE, SE, SW]` (`r_cliff_corners[] = {1,0,2,3}`), while `GetTileVertices` stores
 `[NE, NW, SE, SW]`. The resulting string like `"AABB"` selects the correct model variant.
 
-`R_CliffTexture` selects the first authored cliff index in this same configuration order. W3E index 15 marks a
+`R_CliffTexture` selects the first authored cliff index in **SW, NW, NE, SE** order, independently of the model order.
+W3E index 15 marks a
 non-cliff corner, not a texture layer. Checking only SW discards legitimate faces whose other corners identify the cliff.
+
+The per-map model cache keys the full asset path, not just four configuration letters. `Cliffs` and `CityCliffs`
+(likewise `CliffTrans` and `CityCliffTrans`) contain different geometry with identical configuration suffixes.
+The former four-letter key, introduced in May 2023, returned city models for dirt requests in Human02Interlude.
+This was confirmed by logging requested directory versus the cached model's directory; it was not the courtyard border cause.
 
 ### Ground Override
 
-When a cliff tile is built, the renderer overwrites the `ground` index of all four corners to match the cliff type's `groundTile` entry from `CliffTypes.slk`. This ensures the ground layer paints the right texture on the flat surface at the top of the cliff.
+Before baking ground layers, the renderer overrides the `ground` index around the **entire cliff model footprint** with
+the cliff type's `groundTile` (or authored `upperTile`) from `CliffTypes.slk`. Ordinary cliffs cover one cell/four vertices;
+ramps cover two cells/six vertices, including the low-side neighbour. Merely painting the first cell leaves the ground
+texture border one tile short even when the cliff mesh itself covers the correct area.
 
 ### Ramp Placement
 
-The base MDX translation is `((x+1)*TILE_SIZE, y*TILE_SIZE)`. `R_CliffRampOffset` extends the two-cell model
-into the low-side neighbour that the ground baker intentionally omits. The longer bounding-box axis identifies the ramp axis.
-East–west MDX models occupy local X `[-256,0]`: west-high ramps add 128 to X, east-high ramps keep the base X.
-North–south models occupy local Y `[0,256]`: north-high ramps subtract 128 from Y, south-high ramps keep the base Y.
-The two axes are not interchangeable: applying the Y adjustment rule to X leaves every E/W ramp one cell west.
+Native MDX positions and normals are rotated -90 degrees about Z: `(x,y,z) -> (y,-x,z)`, preserving the authored UVs.
+The base translation is `(x*TILE_SIZE, y*TILE_SIZE)`. `R_CliffRampOffset` extends the two-cell model into the
+low-side neighbour intentionally omitted by the ground baker. Native Y-long models are world east–west ramps;
+native X-long models are world north–south ramps. Both rotated long axes span `[0,256]`.
+East-high ramps shift X by -128; west-high ramps do not shift. North-high ramps shift Y by -128; south-high do not shift.
+
+Do not replace this rotation with cyclically shifted filename letters. The assets are not exact rotated copies:
+in the inspected archive `CityCliffTransHBAL0` has 31 vertices, while `CityCliffTransBALH0` has 32, with different
+interior heights and UV details. The earlier SW-first filename plus X translation repaired coverage but chose the wrong mesh.
+
+### Local Game.dll evidence
+
+The user-provided `data/Warcraft3demo/Game.dll` (SHA-256
+`286823c37a1083e91f07d040e46a9df7af4c4952e01fcbba460589bd4e297654`, preferred image base `0x6f000000`)
+provides these version-specific disassembly anchors:
+
+| Address | Observed contract |
+|---------|-------------------|
+| `0x6f1283e0` | Reads corners `(x,y+1), (x+1,y+1), (x+1,y), (x,y)`: NW, NE, SE, SW. |
+| `0x6f128770` | Ramp filename construction and model lookup. |
+| `0x6f4f9e28` | Sixteen 24-byte ramp records: two four-letter masks, origin X/Y, low-neighbour X/Y. |
+| `0x6f128b90` | Loads -90 degrees (`0x6f4f9e20`) before the position/normal transform at `0x6f11dfb0`. |
+| `0x6f11e200` | Heightmap deformation after rotation; adjusts Z, not an additional XY tile offset. |
+| `0x6f0ea900` | Geometry cache hashes and compares the full filename. |
+
+These are inspection addresses for this demo DLL, not universal offsets or a claim of matching every retail version.
+For example, `radare2 -q -e scr.color=0 -c 'pD 512 @ 0x6f1283e0; q' data/Warcraft3demo/Game.dll` inspects corner order.
+The local Warsmash reference (`environment/Terrain.java`, `realTileTexture`) independently explains the ground-border rule:
+a vertex adjacent to either the high or low ramp cell receives that cliff's ground tile.
 
 ### Human02Interlude terrain-hole regression
 
@@ -138,37 +171,53 @@ The two axes are not interchangeable: applying the Y adjustment rule to X leaves
 the `win` cheat reaches the same map. The inspected local ROC data has 97x65 vertices, tileset X, 9 ground textures,
 2 cliff textures, tile size 128, and world offset `(-7168,-3072)`. Coordinates below are zero-based SW cell coordinates.
 
-Targeted logs at ground rejection and cliff-model baking identified two independent geometry omissions:
+The first investigation's targeted logs at ground rejection and cliff-model baking identified two geometry omissions:
 
 - 73 of 2,284 cliff cells had SW cliff index 15 and were rejected by every cliff layer despite valid indices at other corners.
-  Examples: `(10,29)` AACA and `(65,35)` ABBA use cliff 1; `(75,25)` CCAC and `(77,9)` BBBA use cliff 0.
+  Examples: `(10,29)` and `(65,35)` use cliff 1; `(75,25)` and `(77,9)` use cliff 0.
 - The screenshot's courtyard holes remained after fixing that selection. E/W ramp models at `(36,33)` HAAL,
   `(36,34)` AHLA, and `(36,36)/(36,37)/(36,41)/(36,42)` HBAL/BHLA were baked across columns 35–36 instead of 36–37.
   The ground baker correctly skipped low-side cells `(37,33)`, `(37,34)`, `(37,36)`, `(37,37)`, `(37,41)`, `(37,42)`;
   the misplaced meshes never covered them. The foreground pair starts at world `(-2432,1536)` and `(-2432,1664)`;
   the background pair starts at `(-2432,2176)` and `(-2432,2304)`.
 
-The HBAL MDX vertices confirm X endpoints -256 (high) and 0 (low), with the midpoint at -128. For `(36,36)`,
-the old translation was `(37,36)` tiles and bounds `[35,37] x [36,37]`; the correct translation is `(38,36)` and
-bounds `[36,38] x [36,37]`. This is placement, not inverted normals or flipped UVs. Drawing the skipped cliff ground
-does not repair the ramp holes. The incorrect X rule dates to `62e559a76` (2023), not the recent ramp-classification change.
+Those configuration names describe the **old SW-first implementation**. The incorrect X rule dates to `62e559a76`
+(2023), not the recent ramp-classification change. Drawing the skipped ground does not repair the ramp holes.
+The first correction fixed mesh coverage, but the user's retail comparison exposed a remaining one-tile purple-border error.
+
+Follow-up logs and DLL inspection identified the native corner/rotation contract above and the missing ground override:
+
+| High cell | Native city ramp | Low cell | Far-end ground vertices omitted by the old override |
+|-----------|------------------|----------|----------------------------------------------------|
+| `(36,36)` | `BALH0` | `(37,36)` | `(38,36)`, `(38,37)` |
+| `(36,37)` | `HLAB0` | `(37,37)` | `(38,37)`, `(38,38)` |
+| `(36,41)` | `BALH0` | `(37,41)` | `(38,41)`, `(38,42)` |
+| `(36,42)` | `HLAB0` | `(37,42)` | `(38,42)`, `(38,43)` |
+
+For `(36,36)`, the native rotated model is translated by `(36,36)` tiles and covers `[36,38] x [36,37]`.
+Its cliff type `CXsq` selects `CityCliffTrans`, `Cliff1`, and ground `Xsqd` (index 4). Logs showed `(38,36)` and `(38,37)`
+still carrying ground index 0, while the first four corners carried 4. Covering all six vertices moves the painted edge
+to the ramp's actual low end, beneath Arthas, and likewise repairs the background edge.
+The base and locale archives' W3E data were identical; the discrepancy was not different map input.
 
 Windowed, bounded visual check (the built-in screenshot captures only the game drawable):
 
 ```sh
-make -j8 build test-renderer-model
+make -j8 build test-renderer-model test-renderer-shadows
 build/bin/openwarcraft3 -data 'data/Warcraft III' +set vid_fullscreen 0 +set vid_native 0 +set vid_mode 4 +set skip_cutscene 1 +com_frame_limit 230 +map 'Maps/Campaign/Human02Interlude.w3m' +screenshot 180
 ```
 
 Inspect the generated `screenshots/shot*.jpg` at the courtyard close-up: the foreground and background ramp edges must be
 continuous, without black/sky-coloured gaps. Cinematic timing can vary; adjust the capture frame if necessary.
 `renderer_terrain.cliff_texture_skips_non_cliff_corners` covers corner priority/sentinel handling, and
-`renderer_terrain.ramp_footprints_cover_the_low_neighbour` checks the sampled ramp levels and all four directions without
-requiring retail MPQ data. Camera behavior is a separate issue; see [cinematics](../cinematics.md).
+`renderer_terrain.ramp_footprints_cover_the_low_neighbour` checks sampled ramp levels and all four directions.
+`renderer_terrain.cliff_baker_preserves_native_axes_uvs_and_ground_coverage` runs the actual baker on a synthetic grid,
+checking model names, transformed positions/normals, untouched UVs, all six ramp ground vertices, and ordinary four-corner cliffs.
+`renderer_terrain.cliff_cache_distinguishes_model_directories` exercises actual cache lookup/reuse and cleanup.
+These tests require no retail MPQ data. Camera behavior is separate; see [cinematics](../cinematics.md).
 
-Verification: temporarily restoring only the old X placement reproduced the reported black/sky-coloured holes in the
-same courtyard view and failed 10 footprint assertions. Restoring the fix removed those holes in the matching windowed
-capture; all 2,833 assertions in the 75 renderer-model tests passed. Investigative logs were removed afterward.
+Windowed follow-up captures before/after the ground override show both purple edges reaching their low-side endpoints;
+rotating the native geometry alone did not fix that border. The cleaned build was captured again after the cache fix.
 
 ### Height Snapping
 

--- a/games/warcraft-3/renderer/w3m/r_war3map.h
+++ b/games/warcraft-3/renderer/w3m/r_war3map.h
@@ -31,7 +31,7 @@ DWORD GetTileRamps(LPCWAR3MAPVERTEX vertices);
 DWORD IsTileCliff(LPCWAR3MAPVERTEX vertices);
 DWORD IsTileWater(LPCWAR3MAPVERTEX vertices);
 
-/* A non-cliff SW corner must not discard the face: use the first authored cliff in configuration order. */
+/* A non-cliff SW corner must not discard the face: use the first authored cliff in SW,NW,NE,SE order. */
 static inline DWORD R_CliffTexture(LPCWAR3MAPVERTEX tile) {
     static const BYTE order[] = { 3, 1, 0, 2 }; /* Texture priority is independent of model corner order. */
     FOR_LOOP(i, 4)

--- a/games/warcraft-3/renderer/w3m/r_war3map.h
+++ b/games/warcraft-3/renderer/w3m/r_war3map.h
@@ -4,6 +4,10 @@
 #include "renderer/r_local.h"
 #include "r_terrain_layers.h"
 
+#define BZ_WC3_NO_CLIFF_TEXTURE 15 // index; W3E's non-cliff corner sentinel; excluded from cliff texture selection
+
+static const BYTE r_cliff_corners[] = { 3, 1, 0, 2 }; /* MDX configuration order: SW,NW,NE,SE. */
+
 LPMAPLAYER R_BuildMapSegmentLayer(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD layer);
 LPMAPLAYER R_BuildGroundLayerGlobal(LPCWAR3MAP map, DWORD layer);
 LPMAPLAYER R_BuildMapSegmentCliffs(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD cliff);
@@ -24,6 +28,24 @@ void SetTileUV(LPCWAR3MAPVERTEX mv, DWORD tile, LPVERTEX vertices, LPCTEXTURE te
 DWORD GetTileRamps(LPCWAR3MAPVERTEX vertices);
 DWORD IsTileCliff(LPCWAR3MAPVERTEX vertices);
 DWORD IsTileWater(LPCWAR3MAPVERTEX vertices);
+
+/* A non-cliff SW corner must not discard the face: use the first authored cliff in configuration order. */
+static inline DWORD R_CliffTexture(LPCWAR3MAPVERTEX tile) {
+    FOR_LOOP(i, 4)
+        if (tile[r_cliff_corners[i]].cliff != BZ_WC3_NO_CLIFF_TEXTURE)
+            return tile[r_cliff_corners[i]].cliff;
+    return BZ_WC3_NO_CLIFF_TEXTURE;
+}
+
+/* Extend the two-cell MDX footprint into the low neighbour omitted by the ground baker. */
+static inline VECTOR2 R_CliffRampOffset(LPCWAR3MAPVERTEX tile, LPCBOX3 box) {
+    VECTOR3 span = Vector3_sub(&box->max, &box->min);
+    if (span.x > span.y) {
+        /* MDX X is [-256,0], not [0,256]; the old negative shift left every E/W ramp one cell west. */
+        return (VECTOR2){ .x = tile[3].level + tile[1].level > tile[2].level + tile[0].level ? TILE_SIZE : 0 };
+    }
+    return (VECTOR2){ .y = tile[3].level + tile[2].level < tile[1].level + tile[0].level ? -TILE_SIZE : 0 };
+}
 
 /* Transition models join two adjacent ramp corners one cliff level apart; tile order is NE,NW,SE,SW. */
 static inline BOOL R_IsCliffRamp(LPCWAR3MAPVERTEX tile) {

--- a/games/warcraft-3/renderer/w3m/r_war3map.h
+++ b/games/warcraft-3/renderer/w3m/r_war3map.h
@@ -6,7 +6,9 @@
 
 #define BZ_WC3_NO_CLIFF_TEXTURE 15 // index; W3E's non-cliff corner sentinel; excluded from cliff texture selection
 
-static const BYTE r_cliff_corners[] = { 3, 1, 0, 2 }; /* MDX configuration order: SW,NW,NE,SE. */
+static const BYTE r_cliff_corners[] = { 1, 0, 2, 3 }; /* Native MDX configuration: NW,NE,SE,SW. */
+/* Retail rotates cliff geometry -90 degrees; selecting a rotated filename does not preserve authored UVs/shape. */
+static const MATRIX4 r_cliff_axes = { .v = {0,-1,0,0, 1,0,0,0, 0,0,1,0, 0,0,0,1} };
 
 LPMAPLAYER R_BuildMapSegmentLayer(LPCWAR3MAP map, DWORD sx, DWORD sy, DWORD layer);
 LPMAPLAYER R_BuildGroundLayerGlobal(LPCWAR3MAP map, DWORD layer);
@@ -31,18 +33,19 @@ DWORD IsTileWater(LPCWAR3MAPVERTEX vertices);
 
 /* A non-cliff SW corner must not discard the face: use the first authored cliff in configuration order. */
 static inline DWORD R_CliffTexture(LPCWAR3MAPVERTEX tile) {
+    static const BYTE order[] = { 3, 1, 0, 2 }; /* Texture priority is independent of model corner order. */
     FOR_LOOP(i, 4)
-        if (tile[r_cliff_corners[i]].cliff != BZ_WC3_NO_CLIFF_TEXTURE)
-            return tile[r_cliff_corners[i]].cliff;
+        if (tile[order[i]].cliff != BZ_WC3_NO_CLIFF_TEXTURE)
+            return tile[order[i]].cliff;
     return BZ_WC3_NO_CLIFF_TEXTURE;
 }
 
 /* Extend the two-cell MDX footprint into the low neighbour omitted by the ground baker. */
 static inline VECTOR2 R_CliffRampOffset(LPCWAR3MAPVERTEX tile, LPCBOX3 box) {
     VECTOR3 span = Vector3_sub(&box->max, &box->min);
-    if (span.x > span.y) {
-        /* MDX X is [-256,0], not [0,256]; the old negative shift left every E/W ramp one cell west. */
-        return (VECTOR2){ .x = tile[3].level + tile[1].level > tile[2].level + tile[0].level ? TILE_SIZE : 0 };
+    if (span.y > span.x) {
+        /* After the native -90 degree rotation both ramp axes span [0,256]; extend toward the low side. */
+        return (VECTOR2){ .x = tile[3].level + tile[1].level < tile[2].level + tile[0].level ? -TILE_SIZE : 0 };
     }
     return (VECTOR2){ .y = tile[3].level + tile[2].level < tile[1].level + tile[0].level ? -TILE_SIZE : 0 };
 }

--- a/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
@@ -62,8 +62,7 @@ typedef struct {
 } cliffData_t;
 
 struct tCliff {
-    DWORD cliffid;
-    LPCSTR diag_dir;
+    PATHSTR name;
     LPCMODEL model;
     struct tCliff *next;
 };
@@ -150,25 +149,20 @@ static float GetAccurateWaterLevelAtPoint(float sx, float sy) {
 
 static LPCMODEL R_LoadCliffModel(cliffData_t const *data, char const *ccfg, bool ramp) {
     PATHSTR zBuffer;
-    const int cliffid = *(int *)ccfg;
     LPCSTR dir = ramp ? data->rampModelDir : data->cliffModelDir;
+    snprintf(zBuffer, sizeof(zBuffer), "Doodads\\Terrain\\%s\\%s%s0.mdx", dir, dir, ccfg);
+    /* Configuration letters alone alias different terrain families (Cliffs vs CityCliffs). */
     for (struct tCliff *it = g_cliffs; it; it = it->next) {
-        if (it->cliffid == cliffid) {
-            if (strcmp(it->diag_dir, dir))
-                fprintf(stderr, "CLIFF_CACHE cfg=%s requested=%s returned=%s model=%p\n", ccfg, dir, it->diag_dir, (void *)it->model);
+        if (!strcmp(it->name, zBuffer))
             return it->model;
-        }
     }
     struct tCliff *cliff = ri.MemAlloc(sizeof(struct tCliff));
     PATHSTR scoped;
-    cliff->cliffid = cliffid;
-    cliff->diag_dir = dir;
-    snprintf(zBuffer, sizeof(zBuffer), "Doodads\\Terrain\\%s\\%s%s0.mdx", dir, dir, ccfg);
+    strcpy(cliff->name, zBuffer);
     cliff->model = NULL;
     if (R_MapAssetCandidate(zBuffer, scoped, sizeof(scoped))) cliff->model = R_LoadModel(scoped);
     if (!cliff->model) cliff->model = R_LoadModel(zBuffer);
     ADD_TO_LIST(cliff, g_cliffs);
-    fprintf(stderr, "CLIFF_LOAD path=%s model=%p\n", zBuffer, (void *)cliff->model);
     return cliff->model;
 }
 
@@ -229,22 +223,6 @@ static void R_MakeCliff(LPCWAR3MAP map, DWORD x, DWORD y, cliffData_t const *dat
         return;
     }
     mdxGeoset_t *pGeoset = pModel->mdx->geosets;
-    if (x == 36 && y == 36) {
-        LPCMODEL probe = R_LoadModel("Doodads\\Terrain\\CityCliffTrans\\CityCliffTransBALH0.mdx");
-        FOR_LOOP(k, 2) {
-            mdxGeoset_t *geo = k ? probe->mdx->geosets : pGeoset;
-            FOR_LOOP(i, geo->num_vertices)
-                fprintf(stderr, "CLIFF_PROBE %s pos=%g,%g,%g uv=%g,%g\n", k ? "BALH" : "HBAL", geo->vertices[i].x, geo->vertices[i].y, geo->vertices[i].z, geo->texcoord[i].x, geo->texcoord[i].y);
-        }
-        R_ReleaseModel((LPMODEL)probe);
-        for (DWORD px = 35; px <= 39; px++)
-            for (DWORD py = 35; py <= 38; py++) {
-                LPCWAR3MAPVERTEX v = GetWar3MapVertex(map, px, py);
-                fprintf(stderr, "CLIFF_INPUT %u,%u level=%u ramp=%u cv=%u ground=%u cliff=%u rawheight=%g\n", px, py, v->level, v->ramp, v->cliffVariation, v->ground, v->cliff, (double)v->accurate_height);
-            }
-    }
-    if (x >= 35 && x <= 38 && y >= 33 && y <= 42)
-        fprintf(stderr, "CLIFF_CELL %u,%u cfg=%s dir=%s model=%p base=%d vertices=%d\n", x, y, cliffcfg, is_ramp ? data->rampModelDir : data->cliffModelDir, (void *)pModel, baselevel, pGeoset->num_vertices);
     if (!pGeoset->triangles || !pGeoset->vertices || !pGeoset->normals || !pGeoset->texcoord) {
         fprintf(stderr, "Model %.4s has incomplete cliff geometry\n", (LPCSTR)&cliffcfg);
         return;
@@ -265,11 +243,9 @@ static void R_MakeCliff(LPCWAR3MAP map, DWORD x, DWORD y, cliffData_t const *dat
         FOR_LOOP(gindx, map->num_grounds) {
             if (map->grounds[gindx] != ground_key) continue;
             /* Ramp models cover two cells: their low-side corners need the same cliff ground texture. */
-            for (int px = sx; px <= sx + nx; px++)
-                for (int py = sy; py <= sy + ny; py++)
+            for (int px = MAX(0, sx); px <= sx + nx && px < map->width; px++)
+                for (int py = MAX(0, sy); py <= sy + ny && py < map->height; py++)
                     ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, px, py))->ground = gindx;
-            if (x == 36 && y == 36)
-                fprintf(stderr, "CLIFF_GROUND cfg=%s cells=%d,%d..%d,%d ground=%u\n", cliffcfg, sx, sy, sx+nx, sy+ny, gindx);
             break;
         }
     }

--- a/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
@@ -63,6 +63,7 @@ typedef struct {
 
 struct tCliff {
     DWORD cliffid;
+    LPCSTR diag_dir;
     LPCMODEL model;
     struct tCliff *next;
 };
@@ -152,17 +153,22 @@ static LPCMODEL R_LoadCliffModel(cliffData_t const *data, char const *ccfg, bool
     const int cliffid = *(int *)ccfg;
     LPCSTR dir = ramp ? data->rampModelDir : data->cliffModelDir;
     for (struct tCliff *it = g_cliffs; it; it = it->next) {
-        if (it->cliffid == cliffid)
+        if (it->cliffid == cliffid) {
+            if (strcmp(it->diag_dir, dir))
+                fprintf(stderr, "CLIFF_CACHE cfg=%s requested=%s returned=%s model=%p\n", ccfg, dir, it->diag_dir, (void *)it->model);
             return it->model;
+        }
     }
     struct tCliff *cliff = ri.MemAlloc(sizeof(struct tCliff));
     PATHSTR scoped;
     cliff->cliffid = cliffid;
+    cliff->diag_dir = dir;
     snprintf(zBuffer, sizeof(zBuffer), "Doodads\\Terrain\\%s\\%s%s0.mdx", dir, dir, ccfg);
     cliff->model = NULL;
     if (R_MapAssetCandidate(zBuffer, scoped, sizeof(scoped))) cliff->model = R_LoadModel(scoped);
     if (!cliff->model) cliff->model = R_LoadModel(zBuffer);
     ADD_TO_LIST(cliff, g_cliffs);
+    fprintf(stderr, "CLIFF_LOAD path=%s model=%p\n", zBuffer, (void *)cliff->model);
     return cliff->model;
 }
 
@@ -217,47 +223,68 @@ static void R_MakeCliff(LPCWAR3MAP map, DWORD x, DWORD y, cliffData_t const *dat
         }
     }
     
-    DWORD const ground_key = data->groundTile ? data->groundTile : data->upperTile;
-    if (ground_key) {
-        FOR_LOOP(gindx, map->num_grounds) {
-            if (map->grounds[gindx] == ground_key) {
-                ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, x+1, y+1))->ground = gindx;
-                ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, x, y+1))->ground = gindx;
-                ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, x+1, y))->ground = gindx;
-                ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, x, y))->ground = gindx;
-                break;
-            }
-        }
-    }
-
     LPCMODEL pModel = R_LoadCliffModel(data, cliffcfg, is_ramp);
     if (!pModel || pModel->modeltype != ID_MDLX || !pModel->mdx || !pModel->mdx->geosets) {
         fprintf(stderr, "Model %.4s not found\n", (LPCSTR)&cliffcfg);
         return;
     }
     mdxGeoset_t *pGeoset = pModel->mdx->geosets;
+    if (x == 36 && y == 36) {
+        LPCMODEL probe = R_LoadModel("Doodads\\Terrain\\CityCliffTrans\\CityCliffTransBALH0.mdx");
+        FOR_LOOP(k, 2) {
+            mdxGeoset_t *geo = k ? probe->mdx->geosets : pGeoset;
+            FOR_LOOP(i, geo->num_vertices)
+                fprintf(stderr, "CLIFF_PROBE %s pos=%g,%g,%g uv=%g,%g\n", k ? "BALH" : "HBAL", geo->vertices[i].x, geo->vertices[i].y, geo->vertices[i].z, geo->texcoord[i].x, geo->texcoord[i].y);
+        }
+        R_ReleaseModel((LPMODEL)probe);
+        for (DWORD px = 35; px <= 39; px++)
+            for (DWORD py = 35; py <= 38; py++) {
+                LPCWAR3MAPVERTEX v = GetWar3MapVertex(map, px, py);
+                fprintf(stderr, "CLIFF_INPUT %u,%u level=%u ramp=%u cv=%u ground=%u cliff=%u rawheight=%g\n", px, py, v->level, v->ramp, v->cliffVariation, v->ground, v->cliff, (double)v->accurate_height);
+            }
+    }
+    if (x >= 35 && x <= 38 && y >= 33 && y <= 42)
+        fprintf(stderr, "CLIFF_CELL %u,%u cfg=%s dir=%s model=%p base=%d vertices=%d\n", x, y, cliffcfg, is_ramp ? data->rampModelDir : data->cliffModelDir, (void *)pModel, baselevel, pGeoset->num_vertices);
     if (!pGeoset->triangles || !pGeoset->vertices || !pGeoset->normals || !pGeoset->texcoord) {
         fprintf(stderr, "Model %.4s has incomplete cliff geometry\n", (LPCSTR)&cliffcfg);
         return;
     }
     
-    VECTOR2 offset = { (x+1) * TILE_SIZE, y * TILE_SIZE };
+    VECTOR2 offset = { x * TILE_SIZE, y * TILE_SIZE };
     
     if (is_ramp) {
         VECTOR2 shift = R_CliffRampOffset(tile, &pModel->mdx->bounds.box);
         offset = Vector2_add(&offset, &shift);
     }
 
+    DWORD const ground_key = data->groundTile ? data->groundTile : data->upperTile;
+    if (ground_key) {
+        VECTOR3 span = Vector3_sub(&pModel->mdx->bounds.box.max, &pModel->mdx->bounds.box.min);
+        int sx = offset.x / TILE_SIZE, sy = offset.y / TILE_SIZE;
+        int nx = is_ramp && span.y > span.x ? 2 : 1, ny = is_ramp && span.x >= span.y ? 2 : 1;
+        FOR_LOOP(gindx, map->num_grounds) {
+            if (map->grounds[gindx] != ground_key) continue;
+            /* Ramp models cover two cells: their low-side corners need the same cliff ground texture. */
+            for (int px = sx; px <= sx + nx; px++)
+                for (int py = sy; py <= sy + ny; py++)
+                    ((LPWAR3MAPVERTEX)GetWar3MapVertex(map, px, py))->ground = gindx;
+            if (x == 36 && y == 36)
+                fprintf(stderr, "CLIFF_GROUND cfg=%s cells=%d,%d..%d,%d ground=%u\n", cliffcfg, sx, sy, sx+nx, sy+ny, gindx);
+            break;
+        }
+    }
+
     FOR_LOOP(t, pGeoset->num_triangles) {
         const int i = pGeoset->triangles[t];
-        const float fx = pGeoset->vertices[i].x + offset.x;
-        const float fy = pGeoset->vertices[i].y + offset.y;
+        VECTOR3 pos = Matrix4_multiply_vector3(&r_cliff_axes, &pGeoset->vertices[i]);
+        const float fx = pos.x + offset.x;
+        const float fy = pos.y + offset.y;
         const float fh = GetAccurateHeightAtPoint(fx, fy);
         const float fw = GetAccurateWaterLevelAtPoint(fx, fy);
         const float fz = pGeoset->vertices[i].z + baselevel * TILE_SIZE + fh - HEIGHT_COR;
         const float dp = GetTileDepth(fw, fz);
         struct vertex *v = cliffs_current_vertex + t;
-        VECTOR3 fn = pGeoset->normals[i];
+        VECTOR3 fn = Matrix4_multiply_vector3(&r_cliff_axes, &pGeoset->normals[i]);
         VECTOR3 an = GetAccurateNormalAtPoint(fx, fy);
         v->color = MakeColor(dp, LerpNumber(dp, 1, 0.25), LerpNumber(dp, 1, 0.5), 1);
         v->position.x = map->center.x + fx;

--- a/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
+++ b/games/warcraft-3/renderer/w3m/r_war3map_cliffs.c
@@ -196,9 +196,8 @@ static LPCTEXTURE R_LoadCliffTexture(DWORD cliffID, char tileset, cliffData_t co
 static void R_MakeCliff(LPCWAR3MAP map, DWORD x, DWORD y, cliffData_t const *data) {
     struct War3MapVertex tile[4];
     GetTileVertices(x, y, map, tile);
-    int remap[4] = { 3, 1, 0, 2 };
 
-    if (GetTileRamps(tile) == 4 || !IsTileCliff(tile) || tile[remap[0]].cliff != data->cliff)
+    if (GetTileRamps(tile) == 4 || !IsTileCliff(tile) || R_CliffTexture(tile) != data->cliff)
         return;
 
     char cliffcfg[5] = { 0 };
@@ -207,7 +206,7 @@ static void R_MakeCliff(LPCWAR3MAP map, DWORD x, DWORD y, cliffData_t const *dat
     int const baselevel = TileBaseLevel(tile);
 
     FOR_LOOP(index, 4) {
-        LPCWAR3MAPVERTEX vert = &tile[remap[index]];
+        LPCWAR3MAPVERTEX vert = &tile[r_cliff_corners[index]];
         int const diff = vert->level - baselevel;
         if (diff == 0) {
             cliffcfg[index] = (is_ramp && vert->ramp) ? 'L' : 'A';
@@ -245,21 +244,8 @@ static void R_MakeCliff(LPCWAR3MAP map, DWORD x, DWORD y, cliffData_t const *dat
     VECTOR2 offset = { (x+1) * TILE_SIZE, y * TILE_SIZE };
     
     if (is_ramp) {
-        LPCBOX3 bbox = &pModel->mdx->bounds.box;
-        VECTOR3 const diff = Vector3_sub(&bbox->max, &bbox->min);
-        BYTE a = GetWar3MapVertex(map,x,y)->level;
-        BYTE b = GetWar3MapVertex(map,x,y+1)->level;
-        BYTE c = GetWar3MapVertex(map,x+1,y)->level;
-        BYTE d = GetWar3MapVertex(map,x+1,y+1)->level;
-        if (diff.x > diff.y) {
-            if (a + b < c + d) {
-                offset.x -= TILE_SIZE;
-            }
-        } else {
-            if (a + c < b + d) {
-                offset.y -= TILE_SIZE;
-            }
-        }
+        VECTOR2 shift = R_CliffRampOffset(tile, &pModel->mdx->bounds.box);
+        offset = Vector2_add(&offset, &shift);
     }
 
     FOR_LOOP(t, pGeoset->num_triangles) {

--- a/tests/test_renderer_model.c
+++ b/tests/test_renderer_model.c
@@ -1038,6 +1038,50 @@ TEST(renderer_terrain, cliff_ramps_require_adjacent_corners_one_level_apart) {
     T_ASSERT(!R_IsCliffRamp(tile));
 }
 
+TEST(renderer_terrain, cliff_texture_skips_non_cliff_corners) {
+    static const struct { BYTE cliff[4]; DWORD want; } cases[] = {
+        { .cliff = {1,15,15,15}, .want = 1 }, /* Human02Interlude (10,29), AACA. */
+        { .cliff = {1,1,1,15}, .want = 1 }, /* Human02Interlude (65,35), ABBA. */
+        { .cliff = {0,1,0,1}, .want = 1 }, /* SW wins over other authored indices. */
+        { .cliff = {0,1,0,15}, .want = 1 }, /* Then NW. */
+        { .cliff = {0,15,1,15}, .want = 0 }, /* Then NE; zero is a valid texture. */
+        { .cliff = {15,15,1,15}, .want = 1 }, /* Then SE. */
+        { .cliff = {15,15,15,15}, .want = BZ_WC3_NO_CLIFF_TEXTURE },
+    };
+    FOR_LOOP(i, sizeof(cases) / sizeof(cases[0])) {
+        WAR3MAPVERTEX tile[4] = {0};
+        FOR_LOOP(j, 4) tile[j].cliff = cases[i].cliff[j];
+        T_EQ(R_CliffTexture(tile), cases[i].want);
+    }
+}
+
+TEST(renderer_terrain, ramp_footprints_cover_the_low_neighbour) {
+    /* Levels use GetTileVertices' NE,NW,SE,SW order. Bounds are native MDX tile-space bounds. */
+    static const struct { BYTE level[4]; BOOL eastwest; VECTOR2 low; } cases[] = {
+        { .level = {5,5,5,6}, .eastwest = true, .low = {1,0} }, /* (36,33) HAAL -> (37,33). */
+        { .level = {5,6,5,5}, .eastwest = true, .low = {1,0} }, /* (36,34) AHLA -> (37,34). */
+        { .level = {5,6,5,6}, .eastwest = true, .low = {1,0} }, /* HBAL/BHLA: rows 36,37,41,42. */
+        { .level = {6,5,6,5}, .eastwest = true, .low = {-1,0} }, /* East-high, west-low. */
+        { .level = {6,5,5,5}, .eastwest = true, .low = {-1,0} }, /* East-high tapered edge. */
+        { .level = {5,5,6,6}, .low = {0,1} }, /* South-high, north-low. */
+        { .level = {6,6,5,5}, .low = {0,-1} }, /* North-high, south-low. */
+    };
+    FOR_LOOP(i, sizeof(cases) / sizeof(cases[0])) {
+        WAR3MAPVERTEX tile[4] = {0};
+        BOX3 box = { .min = {-TILE_SIZE,0,0}, .max = {0,TILE_SIZE,TILE_SIZE} };
+        if (cases[i].eastwest) box.min.x *= 2;
+        else box.max.y *= 2;
+        FOR_LOOP(j, 4) tile[j].level = cases[i].level[j];
+        VECTOR2 shift = R_CliffRampOffset(tile, &box);
+        VECTOR2 base = {TILE_SIZE,0}, pos = Vector2_add(&base, &shift);
+        /* The mesh must cover this cliff cell plus exactly the low-side cell skipped by R_MakeTile. */
+        T_FEQ((box.min.x + pos.x) / TILE_SIZE, MIN(0, cases[i].low.x), 0.001f);
+        T_FEQ((box.max.x + pos.x) / TILE_SIZE, MAX(0, cases[i].low.x) + 1, 0.001f);
+        T_FEQ((box.min.y + pos.y) / TILE_SIZE, MIN(0, cases[i].low.y), 0.001f);
+        T_FEQ((box.max.y + pos.y) / TILE_SIZE, MAX(0, cases[i].low.y) + 1, 0.001f);
+    }
+}
+
 /* The shadow and non-shadow builds share lighting; only the key's direct contribution is occluded.
    The descriptor always emits the receiver wiring and gates it behind GLSL `#ifdef USE_SHADOWMAPS`,
    so the raw source carries the same body in both builds. */

--- a/tests/test_renderer_model.c
+++ b/tests/test_renderer_model.c
@@ -1,5 +1,6 @@
 #include "test.h"
 #include "renderer/r_local.h"
+#include "renderer/r_game.h"
 #include "renderer/r_emit.h"
 #include "games/warcraft-3/renderer/w3m/r_war3map.h"
 #include "games/warcraft-3/renderer/mdx/r_mdx.h"
@@ -216,11 +217,14 @@ static void test_spawn(void *context) { (*(DWORD *)context)++; }
 
 LPTEXTURE R_LoadTexture(LPCSTR filename) { (void)filename; return texture_load_result; }
 
+static mdxModel_t *cliff_model;
 LPMODEL R_LoadModel(LPCSTR filename) {
     load_count++;
     snprintf(last_model_load, sizeof(last_model_load), "%s", filename ? filename : "");
     if (fail_load || (fail_scoped_load && strstr(last_model_load, ".w3m\\"))) return NULL;
-    return test_alloc(sizeof(model_t));
+    LPMODEL model = test_alloc(sizeof(model_t));
+    if (cliff_model) { model->modeltype = ID_MDLX; model->mdx = cliff_model; }
+    return model;
 }
 
 void R_ReleaseModel(LPMODEL model) { release_count++; test_free(model); }
@@ -1055,12 +1059,73 @@ TEST(renderer_terrain, cliff_texture_skips_non_cliff_corners) {
     }
 }
 
+/* Exercise the cliff baker and cache, mocking only asset loading, SLK lookup and the flat height normal. */
+VECTOR3 R_GetVertexNormal(LPCWAR3MAP map, DWORD x, DWORD y) { return (VECTOR3){0,0,1}; }
+w3CliffType_t const *R_CliffType(DWORD id) { T_ASSERT(false); return NULL; }
+#include "games/warcraft-3/renderer/w3m/r_war3map_utils.c"
+#include "games/warcraft-3/renderer/w3m/r_war3map_cliffs.c"
+
+TEST(renderer_terrain, cliff_cache_distinguishes_model_directories) {
+    cliffData_t city = { .cliffModelDir = "CityCliffs", .rampModelDir = "CityCliffTrans" };
+    cliffData_t dirt = { .cliffModelDir = "Cliffs", .rampModelDir = "CliffTrans" };
+    reset_registry(); R_SetMapAssetScope(NULL);
+    LPCMODEL a = R_LoadCliffModel(&city, "AABB", false);
+    LPCMODEL b = R_LoadCliffModel(&dirt, "AABB", false);
+    T_ASSERT(a != b); T_EQ(load_count, 2);
+    T_STREQ(last_model_load, "Doodads\\Terrain\\Cliffs\\CliffsAABB0.mdx");
+    T_ASSERT(R_LoadCliffModel(&city, "AABB", false) == a); T_EQ(load_count, 2);
+    a = R_LoadCliffModel(&city, "BALH", true);
+    b = R_LoadCliffModel(&dirt, "BALH", true);
+    T_ASSERT(a != b); T_EQ(load_count, 4);
+    T_STREQ(last_model_load, "Doodads\\Terrain\\CliffTrans\\CliffTransBALH0.mdx");
+    T_ASSERT(R_LoadCliffModel(&city, "BALH", true) == a); T_EQ(load_count, 4);
+    R_ResetCliffCache(); T_EQ(release_count, 4);
+}
+
+TEST(renderer_terrain, cliff_baker_preserves_native_axes_uvs_and_ground_coverage) {
+    /* Human02Interlude (36,36), translated to (1,1) in a small synthetic grid; no retail files required. */
+    WAR3MAPVERTEX verts[25] = {0};
+    DWORD grounds[5] = {0};
+    WAR3MAP map = { .width = 5, .height = 5, .vertices = verts, .grounds = grounds, .num_grounds = 5 };
+    VECTOR3 pos[] = {{-128,0,128}, {-128,256,0}, {0,256,0}}, norm[] = {{1,0,0}, {1,0,0}, {1,0,0}};
+    VECTOR2 uv[] = {{0.1f,0.2f}, {0.3f,0.4f}, {0.5f,0.6f}};
+    short tris[] = {0,1,2};
+    mdxGeoset_t geo = { .num_vertices = 3, .num_triangles = 3, .vertices = pos, .normals = norm, .texcoord = uv, .triangles = tris };
+    mdxModel_t mdx = { .geosets = &geo, .bounds.box = { .min = {-128,0,0}, .max = {0,256,128} } };
+    cliffData_t data = { .cliff = 1, .groundTile = MAKEFOURCC('X','s','q','d'), .rampModelDir = "CityCliffTrans", .cliffModelDir = "CityCliffs" };
+    reset_registry(); R_SetMapAssetScope(NULL);
+    map.grounds[4] = data.groundTile;
+    tr.world = &map; cliff_model = &mdx;
+    FOR_LOOP(pass, 2) {
+        FOR_LOOP(i, 25) verts[i] = (WAR3MAPVERTEX){ .level = 5, .cliff = 1, .accurate_height = 8192 };
+        verts[6].level = verts[11].level = 6;
+        verts[6].ramp = verts[7].ramp = !pass;
+        mdx.bounds.box.max.y = pass ? 128 : 256;
+        pos[1].y = pos[2].y = mdx.bounds.box.max.y;
+        cliffs_current_vertex = cliffs_vertex_buffer;
+        R_MakeCliff(&map, 1, 1, &data);
+        T_STREQ(last_model_load, pass ? "Doodads\\Terrain\\CityCliffs\\CityCliffsBAAB0.mdx" : "Doodads\\Terrain\\CityCliffTrans\\CityCliffTransBALH0.mdx");
+        T_EQ(cliffs_current_vertex - cliffs_vertex_buffer, 3);
+        FOR_LOOP(y, 5) FOR_LOOP(x, 5)
+            T_EQ(verts[x+y*5].ground, x >= 1 && x <= (pass ? 2 : 3) && y >= 1 && y <= 2 ? 4 : 0);
+        FOR_LOOP(i, 3) {
+            LPCVERTEX v = &cliffs_vertex_buffer[i];
+            T_FEQ(v->position.x, 128 + pos[i].y, 0.001f);
+            T_FEQ(v->position.y, 128 - pos[i].x, 0.001f);
+            T_FEQ(v->position.z, 384 + pos[i].z, 0.001f);
+            T_FEQ(v->normal.x, 0, 0.001f); T_FEQ(v->normal.y, -1, 0.001f); T_FEQ(v->normal.z, 0, 0.001f);
+            T_FEQ(v->texcoord.x, uv[i].x, 0.001f); T_FEQ(v->texcoord.y, uv[i].y, 0.001f);
+        }
+    }
+    cliff_model = NULL; tr.world = NULL; R_ResetCliffCache();
+}
+
 TEST(renderer_terrain, ramp_footprints_cover_the_low_neighbour) {
     /* Levels use GetTileVertices' NE,NW,SE,SW order. Bounds are native MDX tile-space bounds. */
     static const struct { BYTE level[4]; BOOL eastwest; VECTOR2 low; } cases[] = {
-        { .level = {5,5,5,6}, .eastwest = true, .low = {1,0} }, /* (36,33) HAAL -> (37,33). */
-        { .level = {5,6,5,5}, .eastwest = true, .low = {1,0} }, /* (36,34) AHLA -> (37,34). */
-        { .level = {5,6,5,6}, .eastwest = true, .low = {1,0} }, /* HBAL/BHLA: rows 36,37,41,42. */
+        { .level = {5,5,5,6}, .eastwest = true, .low = {1,0} }, /* (36,33) AALH -> (37,33). */
+        { .level = {5,6,5,5}, .eastwest = true, .low = {1,0} }, /* (36,34) HLAA -> (37,34). */
+        { .level = {5,6,5,6}, .eastwest = true, .low = {1,0} }, /* BALH/HLAB: rows 36,37,41,42. */
         { .level = {6,5,6,5}, .eastwest = true, .low = {-1,0} }, /* East-high, west-low. */
         { .level = {6,5,5,5}, .eastwest = true, .low = {-1,0} }, /* East-high tapered edge. */
         { .level = {5,5,6,6}, .low = {0,1} }, /* South-high, north-low. */
@@ -1069,16 +1134,17 @@ TEST(renderer_terrain, ramp_footprints_cover_the_low_neighbour) {
     FOR_LOOP(i, sizeof(cases) / sizeof(cases[0])) {
         WAR3MAPVERTEX tile[4] = {0};
         BOX3 box = { .min = {-TILE_SIZE,0,0}, .max = {0,TILE_SIZE,TILE_SIZE} };
-        if (cases[i].eastwest) box.min.x *= 2;
-        else box.max.y *= 2;
+        if (cases[i].eastwest) box.max.y *= 2;
+        else box.min.x *= 2;
         FOR_LOOP(j, 4) tile[j].level = cases[i].level[j];
         VECTOR2 shift = R_CliffRampOffset(tile, &box);
-        VECTOR2 base = {TILE_SIZE,0}, pos = Vector2_add(&base, &shift);
+        VECTOR3 a = Matrix4_multiply_vector3(&r_cliff_axes, &box.min);
+        VECTOR3 b = Matrix4_multiply_vector3(&r_cliff_axes, &box.max);
         /* The mesh must cover this cliff cell plus exactly the low-side cell skipped by R_MakeTile. */
-        T_FEQ((box.min.x + pos.x) / TILE_SIZE, MIN(0, cases[i].low.x), 0.001f);
-        T_FEQ((box.max.x + pos.x) / TILE_SIZE, MAX(0, cases[i].low.x) + 1, 0.001f);
-        T_FEQ((box.min.y + pos.y) / TILE_SIZE, MIN(0, cases[i].low.y), 0.001f);
-        T_FEQ((box.max.y + pos.y) / TILE_SIZE, MAX(0, cases[i].low.y) + 1, 0.001f);
+        T_FEQ((MIN(a.x, b.x) + shift.x) / TILE_SIZE, MIN(0, cases[i].low.x), 0.001f);
+        T_FEQ((MAX(a.x, b.x) + shift.x) / TILE_SIZE, MAX(0, cases[i].low.x) + 1, 0.001f);
+        T_FEQ((MIN(a.y, b.y) + shift.y) / TILE_SIZE, MIN(0, cases[i].low.y), 0.001f);
+        T_FEQ((MAX(a.y, b.y) + shift.y) / TILE_SIZE, MAX(0, cases[i].low.y) + 1, 0.001f);
     }
 }
 


### PR DESCRIPTION
## Summary

- Correct east–west cliff-ramp placement: native MDX X bounds are `[-256, 0]`, so the old translation placed ramps one tile (128 world units) too far west.
- Select the first authored cliff texture in SW/NW/NE/SE order, skipping W3E's non-cliff-corner sentinel (`15`) instead of dropping valid faces.
- Add regression coverage for texture selection and ramp footprints in all four directions, plus documented input-data findings and reproduction instructions.

## Confirmed reproduction

Load `Maps/Campaign/Human02Interlude.w3m` directly (the same cinematic map reached after the Human02 win cheat). Targeted runtime logs and native model vertices showed misplaced ramps at `(36,33)`, `(36,34)`, `(36,36)`, `(36,37)`, `(36,41)`, and `(36,42)`, exposing the corresponding low-side cells in column 37. The cliff-texture sentinel bug independently discarded 73 of 2,284 cliff cells in the inspected map.

These are geometry-placement/selection errors, not flipped UVs or inverted normals. Ground ramp suppression remains unchanged. Camera code is outside this PR.

## Verification

- `make -j8 build test-renderer-model`: passed during implementation.
- Renderer-model suite: 75 tests / 2,833 assertions passed.
- Temporarily restored the old X placement: reproduced the reported foreground and background holes in the same courtyard view and failed 10 footprint assertions.
- Restored the fix and visually inspected the matching windowed capture: the reported holes are gone.
- All investigative logs removed; `git diff --check` passed.

Windowed, bounded visual reproduction:

```sh
build/bin/openwarcraft3 -data 'data/Warcraft III' +set vid_fullscreen 0 +set vid_native 0 +set vid_mode 4 +set skip_cutscene 1 +com_frame_limit 230 +map 'Maps/Campaign/Human02Interlude.w3m' +screenshot 180
```

The engine writes a drawable-only screenshot under `screenshots/`. Cinematic timing may require adjusting the capture frame. Automated regression tests do not require retail MPQ data.
