### PR TITLE
Fix SC2 movement and selection using shared WC3 routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ This codebase is inspired by **Quake 2** (id Software). The developer is deeply 
 | WC3 campaign loading lifecycle, texture references, unused FDF art, cliff transitions | [docs/games/warcraft-3/loading-and-assets.md](docs/games/warcraft-3/loading-and-assets.md) |
 | WC3 perf hot spots: MDX bone/geoset setup, shadow batching, client/server entity scans | [docs/games/warcraft-3/performance.md](docs/games/warcraft-3/performance.md) |
 | WC3 RAM profiling: MDX buffer overhead, FDF pools, texture residency, loopback budgets | [docs/games/warcraft-3/memory.md](docs/games/warcraft-3/memory.md) |
+| SC2 dropped-unit selection/control, shared WC3 routing, M3 picking and selection rings | [docs/games/starcraft-2/selection-and-control.md](docs/games/starcraft-2/selection-and-control.md) |
 | SC2 HUD layout pipeline (sc2BaseFrame_t → uiFrame_t, layer IDs, stat bindings) | [docs/games/starcraft-2/hud-layout-pipeline.md](docs/games/starcraft-2/hud-layout-pipeline.md) |
 | SC2 terrain/cliff rendering, normal welding, and material batches | [docs/games/starcraft-2/terrain-and-world-rendering.md](docs/games/starcraft-2/terrain-and-world-rendering.md) |
 | SC2 Galaxy VM lifecycle, trigger execution, lookup indexes, diagnostics, and gaps | [docs/games/starcraft-2/galaxy-scripting.md](docs/games/starcraft-2/galaxy-scripting.md) |

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ TOOL_BINS := $(addprefix $(BIN_DIR)/,$(addsuffix $(EXE_EXT),$(TOOL_NAMES)))
 TOOL_DEPS := $(shell find tools -maxdepth 1 -name '*.h' | sort) common/mpq.c common/mpq.h
 CLIENT_HEADERS := $(shell find client -name '*.h' | sort)
 COMMON_HEADERS := $(shell find common -name '*.h' | sort)
-WORLD_CORE_SRCS := common/world.c
+WORLD_CORE_SRCS := common/world.c server/sv_routing.c server/routing.h
 FONT_SRC := renderer/conchars.pcx
 FONT_HEADER := renderer/conchars_sysfont.h
 FONT_SYMBOL := conchars_sysfont_pcx
@@ -176,7 +176,7 @@ endef
 define app_schema
 $(1): $(2) | $$(BIN_DIR) install-share
 	@echo "[$(3)]"
-	@$$(call UNITY,client server common sound $(6),! -name 'stb_vorbis.c') | \
+	@$$(call UNITY,client server common sound $(6),! -name 'stb_vorbis.c' ! -name 'sv_routing.c') | \
 		$$(CC) $(4) -x c -o $$@ - $$(RPATH) $$(LDFLAGS) $(5)
 endef
 
@@ -218,7 +218,7 @@ diag: clean
 $(BIN_DIR) $(LIB_DIR):
 	@mkdir -p $@
 
-APP_SRCS          := $(shell find client server common sound -name '*.c')
+APP_SRCS          := $(filter-out server/sv_routing.c,$(shell find client server common sound -name '*.c'))
 RENDERER_BASE_DEPS  := $(SHARED_LIB) $(CLIENT_HEADERS) $(COMMON_HEADERS) $(COMMON_SRCS) $(FONT_HEADER)
 RENDERER_SHARED_LIBS := -lshared $(LIBS) -lz
 SERVER_GAME_SRCS  := server/sv_quest.c

--- a/common/msg.c
+++ b/common/msg.c
@@ -31,11 +31,8 @@ typedef struct {
 
 netField_t entityStateFields[] = {
     { NETF(entityState_t, class_id), NFT_LONG },
-#ifdef WOW
+    /* Whole-unit coordinates turned fractional RTS movement into visible grid steps. */
     { NETF(entityState_t, origin), NFT_VECTOR3_FLOAT },
-#else
-    { NETF(entityState_t, origin), NFT_VECTOR3 },
-#endif
     { NETF(entityState_t, angle), NFT_ANGLE },
 #ifdef WOW
     { NETF(entityState_t, rotation), NFT_VECTOR3 },
@@ -59,13 +56,8 @@ netField_t entityStateFields[] = {
     { NETF(entityState_t, pathing_width), NFT_SHORT },
     { NETF(entityState_t, pathing_height), NFT_SHORT },
     { NETF(entityState_t, pathing_preview), NFT_LONG },
-#ifdef WOW
-    /* WoW creature radii can be 0.5; NFT_ROUND serialized those as zero. WoW radii stay < 65.5 so the packed-float
-     * range is ample. WC3 selection radii (buildings/destructables) exceed 65.5 and must keep NFT_ROUND. */
-    { NETF(entityState_t, radius), NFT_PACKED_FLOAT },
-#else
-    { NETF(entityState_t, radius), NFT_ROUND },
-#endif
+    /* Preserve both sub-unit selection circles and large building radii; integer rounding erased small rings. */
+    { NETF(entityState_t, radius), NFT_FLOAT },
     /* Collision is a world-unit radius and can exceed the packed-float range.
      * It changes rarely, so preserve the exact value rather than rounding it. */
     { NETF(entityState_t, collision), NFT_FLOAT },

--- a/common/net.h
+++ b/common/net.h
@@ -14,7 +14,7 @@
 #define PORT_SERVER 27910
 #endif
 #define PORT_SERVER_STRING BZ_XSTR(PORT_SERVER)
-#define BZ_PROTOCOL_VERSION 4 // version; svc_loading_screen replaces binary loading configstrings
+#define BZ_PROTOCOL_VERSION 5 // version; entity origins and selection radii retain world-unit float precision
 
 typedef void const *LPCVOID;
 typedef struct sizeBuf_s *LPSIZEBUF;

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -235,7 +235,7 @@ The cvars `menu_module` and `g_module` currently document the configured module 
 
 ### Game-Owned World Composition
 
-Entity-aware flow-field routing is composed by each game world wrapper from `games/warcraft-3/common/routing.c`. It is excluded from the shared game-common unity scans because it consumes `edict_t`, `ge`, and `EDICT_NUM`; the algorithm is shared by the current game wrappers, but its dependency boundary is game-owned.
+Entity-aware flow-field routing is composed by each game world wrapper from `server/sv_routing.c`. It is excluded from the shared game-common unity scans because it consumes `edict_t`, `ge`, and `EDICT_NUM`; the algorithm is shared by the current game wrappers, but its dependency boundary is game-owned.
 The wrappers also supply `entity_is_live_walkable_surface`: WC3 resolves live bridge/destructable state, while
 SC2 currently has no dynamic walkable-surface state. The shared router cannot read WC3-only edict fields. Startup code in `common/main.c` uses the neutral declarations in `common/server_api.h`, including `SV_IsActive`, instead of importing server state structs.
 

--- a/docs/games/starcraft-2/readme.md
+++ b/docs/games/starcraft-2/readme.md
@@ -111,3 +111,5 @@ Public reverse-engineering and modding references for how StarCraft II maps are 
 | Catalog-driven unit → model resolution | Layered unit/actor/model lookup implemented; broader catalog conformance remains partial |
 | `.m3a` animation supplements | **not started** |
 | Team-color texture swapping | **not started** |
+
+- [Selection and control](selection-and-control.md): dropped-unit ownership, shared WC3 routing, M3 picking and rings.

--- a/docs/games/starcraft-2/selection-and-control.md
+++ b/docs/games/starcraft-2/selection-and-control.md
@@ -1,0 +1,95 @@
+# SC2 selection and control
+
+## Ownership and input
+
+The single local client retains `ps.number == 1`, matching the current Galaxy
+`PlayerGroupPlayer` session contract. Do not infer its identity from placed army
+size: TRaynor01's script assigns `gv_p1_USER = 1`, while player 2 owns the largest
+placed army. `UnitCargoCreate` asks the game for the transport's owner and creates
+cargo for that owner. `UnitGetOwner` uses the same game callback.
+
+Shared `client/cl_input.c` handles click/rectangle selection and right-click orders
+exactly as WC3. `SC2_CustomizeEntity` marks scenery and foreign units unselectable.
+`select` replaces membership (including empty requests), validates ownership, and
+returns `svc_set_selection`. The existing snapshot path publishes `RF_SELECTED`;
+no new network fields or HUD layouts are involved. `smartpoint` moves the selected
+owned mobile units, and `smart` uses a target entity's position. Selection must
+never suppress the next point order: the shared input already separates the two.
+
+## Shared WC3 routing
+
+`server/sv_routing.c` is the original WC3 router, included by both games' `g_world.c`
+inside their server world. It is excluded from the executable's unity source list
+so it cannot create a competing client-side routing state. `server/routing.h`
+contains `ROUTEPATH` and the default per-tick work budget.
+
+`CM_AccelerateRoute` is extracted from WC3's persistent accelerated-turn helper;
+WC3 and SC2 both use it. `CM_SlideRoute` likewise contains WC3's existing
+15-degree left/right heading search, called by both games when the next step is
+blocked. Without this local steering, SC2 stalled permanently at the radius-expanded
+wall corner even though the shared field supplied a valid route. The WC3 movement member retains the original field order
+and types within `movement.path`. Direct paths, bounded A*, collision-radius
+checks, incremental flow fields, and unreachable-goal adjustment all use the
+existing WC3 `CM_*` implementation. No second pathfinding algorithm is introduced.
+SC2 services pending fields each tick and does not invalidate all fields per order
+or substitute straight-line motion when a route is pending. Flying units retain
+the existing direct flight behavior. Walk/Stand frames use server model sequence
+intervals instead of assigning absolute server time as an animation frame.
+
+SC2's pre-existing terrain adapter still initializes an open terrain grid and
+bakes static entity obstacles. Decoding SC2 navigation/pathing layers, richer
+formation assignment, full WC3-style local unit avoidance, combat, alliances,
+selection of foreign units, and shift order queues remain separate work.
+
+## Model feedback
+
+`R_TraceModel` inverse-transforms the cursor segment into M3 model space and tests
+the authored bounds, returning world-space hit distance. These same bounds serve
+visibility culling. SC2 loads the shared procedural ring and samples terrain Z
+at its vertices; the old empty asset hook and Z=0 splats could not show selection
+on the elevated campaign terrain. The shared renderer draws both selected and
+hover rings from the existing flags.
+
+## Snapshot precision (September 2026)
+
+The cell-stepping report was also a wire-format defect, independent of pathfinding.
+`common/msg.c` serialized non-WoW entity origins as three integer shorts and
+selection radii as an integer short. Runtime logs showed the server publishing
+radius `0.375` while the renderer received `0`, producing a zero-area ring despite
+a valid texture. Moving positions such as `(56.272789, 49.727211)` likewise lost
+their fractional components. Galaxy flight and player orders share this snapshot
+path, so the dropship cutscene suffered the same stepping.
+
+All games now serialize entity origins with `NFT_VECTOR3_FLOAT` and radius with
+`NFT_FLOAT`, matching the existing exact collision-radius contract. The common
+client still interpolates previous/current snapshots in `CL_AddEntity`; no
+SC2-only interpolation path or alternate coordinate representation is needed.
+`entityState_t` is unchanged. Protocol version 5 records the wire change: origins
+cost six additional bytes when sent for WC3/SC2, and radii two additional bytes
+when sent. Unchanged fields still consume no delta payload. Rebuild both ends.
+
+Do not fix this by enlarging the circle, snapping the simulation, or giving SC2
+another router. Inspect server values and decoded client values independently.
+
+## Verification
+
+- `make test-sc2-engine`: selection replacement/clearing, owner filtering, immediate
+  point orders, arrival, rotated/scaled M3 picking, a collision-sized wall detour
+  through the shared accelerator/field/slide, and fractional Galaxy flight snapshots.
+- `make test-galaxy`: cargo inherits a non-default transport owner; invalid cargo
+  creation does not spawn units.
+- `make test`: includes fractional/large-radius snapshot round trips, WC3
+  movement/pathfinding and save/load coverage after the
+  shared router move.
+
+For a paced campaign run (frame limits count main-loop iterations, not server ticks):
+
+```sh
+build/bin/opensc2 -data data/StarCraft2 +com_maxfps 60 +vid_hidden 1 \
+  +map Maps/Campaign/TRaynor01.SC2Map +screenshot 1800 +com_frame_limit 2100
+```
+
+Startup logs identify Galaxy-created entity numbers. After the drop, `cmd select
+<ids...>` and `cmd smartpoint <x> <y>` exercise the same authoritative commands as
+mouse input. `select 0` clears the rings. Use the shared group recall twice to
+center the camera on selected units.

--- a/docs/games/warcraft-3/building-construction.md
+++ b/docs/games/warcraft-3/building-construction.md
@@ -135,7 +135,7 @@ The placement cursor carries its authored pathing-texture width/height in dedica
 - live unit-circle occupancy, excluding the builder;
 - exact build-on-target presence when `isBuildOn` requires a `canBuildOn` structure.
 
-The common collision-model contract exposes `CM_GetPathingFlagsAt()` so the generic client can sample immutable terrain + baked-static pathing without reaching into WC3 routing internals or mutating movement's dynamic path map. WC3 implements the byte-mask query in `games/warcraft-3/common/routing.c`; game backends without this style of pathing grid return `false`, which suppresses cell classification rather than leaving a cross-game unresolved symbol.
+The common collision-model contract exposes `CM_GetPathingFlagsAt()` so the generic client can sample immutable terrain + baked-static pathing without reaching into WC3 routing internals or mutating movement's dynamic path map. WC3 implements the byte-mask query in `server/sv_routing.c`; game backends without this style of pathing grid return `false`, which suppresses cell classification rather than leaving a cross-game unresolved symbol.
 
 A declared pathing texture that fails to load is a placement failure. Do not silently degrade such a structure to a one-cell footprint; `M_LoadPathTex()` already reports the missing asset.
 

--- a/docs/games/warcraft-3/pathfinding.md
+++ b/docs/games/warcraft-3/pathfinding.md
@@ -8,7 +8,7 @@ WC3 movement keeps target selection, static routing, and interaction behavior se
 order / behavior -> target + interaction range -> routing -> collision-aware step
 ```
 
-`games/warcraft-3/game/g_ai.c` owns per-tick steering and local block-and-slide. `games/warcraft-3/common/routing.c` owns static pathmap line tests, connectivity queries, and cached flow fields. Harvest target selection remains in `skills/s_harvest_lumber.c`; the router never changes a tree target by itself.
+`games/warcraft-3/game/g_ai.c` owns per-tick steering and local block-and-slide. `server/sv_routing.c` owns static pathmap line tests, connectivity queries, and cached flow fields. Harvest target selection remains in `skills/s_harvest_lumber.c`; the router never changes a tree target by itself.
 
 Ground Move, Patrol, and Attack-move location orders are collision-size aware from destination selection through line tests, flow generation, and move-time validation. Generic interactions such as attack and repair still own their interaction ranges independently of routing. Harvest has an explicit collision split: Gold Mine approach and all resource-return legs use collision-sized **static-only** routing (live units ignored), while tree approach uses ordinary collision-sized generic movement.
 
@@ -225,3 +225,15 @@ Generic radius-0 point fields are still used for mine entry, resource return, at
 ## See Also
 
 - [Unit Altitude And Support Surfaces](unit-altitude.md) — vertical support surfaces share the WPM terrain classification but are independent of horizontal routing.
+
+### Shared SC2 movement consumers
+
+SC2 and WC3 include the same `server/sv_routing.c` in their server worlds.
+`CM_AccelerateRoute` retains the mover-owned waypoint; `CM_SlideRoute` is WC3's
+bounded generic left/right deflection loop extracted from `unit_desired_heading`.
+WC3 retains its speed-priority ring limit, resource-worker policy, collision
+callbacks, and turn-rate handling. SC2 calls the shared search for blocked static
+steps instead of repeatedly rejecting the same flow direction at a corner.
+See [SC2 selection and control](../starcraft-2/selection-and-control.md) for the
+separate snapshot-precision defect that made both ground and cinematic movement
+appear to advance in whole cells.

--- a/games/starcraft-2/game.mk
+++ b/games/starcraft-2/game.mk
@@ -86,3 +86,13 @@ test-sc2-assets: sc2fixturegen mpqtool sc2map | $(TESTS_DIR)
 
 SC2_PHONY := renderer-sc2 game-sc2 menu-sc2 opensc2 run-sc2 build-run-sc2 \
 	test-sc2 test-sc2-assets
+
+# Exercise authoritative selection/orders in the same module as the live game.
+GAME_SC2_TEST_LIB := $(LIB_DIR)/libgame-sc2-test$(LIB_EXT)
+SC2_TEST_BINARY := $(BIN_DIR)/opensc2-tests$(EXE_EXT)
+$(eval $(call unity_lib_schema,$(GAME_SC2_TEST_LIB),$(SC2_GAME_HEADERS) $(GAME_BASE_DEPS) $(JASS_LIB) $(WORLD_CORE_SRCS) $(SC2_COMMON_SRCS) $(call CSRC,$(SC2_DIR)/game),game-sc2-test,$(SC2_DIR)/game,,$(SC2_IMPL_CFLAGS) -DBZ_TESTS,common/mpq.c,-ljass -lshared $(LIBS) -lm -lz))
+$(eval $(call app_schema,$(SC2_TEST_BINARY),$(SHARED_LIB) $(SHEET_LIB) $(GAME_SC2_TEST_LIB) $(RENDERER_SC2_LIB) $(MENU_SC2_LIB) $(APP_SRCS) $(CLIENT_HEADERS) $(SC2_TEST_DIR)/test_sc2_picking.c,opensc2-tests,$(SC2_IMPL_CFLAGS) -DBZ_TESTS,-lsheet -lshared -lgame-sc2-test -lrenderer-sc2 -lmenu-sc2 $(LIBS) -lz,$(SC2_TEST_DIR)/test_sc2_picking.c))
+.PHONY: test-sc2-engine
+test-sc2-engine: $(SC2_TEST_BINARY) | $(TEST_JUNIT_DIR)
+	TEST_JUNIT="$(TEST_JUNIT_DIR)/test-sc2-engine.xml" TEST_JUNIT_SUITE="test-sc2-engine" $(SC2_TEST_BINARY) -data $(TESTS_DIR) +dedicated 1 +test 'sc2_control.*'
+test-sc2: test-sc2-engine

--- a/games/starcraft-2/game/g_sc2.c
+++ b/games/starcraft-2/game/g_sc2.c
@@ -1,4 +1,5 @@
 #include "g_sc2_local.h"
+#include "server/routing.h"
 #include "games/starcraft-2/common/sc2_map.h"
 #include "games/starcraft-2/game/hud/hud.h"
 #include <stdio.h>
@@ -8,10 +9,9 @@
 
 sc2Level_t sc2_level;
 
-#define SC2_MOVE_SPEED  6.0f
-#define SC2_MOVE_CLOSE  4.0f
-#define SC2_MOVE_EPS    0.25f
-#define SC2_MAX_COLLIDERS 256
+#define SC2_MOVE_SPEED  6.0f // world units/second; existing SC2 simulation speed
+#define SC2_MOVE_EPS    0.25f // world units; existing destination arrival tolerance
+#define SC2_MAX_COLLIDERS 256 // entities/query; bounds local collision candidates
 
 struct game_import gi;
 struct game_export globals;
@@ -31,9 +31,11 @@ typedef struct {
     BOOL moving;
     BOOL mobile;
     BOOL flying;
-    BOOL suppress_next_point;
     VECTOR2 target;
+    ROUTEPATH path;
     FLOAT speed, height;
+    LPCANIMATION anim;
+    DWORD animtime;
 } sc2MoveState_t;
 
 static sc2MoveState_t sc2_move[SC2_MAX_EDICTS];
@@ -122,27 +124,35 @@ static BOOL SC2_IsSelectable(LPCEDICT ent, DWORD player) {
         sc2_move[number].mobile;
 }
 
+/* Selection replaces membership, including empty/invalid requests, then reconciles the client cache. */
 static void SC2_Select(LPEDICT clent, DWORD argc, LPCSTR argv[]) {
-    DWORD player = SC2_ClientPlayer(clent);
-    DWORD client_number = SC2_EdictNumber(clent);
-    BOOL cleared = false;
+    DWORD player = SC2_ClientPlayer(clent), count = 0;
+    DWORD ids[MAX_SELECTED_ENTITIES];
 
-    if (argc == 2 && client_number < SC2_MAX_EDICTS) {
-        sc2_move[client_number].suppress_next_point = true;
+    FOR_LOOP(i, globals.num_edicts) sc2_edicts[i].selected &= ~(1 << player);
+    for (DWORD i = 1; i < argc && count < MAX_SELECTED_ENTITIES; i++) {
+        DWORD num = (DWORD)atoi(argv[i]);
+        if (num >= (DWORD)globals.num_edicts || !SC2_IsSelectable(&sc2_edicts[num], player)) continue;
+        if (sc2_edicts[num].selected & (1 << player)) continue;
+        sc2_edicts[num].selected |= 1 << player;
+        ids[count++] = num;
     }
-    for (DWORD i = 1; i < argc; i++) {
-        DWORD number = (DWORD)atoi(argv[i]);
-        if (number >= (DWORD)globals.num_edicts || !SC2_IsSelectable(&sc2_edicts[number], player)) {
-            continue;
-        }
-        if (!cleared) {
-            FOR_LOOP(j, globals.num_edicts) {
-                sc2_edicts[j].selected &= ~(1 << player);
-            }
-            cleared = true;
-        }
-        sc2_edicts[number].selected |= 1 << player;
+    gi.Write(PF_BYTE, &(LONG){svc_set_selection});
+    gi.Write(PF_BYTE, &(LONG){count});
+    FOR_LOOP(i, count) gi.Write(PF_LONG, &(LONG){ids[i]});
+    gi.unicast(clent);
+}
+
+/* Snapshot frames address the M3 sequence timeline, not the server's absolute clock. */
+static void SC2_UnitAnimation(LPEDICT ent, LPCSTR name) {
+    sc2MoveState_t *move = &sc2_move[SC2_EdictNumber(ent)];
+    move->anim = G_GetAnimation(ent->s.model, name);
+    move->animtime = gi.GetTime();
+    if (!move->anim) {
+        fprintf(stderr, "SC2: unit %u model %u has no '%s' animation\n", ent->s.number, ent->s.model, name);
+        return;
     }
+    ent->s.frame = move->anim->interval[0];
 }
 
 static void SC2_StopUnit(LPEDICT ent) {
@@ -151,7 +161,7 @@ static void SC2_StopUnit(LPEDICT ent) {
         return;
     }
     sc2_move[number].moving = false;
-    ent->s.frame = gi.GetTime();
+    SC2_UnitAnimation(ent, "Stand");
     ent->s.ability = 0;
 }
 
@@ -162,15 +172,15 @@ static void SC2_OrderMove(LPEDICT ent, LPCVECTOR2 target) {
     if (number >= SC2_MAX_EDICTS || !sc2_move[number].mobile) {
         return;
     }
-    CM_ClosestPathablePointForRadius(target, ent->collision, &pathable);
+    if (!sc2_move[number].flying && !CM_ClosestPathablePointForRadius(target, ent->collision, &pathable)) return;
     sc2_move[number].target = pathable;
     sc2_move[number].moving = true;
+    sc2_move[number].path.valid = false;
     sc2_move[number].speed = SC2_MOVE_SPEED;
     sc2_waypoints[number].s.origin2 = pathable;
     sc2_waypoints[number].s.origin.z = SC2_MapHeightAtPoint(pathable.x, pathable.y);
-    ent->s.frame = gi.GetTime();
-    ent->s.ability = 1;
-    CM_InvalidatePathCache();
+    SC2_UnitAnimation(ent, "Stand");
+    ent->s.ability = 0;
 }
 
 static void SC2_MoveSelected(LPEDICT clent, LPCVECTOR2 target) {
@@ -201,6 +211,11 @@ static void SC2_MoveToTargetEntity(LPEDICT clent, DWORD target_number) {
     SC2_MoveSelected(clent, &sc2_edicts[target_number].s.origin2);
 }
 
+/* Use WC3's swept static-path check for both steering candidates and committed steps. */
+static BOOL SC2_MoveIsValid(LPEDICT ent, LPCVECTOR2 point) {
+    return sc2_move[SC2_EdictNumber(ent)].flying || CM_LineIsWalkableForRadius(&ent->s.origin2, point, ent->collision);
+}
+
 static void SC2_RunUnit(LPEDICT ent) {
     DWORD number = SC2_EdictNumber(ent);
     VECTOR2 to_goal;
@@ -214,24 +229,47 @@ static void SC2_RunUnit(LPEDICT ent) {
     to_goal = Vector2_sub(&sc2_move[number].target, &ent->s.origin2);
     dist = Vector2_len(&to_goal);
     step = sc2_move[number].speed * (FRAMETIME / 1000.0f);
-    if (dist <= step + SC2_MOVE_EPS) {
+    if (dist <= step + SC2_MOVE_EPS && (sc2_move[number].flying ||
+        CM_LineIsWalkableForRadius(&ent->s.origin2, &sc2_move[number].target, ent->collision))) {
         ent->s.origin2 = sc2_move[number].target;
         SC2_LinkUnit(ent);
         SC2_StopUnit(ent);
         return;
     }
-    if (sc2_move[number].flying || dist <= SC2_MOVE_CLOSE) {
+    /* Use the WC3 router's radius-aware direct test, cached incremental field, and bounded A* accelerator. */
+    if (sc2_move[number].flying || CM_LineIsWalkableForRadius(&ent->s.origin2, &sc2_move[number].target, ent->collision)) {
+        sc2_move[number].path.valid = false;
         dir = to_goal;
     } else {
-        DWORD heatmap = CM_BuildHeatmap(&sc2_waypoints[number]);
-        dir = get_flow_direction(heatmap, ent->s.origin.x, ent->s.origin.y);
-        if (Vector2_len(&dir) <= 0.001f) {
-            dir = to_goal;
+        DWORD flow = CM_RequestHeatmapForRadius(&sc2_waypoints[number], ent->collision);
+        if (!flow) {
+            pathAccelParams_t params = { &ent->s.origin2, &sc2_move[number].target, ent->collision };
+            if (!CM_AccelerateRoute(&sc2_move[number].path, &params, &dir)) return;
+        } else {
+            sc2_move[number].path.valid = false;
+            dir = get_flow_direction(flow, ent->s.origin2.x, ent->s.origin2.y);
+            if (Vector2_len(&dir) <= 0.001f) {
+                VECTOR2 closest;
+                if (!CM_FlowCanReach(flow, ent->s.origin2.x, ent->s.origin2.y) &&
+                    CM_ClosestReachablePointForRadius(&ent->s.origin2, &sc2_move[number].target, ent->collision, &closest))
+                    SC2_OrderMove(ent, &closest);
+                return;
+            }
         }
     }
     Vector2_normalize(&dir);
     ent->s.angle = atan2f(dir.y, dir.x);
-    ent->s.origin2 = Vector2_mad(&ent->s.origin2, step, &dir);
+    VECTOR2 next = Vector2_mad(&ent->s.origin2, step, &dir);
+    if (!SC2_MoveIsValid(ent, &next)) {
+        /* WC3 resolves blocked flow steps with local steering; SC2 previously stalled at the same corner forever. */
+        ROUTESLIDE slide = { .ent = ent, .angle = ent->s.angle, .dist = step,
+            .rings = BZ_ROUTE_SLIDE_RINGS, .valid = SC2_MoveIsValid };
+        ent->s.angle = CM_SlideRoute(&slide);
+        next = Vector2_mad(&ent->s.origin2, step, &MAKE(VECTOR2, cosf(ent->s.angle), sinf(ent->s.angle)));
+        if (!SC2_MoveIsValid(ent, &next)) return;
+    }
+    if (!ent->s.ability) { SC2_UnitAnimation(ent, "Walk"); ent->s.ability = 1; }
+    ent->s.origin2 = next;
     SC2_LinkUnit(ent);
 }
 
@@ -240,7 +278,9 @@ static BOOL sc2_collision_filter(LPCEDICT ent) {
 }
 
 static void SC2_PushEntity(LPEDICT ent, FLOAT distance, LPCVECTOR2 dir) {
-    ent->s.origin2 = Vector2_mad(&ent->s.origin2, distance, dir);
+    VECTOR2 next = Vector2_mad(&ent->s.origin2, distance, dir);
+    if (!CM_LineIsWalkableForRadius(&ent->s.origin2, &next, ent->collision)) return;
+    ent->s.origin2 = next;
     SC2_LinkUnit(ent);
 }
 
@@ -467,6 +507,8 @@ static void SC2_GalaxyUnitSetPosition(void *ent_ptr, float x, float y, float fac
     ent->s.angle = facing;
 }
 
+static int SC2_GalaxyUnitOwner(void *ptr) { return ((LPCEDICT)ptr)->s.player; }
+
 static BOOL SC2_GalaxyUnitIsAlive(void *ent_ptr) {
     LPEDICT ent = (LPEDICT)ent_ptr;
     return ent && ent->inuse;
@@ -529,9 +571,10 @@ static void *SC2_GalaxyCreateUnit(LPCSTR unit_type, int player, float x, float y
         sc2_move[ent->s.number].flying = !strcasecmp(object.mover, "Fly");
         sc2_move[ent->s.number].speed = SC2_MOVE_SPEED;
         sc2_move[ent->s.number].height = object.move_height;
+        if (sc2_move[ent->s.number].mobile) SC2_UnitAnimation(ent, "Stand");
     SC2_LinkUnit(ent);
-            fprintf(stderr, "SC2_GalaxyCreateUnit: type=%s model=%s mover=%s mobile=%d collision=%.2f player=%d at (%.1f,%.1f)\n",
-                    unit_type, model, object.mover, !!sc2_move[ent->s.number].mobile, ent->collision, player, x, y);
+            fprintf(stderr, "SC2_GalaxyCreateUnit: ent=%u type=%s model=%s mover=%s mobile=%d collision=%.2f player=%d at (%.1f,%.1f)\n",
+                    ent->s.number, unit_type, model, object.mover, !!sc2_move[ent->s.number].mobile, ent->collision, player, x, y);
     return ent;
 }
 
@@ -550,6 +593,7 @@ static void SC2_InitGalaxyHost(void) {
     sc2_galaxy_unit_move          = SC2_GalaxyUnitMove;
     sc2_galaxy_unit_is_moving     = SC2_GalaxyUnitIsMoving;
     sc2_galaxy_unit_is_alive      = SC2_GalaxyUnitIsAlive;
+    sc2_galaxy_unit_owner         = SC2_GalaxyUnitOwner;
 }
 
 static void SC2_InitClients(void) {
@@ -714,10 +758,14 @@ static void SC2_RunFrame(void) {
 #endif
 
     FOR_LOOP(i, globals.num_edicts) {
-        if (sc2_edicts[i].inuse)
-            SC2_RunUnit(&sc2_edicts[i]);
+        if (!sc2_edicts[i].inuse) continue;
+        SC2_RunUnit(&sc2_edicts[i]);
+        LPCANIMATION anim = sc2_move[i].anim;
+        if (anim && anim->interval[1] > anim->interval[0])
+            sc2_edicts[i].s.frame = anim->interval[0] + (gi.GetTime() - sc2_move[i].animtime) % (anim->interval[1] - anim->interval[0]);
     }
     SC2_SolveCollisions();
+    CM_ProcessPathJobs(BZ_PATH_WORK_BUDGET);
 }
 
 static void SC2_ClientBegin(LPEDICT ent) {
@@ -730,27 +778,7 @@ static void SC2_ClientBegin(LPEDICT ent) {
     ent->client = &sc2_clients[number];
     ent->client->ps.client_ui_state = CLIENT_UI_GAME;
 
-    /* Use the first selectable unit's model for the portrait panel. */
-    /* Resolve map player: SC2 mission maps assign the human player a specific
-     * slot index (e.g. player 2 in TRaynor01) that differs from the lobby
-     * client index (ps.number = i+1 from SC2_InitClients).  Find the player
-     * number that owns the most mobile units — that is the controllable player.
-     * Player 0 (neutral) is excluded. */
-    DWORD player_counts[16] = {0};
-    for (DWORD i = SC2_MAX_CLIENTS; i < (DWORD)globals.num_edicts; i++) {
-        LPEDICT u = &sc2_edicts[i];
-        if (u->inuse && u->s.model && sc2_move[i].mobile && u->s.player > 0 && u->s.player < 16)
-            player_counts[u->s.player]++;
-    }
-    DWORD map_player = 0, best_count = 0;
-    for (DWORD p = 1; p < 16; p++)
-        if (player_counts[p] > best_count) { best_count = player_counts[p]; map_player = p; }
-    if (map_player > 0 && map_player != (DWORD)ent->client->ps.number) {
-        fprintf(stderr, "SC2_ClientBegin: remapping client ps.number %u → %u (most units)\n",
-                ent->client->ps.number, map_player);
-        ent->client->ps.number = (int)map_player;
-    }
-
+    /* Preserve the session player (also used by Galaxy PlayerGroupPlayer); army size picked the enemy in TRaynor01. */
     DWORD client_player = SC2_ClientPlayer(ent);
 
     /* Pre-select the first selectable unit so InfoPanel shows unit info. */
@@ -790,7 +818,6 @@ static bool SC2_PrepareMap(LPCSTR filename) {
 }
 
 static void SC2_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
-    DWORD client_number = SC2_EdictNumber(ent);
     VECTOR2 loc;
 
     if (!ent || argc == 0 || !argv || !argv[0]) {
@@ -804,11 +831,8 @@ static void SC2_ClientCommand(LPEDICT ent, DWORD argc, LPCSTR argv[]) {
         if (argc < 3) {
             return;
         }
-        if (client_number < SC2_MAX_EDICTS && sc2_move[client_number].suppress_next_point) {
-            sc2_move[client_number].suppress_next_point = false;
-            return;
-        }
-        loc = (VECTOR2){ atoi(argv[1]), atoi(argv[2]) };
+        /* Shared input sends selection and right-click orders separately; never consume the first move. */
+        loc = (VECTOR2){ atof(argv[1]), atof(argv[2]) };
         SC2_MoveSelected(ent, &loc);
         return;
     }
@@ -843,9 +867,9 @@ static BOOL SC2_CanSeeEntity(DWORD player, LPCEDICT ent) {
     return true;
 }
 
-/* Keep the mandatory snapshot hook inert because SC2 entity state is identical for every recipient. */
+/* Exclude scenery and foreign units from both click and rectangle picking before they fill the client list. */
 static void SC2_CustomizeEntity(DWORD player, LPCEDICT ent, LPENTITYSTATE state) {
-    (void)player; (void)ent; (void)state;
+    if (!SC2_IsSelectable(ent, player)) state->flags |= EF_NOT_SELECTABLE;
 }
 
 static LPCSTR SC2_GetThemeValue(LPCSTR filename) {
@@ -874,3 +898,7 @@ struct game_export *GetGameAPI(struct game_import *import) {
 
     return &globals;
 }
+
+#ifdef BZ_TESTS
+#include "tests/t_control.h"
+#endif

--- a/games/starcraft-2/game/g_world.c
+++ b/games/starcraft-2/game/g_world.c
@@ -23,7 +23,7 @@ static inline BOMStatus G_WorldTextRemoveBom(LPSTR buffer) {
 #define Com_Error(code, ...) gi.error(__VA_ARGS__)
 #include "common/world.c"
 /* This shared routing unit owns CM_GetPathingFlagsAt, including the empty-pathmap result used by SC2. */
-#include "games/warcraft-3/common/routing.c"
+#include "server/sv_routing.c"
 #include "games/starcraft-2/common/sc2_map.c"
 #include "games/starcraft-2/common/world_sc2.c"
 

--- a/games/starcraft-2/game/galaxy/galaxy_host.c
+++ b/games/starcraft-2/game/galaxy/galaxy_host.c
@@ -75,6 +75,7 @@ void (*sc2_galaxy_unit_set_position)(void *ent, float x, float y, float facing);
 void (*sc2_galaxy_unit_move)(void *ent, float x, float y);
 BOOL (*sc2_galaxy_unit_is_moving)(void *ent);
 BOOL (*sc2_galaxy_unit_is_alive)(void *ent);
+int (*sc2_galaxy_unit_owner)(void *ent);
 
 void (*sc2_galaxy_on_actor_create)(unsigned actor_id, const char *model,
                                    unsigned unit_id, float x, float y);

--- a/games/starcraft-2/game/galaxy/galaxy_host.h
+++ b/games/starcraft-2/game/galaxy/galaxy_host.h
@@ -76,6 +76,7 @@ extern void (*sc2_galaxy_unit_set_position)(void *ent, float x, float y, float f
 extern void (*sc2_galaxy_unit_move)(void *ent, float x, float y);
 extern BOOL (*sc2_galaxy_unit_is_moving)(void *ent);
 extern BOOL (*sc2_galaxy_unit_is_alive)(void *ent);
+extern int (*sc2_galaxy_unit_owner)(void *ent);
 
 /* Actor lifecycle — called when Galaxy scripts create, message, or destroy actors.
  * actor_id: 1-based index into sc2_gactors[]; unit_id: owning unit or 0. */

--- a/games/starcraft-2/game/galaxy/galaxy_unit.h
+++ b/games/starcraft-2/game/galaxy/galaxy_unit.h
@@ -75,8 +75,8 @@ static DWORD sc2_UnitSetFacing(LPJASS j) {
 
 static DWORD sc2_UnitSetOwner(LPJASS j)             { (void)j; return jass_pushnull(j); }
 static DWORD sc2_UnitGetOwner(LPJASS j) {
-    (void)jass_checkhandle(j, 1, "unit");  /* consume arg */
-    return jass_pushinteger(j, 0);
+    void *ent = sc2_ent_from_handle(j, 1);
+    return jass_pushinteger(j, ent && sc2_galaxy_unit_owner ? sc2_galaxy_unit_owner(ent) : 0);
 }
 static DWORD sc2_UnitSetHeight(LPJASS j)            { (void)j; return jass_pushnull(j); }
 static DWORD sc2_UnitSetScale(LPJASS j)             { (void)j; return jass_pushnull(j); }
@@ -141,11 +141,18 @@ static DWORD sc2_UnitCargoCreate(LPJASS j) {
     LONG   t_h  = (LONG)(uintptr_t)jass_checkhandle(j, 1, "unit");
     LPCSTR type = jass_checkstring(j, 2);
     LONG   cnt  = jass_checkinteger(j, 3);
+    void *transport = t_h > 0 && t_h <= (LONG)sc2_gunit_n ? sc2_gunits[t_h - 1] : NULL;
+    if (!transport || !sc2_galaxy_unit_owner) {
+        fprintf(stderr, "UnitCargoCreate: transport %ld or owner callback unavailable\n", (long)t_h);
+        return jass_pushnullhandle(j, "unit");
+    }
+    /* Cargo inherits its transport's owner; neutral cargo could never receive the user's orders. */
+    int player = sc2_galaxy_unit_owner(transport);
     if (cnt < 1) cnt = 1;
     LONG handle  = 0;
     for (LONG i = 0; i < cnt && sc2_gunit_n < MAX_GALAXY_UNITS; i++) {
         void *ent = sc2_galaxy_on_unit_create ?
-            sc2_galaxy_on_unit_create(type ? type : "", 0, 0.0f, 0.0f, 0.0f) : NULL;
+            sc2_galaxy_on_unit_create(type ? type : "", player, 0.0f, 0.0f, 0.0f) : NULL;
         if (!ent)
             fprintf(stderr, "sc2_UnitCargoCreate: on_unit_create returned NULL for type '%s' (%ld/%ld) — cargo unit will be invisible\n",
                     type ? type : "(null)", (long)(i + 1), (long)cnt);

--- a/games/starcraft-2/game/tests/t_control.h
+++ b/games/starcraft-2/game/tests/t_control.h
@@ -1,0 +1,121 @@
+/* Included by g_sc2.c so tests drive the production command handlers and movement state. */
+#include "shared/test.h"
+
+static LONG sc2_test_wire[80];
+static DWORD sc2_test_count, sc2_test_time;
+static void sc2_test_write(pfWriteType_t type, void const *value) {
+    if (type == PF_BYTE || type == PF_LONG) sc2_test_wire[sc2_test_count++] = *(LONG const *)value;
+}
+static void sc2_test_unicast(LPEDICT ent) { (void)ent; }
+static void sc2_test_link(LPEDICT ent) { (void)ent; }
+static DWORD sc2_test_clock(void) { return sc2_test_time; }
+
+/* Test invalid requests after a valid selection as well as owner filtering and replacement. */
+TEST(sc2_control, selection_orders_and_clear) {
+    struct game_import saved = gi;
+    animation_t anims[] = { { .name = "Stand", .interval = {0, 1000} }, { .name = "Walk", .interval = {1000, 2000} } };
+    g_cmodel_t model = g_models[1];
+    g_models[1].animations = anims; g_models[1].num_animations = 2;
+    gi.Write = sc2_test_write; gi.unicast = sc2_test_unicast;
+    gi.LinkEntity = sc2_test_link; gi.GetTime = sc2_test_clock;
+    memset(sc2_edicts, 0, sizeof(sc2_edicts));
+    memset(sc2_move, 0, sizeof(sc2_move));
+    globals.num_edicts = 4;
+    sc2_edicts[0].client = &sc2_clients[0]; sc2_clients[0].ps.number = 1;
+    for (DWORD i = 1; i < 4; i++) {
+        sc2_edicts[i] = (edict_t){ .inuse = true, .s = { .number = i, .player = i == 3 ? 2 : 1, .model = 1 } };
+        sc2_move[i].mobile = true;
+    }
+    sc2_test_count = 0;
+    SC2_ClientCommand(sc2_edicts, 5, (LPCSTR[]){"select", "1", "1", "3", "99999"});
+    T_EQ(sc2_edicts[1].selected, 2); T_EQ(sc2_edicts[3].selected, 0);
+    T_EQ(sc2_test_wire[0], svc_set_selection); T_EQ(sc2_test_wire[1], 1); T_EQ(sc2_test_wire[2], 1);
+    entityState_t state = sc2_edicts[1].s;
+    SC2_CustomizeEntity(1, &sc2_edicts[1], &state); T_ASSERT(!(state.flags & EF_NOT_SELECTABLE));
+    SC2_CustomizeEntity(2, &sc2_edicts[1], &state); T_ASSERT(state.flags & EF_NOT_SELECTABLE);
+    sc2_test_count = 0;
+    SC2_ClientCommand(sc2_edicts, 3, (LPCSTR[]){"smartpoint", "2.5", "1.5"});
+    T_ASSERT(sc2_move[1].moving); T_ASSERT(!sc2_move[3].moving);
+    T_FEQ(sc2_move[1].target.x, 2.5f, 0.001f);
+    SC2_RunUnit(&sc2_edicts[1]);
+    T_ASSERT(sc2_edicts[1].s.origin2.x > 0); T_EQ(sc2_edicts[1].s.ability, 1);
+    FOR_LOOP(i, 20) SC2_RunUnit(&sc2_edicts[1]);
+    T_ASSERT(!sc2_move[1].moving); T_EQ(sc2_edicts[1].s.ability, 0);
+    T_FEQ(sc2_edicts[1].s.origin2.x, 2.5f, 0.001f);
+    sc2_test_count = 0;
+    SC2_ClientCommand(sc2_edicts, 2, (LPCSTR[]){"select", "2"});
+    T_EQ(sc2_edicts[1].selected, 0); T_EQ(sc2_edicts[2].selected, 2);
+    sc2_test_count = 0;
+    SC2_ClientCommand(sc2_edicts, 2, (LPCSTR[]){"select", "0"});
+    T_EQ(sc2_edicts[2].selected, 0); T_EQ(sc2_test_wire[1], 0);
+    sc2_test_count = 0;
+    SC2_ClientCommand(sc2_edicts, 3, (LPCSTR[]){"smartpoint", "10", "10"});
+    T_ASSERT(!sc2_move[2].moving);
+    g_models[1] = model;
+    gi = saved;
+}
+
+/* SC2 orders must use WC3's obstacle detour and retain exact reachable click coordinates. */
+TEST(sc2_control, shared_router_detours_and_arrives) {
+    struct game_import saved = gi;
+    sc2Map_t *map = SC2_MapCurrent();
+    sc2MapInfo_t info = map->MapInfo;
+    FLOAT cell = map->cell_size;
+    VECTOR2 origin = map->origin;
+    BYTE cells[32 * 32] = { 0 };
+    animation_t anims[] = { { .name = "Stand", .interval = {0, 1000} }, { .name = "Walk", .interval = {1000, 2000} } };
+    g_cmodel_t model = g_models[1];
+    g_models[1].animations = anims; g_models[1].num_animations = 2;
+    gi.LinkEntity = sc2_test_link; gi.GetTime = sc2_test_clock;
+    memset(sc2_edicts, 0, sizeof(sc2_edicts)); memset(sc2_move, 0, sizeof(sc2_move));
+    globals.num_edicts = 2;
+    map->MapInfo.width = map->MapInfo.height = 32; map->cell_size = 1; map->origin = (VECTOR2){0};
+    FOR_LOOP(y, 20) cells[y * 32 + 16] = 2;
+    CM_SetupPathMap(32, 32, cells);
+    LPEDICT ent = &sc2_edicts[1];
+    *ent = (edict_t){ .inuse = true, .svflags = SVF_MONSTER, .collision = 0.375f,
+        .s = { .number = 1, .model = 1, .origin = {8.25f, 10.25f, 0} } };
+    sc2_move[1].mobile = true;
+    VECTOR2 target = {24.375f, 10.625f};
+    SC2_OrderMove(ent, &target);
+    T_FEQ(sc2_move[1].target.x, target.x, 0.00001f);
+    T_ASSERT(!CM_LineIsWalkableForRadius(&ent->s.origin2, &target, ent->collision));
+    SC2_RunUnit(ent);
+    T_ASSERT(sc2_move[1].path.valid); /* WC3's immediate A* handles a pending field. */
+    BOOL detour = false;
+    for (int i = 0; i < 300 && sc2_move[1].moving; i++) {
+        VECTOR2 prev = ent->s.origin2;
+        CM_ProcessPathJobs(BZ_PATH_WORK_BUDGET);
+        SC2_RunUnit(ent);
+        T_ASSERT(CM_LineIsWalkableForRadius(&prev, &ent->s.origin2, ent->collision));
+        if (ent->s.origin2.y > 20) detour = true;
+    }
+    T_ASSERT(detour); T_ASSERT(!sc2_move[1].moving);
+    T_FEQ(ent->s.origin2.x, target.x, 0.00001f); T_FEQ(ent->s.origin2.y, target.y, 0.00001f);
+    CM_SetupPathMap(0, 0, NULL);
+    map->MapInfo = info; map->cell_size = cell; map->origin = origin;
+    g_models[1] = model; gi = saved;
+}
+
+/* Galaxy flight uses the same snapshots as ground units; interpolation needs every fractional server sample. */
+TEST(sc2_control, cutscene_flight_preserves_positions) {
+    struct game_import saved = gi;
+    animation_t anims[] = { { .name = "Stand", .interval = {0, 1000} }, { .name = "Walk", .interval = {1000, 2000} } };
+    g_cmodel_t model = g_models[1];
+    g_models[1].animations = anims; g_models[1].num_animations = 2;
+    gi.LinkEntity = sc2_test_link; gi.GetTime = sc2_test_clock;
+    memset(sc2_edicts, 0, sizeof(sc2_edicts)); memset(sc2_move, 0, sizeof(sc2_move));
+    globals.num_edicts = 2;
+    LPEDICT ent = &sc2_edicts[1];
+    *ent = (edict_t){ .inuse = true, .s = { .number = 1, .model = 1, .radius = 0.375f } };
+    sc2_move[1].mobile = sc2_move[1].flying = true; sc2_move[1].height = 4.375f;
+    SC2_GalaxyUnitSetPosition(ent, 8.25f, 10.125f, 0);
+    SC2_GalaxyUnitMove(ent, 12.375f, 13.625f);
+    FOR_LOOP(i, 4) {
+        SC2_RunUnit(ent);
+        T_ASSERT(SC2_GalaxyUnitIsMoving(ent));
+        T_ASSERT(fabsf(ent->s.origin.x - floorf(ent->s.origin.x)) > 0.001f);
+        T_FEQ(ent->s.origin.z, 4.375f, 0.00001f);
+    }
+    g_models[1] = model; gi = saved;
+}

--- a/games/starcraft-2/renderer/r_game.c
+++ b/games/starcraft-2/renderer/r_game.c
@@ -5,6 +5,8 @@
 #include "sc2/r_sc2map.h"
 #include <math.h>
 
+#define BZ_SC2_SPLAT_LIFT 0.02f // world units; avoids terrain depth fighting for selection splats
+
 void M3_Init(void);
 void M3_Shutdown(void);
 void M3_RenderModel(renderEntity_t const *entity, m3Model_t const *model, LPCMATRIX4 transform);
@@ -14,6 +16,17 @@ typedef struct {
     DWORD count;
     char paths[256][512];
 } model_texture_cache_t;
+
+typedef struct {
+    LPCVECTOR2 mins, maxs;
+    FLOAT z;
+    LPCTEXTURE texture;
+    splat_shader_t *shader;
+    COLOR32 color;
+    BOOL terrain;
+} SC2SPLAT;
+typedef SC2SPLAT *LPSC2SPLAT;
+typedef SC2SPLAT const *LPCSC2SPLAT;
 
 static model_texture_cache_t model_texture_cache = { 0 };
 
@@ -98,13 +111,13 @@ void R_EvalKeyframeValue(void const *left,
     }
 }
 
-void R_RenderFlatRectSplat(LPCVECTOR2 mins,
-                           LPCVECTOR2 maxs,
-                           FLOAT z,
-                           LPCTEXTURE texture,
-                           splat_shader_t *shader,
-                           COLOR32 color)
-{
+/* Ground rings sample the terrain; explicit plane splats retain their caller-owned elevation. */
+static void R_SC2DrawSplat(LPCSC2SPLAT draw) {
+    LPCVECTOR2 mins = draw->mins, maxs = draw->maxs;
+    FLOAT z = draw->z;
+    LPCTEXTURE texture = draw->texture;
+    splat_shader_t *shader = draw->shader;
+    COLOR32 color = draw->color;
     MATRIX4 model_matrix;
     FLOAT const width = maxs->x - mins->x;
     FLOAT const height = maxs->y - mins->y;
@@ -121,6 +134,9 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins,
         { .position = { mins->x, maxs->y, z }, .texcoord = { 0, 0 }, .normal = { 0, 0, 1 }, .color = color },
     };
 
+    if (draw->terrain) {
+        FOR_LOOP(i, 6) vertices[i].position.z = R_GetHeightAtPoint(vertices[i].position.x, vertices[i].position.y) + BZ_SC2_SPLAT_LIFT;
+    }
     Matrix4_identity(&model_matrix);
     R_BindTexture(texture, 0);
 
@@ -138,13 +154,18 @@ void R_RenderFlatRectSplat(LPCVECTOR2 mins,
     R_Call(glDepthMask, GL_TRUE);
 }
 
+void R_RenderFlatRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, FLOAT z, LPCTEXTURE texture, splat_shader_t *shader, COLOR32 color) {
+    R_SC2DrawSplat(&(SC2SPLAT){ .mins = mins, .maxs = maxs, .z = z, .texture = texture, .shader = shader, .color = color });
+}
+
 void R_RenderRectSplat(LPCVECTOR2 mins,
                        LPCVECTOR2 maxs,
                        LPCTEXTURE texture,
                        splat_shader_t *shader,
                        COLOR32 color)
 {
-    R_RenderFlatRectSplat(mins, maxs, 0.0f, texture, shader, color);
+    /* Selection rings previously lay at Z=0 underneath the campaign terrain. */
+    R_SC2DrawSplat(&(SC2SPLAT){ .mins = mins, .maxs = maxs, .texture = texture, .shader = shader, .color = color, .terrain = true });
 }
 
 void R_RenderSplat(LPCVECTOR2 position,
@@ -174,7 +195,10 @@ void R_AddRectSplat(LPCVECTOR2 mins, LPCVECTOR2 maxs, LPCTEXTURE texture, COLOR3
 }
 void R_EndSplatBatch(void) { }
 
+/* SC2 uses the shared procedural ring for the basic model-selection presentation. */
 void R_LoadAssets(void) {
+    LPTEXTURE ring = R_MakeSelectionCircleTexture();
+    FOR_LOOP(i, NUM_SELECTION_CIRCLES) tr.texture[TEX_SELECTION_CIRCLE+i] = ring;
 }
 
 void R_Init(void) {
@@ -293,11 +317,19 @@ void R_RenderModel(renderEntity_t const *entity) {
     M3_RenderModel(entity, entity->model->m3, &transform);
 }
 
+/* Pick in model space so authored M3 bounds follow the rendered rotation and scale. */
 bool R_TraceModel(renderEntity_t const *entity, LPCLINE3 line, LPFLOAT distance) {
-    (void)entity;
-    (void)line;
-    (void)distance;
-    return false;
+    MATRIX4 matrix, inverse;
+    VECTOR3 hit;
+    BOX3 box;
+    if (!R_GetEntityBounds(entity, &box)) return false;
+    R_GetEntityMatrix(entity, &matrix);
+    Matrix4_inverse(&matrix, &inverse);
+    LINE3 local = { Matrix4_multiply_vector3(&inverse, &line->a), Matrix4_multiply_vector3(&inverse, &line->b) };
+    if (!Line3_intersect_box3(&local, &box, &hit)) return false;
+    hit = Matrix4_multiply_vector3(&matrix, &hit);
+    if (distance) *distance = Vector3_distance(&line->a, &hit);
+    return true;
 }
 
 bool R_EntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix) {
@@ -307,8 +339,10 @@ bool R_EntityMatrix(renderEntity_t const *entity, LPMATRIX4 matrix) {
 }
 
 bool R_GetEntityBounds(renderEntity_t const *entity, LPBOX3 bounds) {
-    (void)entity; (void)bounds;
-    return false;
+    if (!entity || !bounds || !entity->model || entity->model->modeltype != ID_43DM || !entity->model->m3)
+        return false;
+    *bounds = (BOX3){ entity->model->m3->boundings.min, entity->model->m3->boundings.max };
+    return true;
 }
 
 bool R_RenderShadow(renderEntity_t const *entity, LPCVECTOR2 origin) {

--- a/games/starcraft-2/tests/test_sc2_picking.c
+++ b/games/starcraft-2/tests/test_sc2_picking.c
@@ -1,0 +1,40 @@
+#include "renderer/r_game.h"
+#include "games/starcraft-2/renderer/m3/r_m3.h"
+#include "shared/test.h"
+
+/* The ray must follow model rotation/scale and return world-space distance for nearest-hit sorting. */
+TEST(sc2_control, m3_picking) {
+    m3Model_t m3 = { .boundings = { .min = {-1, -0.5f, 0}, .max = {1, 0.5f, 2} } };
+    model_t model = { .modeltype = ID_43DM, .m3 = &m3 };
+    renderEntity_t ent = { .model = &model, .origin = {10, 20, 8}, .scale = 2, .angle = M_PI / 2 };
+    LINE3 ray = {{10, 21.5f, 20}, {10, 21.5f, 0}};
+    FLOAT dist;
+    BOX3 box;
+    T_ASSERT(R_GetEntityBounds(&ent, &box)); T_FEQ(box.max.z, 2, 0.001f);
+    T_ASSERT(R_TraceModel(&ent, &ray, &dist)); T_FEQ(dist, 8, 0.001f);
+    ray.a.x = ray.b.x = 11.5f;
+    T_ASSERT(!R_TraceModel(&ent, &ray, &dist));
+    ent.model = NULL;
+    T_ASSERT(!R_GetEntityBounds(&ent, &box)); T_ASSERT(!R_TraceModel(&ent, &ray, &dist));
+}
+
+/* Exercise the SC2 executable's wire schema, including the radius consumed by its renderer. */
+TEST(sc2_control, fractional_snapshot_geometry) {
+    entityState_t from = {0}, to = { .number = 1, .model = 1, .origin = {35.275f, 23.625f, 8.125f},
+        .radius = 0.375f, .renderfx = RF_SELECTED }, out = {0};
+    FOR_LOOP(i, 2) {
+        BYTE buf[256];
+        sizeBuf_t msg = { .data = buf, .maxsize = sizeof(buf) };
+        DWORD bits = 0;
+        MSG_WriteDeltaEntity(&msg, &from, &to, true);
+        int num = MSG_ReadEntityBits(&msg, &bits);
+        MSG_ReadDeltaEntity(&msg, &out, num, bits);
+        T_FEQ(out.origin.x, to.origin.x, 0.00001f);
+        T_FEQ(out.origin.y, to.origin.y, 0.00001f);
+        T_FEQ(out.origin.z, to.origin.z, 0.00001f);
+        renderEntity_t ent = { .radius = out.radius };
+        T_FEQ(R_SelectionRadius(&ent), 0.375f, 0.00001f);
+        T_ASSERT(out.renderfx & RF_SELECTED);
+        from = to; to.origin.x += 0.125f;
+    }
+}

--- a/games/warcraft-3/game.mk
+++ b/games/warcraft-3/game.mk
@@ -35,7 +35,7 @@ ifeq ($(WC3_DEBUG_GLUE),1)
 WC3_CFLAGS += -DWC3_DEBUG_GLUE
 endif
 WC3_FDF_CFLAGS := $(WC3_CFLAGS) -DSTB_FDF_IMPLEMENTATION -DSTB_FDF_GLOBALS
-WC3_COMMON_SRCS := $(filter-out $(WC3_DIR)/common/routing.c,$(shell find $(WC3_DIR)/common -name '*.c' 2>/dev/null | sort))
+WC3_COMMON_SRCS := $(shell find $(WC3_DIR)/common -name '*.c' 2>/dev/null | sort)
 MENU_HEADERS := $(shell find $(WC3_DIR)/menu -name '*.h' | sort) client/menu.h
 
 JASS_LIB     := $(LIB_DIR)/libjass$(LIB_EXT)
@@ -105,8 +105,8 @@ JASS_HEADERS := $(COMMON_HEADERS) $(CLIENT_HEADERS) $(shell find $(WC3_DIR)/game
 $(eval $(call unity_lib_schema,$(JASS_LIB),$(SHARED_LIB) $(JASS_HEADERS) $(shell find $(WC3_JASS_DIR) -name '*.c' -o -name '*.h'),jass,$(WC3_JASS_DIR),,$(WC3_CFLAGS),,-lshared -lm))
 $(eval $(call src_lib_schema,$(SHEET_LIB),$(WC3_SHEET_DIR)/parser.c $(WC3_SHEET_DIR)/sheet.c common/common.h,sheet,$(CFLAGS),$(WC3_SHEET_DIR)/parser.c $(WC3_SHEET_DIR)/sheet.c,))
 $(eval $(call unity_lib_schema,$(RENDERER_LIB),$(RENDERER_BASE_DEPS) $(call CSRC,renderer $(WC3_DIR)/renderer),renderer,renderer $(WC3_DIR)/renderer,,$(WC3_CFLAGS),common/mpq.c,$(RENDERER_SHARED_LIBS)))
-$(eval $(call unity_lib_schema,$(GAME_LIB),$(GAME_BASE_DEPS) $(JASS_LIB) $(SHEET_LIB) $(WORLD_CORE_SRCS) $(WC3_COMMON_SRCS) $(call CSRC,$(WC3_DIR)/game),game,$(WC3_DIR)/game $(WC3_DIR)/common,! -name 'world_w3.c' ! -name 'routing.c',$(WC3_FDF_CFLAGS),common/mpq.c,-lsheet -lshared -ljass $(LIBS) -lm -lz))
-$(eval $(call unity_lib_schema,$(MENU_LIB),$(UI_BASE_DEPS) $(MENU_HEADERS) common/mpq.c common/mpq.h $(WC3_COMMON_SRCS) $(call CSRC,$(WC3_DIR)/menu),menu,$(WC3_DIR)/menu $(WC3_DIR)/common,! -name 'world_w3.c' ! -name 'routing.c',$(WC3_FDF_CFLAGS),common/mpq.c,-lshared -lsheet -lm -lz))
+$(eval $(call unity_lib_schema,$(GAME_LIB),$(GAME_BASE_DEPS) $(JASS_LIB) $(SHEET_LIB) $(WORLD_CORE_SRCS) $(WC3_COMMON_SRCS) $(call CSRC,$(WC3_DIR)/game),game,$(WC3_DIR)/game $(WC3_DIR)/common,! -name 'world_w3.c',$(WC3_FDF_CFLAGS),common/mpq.c,-lsheet -lshared -ljass $(LIBS) -lm -lz))
+$(eval $(call unity_lib_schema,$(MENU_LIB),$(UI_BASE_DEPS) $(MENU_HEADERS) common/mpq.c common/mpq.h $(WC3_COMMON_SRCS) $(call CSRC,$(WC3_DIR)/menu),menu,$(WC3_DIR)/menu $(WC3_DIR)/common,! -name 'world_w3.c',$(WC3_FDF_CFLAGS),common/mpq.c,-lshared -lsheet -lm -lz))
 # The remote client loads collision data before any game imports exist; compile its format reader into the engine.
 $(eval $(call app_schema,$(BINARY),$(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB) $(GAME_LIB) $(RENDERER_LIB) $(MENU_LIB) $(APP_SRCS) $(WC3_COMMON_SRCS) $(CLIENT_HEADERS) $(COMMON_HEADERS),openwarcraft3,$(WC3_FDF_CFLAGS) -DBZ_CLIENT_WORLD,-lsheet -lshared -ljass -lgame -lrenderer -lmenu $(LIBS) $(WC3_FFMPEG_LIBS) -lz,$(WC3_DIR)/common/world_w3.c))
 
@@ -124,7 +124,7 @@ $(eval $(call app_schema,$(BINARY),$(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB) $(GAME
 GAME_WC3_TEST_LIB := $(LIB_DIR)/libgame-wc3-test$(LIB_EXT)
 WC3_TEST_BINARY   := $(BIN_DIR)/openwarcraft3-tests$(EXE_EXT)
 
-$(eval $(call unity_lib_schema,$(GAME_WC3_TEST_LIB),$(GAME_BASE_DEPS) $(JASS_LIB) $(SHEET_LIB) $(WORLD_CORE_SRCS) $(WC3_COMMON_SRCS) $(call CSRC,$(WC3_DIR)/game),game-wc3-test,$(WC3_DIR)/game $(WC3_DIR)/common,! -name 'world_w3.c' ! -name 'routing.c',$(WC3_FDF_CFLAGS) -DBZ_TESTS,common/mpq.c,-lsheet -lshared -ljass $(LIBS) -lm -lz))
+$(eval $(call unity_lib_schema,$(GAME_WC3_TEST_LIB),$(GAME_BASE_DEPS) $(JASS_LIB) $(SHEET_LIB) $(WORLD_CORE_SRCS) $(WC3_COMMON_SRCS) $(call CSRC,$(WC3_DIR)/game),game-wc3-test,$(WC3_DIR)/game $(WC3_DIR)/common,! -name 'world_w3.c',$(WC3_FDF_CFLAGS) -DBZ_TESTS,common/mpq.c,-lsheet -lshared -ljass $(LIBS) -lm -lz))
 $(eval $(call app_schema,$(WC3_TEST_BINARY),$(SHARED_LIB) $(JASS_LIB) $(SHEET_LIB) $(GAME_WC3_TEST_LIB) $(RENDERER_LIB) $(MENU_LIB) $(APP_SRCS) $(WC3_COMMON_SRCS) $(CLIENT_HEADERS) $(COMMON_HEADERS),openwarcraft3-tests,$(WC3_FDF_CFLAGS) -DBZ_CLIENT_WORLD -DBZ_TESTS,-lsheet -lshared -ljass -lgame-wc3-test -lrenderer -lmenu $(LIBS) $(WC3_FFMPEG_LIBS) -lz,$(WC3_DIR)/common/world_w3.c))
 
 openwarcraft3-tests: $(WC3_TEST_BINARY)

--- a/games/warcraft-3/game/g_ai.c
+++ b/games/warcraft-3/game/g_ai.c
@@ -57,8 +57,8 @@ FLOAT unit_movedistance(LPEDICT self) {
  * immovable obstacles: walking into one never displaces it (the WC3 invariant
  * that the old post-move push solver violated). */
 
-#define MOVE_SLIDE_STEP        (15.0f * (FLOAT)M_PI / 180.0f)  /* deflection step */
-#define MOVE_SLIDE_RINGS       6                               /* up to +/- 90 deg */
+#define MOVE_SLIDE_STEP BZ_ROUTE_SLIDE_STEP
+#define MOVE_SLIDE_RINGS BZ_ROUTE_SLIDE_RINGS
 #define MOVE_SLIDE_RINGS_YIELD 2                               /* +/- 30 deg: faster unit holds its line */
 #define MOVE_WORKER_QUEUE_TICKS 4                              /* same-stream blocker: queue before passing */
 #define MOVE_WORKER_ESCAPE_TICKS 8                             /* widen bounded escape corridor after this */
@@ -185,6 +185,9 @@ static BOOL move_is_valid(LPEDICT self, LPCVECTOR2 cand) {
     return move_is_valid_policy(self, cand, MOVE_COLLIDE_UNITS);
 }
 
+/* Shared steering uses the same static-only policy as resource interaction movement. */
+static BOOL move_static_is_valid(LPEDICT self, LPCVECTOR2 cand) { return move_is_valid_policy(self, cand, MOVE_IGNORE_UNITS); }
+
 /* Public: would 'pos' be a free standing spot for 'self' (terrain + units)?
  * Used by the move arrival to avoid snapping a unit onto an occupied goal. */
 BOOL M_MoveIsValid(LPEDICT self, LPCVECTOR2 pos) {
@@ -221,7 +224,7 @@ static void unit_moveindirection_policy(LPEDICT self,
      * step using the unit's previous facing/heading while the requested route
      * is still being built.  This is the common safety net for Move, Harvest,
      * Patrol, Attack, Build, Repair, and resource-return walkers. */
-    if (!self->movement.flow_direct && !self->movement.path_valid && self->movement.flow_generation == 0)
+    if (!self->movement.flow_direct && !self->movement.path.valid && self->movement.flow_generation == 0)
         return;
 
     FLOAT const dist = unit_movedistance(self);
@@ -386,16 +389,9 @@ static FLOAT unit_desired_heading(LPEDICT self, FLOAT goal_angle, FLOAT dist,
         unit_current_speed(self) > unit_current_speed(b)) {
         max_rings = MOVE_SLIDE_RINGS_YIELD;
     }
-    for (int ring = 1; ring <= max_rings; ring++) {
-        for (int sign = 1; sign >= -1; sign -= 2) {
-            FLOAT const angle = angle_wrap(goal_angle + sign * ring * MOVE_SLIDE_STEP);
-            VECTOR2 const cand = Vector2_mad(&self->s.origin2, dist,
-                                             &MAKE(VECTOR2, cosf(angle), sinf(angle)));
-            if (move_is_valid_policy(self, &cand, collision_policy))
-                return angle;
-        }
-    }
-    return goal_angle;  /* boxed in: aim at the goal, hold (move step will fail) */
+    ROUTESLIDE slide = { .ent = self, .angle = goal_angle, .dist = dist, .rings = max_rings,
+        .valid = collision_policy == MOVE_IGNORE_UNITS ? move_static_is_valid : move_is_valid };
+    return CM_SlideRoute(&slide);
 }
 
 static void unit_apply_heading(LPEDICT self, LPCVECTOR2 dir, moveAvoidPolicy_t policy) {
@@ -432,25 +428,9 @@ static void unit_changeangle_towards_point_policy(LPEDICT self, LPCVECTOR2 point
  * route progress on each mover instead of rebuilding from its current point. */
 static BOOL unit_accel_direction_to_point(LPEDICT self, LPCVECTOR2 target,
                                           FLOAT radius, LPVECTOR2 dir) {
-    FLOAT const reached = CM_PathCellWorldSize();
-
-    if (!self || !target || !dir)
-        return false;
-    if (self->movement.path_valid &&
-        (Vector2_distance(&self->movement.path_target, target) >= 1.0f ||
-         fabsf(self->movement.path_radius - radius) >= 0.01f ||
-         Vector2_distance(&self->s.origin2, &self->movement.path_waypoint) <= reached ||
-         !CM_LineIsWalkableForRadius(&self->s.origin2, &self->movement.path_waypoint, radius)))
-        self->movement.path_valid = false;
-    if (!self->movement.path_valid) {
-        pathAccelParams_t params = { &self->s.origin2, target, radius };
-        if (!CM_FindPathWaypoint(&params, &self->movement.path_waypoint)) return false;
-        self->movement.path_target = *target;
-        self->movement.path_radius = radius;
-        self->movement.path_valid = true;
-    }
-    *dir = Vector2_sub(&self->movement.path_waypoint, &self->s.origin2);
-    return true;
+    if (!self || !target || !dir) return false;
+    pathAccelParams_t params = { &self->s.origin2, target, radius };
+    return CM_AccelerateRoute(&self->movement.path, &params, dir);
 }
 
 static BOOL unit_accel_direction(LPEDICT self, FLOAT radius, LPVECTOR2 dir) {
@@ -484,7 +464,7 @@ BOOL unit_changeangle_towards_point_ignore_units(LPEDICT self, LPCVECTOR2 point)
      * collision-sized mover-owned A* accelerator used while shared fields are
      * pending.  Live units remain ignored by the steering/move policy. */
     if (CM_LineIsWalkableForRadius(&self->s.origin2, point, self->collision)) {
-        self->movement.path_valid = false;
+        self->movement.path.valid = false;
         self->movement.flow_direct = true;
         dir = Vector2_sub(point, &self->s.origin2);
     } else if (!unit_accel_direction_to_point(self, point, self->collision, &dir)) {
@@ -516,7 +496,7 @@ static void unit_changeangle_policy(LPEDICT self, moveAvoidPolicy_t policy) {
      * use the same footprint as move-time collision; point routing previously
      * sent units into narrow gaps and touching obstacle corners. */
     if (CM_LineIsWalkableForRadius(&self->s.origin2, &self->goalentity->s.origin2, radius)) {
-        self->movement.path_valid = false;
+        self->movement.path.valid = false;
         self->movement.flow_direct = true;
         dir = to_goal;
     } else {
@@ -530,7 +510,7 @@ static void unit_changeangle_policy(LPEDICT self, moveAvoidPolicy_t policy) {
             unit_apply_heading(self, &dir, policy);
             return;
         }
-        self->movement.path_valid = false;
+        self->movement.path.valid = false;
         if (CM_FlowReachedGoal(heatmap, self->s.origin.x, self->s.origin.y)) {
             /* Location orders stop at their collision-safe route endpoint in
              * the owning behavior.  Interaction orders use a point field whose
@@ -597,7 +577,7 @@ static void unit_changeangle_for_radius_policy(LPEDICT self, FLOAT radius,
     if (CM_LineIsWalkableForRadius(&self->s.origin2,
                                    &self->goalentity->s.origin2,
                                    radius)) {
-        self->movement.path_valid = false;
+        self->movement.path.valid = false;
         self->movement.flow_direct = true;
         dir = to_goal;
     } else {
@@ -609,7 +589,7 @@ static void unit_changeangle_for_radius_policy(LPEDICT self, FLOAT radius,
             unit_apply_heading(self, &dir, policy);
             return;
         }
-        self->movement.path_valid = false;
+        self->movement.path.valid = false;
 
         if (CM_FlowReachedGoal(heatmap, self->s.origin.x, self->s.origin.y)) {
             self->movement.flow_goal_reached = true;

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -10,6 +10,7 @@
 #include "common/stb_fdf.h"
 #include "common/stb_slk.h"
 #include "server/game.h"
+#include "server/routing.h"
 #include "g_shared.h"
 #include "g_unitrow.h"
 #include "jass/jlex.h"
@@ -21,7 +22,6 @@
 #define MAX_EVENT_QUEUE 256
 #define MAX_MESSAGE_SUBSCRIBERS 8 // callbacks; bounded because messages are synchronous and game-local
 #define MAX_UNIT_SELECT_SOUNDS 6 // sounds; largest UnitAckSounds *What variant list in ROC/TFT data
-#define WC3_PATH_WORK_BUDGET 32768 // queue pops/server frame; completes a 256x256 open field in two 10 Hz ticks
 #define BZ_STRINGIFY_INNER(value) #value
 #define BZ_STRINGIFY(value) BZ_STRINGIFY_INNER(value)
 #define MAX_ENTITIES MAX_GAME_ENTITIES
@@ -1056,9 +1056,7 @@ struct edict_s {
         BOOL flow_goal_reached; /* mover occupies the route's adjusted goal cell */
         BOOL flow_unreachable;  /* field exists but current cell has no route */
         BOOL flow_direct;       /* static path from mover to requested goal is clear */
-        VECTOR2 path_waypoint, path_target; /* persistent accelerated turn and the destination that produced it */
-        FLOAT path_radius;
-        BOOL path_valid;
+        ROUTEPATH path; /* persistent WC3 accelerator state shared with other server games */
         FLOAT group_speed;  // slowest member's speed for a group move (0 = no cap), keeps the group together
         FLOAT heading;      // avoidance-resolved heading chosen this tick by unit_changeangle; movement follows it
         VECTOR2 worker_avoid_origin; /* start of the active resource-worker avoidance corridor */

--- a/games/warcraft-3/game/g_main.c
+++ b/games/warcraft-3/game/g_main.c
@@ -843,7 +843,7 @@ void G_RequestCampaignSelect(void) {
  * a map loads, the JASS "main" function is invoked to run map initialization
  * triggers. */
 static void G_RunFrame(void) {
-    int path_work_budget = WC3_PATH_WORK_BUDGET;
+    int path_work_budget = BZ_PATH_WORK_BUDGET;
     LPCSTR path_work_value;
 
     if (!level.started)
@@ -873,7 +873,7 @@ static void G_RunFrame(void) {
      * never depend on a lifetime quota of synchronous whole-map floods.  Keep
      * the per-frame relaxation budget runtime-tunable for slower handhelds. */
     path_work_value = gi.CvarString
-        ? gi.CvarString("wc3_path_work_budget", BZ_STRINGIFY(WC3_PATH_WORK_BUDGET)) : NULL;
+        ? gi.CvarString("wc3_path_work_budget", BZ_STRINGIFY(BZ_PATH_WORK_BUDGET)) : NULL;
     if (path_work_value)
         path_work_budget = atoi(path_work_value);
     path_work_budget = MAX(256, MIN(path_work_budget, 65536));

--- a/games/warcraft-3/game/g_world.c
+++ b/games/warcraft-3/game/g_world.c
@@ -29,7 +29,7 @@ static inline BOMStatus G_WorldTextRemoveBom(LPSTR buffer) {
 #pragma GCC visibility push(hidden)
 #include "common/world.c"
 #include "common/world_w3.c"
-#include "games/warcraft-3/common/routing.c"
+#include "server/sv_routing.c"
 #pragma GCC visibility pop
 
 #undef FS_ReadFile

--- a/games/warcraft-3/game/skills/s_goldmine.c
+++ b/games/warcraft-3/game/skills/s_goldmine.c
@@ -110,8 +110,8 @@ static void goldmine_debug_log_approach(LPEDICT ent, LPEDICT mine,
             ent->s.number, (LPCSTR)&ent->s.class_id, ent->s.origin.x, ent->s.origin.y, ent->collision,
             mine->s.number, (LPCSTR)&mine->s.class_id, mine->s.origin.x, mine->s.origin.y,
             mine->s.angle, mine->collision, dist, contact, step, footprint_dist,
-            ent->movement.heading, ent->movement.flow_direct, ent->movement.path_valid,
-            ent->movement.path_waypoint.x, ent->movement.path_waypoint.y,
+            ent->movement.heading, ent->movement.flow_direct, ent->movement.path.valid,
+            ent->movement.path.waypoint.x, ent->movement.path.waypoint.y,
             ent->movement.flow_generation, ent->movement.flow_goal_reached,
             ent->movement.flow_unreachable);
 }
@@ -121,7 +121,7 @@ static void goldmine_debug_log_approach(LPEDICT ent, LPEDICT mine,
  * in an unrelated direction while the shared route is still being built. */
 static BOOL gold_route_pending(LPCEDICT worker) {
     return worker && !worker->movement.flow_direct &&
-           !worker->movement.path_valid &&
+           !worker->movement.path.valid &&
            worker->movement.flow_generation == 0;
 }
 

--- a/games/warcraft-3/game/skills/s_move.c
+++ b/games/warcraft-3/game/skills/s_move.c
@@ -485,7 +485,7 @@ static void ai_move_walk(LPEDICT ent) {
             move_hold(ent); /* static topology says this goal cannot be reached */
             return;
         }
-        if (!ent->movement.flow_direct && !ent->movement.path_valid && !ent->movement.flow_generation) {
+        if (!ent->movement.flow_direct && !ent->movement.path.valid && !ent->movement.flow_generation) {
             return; /* resumable route field is still being built */
         }
         if (ent->movement.flow_goal_reached) {

--- a/games/warcraft-3/game/tests/t_movement.c
+++ b/games/warcraft-3/game/tests/t_movement.c
@@ -403,9 +403,9 @@ TEST(wc3_movement, worker_resource_static_detour_uses_worker_radius) {
         .max = { 1024.0f,  1024.0f}));
     worker->currentmove->think(worker);
 
-    T_ASSERT(worker->movement.path_valid);
-    T_FEQ(worker->movement.path_radius, worker->collision, 0.001f);
-    T_ASSERT(fabsf(worker->movement.path_waypoint.y) >= CM_PathCellWorldSize());
+    T_ASSERT(worker->movement.path.valid);
+    T_FEQ(worker->movement.path.radius, worker->collision, 0.001f);
+    T_ASSERT(fabsf(worker->movement.path.waypoint.y) >= CM_PathCellWorldSize());
 
     G_SetSLKRows("AbilityData", old_abilities);
     free_slk_rows(rows);
@@ -453,10 +453,10 @@ TEST(wc3_movement, worker_resource_gold_return_targets_near_side_edge) {
     T_ASSERT(harvest_gold_return_to(worker, hall));
     worker->currentmove->think(worker);
 
-    T_ASSERT(worker->movement.path_valid);
-    T_FEQ(worker->movement.path_radius, worker->collision, 0.001f);
-    T_ASSERT(worker->movement.path_target.x < hall->s.origin2.x);
-    T_ASSERT(worker->movement.path_target.x > worker->s.origin2.x);
+    T_ASSERT(worker->movement.path.valid);
+    T_FEQ(worker->movement.path.radius, worker->collision, 0.001f);
+    T_ASSERT(worker->movement.path.target.x < hall->s.origin2.x);
+    T_ASSERT(worker->movement.path.target.x > worker->s.origin2.x);
 
     hall->pathtex = NULL;
     gi.MemFree(hall_pathtex);
@@ -498,10 +498,10 @@ TEST(wc3_movement, worker_resource_lumber_return_targets_near_side_edge) {
     T_ASSERT(harvest_lumber_return_to(worker, mill));
     worker->currentmove->think(worker);
 
-    T_ASSERT(worker->movement.path_valid);
-    T_FEQ(worker->movement.path_radius, worker->collision, 0.001f);
-    T_ASSERT(worker->movement.path_target.x < mill->s.origin2.x);
-    T_ASSERT(worker->movement.path_target.x > worker->s.origin2.x);
+    T_ASSERT(worker->movement.path.valid);
+    T_FEQ(worker->movement.path.radius, worker->collision, 0.001f);
+    T_ASSERT(worker->movement.path.target.x < mill->s.origin2.x);
+    T_ASSERT(worker->movement.path.target.x > worker->s.origin2.x);
 
     mill->pathtex = NULL;
     gi.MemFree(mill_pathtex);
@@ -1009,8 +1009,8 @@ TEST(wc3_movement, nearby_move_starts_on_accelerated_waypoint) {
 
     T_EQ(unit->movement.flow_generation, 0);
     T_ASSERT(!unit->movement.flow_direct);
-    T_ASSERT(unit->movement.path_valid);
-    T_ASSERT(CM_LineIsWalkableForRadius(&origin, &unit->movement.path_waypoint, unit->collision));
+    T_ASSERT(unit->movement.path.valid);
+    T_ASSERT(CM_LineIsWalkableForRadius(&origin, &unit->movement.path.waypoint, unit->collision));
     T_ASSERT(Vector2_distance(&unit->s.origin2, &origin) > 0.001f);
     T_STREQ(unit->currentmove->animation, "walk");
 }
@@ -1373,14 +1373,14 @@ TEST(wc3_movement, gold_three_workers_hold_while_shared_route_is_pending) {
         T_FEQ(Vector2_distance(&workers[i]->s.origin2, &origin[i]), 0.0f, 0.001f);
         T_EQ(workers[i]->movement.flow_generation, 0);
         T_ASSERT(!workers[i]->movement.flow_direct);
-        T_ASSERT(!workers[i]->movement.path_valid);
+        T_ASSERT(!workers[i]->movement.path.valid);
     }
 
     CM_ProcessPathJobs(65536);
     FOR_LOOP(i, WORKERS) {
         workers[i]->currentmove->think(workers[i]);
         T_ASSERT(workers[i]->movement.flow_generation != 0);
-        T_ASSERT(!workers[i]->movement.path_valid);
+        T_ASSERT(!workers[i]->movement.path.valid);
         T_ASSERT(Vector2_distance(&workers[i]->s.origin2, &origin[i]) > 0.001f);
     }
 
@@ -1537,12 +1537,12 @@ TEST(wc3_movement, gold_return_holds_while_shared_route_is_pending) {
     T_FEQ(Vector2_distance(&worker->s.origin2, &origin), 0.0f, 0.001f);
     T_EQ(worker->movement.flow_generation, 0);
     T_ASSERT(!worker->movement.flow_direct);
-    T_ASSERT(!worker->movement.path_valid);
+    T_ASSERT(!worker->movement.path.valid);
 
     CM_ProcessPathJobs(65536);
     worker->currentmove->think(worker);
     T_ASSERT(worker->movement.flow_generation != 0);
-    T_ASSERT(!worker->movement.path_valid);
+    T_ASSERT(!worker->movement.path.valid);
     T_ASSERT(Vector2_distance(&worker->s.origin2, &origin) > 0.001f);
 }
 

--- a/games/warcraft-3/game/tests/t_pathfinding.c
+++ b/games/warcraft-3/game/tests/t_pathfinding.c
@@ -314,9 +314,9 @@ TEST(wc3_pathfinding, production_budget_completes_large_open_field_in_two_frames
     goal = make_waypoint(128.0f, 128.0f);
 
     T_EQ(CM_RequestHeatmapForRadius(goal, 0.0f), 0);
-    CM_ProcessPathJobs(WC3_PATH_WORK_BUDGET);
+    CM_ProcessPathJobs(BZ_PATH_WORK_BUDGET);
     if (!CM_RequestHeatmapForRadius(goal, 0.0f))
-        CM_ProcessPathJobs(WC3_PATH_WORK_BUDGET);
+        CM_ProcessPathJobs(BZ_PATH_WORK_BUDGET);
     T_ASSERT(CM_RequestHeatmapForRadius(goal, 0.0f) != 0);
 }
 

--- a/server/routing.h
+++ b/server/routing.h
@@ -1,0 +1,28 @@
+#ifndef BZ_SERVER_ROUTING_H
+#define BZ_SERVER_ROUTING_H
+
+#define BZ_ROUTE_SLIDE_STEP (15.0f * (FLOAT)M_PI / 180.0f) // radians; WC3 deflection increment; used by local steering
+#define BZ_ROUTE_SLIDE_RINGS 6 // steps/side; WC3 searches through 90 degrees; bounds local steering
+
+#define BZ_PATH_WORK_BUDGET 32768 // queue pops/tick; WC3 default completes a 256x256 open field in two ticks
+
+typedef struct {
+    VECTOR2 waypoint, target;
+    FLOAT radius;
+    BOOL valid;
+} ROUTEPATH;
+typedef ROUTEPATH *LPROUTEPATH;
+typedef ROUTEPATH const *LPCROUTEPATH;
+
+typedef struct {
+    LPEDICT ent;
+    FLOAT angle, dist;
+    int rings;
+    BOOL (*valid)(LPEDICT ent, LPCVECTOR2 point);
+} ROUTESLIDE;
+typedef ROUTESLIDE *LPROUTESLIDE;
+typedef ROUTESLIDE const *LPCROUTESLIDE;
+
+FLOAT CM_SlideRoute(LPCROUTESLIDE slide);
+BOOL CM_AccelerateRoute(LPROUTEPATH path, pathAccelParams_t const *params, LPVECTOR2 dir);
+#endif

--- a/server/sv_routing.c
+++ b/server/sv_routing.c
@@ -3,6 +3,7 @@
 #define EDICT_NUM(n) (globals.edicts + (n))
 #endif
 
+#include "server/routing.h"
 #include <float.h>
 #include <limits.h>
 #include <stdlib.h>  /* abs (CM_LineIsWalkable) */
@@ -1524,3 +1525,36 @@ void CM_SetupTestPathmap(DWORD width, DWORD height, BYTE const *cells) {
     CM_SetupPathMap(width, height, cells);
 }
 #endif
+
+/* WC3's mover-owned turn cache: retain the accelerated waypoint until reached or invalidated. */
+BOOL CM_AccelerateRoute(LPROUTEPATH path, pathAccelParams_t const *params, LPVECTOR2 dir) {
+    FLOAT const reached = CM_PathCellWorldSize();
+    if (!path || !params || !dir) return false;
+    if (path->valid && (Vector2_distance(&path->target, params->target) >= 1.0f ||
+        fabsf(path->radius - params->radius) >= 0.01f ||
+        Vector2_distance(params->from, &path->waypoint) <= reached ||
+        !CM_LineIsWalkableForRadius(params->from, &path->waypoint, params->radius)))
+        path->valid = false;
+    if (!path->valid) {
+        if (!CM_FindPathWaypoint(params, &path->waypoint)) return false;
+        path->target = *params->target;
+        path->radius = params->radius;
+        path->valid = true;
+    }
+    *dir = Vector2_sub(&path->waypoint, params->from);
+    return true;
+}
+
+/* Share WC3's bounded left/right deflection; each game supplies its movement collision policy. */
+FLOAT CM_SlideRoute(LPCROUTESLIDE slide) {
+    for (int ring = 1; ring <= slide->rings; ring++) {
+        for (int sign = 1; sign >= -1; sign -= 2) {
+            FLOAT angle = slide->angle + sign * ring * BZ_ROUTE_SLIDE_STEP;
+            while (angle > (FLOAT)M_PI) angle -= 2.0f * (FLOAT)M_PI;
+            while (angle < -(FLOAT)M_PI) angle += 2.0f * (FLOAT)M_PI;
+            VECTOR2 cand = Vector2_mad(&slide->ent->s.origin2, slide->dist, &MAKE(VECTOR2, cosf(angle), sinf(angle)));
+            if (slide->valid(slide->ent, &cand)) return angle;
+        }
+    }
+    return slide->angle; /* Boxed in; the caller's move-time check holds the unit in place. */
+}

--- a/tests/test_galaxy.c
+++ b/tests/test_galaxy.c
@@ -76,6 +76,13 @@ static void *gal_unit_create(LPCSTR type, int player, float x, float y, float an
     (void)type; (void)player; (void)x; (void)y; (void)angle;
     return (void *)(uintptr_t)1;
 }
+static int gal_owners[8], gal_units;
+static void *gal_owned_create(LPCSTR type, int player, float x, float y, float angle) {
+    (void)type; (void)x; (void)y; (void)angle;
+    gal_owners[gal_units] = player;
+    return &gal_owners[gal_units++];
+}
+static int gal_unit_owner(void *ent) { return *(int *)ent; }
 static void gal_unit_move(void *ent, float x, float y) {
     (void)ent; (void)y; gal_move_count++; gal_move_x = x; gal_unit_moving = true;
 }
@@ -1000,7 +1007,26 @@ TEST(galaxy, vm_objective_lifecycle) {
     gal_destroy(&s);
 }
 
-/* The native signature must accept a non-null scope in argument one, as NativeLib's attachment helper does. */
+/* Cargo must retain the real transport owner rather than defaulting to neutral. */
+TEST(galaxy, cargo_inherits_transport_owner) {
+    gal_state_t s = gal_new();
+    galaxy_reset(); gal_units = 0;
+    sc2_galaxy_on_unit_create = gal_owned_create;
+    sc2_galaxy_unit_owner = gal_unit_owner;
+    jass_sethost(&MAKE(JASSHOST, .MemAlloc = gal_alloc, .MemFree = gal_free, .natives = gal_assert_natives, .galaxy_natives = galaxy_get_natives()));
+    T_ASSERT(gal_run(&s,
+        "native void TestFail(string msg); void main() {"
+        "UnitCreate(1, \"Dropship\", 0, 4, Point(0.0, 0.0), 0.0);"
+        "unit ship = UnitLastCreated(); UnitCargoCreate(ship, \"Marine\", 2);"
+        "if (UnitGetOwner(UnitCargoLastCreated()) != 4) { TestFail(\"cargo owner\"); }"
+        "if (UnitGetOwner(ship) != 4) { TestFail(\"transport owner\"); }"
+        "UnitCargoCreate(null, \"Marine\", 1);"
+        "}"));
+    T_EQ(gal_units, 3); T_EQ(gal_owners[1], 4); T_EQ(gal_owners[2], 4);
+    sc2_galaxy_on_unit_create = NULL; sc2_galaxy_unit_owner = NULL;
+    galaxy_reset(); gal_destroy(&s);
+}
+
 TEST(galaxy, vm_actor_scope_first) {
     gal_state_t s = gal_new();
     galaxy_reset();

--- a/tests/test_net.c
+++ b/tests/test_net.c
@@ -2270,8 +2270,7 @@ TEST(net, fow_malformed_payload_does_not_overread) {
     reset_fow_client_state();
 }
 
-/* WC3 selection radii (buildings/destructables) exceed the packed-float range of ±65.5, so radius must stay
- * NFT_ROUND. Guard the WC3 delta path against a regression back to a narrow two-byte encoding. */
+/* Static entities must not consume snapshot bandwidth when their state is unchanged. */
 TEST(net, unchanged_entity_delta_emits_nothing) {
     BYTE buf[256];
     sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
@@ -2299,6 +2298,27 @@ TEST(net, entity_delta_preserves_large_wc3_radii) {
 
         T_EQ(number, 9);
         T_FEQ(out.radius, radii[i], 0.001f);
+    }
+}
+
+/* Small RTS units need fractional radii and positions on both initial and moving snapshots. */
+TEST(net, entity_delta_preserves_fractional_geometry) {
+    entityState_t from = { 0 }, to = { .number = 9, .model = 1, .radius = 0.375f,
+        .origin = { 42.375f, -44.625f, 8.125f }, .renderfx = RF_SELECTED }, out = { 0 };
+    FOR_LOOP(i, 2) {
+        BYTE buf[256];
+        sizeBuf_t sb = make_msg_buf(buf, sizeof(buf));
+        DWORD bits = 0;
+        MSG_WriteDeltaEntity(&sb, &from, &to, true);
+        int num = MSG_ReadEntityBits(&sb, &bits);
+        MSG_ReadDeltaEntity(&sb, &out, num, bits);
+        T_FEQ(out.radius, to.radius, 0.00001f);
+        T_FEQ(out.origin.x, to.origin.x, 0.00001f);
+        T_FEQ(out.origin.y, to.origin.y, 0.00001f);
+        T_FEQ(out.origin.z, to.origin.z, 0.00001f);
+        T_ASSERT(out.renderfx & RF_SELECTED);
+        from = to;
+        to.origin.x += 0.125f; to.origin.y -= 0.25f;
     }
 }
 


### PR DESCRIPTION
SC2 units appeared to move in whole cells, including during the opening cutscene, and selection rings were invisible. Entity snapshots truncated fractional positions and reduced a 0.375 selection radius to zero. Preserve both as floats and use WC3's shared routing and obstacle steering for SC2 ground orders.

- Move the existing WC3 router to `server/sv_routing.c`, retaining game-owned world state. Both games share the persistent waypoint accelerator and bounded heading search; SC2 uses collision-sized routes and incremental path jobs.
- Restore M3 picking and terrain-height selection rings, reconcile selection with the client, and allow the first move after selecting. Preserve the session player and inherit cargo ownership from its transport.
- Use authored Stand/Walk sequence intervals and preserve fractional snapshot positions for both player orders and Galaxy cutscene movement.
- Add routing, selection, picking, cargo ownership, and snapshot regression coverage; document the shared contracts and confirmed failure causes.

Validation: `make test TEST_JOBS=8` passed, including WC3 ROC/TFT suites and all five SC2 control tests (102 assertions). Rebuilt `opensc2` and `openwarcraft3`; completed bounded SC2 campaign/TerranTest and WC3 Human01 gameplay runs. Rendered screenshots confirm visible selection rings.

Wire compatibility: protocol version 5 records float origin/radius encoding. No entity-state fields are added, but both endpoints must be rebuilt; a transmitted WC3/SC2 origin uses six more bytes, and a transmitted radius uses two more bytes. SC2 navigation-layer decoding and full WC3 unit-avoidance/formation behavior remain outside this change.
