### PR TITLE
wc3: fix ability lifecycle, targeting, and item modifiers

### DIFF
--- a/docs/games/warcraft-3/ability-verification-review.md
+++ b/docs/games/warcraft-3/ability-verification-review.md
@@ -1,0 +1,126 @@
+# Ability verification and lifecycle fixes
+
+## Scope and evidence
+
+The September 2026 review at `41602e54` inspected all 39 Warcraft III
+`game/skills/*.c` files. Three agents covered combat spells, orders/economy,
+and passives/items/campaign handlers; the coordinator covered shared dispatch.
+The original baseline passed 1,132 WC3 tests in each archive mode, but sixteen
+new behavior scenarios failed and enabling Human autocast crashed. Registry
+presence and status-record creation had overstated working functionality.
+
+The fixes retain these reproductions as permanent tests, extend their inverse
+and lifecycle coverage, and correct additional failures exposed by that work.
+The four new suites contain 37 tests / 302 assertions, passing in both ROC and
+TFT modes. Five save-schema tests additionally cover the new channel fields.
+This verifies the named contracts, not exhaustive retail parity or rendered art.
+
+## Fixed contracts
+
+| Area | Previous failure | Owning fix and regression evidence |
+|---|---|---|
+| Human autocast | A boolean message was dereferenced as a target pointer; aliases used base data | Human, validated-spell, Avatar and bolt procedures decode only the current message's union member. The command/HUD/scheduler retain the actual rawcode. Alias cost/heal, runtime membership, switching, removal and unsupported-policy rollback are tested. |
+| Repair autocast | Switching related procedures could clear their shared policy flag | Disable the old policy before enabling its replacement; disabling a nonselected alias has no effect. Rejected enable restores the previous policy. |
+| Hold Position | Out-of-range acquisition walked toward enemies | Attack returns to stationary scanning; an in-range enemy can still be attacked. |
+| Delayed damage | An old projectile kill replaced a newer Move or consumed its queue | Combat completion requires the current Attack procedure and matching target. Animationless post-hit fallback also requires unchanged move and target. |
+| Explicit Attack/Smart | Replaced Follow/Patrol/Attack-move resumed after combat | `S_OrderAttack` clears retained movement only after accepting an explicit order. Autonomous acquisition keeps continuation; queued orders replace it only when executed. |
+| Repair completion | `building->stand` erased the producer queue | Repair owns the worker's completion only; the target keeps its production behavior and queue. Tests advance the retained trainee. |
+| Flame Strike | Damage was treated as a long cast delay; pulses ran every frame | Read Cast/HeroDur/Dur and Hfs1–Hfs6 correctly; preserve absolute fractional pulse deadlines, phases, building multiplier and aggregate cap. |
+| Blizzard | Zero Dur truncated six authored waves to two | Wave count and authored interval determine completion, independently of the zero-duration sentinel. |
+| Life Drain / Siphon Mana | Life Drain affected mana; channels survived cancellation | Separate authored health/mana fields and allied transfer; validate each cast, tether and entity incarnation at every pulse. |
+| Channel lifecycle | No-target casts lacked state; old thinkers survived recasts or stopped new orders | Start all channel shapes consistently; capture a cast serial and owner/target incarnation; route move-leave to the active procedure and explicitly cancel on Stop. Stun, movement, recast, expiry, reuse and save continuation are tested. |
+| Aerial Shackles | The caster buff was applied to the victim, so movement/attacks remained allowed | Read the target member of the authored buff pair. Remove its lock when that channel ends, preserving a replacement cast's lock. |
+| Storm Bolt | Spell immunity blocked damage but not stun; creep level selected Hero duration | Check impact acceptance before applying stun and use actual Hero identity for HeroDur. |
+| Frost Nova | A no-target burst damaged around the caster | Register a unit target; apply direct DataB damage and area DataA damage around that target. |
+| Resurrection | Only Heroes were eligible | The no-target spell finds ordinary friendly corpses in the authored area/count, reuses their edicts, retires death state and restores unit/food activity. Reject an empty cast before committing resources. |
+| Attribute items | Strength, Agility and Intelligence were rotated | Both permanent tomes and passive attribute aliases use DataA=Agility, DataB=Intelligence, DataC=Strength. |
+| Passive items | Exact base-code comparisons discarded stock alias bonuses | `A_ITEM_ADD` / `A_ITEM_REMOVE` carry `abilityitem_t` to the owning passive procedure. Read each alias's amount on pickup/drop; no per-family global amount cache. Stacked items survive save/load and independent removal. |
+| Natural creep sleep | Wake removed unrelated owned overlays | Tag sleep art with ACsp and require that identity during cleanup. Wake, move and disable preserve regeneration art. |
+
+## Data and timing
+
+Use the archive audit instead of inferring fields from tooltip prose:
+
+```sh
+build/bin/ability_audit -data 'data/Warcraft III' -roc -raw AIsm
+build/bin/ability_audit -data 'data/Warcraft III' -tft -raw AHfs
+python3 tools/wc3_ability_class_audit.py --format=coverage
+```
+
+The active TFT Flame Strike row uses Hfs1/DataA for full pulse damage,
+Hfs2/DataB for its interval, Hfs3/DataC for lesser pulse damage, Hfs4/DataD
+for its interval, Hfs5/DataE for the building multiplier, and Hfs6/DataF
+for the aggregate damage cap. Cast is the initial delay; HeroDur supplies
+the full-damage phase and Dur the damage lifetime. Deadlines advance from
+the previous scheduled pulse, so a 0.33-second interval does not become
+0.4 seconds on every 100 ms server tick. Positive sub-frame intervals are
+caught up at the next simulation step; invalid intervals are rejected/logged.
+
+Both ROC and TFT archive audits confirm AItg → AIat (attack bonus 1),
+AId1 → AIde (armor 1), and the three tome attribute columns. Combat fixtures
+include an explicit ROC numbered Data11/Data12 conversion test for Blizzard.
+Running TFT numeric fixtures in ROC mode verifies runtime compatibility;
+it does not independently verify every ROC authored value or TFT-only spell.
+
+## Dispatch and persistence
+
+`abilityCall_t` is a message-tagged union. `A_COMMAND` supplies a client,
+`A_INIT` a classname, `A_AUTOCAST_SET` a boolean, and only target-bearing
+messages supply a `spellTarget_t`. Never eagerly read the target union member
+before deciding which message is being handled.
+
+`edict.channel.code` is nonzero on the caster only. Each channel thinker
+retains its spell rawcode in `class_id`, the cast `channel.serial`, and
+`owner_spawn_time` / `target_spawn_time` where applicable. Reused owner/target
+slots and replacement casts cannot inherit an old effect. `S_SpellEndChannel`
+clears only a matching cast, then releases its thinker; cancellation does not
+install Stand over an already accepted replacement order.
+
+Save format **21** adds this channel identity state to the edict schema.
+Older save versions are rejected. The new channel callbacks are appended to
+`save_cfunctions[]`; never reorder existing callback indexes. The saved
+channel origin is preserved for movement cancellation after loading. A live
+drain and stacked passive item aliases have production WriteGame/ReadGame
+continuation tests, in addition to the individual schema tests.
+
+## Tests
+
+```sh
+make test-wc3-engine WC3_PATTERN='wc3_ability_*'
+make test-wc3-engine WC3_PATTERN='wc3_order_lifecycle.*'
+make test-wc3-engine WC3_PATTERN='wc3_item_lifecycle.*'
+make test-wc3-engine WC3_PATTERN='wc3_save.*'
+make test
+make build
+```
+
+Permanent regression sources are `game/tests/t_ability_dispatch.c`,
+`t_ability_lifecycle.c`, `t_order_lifecycle.c`, and `t_item_lifecycle.c`.
+Existing combat, building, spell and save tests also check affected paths.
+Final verification on 2026-09-13: `make test` passes 3,228 test invocations /
+65,585 assertions across 20 suite invocations, including 1,174 WC3 tests /
+25,316 assertions per archive mode. `make build` passes. Both builds emit no
+compiler warnings; registry coverage remains 193 registered TFT class IDs.
+Use full local socket access for the aggregate suite's UDP tests; sandbox
+bind denial is not a gameplay failure. No interactive game launch was needed.
+
+## Limits and history
+
+The fixes address reproduced defects and their related lifecycle cases.
+Previously documented partial implementations remain partial: Wisp/Acolyte
+harvesting, mine transformations, general transport drop, Purchase Item,
+Mirror Image's complete illusion semantics, several status-only spells,
+and Siphon Mana's temporary above-maximum mana/decay behavior. Visual effects,
+full target-mask vocabulary and comprehensive retail spell parity remain
+separate work. Do not interpret a registered procedure as complete behavior.
+
+Blame traced the unsafe Human union reads to `e12b63ad0`, Flame/Drain field
+and timer errors to `22ff3692`, item alias/attribute errors to `85fd0906`,
+attack continuation to `317fc09ae`, Repair completion to `6d5025e92`, and sleep
+overlay cleanup to `ebbe30e2`. These histories explain why the new regressions
+exercise caller/event order, authored aliases and inverse behavior rather
+than only testing procedure lookup.
+
+See [ability coverage](architecture/ability-coverage.md),
+[ability implementation](ability-implementation-plan.md),
+[save/load](save-load.md), and [autocast](autocast.md).

--- a/docs/games/warcraft-3/architecture/ability-coverage.md
+++ b/docs/games/warcraft-3/architecture/ability-coverage.md
@@ -3,6 +3,9 @@
 This note tracks the current OpenWarcraft3 game-side ability registry against
 the reference ability base-code list used for parity work.
 
+See the [implemented ability verification review](../ability-verification-review.md) for the
+September 2026 source audit, lifecycle fixes, and current coverage limits.
+
 Primary local files:
 
 - `games/warcraft-3/game/skills/s_skills.c`
@@ -29,8 +32,6 @@ follow-up contracts when their authored rows and runtime consumers are added.
 
 OpenWarcraft3 uses a small Quake-style `ability_t` registry row and one `abilityProc_t` per behavior. Flags select command, spell, item, autocast and update paths; those paths send typed `abilityMsg_t` messages. `UnitAddAbility` and `UnitRemoveAbility` send `A_ENABLE` and `A_DISABLE` immediately. Stateful abilities answer `A_LEVEL`, and `S_RefreshAbilityLevel()` forwards the value through `A_LEVEL_CHANGED`. Command-card discovery uses `S_AbilityHasCommand`, so passive/no-op procedures do not create dead buttons. Concrete procedures explicitly call their TFT parent procedure for unhandled messages; no callback descriptor or runtime parent table exists.
 `Aoar` (Healing Ward Aura), `Aabr` (Aura of Blight), and `Aarm` (Mana Regeneration Aura) are registered passive regeneration families. Alias rows such as `ACnr -> Aoar` and `ANre -> Aarm` are discovered on the owning unit and keep alias-authored area, targets, and DataA/DataB values. Percentage mode scales against the recipient's maximum HP/mana; same-family sources use the strongest value while `Aoar` and `Aabr` remain distinct contributors. Presentation effects remain separate work. See [Regeneration Auras And Fountains](../regeneration-auras.md).
-
-OpenWarcraft3 uses a small Quake-style `ability_t` dispatch object. Command-capable abilities provide a `cmd` hook; optional hooks cover toggle presentation, spell metadata, synchronous item use, autocast, membership changes, and levels. `UnitAddAbility` and `UnitRemoveAbility` invoke `enabled` and `disabled` immediately. Stateful abilities derive their current level through `level`; the owning gameplay mutation calls `S_RefreshAbilityLevel()`, which forwards that value to `level_changed`. Command-card discovery requires a real `cmd`, so registered passive/stub handlers do not create dead buttons.
 
 The CommonAbility base codes use the subsystem that already owns their behavior.
 `AEbu`, `AGbu`, `AHbu`, `ANbu`, `AObu`, and `AUbu` share the build command;
@@ -112,7 +113,7 @@ thinker therefore follows the caster like `AOww` while retaining the normal
 channel lifetime and periodic area-status path.
 
 The selected neutral-hero contracts now also cover `ANms` (Mana Shield) at the
-central damage boundary, `AHre` (Resurrection) through persistent dead-hero
+central damage boundary, `AHre` (Resurrection) through nearby ordinary friendly-corpse
 revival, `ANbf` (Breath of Fire) through point-area damage, `ANdb` (Drunken
 Brawler) through the existing critical/evasion hooks, `ANdh` (Drunken Haze) and
 `ANdo` (Doom) through timed target buffs, `ANht` (Howl of Terror) through its

--- a/docs/games/warcraft-3/autocast.md
+++ b/docs/games/warcraft-3/autocast.md
@@ -2,21 +2,33 @@
 
 ## Scope
 
-OpenRealm has a small generic autocast contract in `ability_t` and currently uses it for the Repair family (`Arep`, `Aren`, `Arst`). The scheduler owns *when* an idle unit gets an automatic acquisition opportunity; the ability owns toggle state, target selection, and issuance of its ordinary order.
+OpenRealm has a small generic autocast contract in `ability_t` and uses it for the Repair family (`Arep`, `Aren`, `Arst`) and Human support spells. The scheduler owns *when* an idle unit gets an automatic acquisition opportunity; the ability owns toggle state, target selection, and issuance of its ordinary order.
 
 The implementation intentionally does not turn the existing `AB_AUTOCAST` metadata flag into behavior for every spell. Cold Arrows and other autocast abilities still need their own targeting/execution rules.
 
 ## Ability contract
 
-`ability_t` appends three optional hooks after the existing dispatch fields:
+Autocast procedures receive three typed messages:
 
-- `autocast_is_on(unit)` reads ability-specific toggle state;
-- `autocast_set(unit, enabled)` changes it;
-- `autocast_acquire(unit)` looks for a target and, on success, issues the normal ability order.
+- `A_AUTOCAST_ON` checks the selected policy;
+- `A_AUTOCAST_SET` supplies `call->enabled` and returns whether the procedure accepts the change;
+- `A_AUTOCAST_ACQUIRE` acquires a target and issues its ordinary order using `call->item->code`.
 
-`G_SetUnitAutocast()` enforces the current Warsmash-compatible one-selected-autocast rule: enabling one autocast-capable ability disables the other autocast hooks present on that unit. `AI_AUTOCAST_ACTIVE` is only a fast unit-wide marker; ability-specific state remains authoritative.
+`G_SetUnitAutocast(unit, rawcode, enabled)` enforces one selected autocast ability.
+`edict.autocast_code` retains the actual authored alias; `AI_AUTOCAST_ACTIVE` is
+its fast scheduler marker. Human Heal, Inner Fire, Slow and Spell Steal use that
+selection directly. Repair additionally stores its policy bit in
+`AI_AUTOCAST_REPAIR`. Both fields survive ordinary completion and interruption.
 
-The Repair family stores its state in `AI_AUTOCAST_REPAIR`, so the toggle survives ordinary Repair completion and order interruption with the rest of the edict state.
+Switching disables the previous policy before enabling the new one because
+related procedures can share a policy bit. If the new procedure rejects the
+change, the old policy is restored. Disabling a nonselected alias leaves the
+selection intact. Removal disables a selected ability; acquisition accepts
+runtime-added abilities and does not require a static UnitAbilities entry.
+
+`abilityCall_t` is a message-tagged union: boolean messages must not decode
+`call->target`. See [ability verification](ability-verification-review.md) for
+alias, switching, removal and crash regression coverage.
 
 ## Command-card toggle
 
@@ -30,7 +42,7 @@ autocast <repair rawcode>
 
 Left click remains the normal Repair targeting action. Right-button down/up over a command button with a secondary command is consumed by the client layout layer so it cannot also become a world Smart order. Right-button up sends the secondary command.
 
-The server toggles all controllable selected units that carry the same Repair handler and plays `AutoCastButtonClick`. Enabling Auto Repair on an already idle worker immediately tries one acquisition pass; toggling during active movement/work does not interrupt that behavior.
+The server toggles all controllable selected units that carry the requested authored rawcode and plays `AutoCastButtonClick`. Enabling Auto Repair on an already idle worker immediately tries one acquisition pass; toggling during active movement/work does not interrupt that behavior.
 
 JASS/string immediate orders `repairon` and `repairoff` use the same toggle path. Numeric `IssueImmediateOrderById` now exists for canonical table entries, but repair toggle order IDs are not part of that table and continue to use their string path.
 

--- a/docs/games/warcraft-3/readme.md
+++ b/docs/games/warcraft-3/readme.md
@@ -110,6 +110,7 @@ File formats, renderer notes, UI/FDF behavior, and gameplay coverage work used b
 - [Inventory And World Items](inventory-and-items.md)
 - [Ability And Item Effects](ability-and-item-effects.md)
 - [Adding Warcraft III Abilities](ability-implementation-plan.md): data, procedure macros, registration, and tests.
+- [Implemented Ability Verification Review](ability-verification-review.md): reproduced failures, lifecycle fixes, and permanent regression coverage.
 - [Ability Coverage](architecture/ability-coverage.md)
 - [Flat C Ability System: Flags and Message Procedures](ability-inheritance-plan.md)
 - [Ability Inheritance: Binary Evidence](ability-inheritance-binary.md)

--- a/docs/games/warcraft-3/save-load.md
+++ b/docs/games/warcraft-3/save-load.md
@@ -6,7 +6,7 @@ The WC3 game module owns save/load. `GetGameAPI()` exposes `SaveGame` and `LoadG
 
 `WriteGame()` writes the current game state to a versioned binary file. The file contains:
 
-- `W3SV` magic, format version 20, canonical map path, `sizeof(edict_t)`, entity count, client count, script identity, and native-handle registry counts;
+- `W3SV` magic, format version 21, canonical map path, `sizeof(edict_t)`, entity count, client count, script identity, and native-handle registry counts;
 - level frame/time, authoritative Warcraft time-of-day state, map-global camera bounds, and started/script-started flags;
 - each client `GAMECLIENT` state, including its `PLAYER` state, JASS settings, runtime removed/result-presentation state, researched tech, text storage, camera values, messages, and HUD caches;
 - each camera target as an entity index;
@@ -357,3 +357,7 @@ See [Neutral Creep Sleep](creep-sleep.md).
 ## Environmental distance fog
 
 Save format version 16 adds the active WC3 environmental terrain-fog state and its `[DefaultZFog]` reset target to the level field schema. `ReadGame()` republishes the restored active state through `CS_SCENE_FOG` after the map reload and level-state restore, preventing the client from keeping the freshly initialized map fog instead of the saved scripted value. See [Environmental Terrain Fog](environmental-fog.md).
+
+Channel cast serials, saved origins, and owner/target incarnation stamps are persisted in version 21.
+The appended channel thinker callback roster and continuation tests are described in
+[ability verification](ability-verification-review.md#dispatch-and-persistence).

--- a/games/warcraft-3/game/g_commands.c
+++ b/games/warcraft-3/game/g_commands.c
@@ -770,10 +770,10 @@ CLIENTCOMMAND(Autocast) {
         return;
     }
 
-    enabled = !G_UnitAutocastIsOn(main, ability);
+    enabled = !G_UnitAutocastIsOn(main, FS_SLKKey(classname));
     FOR_CONTROLLABLE_SELECTED_UNITS(client, ent) {
         if (!G_ActorHasSkill(ent, classname)) continue;
-        if (G_SetUnitAutocast(ent, ability, enabled)) {
+        if (G_SetUnitAutocast(ent, FS_SLKKey(classname), enabled)) {
             changed = true;
             /* The toggle itself must not interrupt active work or movement, but
              * an already-idle worker should respond immediately rather than

--- a/games/warcraft-3/game/g_items.c
+++ b/games/warcraft-3/game/g_items.c
@@ -1,12 +1,6 @@
 #include "g_local.h"
 #include "skills/s_skills.h"
 
-/* Passive item-effect hooks remain centralized here so every inventory exit
- * reverses the corresponding inventory entry. Effect coverage is expanded in
- * a later item-system phase. */
-void item_stat_apply(LPEDICT unit, DWORD item_code);
-void item_stat_remove(LPEDICT unit, DWORD item_code);
-
 /* Keep the native itemtype mapping in one table shared by GetItemType and the
  * random-item selectors. */
 DWORD G_ItemTypeFromClass(LPCSTR cls) {
@@ -88,8 +82,9 @@ static void G_ApplyItemStats(LPEDICT unit, LPCEDICT item, BOOL apply) {
     LPCSTR abilities = G_ItemAbilityList(item);
     if (!abilities || !*abilities) return;
     PARSE_LIST(abilities, ability, parse_segment) {
-        DWORD code = *((DWORD const *)ability);
-        apply ? item_stat_apply(unit, code) : item_stat_remove(unit, code);
+        abilityitem_t entry = S_AbilityItem(FS_SLKKey(ability));
+        abilityCall_t call = MAKE(abilityCall_t, .item = &entry);
+        S_AbilityMessage(unit, apply ? A_ITEM_ADD : A_ITEM_REMOVE, &call);
     }
 }
 

--- a/games/warcraft-3/game/g_local.h
+++ b/games/warcraft-3/game/g_local.h
@@ -583,6 +583,8 @@ typedef enum {
     A_VALIDATE,         /* Spell pipeline: validate call->target before spending resources; return allowed. */
     A_EXECUTE,          /* Spell pipeline: apply the effect to call->target; return whether it executed. */
     A_ITEM_USE,         /* Inventory click: apply an immediate item effect; return success for charge use. */
+    A_ITEM_ADD,         /* Inventory pickup: apply this item's authored passive modifier. */
+    A_ITEM_REMOVE,      /* Inventory removal: undo this item's authored passive modifier. */
     A_AUTOCAST_ON,      /* Autocast/UI query: return whether autocast is enabled on ent. */
     A_AUTOCAST_SET,     /* Autocast command: set ent's state from call->enabled. */
     A_AUTOCAST_ACQUIRE, /* Unit scheduler: acquire a target and issue an autocast; return whether issued. */
@@ -1092,8 +1094,11 @@ struct edict_s {
         BOOL can_sleep; /* mutable natural/night sleep eligibility; seeded from UnitData.canSleep */
         BOOL sleeping;  /* natural creep sleep only; intentionally excludes spell-induced BUsL */
     } sleep;
-    struct {
+    struct edictChannel_s {
         DWORD code;     // ability code being channeled (0 = none)
+        DWORD serial;   // cast identity; old thinkers cannot continue or cancel a replacement cast
+        DWORD owner_spawn_time; // thinker copy of caster identity; rejects reused owner slots
+        DWORD target_spawn_time; // thinker copy of target identity; rejects reused target slots
         VECTOR2 origin; // position when channel started (movement cancels channel)
     } channel;
     DWORD unit_color;   // explicit per-unit color override (0 = use owner color)
@@ -1845,8 +1850,8 @@ void InitAbilities(void);
 #ifdef WC3_DEBUG_AUTOCAST
 int G_AutocastDebugLevel(void);
 #endif
-BOOL G_UnitAutocastIsOn(LPEDICT ent, ability_t const *ability);
-BOOL G_SetUnitAutocast(LPEDICT ent, ability_t const *ability, BOOL enabled);
+BOOL G_UnitAutocastIsOn(LPEDICT ent, DWORD code);
+BOOL G_SetUnitAutocast(LPEDICT ent, DWORD code, BOOL enabled);
 BOOL G_TryUnitAutocast(LPEDICT ent);
 
 // g_metadata.c
@@ -2216,6 +2221,7 @@ void S_SpellResetCooldowns(LPEDICT caster);
 LPCSTR S_SpellString(DWORD code, LPCSTR field, DWORD level);
 
 void order_attack(LPEDICT, LPEDICT);
+BOOL S_OrderAttack(LPEDICT self, LPEDICT target);
 void order_move(LPEDICT, LPEDICT);
 BOOL move_is_active_order_walk(LPCEDICT);
 void order_stop(LPEDICT);
@@ -2266,6 +2272,12 @@ void blight_mine_think(LPEDICT);
 void blizzard_think(LPEDICT);
 void flame_strike_tick(LPEDICT);
 void siphon_mana_think(LPEDICT);
+void rain_of_fire_think(LPEDICT);
+void starfall_think(LPEDICT);
+void death_and_decay_think(LPEDICT);
+void tranquility_think(LPEDICT);
+void earthquake_think(LPEDICT);
+void whirlwind_think(LPEDICT);
 BOOL move_selectlocation(LPEDICT, LPCVECTOR2);
 BOOL move_should_arrive(LPEDICT, FLOAT);
 BOOL move_is_blocked(LPEDICT, FLOAT, FLOAT);

--- a/games/warcraft-3/game/g_save.c
+++ b/games/warcraft-3/game/g_save.c
@@ -70,7 +70,7 @@ enum {
 
 static DWORD const save_magic = MAKEFOURCC('W', '3', 'S', 'V');
 static DWORD const save_commit = MAKEFOURCC('W', '3', 'O', 'K');
-static DWORD const save_version = 20; // format version; adds race-specific construction state to the v19 edict layout
+static DWORD const save_version = 21; // format version; persists channel cast and entity identities in the edict layout
 #define MAX_SAVE_STRING (1u << 20) // bytes; bounds quest-string allocations from corrupt saves
 #define MAX_SAVE_GROUP_HANDLES 65536u // corrupt-save bound only; runtime group registry itself grows dynamically
 #define UMOVE_RELOC_RANGE (64 << 20) // bytes; every umove_t is static data in libgame, so a valid offset from the anchor stays well inside one module image
@@ -109,6 +109,12 @@ static saveCFunction_t const save_cfunctions[] = {
     SAVE_CFUNCTION(tree_pain),
     SAVE_CFUNCTION(tree_die),
     SAVE_CFUNCTION(human_ability_think),
+    SAVE_CFUNCTION(rain_of_fire_think),
+    SAVE_CFUNCTION(starfall_think),
+    SAVE_CFUNCTION(death_and_decay_think),
+    SAVE_CFUNCTION(tranquility_think),
+    SAVE_CFUNCTION(earthquake_think),
+    SAVE_CFUNCTION(whirlwind_think),
 };
 
 static int SaveCFunctionIndex(void *func) {
@@ -412,6 +418,15 @@ static field_t const sleep_fields[] = {
     { NULL, 0, 0, 0, 0, 0 }
 };
 
+static field_t const channel_fields[] = {
+    F(edictChannel_s, code, F_INT),
+    F(edictChannel_s, serial, F_INT),
+    F(edictChannel_s, owner_spawn_time, F_INT),
+    F(edictChannel_s, target_spawn_time, F_INT),
+    F(edictChannel_s, origin, F_VECTOR),
+    { NULL, 0, 0, 0, 0, 0 }
+};
+
 /* Every persistent and process-owned edict field crossing the save boundary is represented here. */
 field_t edict_fields[] = {
     F(edict_s, class_id, F_INT),
@@ -425,6 +440,7 @@ field_t edict_fields[] = {
     F(edict_s, peonsinside, F_INT),
     F(edict_s, aiflags, F_INT),
     F(edict_s, autocast_code, F_INT),
+    F(edict_s, channel, F_STRUCT, 1, channel_fields),
     F(edict_s, damage, F_INT),
     F(edict_s, collision, F_FLOAT),
     F(edict_s, s, F_STRUCT, 1, entity_state_fields),

--- a/games/warcraft-3/game/hud/hud_unit.c
+++ b/games/warcraft-3/game/hud/hud_unit.c
@@ -225,7 +225,7 @@ static BOOL G_BuildCommandButtonState(LPEDICT ent, LPCSTR code, BOOL research, D
     if (!research && ability && (ability->flags & AB_AUTOCAST)) {
         strlcpy(button->alternate, "autocast ", sizeof(button->alternate));
         strlcat(button->alternate, code, sizeof(button->alternate));
-        button->alternate_active = G_UnitAutocastIsOn(ent, ability) ? 1 : 0;
+        button->alternate_active = G_UnitAutocastIsOn(ent, FS_SLKKey(code)) ? 1 : 0;
     }
     hotkey = research ? G_StringForLevel(hotkey, level) : hotkey;
     button->hotkey = hotkey && *hotkey ? *hotkey : '\0';

--- a/games/warcraft-3/game/m_unit.c
+++ b/games/warcraft-3/game/m_unit.c
@@ -508,13 +508,11 @@ static BOOL unit_issuetargetorder_now(LPEDICT self, LPCSTR order, LPEDICT target
             if (S_UnitPolymorphed(self) || !G_DestructableAcceptsSmartAttack(self, target)) {
                 return false;
             }
-            order_attack(self, target);
-            return true;
+            return S_OrderAttack(self, target);
         }
         if (unit_smart_target_is_enemy(self, target)) {
             if (S_UnitPolymorphed(self)) return false;
-            order_attack(self, target);
-            return true;
+            return S_OrderAttack(self, target);
         }
         /* Friendly transports, including Orc Burrows, consume Smart as a
          * boarding order when this unit satisfies their cargo restrictions. */
@@ -539,8 +537,7 @@ static BOOL unit_issuetargetorder_now(LPEDICT self, LPCSTR order, LPEDICT target
         if (G_IsDestructable(target) && !G_DestructableCanBeAttackedBy(self, target)) {
             return false;
         }
-        order_attack(self, target);
-        return true;
+        return S_OrderAttack(self, target);
     }
     if (!strcmp(order, "militia") || !strcmp(order, "militiaoff")) {
         return S_MilitiaTargetOrder(self, order, target);

--- a/games/warcraft-3/game/skills/s_area_spell.c
+++ b/games/warcraft-3/game/skills/s_area_spell.c
@@ -37,19 +37,17 @@ static void area_spell_damage(LPEDICT ent, FLOAT maxtotal) {
 void blizzard_think(LPEDICT ent) {
     DWORD now = G_Time();
 
+    if (!S_SpellChannelActive(ent)) { S_SpellEndChannel(ent); return; }
     if (ent->freetime && now < ent->freetime)
         return;
     area_spell_damage(ent, ent->velocity); /* velocity reused: max damage per wave */
     if (ent->resources > 0)
         ent->resources--;
-    if (ent->resources == 0 || (ent->spawn_time && now >= ent->spawn_time)) {
-        LPEDICT caster = ent->owner;
-        if (caster && caster->channel.code == ent->class_id)
-            S_SpellCancelChannel(caster);
-        G_FreeEdict(ent);
+    if (ent->resources == 0) {
+        S_SpellEndChannel(ent);
         return;
     }
-    ent->freetime = now + 1000;
+    ent->freetime = now + (DWORD)MAX(FRAMETIME, ent->wait * 1000.0f);
 }
 
 static BOOL shockwave_hits(LPEDICT target, shockwaveContext_t const *ctx) {
@@ -64,33 +62,31 @@ static BOOL shockwave_hits(LPEDICT target, shockwaveContext_t const *ctx) {
     return along >= 0.0f && along <= ctx->length && fabsf(across) <= ctx->width;
 }
 
-static void rain_of_fire_think(LPEDICT ent) {
+void rain_of_fire_think(LPEDICT ent) {
     DWORD now = G_Time();
 
+    if (!S_SpellChannelActive(ent)) { S_SpellEndChannel(ent); return; }
     if (ent->freetime && now < ent->freetime) return;
     area_spell_damage(ent, 0.0f);
-    if (ent->resources == 0) {
-        G_FreeEdict(ent);
+    if (!--ent->resources) {
+        S_SpellEndChannel(ent);
         return;
     }
-    ent->resources--;
     ent->freetime = now + (DWORD)(MAX(0.1f, ent->velocity) * 1000.0f);
 }
 
 /* Starfall: self-centered periodic area damage.  AbilityData stores the
  * authored damage in DataA, wave interval in DataB, area in Area, and the
  * channel lifetime in Dur. */
-static void starfall_think(LPEDICT ent) {
+void starfall_think(LPEDICT ent) {
     DWORD now = G_Time();
 
+    if (!S_SpellChannelActive(ent)) { S_SpellEndChannel(ent); return; }
     if (ent->freetime && now < ent->freetime)
         return;
     area_spell_damage(ent, 0.0f);
     if (ent->spawn_time && now >= ent->spawn_time) {
-        LPEDICT caster = ent->owner;
-        if (caster && caster->channel.code == ent->class_id)
-            S_SpellCancelChannel(caster);
-        G_FreeEdict(ent);
+        S_SpellEndChannel(ent);
         return;
     }
     ent->freetime = now + (DWORD)MAX(1.0f, ent->velocity * 1000.0f);
@@ -109,9 +105,7 @@ BZ_SIMPLE_SPELL_PROC(AbilityBlizzard) {
     FLOAT area = S_SpellNumber(spell->code, ABILITY_NUMBER_AREA, level);
     LPEDICT thinker;
 
-    thinker = G_Spawn();
-    thinker->owner = caster;
-    thinker->class_id = spell->code;
+    thinker = S_SpellChannelThinker(caster, spell->code);
     thinker->s.origin2 = st.point;
     thinker->s.origin.x = st.point.x;
     thinker->s.origin.y = st.point.y;
@@ -119,7 +113,7 @@ BZ_SIMPLE_SPELL_PROC(AbilityBlizzard) {
     thinker->damage = damage ? damage : 1;
     thinker->resources = waves ? waves : 1;
     thinker->velocity = S_SpellData(spell->code, level, 6); /* DataF = Max Damage per Wave */
-    thinker->spawn_time = G_Time() + (DWORD)(MAX(1.0f, S_SpellDuration(spell->code, level, false)) * 1000.0f);
+    thinker->wait = S_SpellNumber(spell->code, ABILITY_NUMBER_CAST, level);
     thinker->think = blizzard_think;
     blizzard_think(thinker); /* first wave immediately */
 }
@@ -169,10 +163,7 @@ BZ_SIMPLE_SPELL_PROC(AbilityShockwave) {
  */
 BZ_SIMPLE_SPELL_PROC(AbilityRainOfFire) {
     DWORD level = S_SpellLevel(caster, spell->code);
-    LPEDICT thinker = G_Spawn();
-
-    thinker->owner = caster;
-    thinker->class_id = spell->code;
+    LPEDICT thinker = S_SpellChannelThinker(caster, spell->code);
     thinker->s.origin2 = st.point;
     thinker->s.origin.x = st.point.x;
     thinker->s.origin.y = st.point.y;
@@ -186,10 +177,11 @@ BZ_SIMPLE_SPELL_PROC(AbilityRainOfFire) {
 
 /* Death and Decay deals the authored percentage of each enemy's maximum life
  * on every pulse; unlike Rain of Fire, DataA is not a fixed damage amount. */
-static void death_and_decay_think(LPEDICT ent) {
+void death_and_decay_think(LPEDICT ent) {
     DWORD now = G_Time();
     LPEDICT caster = ent->owner;
 
+    if (!S_SpellChannelActive(ent)) { S_SpellEndChannel(ent); return; }
     if (ent->freetime && now < ent->freetime) return;
     FILTER_EDICTS(target, target->inuse && S_SpellIsAliveTarget(target) &&
                   S_SpellIsEnemy(caster, target) &&
@@ -197,9 +189,7 @@ static void death_and_decay_think(LPEDICT ent) {
         S_SpellDamage(target, caster, (DWORD)MAX(1.0f, target->health.max_value * ent->wait));
     }
     if (ent->spawn_time && now >= ent->spawn_time) {
-        if (caster && caster->channel.code == ent->class_id)
-            S_SpellCancelChannel(caster);
-        G_FreeEdict(ent);
+        S_SpellEndChannel(ent);
         return;
     }
     ent->freetime = now + (DWORD)(MAX(0.1f, ent->velocity) * 1000.0f);
@@ -210,10 +200,7 @@ static void death_and_decay_think(LPEDICT ent) {
  */
 BZ_SIMPLE_SPELL_PROC(AbilityDeathAndDecay) {
     DWORD level = S_SpellLevel(caster, spell->code);
-    LPEDICT thinker = G_Spawn();
-
-    thinker->owner = caster;
-    thinker->class_id = spell->code;
+    LPEDICT thinker = S_SpellChannelThinker(caster, spell->code);
     thinker->s.origin2 = st.point;
     thinker->s.origin.x = st.point.x;
     thinker->s.origin.y = st.point.y;
@@ -248,21 +235,32 @@ BZ_SIMPLE_SPELL_PROC(AbilityThunderClap) { area_damage_status_execute(caster, st
 /* Name=Frost Nova
  * Ubertip="Blasts nearby enemy units with frost, damaging and slowing them."
  */
-BZ_SIMPLE_SPELL_PROC(AbilityFrostNova) { area_damage_status_execute(caster, st, spell); }
+BZ_SIMPLE_SPELL_PROC(AbilityFrostNova) {
+    DWORD rank = S_SpellLevel(caster, spell->code);
+    FLOAT radius = S_SpellNumber(spell->code, ABILITY_NUMBER_AREA, rank);
+    LPCSTR buff = G_AbilityLevel(spell->code, rank)->buffID;
+    VECTOR2 center = st.entity->s.origin2;
+    FILTER_EDICTS(target, S_SpellIsEnemy(caster, target) && S_SpellAllowsTarget(spell->code, caster, target) &&
+                  Vector2_distance(&target->s.origin2, &center) <= radius) {
+        FLOAT damage = S_SpellData(spell->code, rank, 1);
+        if (target == st.entity) damage += S_SpellData(spell->code, rank, 2);
+        if (S_SpellDamage(target, caster, (int)damage) && !M_IsDead(target) && buff && strlen(buff) >= 4)
+            unit_addtimedstatus(target, buff, rank, S_SpellDuration(spell->code, rank, G_UnitIsHero(target)));
+    }
+}
 
-static void tranquility_think(LPEDICT ent) {
+void tranquility_think(LPEDICT ent) {
     DWORD now = G_Time();
     LPEDICT caster = ent->owner;
 
+    if (!S_SpellChannelActive(ent)) { S_SpellEndChannel(ent); return; }
     if (ent->freetime && now < ent->freetime) return;
     FILTER_EDICTS(target, target->inuse && S_SpellIsAliveTarget(target) &&
                   S_SpellIsFriend(caster, target) &&
                   Vector2_distance(&target->s.origin2, &ent->s.origin2) <= ent->collision)
         S_SpellHeal(target, ent->damage);
     if (ent->spawn_time && now >= ent->spawn_time) {
-        if (caster && caster->channel.code == ent->class_id)
-            S_SpellCancelChannel(caster);
-        G_FreeEdict(ent);
+        S_SpellEndChannel(ent);
         return;
     }
     ent->freetime = now + (DWORD)(MAX(0.1f, ent->velocity) * 1000.0f);
@@ -273,10 +271,7 @@ static void tranquility_think(LPEDICT ent) {
  */
 BZ_SIMPLE_SPELL_PROC(AbilityTranquility) {
     DWORD level = S_SpellLevel(caster, spell->code);
-    LPEDICT thinker = G_Spawn();
-
-    thinker->owner = caster;
-    thinker->class_id = spell->code;
+    LPEDICT thinker = S_SpellChannelThinker(caster, spell->code);
     thinker->s.origin2 = caster->s.origin2;
     thinker->s.origin.x = caster->s.origin.x;
     thinker->s.origin.y = caster->s.origin.y;
@@ -293,10 +288,7 @@ BZ_SIMPLE_SPELL_PROC(AbilityTranquility) {
  */
 BZ_SIMPLE_SPELL_PROC(AbilityStarfall) {
     DWORD level = S_SpellLevel(caster, spell->code);
-    LPEDICT thinker = G_Spawn();
-
-    thinker->owner = caster;
-    thinker->class_id = spell->code;
+    LPEDICT thinker = S_SpellChannelThinker(caster, spell->code);
     thinker->s.origin2 = caster->s.origin2;
     thinker->s.origin.x = caster->s.origin.x;
     thinker->s.origin.y = caster->s.origin.y;

--- a/games/warcraft-3/game/skills/s_attack.c
+++ b/games/warcraft-3/game/skills/s_attack.c
@@ -111,10 +111,12 @@ static BOOL attack_target_is_valid(LPCEDICT attacker, LPCEDICT target) {
     return !M_IsDead((LPEDICT)target);
 }
 
-static void attack_finish_after_combat(LPEDICT attacker) {
-    if (!attacker) {
-        return;
-    }
+/* Delayed damage can outlive its attack order; only that order may complete or resume its parent behavior. */
+static void attack_finish_after_combat(LPEDICT attacker, LPCEDICT target) {
+    if (!attacker || M_IsDead(attacker) || !attacker->currentmove ||
+        attacker->currentmove->proc != CAbilityAttack || attacker->goalentity != target) return;
+    unit_leavecombat(attacker);
+    attacker->goalentity = NULL;
     if (attacker->movement.patrol_a) {
         order_patrol_resume(attacker);
     } else if (attacker->movement.attackmove_waypoint) {
@@ -130,11 +132,7 @@ static BOOL attack_stop_if_target_invalid(LPEDICT attacker) {
     if (attack_target_is_valid(attacker, attacker ? attacker->goalentity : NULL)) {
         return false;
     }
-    if (attacker) {
-        unit_leavecombat(attacker);
-        attacker->goalentity = NULL;
-        attack_finish_after_combat(attacker);
-    }
+    if (attacker) attack_finish_after_combat(attacker, attacker->goalentity);
     return true;
 }
 
@@ -203,7 +201,7 @@ void T_Damage(LPEDICT target, LPEDICT attacker, int damage) {
     if (damage <= 0) return;
     if (G_IsDestructable(target)) {
         if (G_DestructableApplyDamage(target, attacker, (FLOAT)damage)) {
-            attack_finish_after_combat(attacker);
+            attack_finish_after_combat(attacker, target);
         }
         return;
     }
@@ -220,9 +218,8 @@ void T_Damage(LPEDICT target, LPEDICT attacker, int damage) {
     if (target->health.value <= damage) {
         G_SetHealth(target, 0);
         unit_leavecombat(target);
-        unit_leavecombat(attacker);
         target->die(target, attacker);
-        attack_finish_after_combat(attacker);
+        attack_finish_after_combat(attacker, target);
         return;
     } else {
         G_AddHealth(target, -damage);
@@ -281,6 +278,8 @@ static BOOL attack_animation_can_finish(LPCEDICT ent) {
 
 static void damage_target(LPEDICT ent) {
     if (attack_stop_if_target_invalid(ent)) return;
+    umove_t const *move = ent->currentmove;
+    LPEDICT target = ent->goalentity;
     S_ResolveAttackHit(ent, ent->goalentity, G_AttackDamage(ent, ent->goalentity, ai_rolldamage1(ent, 1)));
     /* Normal units enter recovery from the attack animation's end callback.
      * Some building models (notably Orc Burrows in the current asset path) do
@@ -288,8 +287,10 @@ static void damage_target(LPEDICT ent) {
      * fires the first hit, but M_MoveFrame() can never reach the move endfunc,
      * leaving the attack state parked at wait==0 forever. Treat the completed
      * hit as the end of the windup when there is no finite animation to drive
-     * that transition. */
-    if (attack_target_is_valid(ent, ent->goalentity) && !attack_animation_can_finish(ent))
+     * that transition. A lethal hit may already have resumed Follow or the next
+     * queued order, so only the unchanged attack may enter this recovery. */
+    if (ent->currentmove == move && ent->goalentity == target &&
+        attack_target_is_valid(ent, target) && !attack_animation_can_finish(ent))
         attack_melee_cooldown(ent);
 }
 
@@ -385,6 +386,11 @@ static void ai_attack_walk(LPEDICT ent) {
         return;
     }
     if (attack_target_out_of_range(ent)) {
+        /* Hold still acquires at sight range, but must return to its stationary scan instead of chasing. */
+        if (ent->movement.holding_position) {
+            attack_finish_after_combat(ent, ent->goalentity);
+            return;
+        }
         unit_changeangle(ent);
         unit_moveindirection(ent);
     } else if (ent->attack1.weapon == WPN_MISSILE) {
@@ -412,6 +418,18 @@ void order_attack(LPEDICT self, LPEDICT target) {
     unit_entercombat(self, target);
     self->goalentity = target;
     attack_walk(self);
+}
+
+/* Player orders replace retained movement; automatic acquisition keeps it so combat can resume Follow/Patrol. */
+BOOL S_OrderAttack(LPEDICT self, LPEDICT target) {
+    if (!self || M_IsDead(self) || S_GoldMineWorkerIsInside(self) || !attack_target_is_valid(self, target))
+        return false;
+    self->movement.attackmove_waypoint = NULL;
+    self->movement.patrol_a = self->movement.patrol_b = self->movement.patrol_target = NULL;
+    self->movement.follow_target = NULL;
+    self->movement.holding_position = false;
+    order_attack(self, target);
+    return true;
 }
 
 static FLOAT attack_speed_divisor(LPEDICT self) {

--- a/games/warcraft-3/game/skills/s_creep_sleep.c
+++ b/games/warcraft-3/game/skills/s_creep_sleep.c
@@ -20,7 +20,8 @@ static umove_t creep_sleep_move = { .animation = "sleep", .think = creep_sleep_t
 
 /* Match only the overlay owned by this unit, leaving unrelated target effects untouched. */
 static BOOL is_creep_sleep_overlay(LPCEDICT effect, LPCEDICT unit) {
-    return effect && effect->inuse && effect->owner == unit && effect->goalentity == unit;
+    return effect && effect->inuse && effect->owner == unit && effect->goalentity == unit &&
+           effect->summon_ability == BZ_CREEP_SLEEP;
 }
 
 /* Destroy every natural-sleep overlay before the unit leaves its sleep move. */
@@ -50,6 +51,7 @@ static void add_creep_sleep_overlay(LPEDICT unit, DWORD code) {
         return;
     }
     effect->owner = unit;
+    effect->summon_ability = BZ_CREEP_SLEEP;
 }
 
 /* Restrict automatic sleep to authored neutral-creep candidates. */

--- a/games/warcraft-3/game/skills/s_flame_strike.c
+++ b/games/warcraft-3/game/skills/s_flame_strike.c
@@ -1,64 +1,57 @@
 #include "s_skills.h"
 
-/* Flame Strike (ANfs): delayed AoE point-target spell.  Creates a fire patch at
- * the target location that deals initial damage after a short delay, then
- * periodic burn damage to units in the area. */
-
+/* Flame Strike stores its cast rank and start time; Hfs1/Hfs3 are pulse damage,
+ * Hfs2/Hfs4 are pulse intervals, Cast is the delay and HeroDur is the full-damage phase. */
 void flame_strike_tick(LPEDICT ent) {
-    LPEDICT caster = ent->owner;
-    FLOAT radius = ent->collision;
-    DWORD now = G_Time();
+    DWORD now = G_Time(), rank = ent->resources, code = ent->class_id;
+    FLOAT delay = S_SpellNumber(code, ABILITY_NUMBER_CAST, rank);
+    FLOAT age = (now - ent->spawn_time) / 1000.0f - delay;
+    FLOAT duration = S_SpellDuration(code, rank, false);
+    FLOAT limit = S_SpellData(code, rank, 6);
 
-    if (ent->freetime && now < ent->freetime)
-        return;
-
-#define FLAME_HITS(t) ((t)->inuse && S_SpellIsAliveTarget(t) &&             \
-                       S_SpellIsEnemy(caster, t) &&                          \
-                       Vector2_distance(&(t)->s.origin2, &ent->s.origin2) <= radius)
-
-    /* Initial burst damage on first tick only. */
-    if (ent->resources & 1) {/* resources bit 0 = initial burst pending */
-        FILTER_EDICTS(target, FLAME_HITS(target))
-            S_SpellDamage(target, caster, ent->damage);
-        ent->resources &= ~1;
+    if (age > duration) { G_FreeEdict(ent); return; }
+    while (ent->freetime <= now) {
+        BOOL full = (ent->freetime - ent->spawn_time) / 1000.0f - delay <= S_SpellDuration(code, rank, true);
+        FLOAT damage = S_SpellData(code, rank, full ? 1 : 3), total = 0;
+        DWORD step = (DWORD)(S_SpellData(code, rank, full ? 2 : 4) * 1000.0f);
+        if (!step) {
+            fprintf(stderr, "WC3 Flame Strike: damage interval became zero for %.4s\n", (LPCSTR)&code);
+            G_FreeEdict(ent); return;
+        }
+#define BZ_FLAME_HITS(t) (S_SpellAllowsTarget(code, ent->owner, t) && \
+    Vector2_distance(&(t)->s.origin2, &ent->s.origin2) <= ent->collision)
+        FILTER_EDICTS(target, BZ_FLAME_HITS(target))
+            total += damage * (G_UnitIsBuilding(target->class_id) ? S_SpellData(code, rank, 5) : 1);
+        FILTER_EDICTS(target, BZ_FLAME_HITS(target)) {
+            FLOAT hit = damage * (G_UnitIsBuilding(target->class_id) ? S_SpellData(code, rank, 5) : 1);
+            if (limit > 0 && total > limit) hit *= limit / total;
+            S_SpellDamage(target, ent->owner, (int)hit);
+        }
+#undef BZ_FLAME_HITS
+        ent->freetime += step;
+        if (full && (ent->freetime - ent->spawn_time) / 1000.0f - delay > S_SpellDuration(code, rank, true))
+            ent->freetime = ent->spawn_time + (DWORD)((delay + S_SpellDuration(code, rank, true) + S_SpellData(code, rank, 4)) * 1000.0f);
     }
-    /* Per-tick burn damage. */
-    FILTER_EDICTS(target, FLAME_HITS(target))
-        S_SpellDamage(target, caster, ent->velocity); /* velocity = burn damage per tick */
-#undef FLAME_HITS
-
-    if (ent->spawn_time && now >= ent->spawn_time) {
-        G_FreeEdict(ent);
-        return;
-    }
-    /* Ticks every second after the initial delay. */
-    if (!ent->freetime)
-        ent->freetime = now + 1000;
 }
 
+/* Zero damage intervals cannot schedule a fire patch; reject malformed rows rather than substituting guessed values. */
+static BOOL flame_strike_validate(LPEDICT caster, spellTarget_t st, abilityitem_t const *spell) {
+    DWORD rank = S_SpellLevel(caster, spell->code);
+    if (S_SpellData(spell->code, rank, 2) >= .001f && S_SpellData(spell->code, rank, 4) >= .001f) return true;
+    fprintf(stderr, "WC3 Flame Strike: invalid damage intervals for %.4s rank %u\n", (LPCSTR)&spell->code, rank);
+    return false;
+}
+
+/* The authored delay and intervals schedule persistent ground damage independently of the caster's next order. */
 static void flame_strike_execute(LPEDICT caster, spellTarget_t st, abilityitem_t const *spell) {
-    DWORD level = S_SpellLevel(caster, spell->code);
-    FLOAT delay = S_SpellData(spell->code, level, 1); /* DataA = Cast time / delay before flame (seconds) */
-    DWORD initial_damage = (DWORD)MAX(1.0f, S_SpellData(spell->code, level, 2)); /* DataB = Initial Damage */
-    DWORD burn_damage = (DWORD)MAX(1.0f, S_SpellData(spell->code, level, 3)); /* DataC = Damage Per Second */
-    DWORD burn_ticks = (DWORD)MAX(1.0f, S_SpellData(spell->code, level, 4)); /* DataD = Full Damage Interval (ticks) */
-    FLOAT area = S_SpellNumber(spell->code, ABILITY_NUMBER_AREA, level);
-    LPEDICT thinker;
-
-    thinker = G_Spawn();
-    thinker->owner = caster;
-    thinker->s.origin2 = st.point;
-    thinker->s.origin.x = st.point.x;
-    thinker->s.origin.y = st.point.y;
-    thinker->collision = area > 0 ? area : 200.0f;
-    thinker->damage = initial_damage;
-    thinker->velocity = (FLOAT)burn_damage; /* stash burn per tick */
-    thinker->resources = 1; /* bit 0: initial burst pending */
-    /* Freetime = G_Time() + delay_ms so the first tick fires after delay. */
-    thinker->freetime = G_Time() + (DWORD)(MAX(0.1f, delay) * 1000.0f);
-    thinker->spawn_time = thinker->freetime + burn_ticks * 1000;
-    thinker->think = flame_strike_tick;
+    DWORD rank = S_SpellLevel(caster, spell->code);
+    LPEDICT ent = G_Spawn();
+    ent->owner = caster; ent->class_id = spell->code; ent->resources = rank;
+    ent->s.origin2 = st.point; ent->collision = S_SpellNumber(spell->code, ABILITY_NUMBER_AREA, rank);
+    ent->spawn_time = G_Time();
+    ent->freetime = G_Time() + (DWORD)(S_SpellNumber(spell->code, ABILITY_NUMBER_CAST, rank) * 1000.0f);
+    ent->think = flame_strike_tick;
 }
 
-BZ_SIMPLE_SPELL_PROC(AbilityFlameStrikeNeutral) { flame_strike_execute(caster, st, spell); }
-BZ_SIMPLE_SPELL_PROC(AbilityFlameStrike) { flame_strike_execute(caster, st, spell); }
+BZ_VALIDATED_SPELL_PROC(AbilityFlameStrikeNeutral, flame_strike_validate, flame_strike_execute)
+BZ_VALIDATED_SPELL_PROC(AbilityFlameStrike, flame_strike_validate, flame_strike_execute)

--- a/games/warcraft-3/game/skills/s_human_abilities.c
+++ b/games/warcraft-3/game/skills/s_human_abilities.c
@@ -108,9 +108,18 @@ static void avatar_execute(LPEDICT caster, spellTarget_t target, abilityitem_t c
     G_AddUnitAnimationProperties(caster, "alternate", true); G_InvalidateUnitInfoPanel(caster);
 }
 
+/* BuffID orders the caster and victim markers; only the victim marker owns movement/attack locks. */
+static DWORD shackles_buff(DWORD code, DWORD rank) {
+    LPCSTR buffs = G_AbilityLevel(code, rank)->buffID;
+    char source[5], target[5];
+    if (buffs && sscanf(buffs, "%4[^,],%4s", source, target) == 2) return FS_SLKKey(target);
+    fprintf(stderr, "WC3 Shackles: missing caster/target buff pair for %08x\n", code);
+    return 0;
+}
+
 static BOOL aerial_shackles_validate(LPEDICT caster, spellTarget_t st, abilityitem_t const *spell) {
-    (void)spell;
-    return st.entity && st.entity->targtype == TARG_AIR && S_SpellIsEnemy(caster, st.entity);
+    return st.entity && st.entity->targtype == TARG_AIR && S_SpellIsEnemy(caster, st.entity) &&
+        shackles_buff(spell->code, S_SpellLevel(caster, spell->code));
 }
 
 static BOOL control_magic_validate(LPEDICT caster, spellTarget_t st, abilityitem_t const *spell) {
@@ -315,14 +324,28 @@ static void polymorph_execute(LPEDICT caster, spellTarget_t st, abilityitem_t co
 
 static void aerial_shackles_execute(LPEDICT caster, spellTarget_t st, abilityitem_t const *spell) {
     DWORD level = S_SpellLevel(caster, spell->code);
-    LPEDICT thinker = G_Spawn();
-    LPCSTR buff = human_buff(spell, level);
-    thinker->owner = caster; thinker->goalentity = st.entity; thinker->class_id = spell->code;
+    LPEDICT thinker = S_SpellChannelThinker(caster, spell->code);
+    thinker->goalentity = st.entity; thinker->channel.target_spawn_time = st.entity->spawn_time;
+    thinker->resources = shackles_buff(spell->code, level);
     thinker->damage = (DWORD)S_SpellData(spell->code, level, 1); thinker->spawn_time = G_Time() +
         (DWORD)(S_SpellDuration(spell->code, level, G_UnitIsHero(st.entity)) * 1000.0f);
     thinker->think = human_ability_think;
-    if (buff) unit_addtimedstatus(st.entity, buff, level, S_SpellDuration(spell->code, level, G_UnitIsHero(st.entity)));
+    unit_addtimedstatus(st.entity, GetClassName(thinker->resources), level, S_SpellDuration(spell->code, level, G_UnitIsHero(st.entity)));
     human_ability_think(thinker);
+}
+
+/* A cancelled cast must release its lock without erasing a replacement cast's lock on the same victim. */
+static void shackles_end(LPEDICT thinker) {
+    LPEDICT target = thinker->goalentity;
+    BOOL retained = false;
+    if (target && target->inuse && target->spawn_time == thinker->channel.target_spawn_time) {
+        FILTER_EDICTS(other, other != thinker && other->think == human_ability_think && other->goalentity == target &&
+            other->resources == thinker->resources && other->channel.target_spawn_time == target->spawn_time) {
+            if (S_SpellChannelActive(other)) { retained = true; break; }
+        }
+        if (!retained) human_remove_status(target, thinker->resources);
+    }
+    S_SpellEndChannel(thinker);
 }
 
 void human_ability_think(LPEDICT thinker) {
@@ -333,11 +356,10 @@ void human_ability_think(LPEDICT thinker) {
                             S_SpellNumber(thinker->class_id, ABILITY_NUMBER_AREA, 1));
         return;
     }
-    if (now >= thinker->spawn_time || !thinker->owner || !thinker->goalentity ||
-        !thinker->owner->inuse || !S_SpellIsAliveTarget(thinker->goalentity) ||
-        thinker->owner->channel.code != thinker->class_id) {
-        if (thinker->owner && thinker->owner->inuse) S_SpellCancelChannel(thinker->owner);
-        G_FreeEdict(thinker); return;
+    if (now >= thinker->spawn_time || !S_SpellChannelActive(thinker) ||
+        !S_SpellIsAliveTarget(thinker->goalentity) ||
+        thinker->goalentity->spawn_time != thinker->channel.target_spawn_time) {
+        shackles_end(thinker); return;
     }
     if (!thinker->freetime || now >= thinker->freetime) {
         S_SpellDamage(thinker->goalentity, thinker->owner, thinker->damage); thinker->freetime = now + 1000;
@@ -365,11 +387,6 @@ static void spell_steal_execute(LPEDICT caster, spellTarget_t st, abilityitem_t 
                         stolen.timestamp > G_Time() ? (stolen.timestamp - G_Time()) / 1000.0f : 0.0f);
 }
 
-static BOOL human_autocast_is_on(LPEDICT ent, DWORD code) { return ent && ent->autocast_code == code; }
-static void human_autocast_set(LPEDICT ent, DWORD code, BOOL enabled) {
-    if (ent) ent->autocast_code = enabled ? code : (ent->autocast_code == code ? 0 : ent->autocast_code);
-}
-
 static BOOL human_autocast_acquire(LPEDICT caster, DWORD code, BOOL friendly, BOOL wounded) {
     LPEDICT best = NULL;
     FLOAT range = S_SpellRange(code, S_SpellLevel(caster, code));
@@ -386,36 +403,18 @@ static BOOL human_autocast_acquire(LPEDICT caster, DWORD code, BOOL friendly, BO
     return best && S_CastUnitTargetSpell(caster, code, best);
 }
 
-#define HUMAN_AUTOCAST(NAME, CODE, FRIENDLY, WOUNDED) \
-    static BOOL NAME##_is_on(LPEDICT ent) { return human_autocast_is_on(ent, MAKEFOURCC CODE); } \
-    static void NAME##_set(LPEDICT ent, BOOL enabled) { human_autocast_set(ent, MAKEFOURCC CODE, enabled); } \
-    static BOOL NAME##_acquire(LPEDICT ent) { return human_autocast_acquire(ent, MAKEFOURCC CODE, FRIENDLY, WOUNDED); }
-
-HUMAN_AUTOCAST(spell_steal, ('A','s','p','s'), false, false)
-HUMAN_AUTOCAST(inner_fire, ('A','i','n','f'), true, false)
-HUMAN_AUTOCAST(heal, ('A','h','e','a'), true, true)
-HUMAN_AUTOCAST(slow, ('A','s','l','o'), false, false)
-
-#define HUMAN_AUTOCAST_SPELL(NAME, EXECUTE, PREFIX) \
+/* The message selects the union member: boolean toggles must never be decoded as target pointers. */
+#define BZ_HUMAN_AUTOCAST_SPELL(NAME, VALIDATE, EXECUTE, FRIENDLY, WOUNDED) \
     BZ_ABILITY_PROC(C##NAME) { \
-        spellTarget_t target = call && call->target ? *call->target : MAKE(spellTarget_t, .type = SPELL_TARGET_NONE); \
+        spellTarget_t target = (msg == A_VALIDATE || msg == A_EXECUTE) && call && call->target ? \
+            *call->target : MAKE(spellTarget_t, .type = SPELL_TARGET_NONE); \
+        DWORD code = call && call->item ? call->item->code : 0; \
         switch (msg) { \
+        case A_VALIDATE: return VALIDATE; \
         case A_EXECUTE: EXECUTE(ent, target, call ? call->item : NULL); return true; \
-        case A_AUTOCAST_ON: return PREFIX##_is_on(ent); \
-        case A_AUTOCAST_SET: PREFIX##_set(ent, call && call->enabled); return true; \
-        case A_AUTOCAST_ACQUIRE: return PREFIX##_acquire(ent); \
-        default: return CAbilitySimpleSpell(ent, msg, call); \
-        } \
-    }
-#define HUMAN_VALIDATED_AUTOCAST_SPELL(NAME, VALIDATE, EXECUTE, PREFIX) \
-    BZ_ABILITY_PROC(C##NAME) { \
-        spellTarget_t target = call && call->target ? *call->target : MAKE(spellTarget_t, .type = SPELL_TARGET_NONE); \
-        switch (msg) { \
-        case A_VALIDATE: return VALIDATE(ent, target, call ? call->item : NULL); \
-        case A_EXECUTE: EXECUTE(ent, target, call ? call->item : NULL); return true; \
-        case A_AUTOCAST_ON: return PREFIX##_is_on(ent); \
-        case A_AUTOCAST_SET: PREFIX##_set(ent, call && call->enabled); return true; \
-        case A_AUTOCAST_ACQUIRE: return PREFIX##_acquire(ent); \
+        case A_AUTOCAST_ON: return ent && ent->autocast_code == code; \
+        case A_AUTOCAST_SET: return true; \
+        case A_AUTOCAST_ACQUIRE: return human_autocast_acquire(ent, code, FRIENDLY, WOUNDED); \
         default: return CAbilitySimpleSpell(ent, msg, call); \
         } \
     }
@@ -431,7 +430,7 @@ BZ_VALIDATED_SPELL_PROC(AbilityControlMagic, control_magic_validate, control_mag
 /* Name=Magic Defense; Untip=Stop Magic Defense */
 BZ_SIMPLE_SPELL_PROC(AbilityMagicDefense) { human_toggle_execute(caster, st, spell); }
 /* Name=Spell Steal; Untip="Right-click to activate auto-casting." */
-HUMAN_AUTOCAST_SPELL(AbilitySpellSteal, spell_steal_execute, spell_steal)
+BZ_HUMAN_AUTOCAST_SPELL(AbilitySpellSteal, true, spell_steal_execute, false, false)
 /* Name=Cloud; Ubertip="Cast on enemy buildings with ranged attacks to stop the buildings from attacking. Lasts <Aclf,Dur1> seconds." */
 BZ_VALIDATED_SPELL_PROC(AbilityCloudOfFog, cloud_validate, human_status_execute)
 /* Name=Defend; Untip=Stop Defend */
@@ -445,7 +444,7 @@ BZ_SIMPLE_SPELL_PROC(AbilityFlare) {
     thinker->think = human_ability_think; human_ability_think(thinker);
 }
 /* Name=Inner Fire; Untip="Right-click to activate auto-casting." */
-HUMAN_VALIDATED_AUTOCAST_SPELL(AbilityInnerFire, inner_fire_validate, human_status_execute, inner_fire)
+BZ_HUMAN_AUTOCAST_SPELL(AbilityInnerFire, inner_fire_validate(ent, target, call ? call->item : NULL), human_status_execute, true, false)
 /* Name=Dispel Magic; Ubertip="Removes all buffs from units in a target area. Deals <Adis,DataB1> damage to summoned units." */
 BZ_SIMPLE_SPELL_PROC(AbilityDispelMagic) {
     DWORD level = S_SpellLevel(caster, spell->code);
@@ -462,16 +461,17 @@ BZ_SIMPLE_SPELL_PROC(AbilityDispelMagic) {
     }
 }
 /* Name=Heal; Ubertip="Heals a target friendly non-mechanical wounded unit for <Ahea,DataA1> hit points." */
-HUMAN_VALIDATED_AUTOCAST_SPELL(AbilityHeal, heal_validate, heal_execute, heal)
+BZ_HUMAN_AUTOCAST_SPELL(AbilityHeal, heal_validate(ent, target, call ? call->item : NULL), heal_execute, true, true)
 /* Name=Slow; Untip="Right-click to activate auto-casting." */
-HUMAN_VALIDATED_AUTOCAST_SPELL(AbilitySlow, slow_validate, human_status_execute, slow)
+BZ_HUMAN_AUTOCAST_SPELL(AbilitySlow, slow_validate(ent, target, call ? call->item : NULL), human_status_execute, false, false)
 /* Name=Invisibility; Ubertip="Makes a unit invisible. If the unit attacks, uses an ability or casts a spell, it will become visible." */
 BZ_VALIDATED_SPELL_PROC(AbilityInvisibility, invisibility_validate, invisibility_execute)
 /* Name=Polymorph; Ubertip="Turns a target enemy unit into a sheep. Cannot be cast on Heroes. Lasts <Aply,Dur1> seconds." */
 BZ_VALIDATED_SPELL_PROC(AbilityPolymorph, polymorph_validate, polymorph_execute)
 /* Name=Avatar */
 BZ_ABILITY_PROC(CAbilityAvatar) {
-    spellTarget_t target = call && call->target ? *call->target : MAKE(spellTarget_t, .type = SPELL_TARGET_NONE);
+    spellTarget_t target = (msg == A_VALIDATE || msg == A_EXECUTE) && call && call->target ?
+        *call->target : MAKE(spellTarget_t, .type = SPELL_TARGET_NONE);
     switch (msg) {
     case A_VALIDATE: return avatar_validate(ent, target, call ? call->item : NULL);
     case A_EXECUTE: avatar_execute(ent, target, call ? call->item : NULL); return true;

--- a/games/warcraft-3/game/skills/s_item.c
+++ b/games/warcraft-3/game/skills/s_item.c
@@ -60,9 +60,9 @@ BZ_ITEM_PROC(AbilityMaxLifeMod) {
 BZ_ITEM_PROC(AbilityStrengthMod) {
     LPEDICT target = G_GetMainSelectedUnit(clent->client);
     DWORD code = S_SpellCurrentCode(clent, 0);
-    FLOAT str = S_SpellData(code, 1, 1);
-    FLOAT agi = S_SpellData(code, 1, 2);
-    FLOAT intel = S_SpellData(code, 1, 3);
+    FLOAT str = S_SpellData(code, 1, 3);
+    FLOAT agi = S_SpellData(code, 1, 1);
+    FLOAT intel = S_SpellData(code, 1, 2);
 
     if (!target || !G_UnitIsHero(target)) {
         return false;
@@ -177,19 +177,3 @@ BZ_ITEM_PROC(AbilityItemChangeTOD) {
     G_SetFalseTimeOfDay(hour, minute, duration);
     return true;
 }
-
-/* Passive items: init reads bonus value from SLK, actual apply/remove
- * handled by s_item_stats.c via inventory lifecycle hooks. */
-#define BZ_ITEM_INIT_PROC(NAME, INIT) \
-    BZ_ABILITY_PROC(C##NAME) { \
-        (void)ent; \
-        if (msg != A_INIT || !call || !call->classname) return false; \
-        INIT(call->classname); \
-        return true; \
-    }
-
-BZ_ITEM_INIT_PROC(AbilityAttackBonus, SP_ability_item_attack_bonus)
-BZ_ITEM_INIT_PROC(AbilityAttributeBonus, SP_ability_item_stat_bonus)
-BZ_ITEM_INIT_PROC(AbilityDefenseBonus, SP_ability_item_defense_bonus)
-BZ_ITEM_INIT_PROC(AbilityMaxLifeBonus, SP_ability_item_life_bonus)
-BZ_ITEM_INIT_PROC(AbilityMaxManaBonus, SP_ability_item_mana_bonus)

--- a/games/warcraft-3/game/skills/s_item_stats.c
+++ b/games/warcraft-3/game/skills/s_item_stats.c
@@ -4,26 +4,6 @@
  * Follows WarSmash pattern: CAbilityItemAttackBonus.onAdd/onRemove,
  * CAbilityItemDefenseBonus.onAdd/onRemove, etc. */
 
-typedef struct {
-    DWORD code;
-    FLOAT bonus;
-} itemstat_t;
-
-/* Per-type bonus storage, populated by init functions. */
-static FLOAT item_attack_bonus_val;
-static FLOAT item_defense_bonus_val;
-static FLOAT item_life_bonus_val;
-static FLOAT item_mana_bonus_val;
-static FLOAT item_stat_str_val;
-static FLOAT item_stat_agi_val;
-static FLOAT item_stat_int_val;
-
-#define ID_ITEM_ATTACK   MAKEFOURCC('A', 'I', 'a', 't')
-#define ID_ITEM_DEFENSE  MAKEFOURCC('A', 'I', 'd', 'e')
-#define ID_ITEM_LIFE     MAKEFOURCC('A', 'I', 'm', 'l')
-#define ID_ITEM_MANA_BONUS MAKEFOURCC('A', 'I', 'm', 'm')
-#define ID_ITEM_STAT     MAKEFOURCC('A', 'I', 'a', 'b')
-
 static void apply_attack(LPEDICT unit, FLOAT amount) {
     unit->attack1.temporaryDamageBonus += amount;
     unit->attack2.temporaryDamageBonus += amount;
@@ -52,7 +32,11 @@ static void apply_mana(LPEDICT unit, FLOAT amount) {
     unit->mana.value = unit->mana.max_value * ratio;
 }
 
-static void apply_stat(LPEDICT unit, FLOAT str, FLOAT agi, FLOAT intel) {
+/* Attribute aliases share the authored Agility/Intelligence/Strength field order used by tomes. */
+static void apply_stat(LPEDICT unit, DWORD code, FLOAT sign) {
+    FLOAT str = sign * S_SpellData(code, 1, 3);
+    FLOAT agi = sign * S_SpellData(code, 1, 1);
+    FLOAT intel = sign * S_SpellData(code, 1, 2);
     if (!G_UnitIsHero(unit)) {
         return;
     }
@@ -62,68 +46,26 @@ static void apply_stat(LPEDICT unit, FLOAT str, FLOAT agi, FLOAT intel) {
     G_RecomputeHeroStats(unit);
 }
 
-void item_stat_apply(LPEDICT unit, DWORD item_code) {
-    if (!unit) {
-        return;
+/* Inventory messages retain the authored alias, including distinct values on stacked items. */
+#define BZ_ITEM_BONUS_PROC(NAME, APPLY) \
+    BZ_ABILITY_PROC(C##NAME) { \
+        if (msg != A_ITEM_ADD && msg != A_ITEM_REMOVE) return CAbilityPassive(ent, msg, call); \
+        if (!ent || !call || !call->item) return false; \
+        FLOAT sign = msg == A_ITEM_ADD ? 1.0f : -1.0f; \
+        APPLY(ent, sign * S_SpellData(call->item->code, 1, 1)); \
+        return true; \
     }
-    if (item_code == ID_ITEM_ATTACK && item_attack_bonus_val != 0) {
-        apply_attack(unit, item_attack_bonus_val);
-    }
-    if (item_code == ID_ITEM_DEFENSE && item_defense_bonus_val != 0) {
-        apply_defense(unit, item_defense_bonus_val);
-    }
-    if (item_code == ID_ITEM_LIFE && item_life_bonus_val != 0) {
-        apply_life(unit, item_life_bonus_val);
-    }
-    if (item_code == ID_ITEM_MANA_BONUS && item_mana_bonus_val != 0) {
-        apply_mana(unit, item_mana_bonus_val);
-    }
-    if (item_code == ID_ITEM_STAT) {
-        apply_stat(unit, item_stat_str_val, item_stat_agi_val, item_stat_int_val);
-    }
-}
 
-void item_stat_remove(LPEDICT unit, DWORD item_code) {
-    if (!unit) {
-        return;
-    }
-    if (item_code == ID_ITEM_ATTACK && item_attack_bonus_val != 0) {
-        apply_attack(unit, -item_attack_bonus_val);
-    }
-    if (item_code == ID_ITEM_DEFENSE && item_defense_bonus_val != 0) {
-        apply_defense(unit, -item_defense_bonus_val);
-    }
-    if (item_code == ID_ITEM_LIFE && item_life_bonus_val != 0) {
-        apply_life(unit, -item_life_bonus_val);
-    }
-    if (item_code == ID_ITEM_MANA_BONUS && item_mana_bonus_val != 0) {
-        apply_mana(unit, -item_mana_bonus_val);
-    }
-    if (item_code == ID_ITEM_STAT) {
-        apply_stat(unit, -item_stat_str_val, -item_stat_agi_val, -item_stat_int_val);
-    }
-}
+BZ_ITEM_BONUS_PROC(AbilityAttackBonus, apply_attack)
+BZ_ITEM_BONUS_PROC(AbilityDefenseBonus, apply_defense)
+BZ_ITEM_BONUS_PROC(AbilityMaxLifeBonus, apply_life)
+BZ_ITEM_BONUS_PROC(AbilityMaxManaBonus, apply_mana)
 
-/* Init functions — read bonus values from AbilityData.slk at startup. */
-
-void SP_ability_item_attack_bonus(LPCSTR classname) {
-    item_attack_bonus_val = G_AbilityDataName(classname)->level[0].data[0].number;
-}
-
-void SP_ability_item_defense_bonus(LPCSTR classname) {
-    item_defense_bonus_val = G_AbilityDataName(classname)->level[0].data[0].number;
-}
-
-void SP_ability_item_life_bonus(LPCSTR classname) {
-    item_life_bonus_val = G_AbilityDataName(classname)->level[0].data[0].number;
-}
-
-void SP_ability_item_mana_bonus(LPCSTR classname) {
-    item_mana_bonus_val = G_AbilityDataName(classname)->level[0].data[0].number;
-}
-
-void SP_ability_item_stat_bonus(LPCSTR classname) {
-    item_stat_str_val = G_AbilityDataName(classname)->level[0].data[0].number;
-    item_stat_agi_val = G_AbilityDataName(classname)->level[0].data[1].number;
-    item_stat_int_val = G_AbilityDataName(classname)->level[0].data[2].number;
+/* Read every attribute from the same alias on acquisition and removal. */
+BZ_ABILITY_PROC(CAbilityAttributeBonus) {
+    if (msg != A_ITEM_ADD && msg != A_ITEM_REMOVE) return CAbilityPassive(ent, msg, call);
+    if (!ent || !call || !call->item) return false;
+    FLOAT sign = msg == A_ITEM_ADD ? 1.0f : -1.0f;
+    apply_stat(ent, call->item->code, sign);
+    return true;
 }

--- a/games/warcraft-3/game/skills/s_repair.c
+++ b/games/warcraft-3/game/skills/s_repair.c
@@ -421,7 +421,7 @@ static void ai_repair(LPEDICT ent) {
     }
     if (hp->value >= hp->max_value) {
         G_SetHealth(building, hp->max_value);
-        building->stand(building);
+        /* Repair completes the worker's order; the target may still be training, researching, or attacking. */
         repair_stop_reason(ent, "repair_complete");
     }
 }
@@ -644,16 +644,8 @@ static FLOAT repair_autocast_distance(LPCEDICT ent, LPCEDICT target) {
 }
 
 BOOL S_SetRepairAutocast(LPEDICT ent, BOOL enabled) {
-    char rawcode[5];
-    DWORD code;
-    ability_t const *ability;
-
     if (!ent) return false;
-    code = repair_find_code(ent, NULL, 0);
-    repair_code_string(code, rawcode);
-    ability = FindAbilityForCommand(rawcode);
-    if (!ability) return false;
-    return G_SetUnitAutocast(ent, ability, enabled);
+    return G_SetUnitAutocast(ent, repair_find_code(ent, NULL, 0), enabled);
 }
 
 /* Repair uses Warsmash's NEARESTVALID autocast policy: acquisition range only

--- a/games/warcraft-3/game/skills/s_requested_abilities.c
+++ b/games/warcraft-3/game/skills/s_requested_abilities.c
@@ -1,6 +1,6 @@
 #include "s_skills.h"
 
-static void whirlwind_think(LPEDICT ent);
+void whirlwind_think(LPEDICT ent);
 
 typedef struct {
     LPEDICT caster;
@@ -51,12 +51,13 @@ static void radial_damage_status(LPEDICT caster, VECTOR2 point, abilityitem_t co
     }
 }
 
-static void earthquake_think(LPEDICT ent) {
+void earthquake_think(LPEDICT ent) {
+    if (!S_SpellChannelActive(ent)) { S_SpellEndChannel(ent); return; }
     DWORD level = S_SpellLevel(ent->owner, ent->class_id), now = G_Time();
     abilityitem_t item = S_AbilityItem(ent->class_id);
     abilityitem_t const *spell = &item;
     LPCSTR buff = spell_buff(spell, level);
-    if (now >= ent->spawn_time) { S_SpellCancelChannel(ent->owner); G_FreeEdict(ent); return; }
+    if (now >= ent->spawn_time) { S_SpellEndChannel(ent); return; }
     if (ent->freetime && now < ent->freetime) return;
     FILTER_EDICTS(target, S_SpellIsAliveTarget(target) && S_SpellIsEnemy(ent->owner, target) &&
                   Vector2_distance(&target->s.origin2, &ent->s.origin2) <= S_SpellNumber(ent->class_id, ABILITY_NUMBER_AREA, level)) {
@@ -66,10 +67,11 @@ static void earthquake_think(LPEDICT ent) {
     ent->freetime = now + 1000;
 }
 
-static void whirlwind_think(LPEDICT ent) {
+void whirlwind_think(LPEDICT ent) {
+    if (!S_SpellChannelActive(ent)) { S_SpellEndChannel(ent); return; }
     abilityitem_t item = S_AbilityItem(ent->class_id);
     DWORD data = item.ability && item.ability->proc == CAbilityStampede ? 2 : 1;
-    if (G_Time() >= ent->spawn_time) { S_SpellCancelChannel(ent->owner); G_FreeEdict(ent); return; }
+    if (G_Time() >= ent->spawn_time) { S_SpellEndChannel(ent); return; }
     if (ent->freetime && G_Time() < ent->freetime) return;
     if (item.ability && (item.ability->proc == CAbilityWhirlwind || item.ability->proc == CAbilityTornado))
         ent->s.origin2 = ent->owner->s.origin2;
@@ -79,8 +81,7 @@ static void whirlwind_think(LPEDICT ent) {
 
 static void whirlwind_execute(LPEDICT caster, spellTarget_t st, abilityitem_t const *spell) {
     DWORD level = S_SpellLevel(caster, spell->code);
-    LPEDICT thinker = G_Spawn();
-    thinker->owner = caster; thinker->class_id = spell->code;
+    LPEDICT thinker = S_SpellChannelThinker(caster, spell->code);
     thinker->spawn_time = G_Time() + (DWORD)(S_SpellDuration(spell->code, level, true) * 1000.0f);
     thinker->think = whirlwind_think; whirlwind_think(thinker);
 }
@@ -200,8 +201,7 @@ BZ_SIMPLE_SPELL_PROC(AbilityMassTeleport) {
  */
 BZ_SIMPLE_SPELL_PROC(AbilityStampede) {
     DWORD level = S_SpellLevel(caster, spell->code);
-    LPEDICT thinker = G_Spawn();
-    thinker->owner = caster; thinker->class_id = spell->code; thinker->s.origin2 = st.point;
+    LPEDICT thinker = S_SpellChannelThinker(caster, spell->code); thinker->s.origin2 = st.point;
     thinker->spawn_time = G_Time() + (DWORD)(S_SpellDuration(spell->code, level, false) * 1000.0f);
     thinker->freetime = G_Time(); thinker->think = whirlwind_think;
 }
@@ -356,8 +356,7 @@ BZ_SIMPLE_SPELL_PROC(AbilityForkedLightning) {
  */
 BZ_SIMPLE_SPELL_PROC(AbilityEarthquake) {
     DWORD level = S_SpellLevel(caster, spell->code);
-    LPEDICT thinker = G_Spawn();
-    thinker->owner = caster; thinker->class_id = spell->code; thinker->s.origin2 = st.point;
+    LPEDICT thinker = S_SpellChannelThinker(caster, spell->code); thinker->s.origin2 = st.point;
     thinker->spawn_time = G_Time() + (DWORD)(S_SpellDuration(spell->code, level, true) * 1000.0f);
     thinker->think = earthquake_think; earthquake_think(thinker);
 }
@@ -369,20 +368,37 @@ BZ_SIMPLE_SPELL_PROC(AbilityFarSight) {
     G_FowSetStateRadius(&(FOGWRITE){ caster->s.player, WC3_FOG_STATE_VISIBLE, true }, &st.point,
                         S_SpellNumber(spell->code, ABILITY_NUMBER_AREA, level));
 }
-/* Name=Resurrection
- * Ubertip="Brings dead friendly Heroes back to life."
- */
-BZ_SIMPLE_SPELL_PROC(AbilityResurrection) {
-    DWORD level = S_SpellLevel(caster, spell->code), count = 0;
-    DWORD limit = (DWORD)MAX(1.0f, S_SpellData(spell->code, level, 1));
-    FLOAT radius = S_SpellNumber(spell->code, ABILITY_NUMBER_AREA, level);
-    FILTER_EDICTS(target, count < limit && target != caster && target->inuse && G_UnitIsHero(target) &&
-                  M_IsDead(target) && S_SpellIsFriend(caster, target) &&
-                  Vector2_distance(&target->s.origin2, &st.point) <= radius) {
-        G_ReviveHero(target, target->s.origin2.x, target->s.origin2.y);
+/* Resurrection operates on nearby ordinary corpses; Heroes retain their separate altar revival lifecycle. */
+static BOOL resurrection_target(LPEDICT caster, LPEDICT target, abilityitem_t const *spell) {
+    FLOAT radius = S_SpellNumber(spell->code, ABILITY_NUMBER_AREA, S_SpellLevel(caster, spell->code));
+    return target->inuse && (target->svflags & SVF_MONSTER) && M_IsDead(target) &&
+        !G_UnitIsHero(target) && !G_UnitIsBuilding(target->class_id) && S_SpellIsFriend(caster, target) &&
+        Vector2_distance(&target->s.origin2, &caster->s.origin2) <= radius;
+}
+
+/* Reject empty casts before the shared pipeline commits mana and cooldown. */
+static BOOL resurrection_validate(LPEDICT caster, spellTarget_t st, abilityitem_t const *spell) {
+    FILTER_EDICTS(target, resurrection_target(caster, target, spell)) return true;
+    return false;
+}
+
+/* Reuse each corpse's edict and retire its death animation/timer before restoring ordinary unit activity. */
+static void resurrection_execute(LPEDICT caster, spellTarget_t st, abilityitem_t const *spell) {
+    DWORD rank = S_SpellLevel(caster, spell->code), count = 0;
+    DWORD limit = (DWORD)S_SpellData(spell->code, rank, 1);
+    FILTER_EDICTS(target, count < limit && resurrection_target(caster, target, spell)) {
+        target->svflags &= ~SVF_DEADMONSTER; target->s.flags &= ~EF_NOT_SELECTABLE;
+        target->aiflags &= ~AI_HOLD_FRAME; target->s.renderfx &= ~RF_HIDDEN;
+        target->combatentity = target->goalentity = target->secondarygoal = NULL;
+        target->wait = 0; G_ClearUnitOrderQueue(target);
+        G_SetHealth(target, target->health.max_value); G_ActivateUnitFood(target);
+        unit_stand(target); gi.LinkEntity(target);
+        G_SpawnAbilityEffectTarget(spell->code, WC3_EFFECT_TARGET, 0, target, NULL, true);
         count++;
     }
 }
+
+BZ_VALIDATED_SPELL_PROC(AbilityResurrection, resurrection_validate, resurrection_execute)
 /* Name=Breath of Fire
  * Ubertip="Breathes a cone of fire at enemy units, dealing <ANcf,DataA1> initial damage."
  */

--- a/games/warcraft-3/game/skills/s_siphon_mana.c
+++ b/games/warcraft-3/game/skills/s_siphon_mana.c
@@ -1,60 +1,57 @@
 #include "s_skills.h"
 
-/* Siphon Mana (ANdr): channeled unit-target spell.  Drains mana from the target
- * and transfers it to the caster over time.  AB_CHANNEL flag locks the caster
- * in place; movement or stun cancels the drain. */
-
-void siphon_mana_think(LPEDICT ent) {
-    LPEDICT caster = ent->owner;
-    LPEDICT target = ent->goalentity;
-    DWORD now = G_Time();
-
-    if (!target || !target->inuse || M_IsDead(target)) {
-        S_SpellCancelChannel(caster);
-        G_FreeEdict(ent);
-        return;
-    }
-
-    if (ent->freetime && now < ent->freetime)
-        return;
-
-    /* Drain per tick. */
-    FLOAT drain = ent->velocity; /* velocity = mana drained per second */
-    if (target->mana.value > 0) {
-        FLOAT transfer = MIN(drain, target->mana.value);
-        target->mana.value -= transfer;
-        caster->mana.value = MIN(caster->mana.max_value, caster->mana.value + transfer);
-    }
-
-    if (ent->resources > 0)
-        ent->resources--;
-    if (ent->resources == 0) {
-        S_SpellCancelChannel(caster);
-        G_FreeEdict(ent);
-        return;
-    }
-    ent->freetime = now + 1000;
-}
-
-static void siphon_mana_execute(LPEDICT caster, spellTarget_t st, abilityitem_t const *spell) {
+/* Drain's Ndr1/Ndr2 select health/mana independently; allied transfer uses Ndr4/Ndr5 instead. */
+static BOOL siphon_mana_validate(LPEDICT caster, spellTarget_t st, abilityitem_t const *spell) {
     LPEDICT target = st.entity;
-    DWORD level = S_SpellLevel(caster, spell->code);
-    FLOAT mana_per_second = MAX(S_SpellData(spell->code, level, 1), S_SpellData(spell->code, level, 2));
-    DWORD ticks = (DWORD)MAX(1.0f, S_SpellDuration(spell->code, level, true));
-    LPEDICT thinker;
-
-    /* Cannot drain from an empty mana pool. */
-    if (target->mana.value <= 0)
-        return;
-
-    thinker = G_Spawn();
-    thinker->owner = caster;
-    thinker->goalentity = target;
-    thinker->velocity = mana_per_second;
-    thinker->resources = ticks;
-    thinker->think = siphon_mana_think;
-    thinker->freetime = G_Time() + 1000;
+    DWORD rank = S_SpellLevel(caster, spell->code);
+    if (!target || target == caster) return false;
+    if (S_SpellIsFriend(caster, target))
+        return (S_SpellData(spell->code, rank, 4) > 0 && caster->health.value > 1 && target->health.value < target->health.max_value) ||
+            (S_SpellData(spell->code, rank, 5) > 0 && caster->mana.value > 0 && target->mana.value < target->mana.max_value);
+    return S_SpellIsEnemy(caster, target) &&
+        (S_SpellData(spell->code, rank, 1) > 0 || (S_SpellData(spell->code, rank, 2) > 0 && target->mana.value > 0));
 }
 
-BZ_SIMPLE_SPELL_PROC(AbilityDrainNeutral) { siphon_mana_execute(caster, st, spell); }
-BZ_SIMPLE_SPELL_PROC(AbilityDrain) { siphon_mana_execute(caster, st, spell); }
+/* Recheck both edict incarnations and the cast serial before every pulse; cancelled drains cannot revive on recast. */
+void siphon_mana_think(LPEDICT ent) {
+    LPEDICT caster = ent->owner, target = ent->goalentity;
+    DWORD now = G_Time(), code = ent->class_id, rank = ent->resources;
+    FLOAT amount, before;
+    if (!S_SpellChannelActive(ent) || !S_SpellIsAliveTarget(target) ||
+        target->spawn_time != ent->channel.target_spawn_time || !S_SpellAllowsTarget(code, caster, target) ||
+        !S_SpellTargetInRange(caster, target, ent->collision)) { S_SpellEndChannel(ent); return; }
+    if (now < ent->freetime) return;
+    if (S_SpellIsFriend(caster, target)) {
+        amount = MIN(MAX(0, caster->health.value - 1), S_SpellData(code, rank, 4) * ent->velocity);
+        amount = MIN(amount, target->health.max_value - target->health.value);
+        G_SetHealth(caster, caster->health.value - amount); S_SpellHeal(target, amount);
+        amount = MIN(caster->mana.value, S_SpellData(code, rank, 5) * ent->velocity);
+        amount = MIN(amount, target->mana.max_value - target->mana.value);
+        caster->mana.value -= amount; target->mana.value += amount;
+    } else {
+        before = target->health.value;
+        amount = MIN(before, S_SpellData(code, rank, 1) * ent->velocity);
+        if (amount > 0 && S_SpellDamage(target, caster, (int)amount))
+            S_SpellHeal(caster, MAX(0, before - target->health.value));
+        amount = MIN(target->mana.value, S_SpellData(code, rank, 2) * ent->velocity);
+        target->mana.value -= amount;
+        caster->mana.value = MIN(caster->mana.max_value, caster->mana.value + amount);
+    }
+    if (now >= ent->spawn_time || !S_SpellIsAliveTarget(target)) { S_SpellEndChannel(ent); return; }
+    ent->freetime = now + (DWORD)MAX(FRAMETIME, ent->velocity * 1000.0f);
+}
+
+/* A shared thinker keeps the requested rawcode and rank, so Life Drain and Siphon Mana retain different data. */
+static void siphon_mana_execute(LPEDICT caster, spellTarget_t st, abilityitem_t const *spell) {
+    DWORD rank = S_SpellLevel(caster, spell->code);
+    LPEDICT ent = S_SpellChannelThinker(caster, spell->code);
+    ent->goalentity = st.entity; ent->channel.target_spawn_time = st.entity->spawn_time;
+    ent->resources = rank; ent->velocity = S_SpellData(spell->code, rank, 3);
+    ent->collision = S_SpellNumber(spell->code, ABILITY_NUMBER_AREA, rank);
+    ent->spawn_time = G_Time() + (DWORD)(S_SpellDuration(spell->code, rank, G_UnitIsHero(st.entity)) * 1000.0f);
+    ent->think = siphon_mana_think;
+    ent->freetime = G_Time() + (DWORD)MAX(FRAMETIME, ent->velocity * 1000.0f);
+}
+
+BZ_VALIDATED_SPELL_PROC(AbilityDrainNeutral, siphon_mana_validate, siphon_mana_execute)
+BZ_VALIDATED_SPELL_PROC(AbilityDrain, siphon_mana_validate, siphon_mana_execute)

--- a/games/warcraft-3/game/skills/s_skills.c
+++ b/games/warcraft-3/game/skills/s_skills.c
@@ -138,7 +138,7 @@ static ability_t abilitylist[] = {
     { "AHhb", CAbilityHolyBolt, AB_SPELL, SPELL_TARGET_UNIT },  /* Holy Light */
     { "AHds", CAbilityDivineShield, AB_SPELL },  /* Divine Shield */
     { "AHad", CAbilityAuraDevotion, AB_SPELL },  /* Devotion Aura */
-    { "AHre", CAbilityResurrection, AB_SPELL, SPELL_TARGET_POINT },  /* Resurrection */
+    { "AHre", CAbilityResurrection, AB_SPELL, SPELL_TARGET_NONE },  /* Resurrection */
     { "Amil", CAbilityMilitia, AB_COMMAND },  /* Call to Arms */
     { "Amic", CAbilityMilitiaConvert, AB_COMMAND | AB_SEPARATE_OFF },  /* Call To Arms */
 
@@ -255,7 +255,7 @@ static ability_t abilitylist[] = {
     { "AUcs", CAbilityCarrionSwarm, AB_SPELL, SPELL_TARGET_POINT },  /* Carrion Swarm */
     { "AUsl", CAbilitySleep, AB_SPELL, SPELL_TARGET_UNIT },  /* Sleep */
     { "AUav", CAbilityPassive, AB_PASSIVE },  /* Vampiric Aura */
-    { "AUfn", CAbilityFrostNova, AB_SPELL },  /* Frost Nova */
+    { "AUfn", CAbilityFrostNova, AB_SPELL, SPELL_TARGET_UNIT },  /* Frost Nova */
     { "AUfa", CAbilityFrostArmor, AB_SPELL, SPELL_TARGET_UNIT },  /* Frost Armor */
     { "AUfu", CAbilityFrostArmor, AB_SPELL, SPELL_TARGET_UNIT },  /* Frost Armor */
     { "AUdr", CAbilityDarkRitual, AB_SPELL, SPELL_TARGET_UNIT },  /* Dark Ritual */
@@ -941,6 +941,11 @@ void S_RunAbilityUpdates(LPEDICT ent) {
  * idle and acquisition queries stop when an owner consumes the decision. */
 BOOL S_UnitAbilityEvent(LPEDICT ent, abilityMsg_t msg) {
     BOOL handled = false;
+    if (msg == A_MOVE_LEAVE && ent && ent->channel.code) {
+        abilityitem_t item = S_AbilityItem(ent->channel.code);
+        abilityCall_t call = MAKE(abilityCall_t, .item = &item);
+        handled = S_AbilityMessage(ent, msg, &call) != 0;
+    }
     FOR_LOOP(i, num_innate) {
         abilityCall_t call = MAKE(abilityCall_t, .item = innate_items + i);
         handled |= S_AbilityMessage(ent, msg, &call) != 0;
@@ -992,6 +997,7 @@ void S_EnableAbility(LPEDICT ent, DWORD code) {
 }
 
 void S_DisableAbility(LPEDICT ent, DWORD code) {
+    if (ent && ent->autocast_code == code) G_SetUnitAutocast(ent, code, false);
     abilityitem_t item = S_AbilityItem(code);
     abilityCall_t call = MAKE(abilityCall_t, .item = &item);
     if (item.ability) S_AbilityMessage(ent, A_DISABLE, &call);
@@ -1006,136 +1012,47 @@ void S_RefreshAbilityLevel(LPEDICT ent, ability_t const *ability) {
     S_AbilityMessage(ent, A_LEVEL_CHANGED, &changed);
 }
 
-static BOOL unit_has_ability_handler(LPEDICT ent, ability_t const *wanted) {
-    LPCSTR abilities;
-
-    if (!ent || !wanted || !ent->data.UnitAbilities) return false;
-    abilities = ent->data.UnitAbilities->abilList;
-    if (!abilities) return false;
-
-    PARSE_LIST(abilities, ability_name, parse_segment) {
-        ability_t const *ability = FindAbilityForCommand(ability_name);
-        if (ability && ability->proc == wanted->proc) return true;
-    }
-    return false;
-}
-
-BOOL G_UnitAutocastIsOn(LPEDICT ent, ability_t const *ability) {
-    abilityitem_t item = MAKE(abilityitem_t, .ability = ability);
+/* The selected rawcode is shared state; each procedure owns its autocast policy and side effects. */
+BOOL G_UnitAutocastIsOn(LPEDICT ent, DWORD code) {
+    abilityitem_t item = S_AbilityItem(code);
     abilityCall_t call = MAKE(abilityCall_t, .item = &item);
-    return ent && ability && (ability->flags & AB_AUTOCAST) && unit_has_ability_handler(ent, ability) &&
-           S_AbilityMessage(ent, A_AUTOCAST_ON, &call);
+    return ent && code && ent->autocast_code == code && item.ability && (item.ability->flags & AB_AUTOCAST) &&
+        G_UnitAbilityLevel(ent, code) && S_AbilityMessage(ent, A_AUTOCAST_ON, &call);
 }
 
-BOOL G_SetUnitAutocast(LPEDICT ent, ability_t const *ability, BOOL enabled) {
-    abilityitem_t item = MAKE(abilityitem_t, .ability = ability);
+/* Keeping the alias through the UI and scheduler preserves authored cost, range and effect data. */
+BOOL G_SetUnitAutocast(LPEDICT ent, DWORD code, BOOL enabled) {
+    abilityitem_t item = S_AbilityItem(code), old;
     abilityCall_t call = MAKE(abilityCall_t, .item = &item, .enabled = enabled);
-    LPCSTR abilities;
-
-    if (!ent || !ability || !(ability->flags & AB_AUTOCAST) || !unit_has_ability_handler(ent, ability)) {
-#ifdef WC3_DEBUG_AUTOCAST
-        if (G_AutocastDebugLevel() >= 1) {
-            fprintf(stderr, "WC3_AUTOCAST toggle rejected unit=%ld ability=%p enabled=%d flags=0x%x\n",
-                    ent && g_edicts ? (long)(ent - g_edicts) : -1L, (void *)ability,
-                    enabled ? 1 : 0, ent ? ent->aiflags : 0);
-        }
-#endif
+    if (!ent || !item.ability || !(item.ability->flags & AB_AUTOCAST) ||
+        (enabled && !G_UnitAbilityLevel(ent, code))) return false;
+    old = S_AbilityItem(ent->autocast_code);
+    if (!enabled && old.code != code) return true;
+    abilityCall_t prev = MAKE(abilityCall_t, .item = &old, .enabled = false);
+    BOOL switched = enabled && old.code && old.code != code;
+    /* Distinct procedures may share policy state (the two Repair families). Retire it before enabling the next. */
+    if (switched) S_AbilityMessage(ent, A_AUTOCAST_SET, &prev);
+    if (!S_AbilityMessage(ent, A_AUTOCAST_SET, &call)) {
+        prev.enabled = true;
+        if (switched) S_AbilityMessage(ent, A_AUTOCAST_SET, &prev);
         return false;
     }
-
-    /* Warsmash keeps one selected autocast ability per unit. Turning a new one
-     * on first disables every other autocast-capable ability currently present
-     * on this unit; abilities without autocast hooks remain untouched. */
-    if (enabled && ent->data.UnitAbilities && (abilities = ent->data.UnitAbilities->abilList)) {
-        PARSE_LIST(abilities, ability_name, parse_segment) {
-            ability_t const *other = FindAbilityForCommand(ability_name);
-            abilityitem_t other_item = MAKE(abilityitem_t, .code = FS_SLKKey(ability_name), .ability = other);
-            abilityCall_t other_call = MAKE(abilityCall_t, .item = &other_item, .enabled = false);
-            if (other && other->proc != ability->proc && (other->flags & AB_AUTOCAST))
-                S_AbilityMessage(ent, A_AUTOCAST_SET, &other_call);
-        }
-    }
-    S_AbilityMessage(ent, A_AUTOCAST_SET, &call);
     if (enabled) {
+        ent->autocast_code = code;
         ent->aiflags |= AI_AUTOCAST_ACTIVE;
-    } else {
-        BOOL any_enabled = false;
-        if (ent->data.UnitAbilities && (abilities = ent->data.UnitAbilities->abilList)) {
-            PARSE_LIST(abilities, ability_name, parse_segment) {
-                ability_t const *other = FindAbilityForCommand(ability_name);
-                abilityitem_t other_item = MAKE(abilityitem_t, .code = FS_SLKKey(ability_name), .ability = other);
-                abilityCall_t other_call = MAKE(abilityCall_t, .item = &other_item);
-                if (other && (other->flags & AB_AUTOCAST) && S_AbilityMessage(ent, A_AUTOCAST_ON, &other_call)) {
-                    any_enabled = true;
-                    break;
-                }
-            }
-        }
-        if (!any_enabled) ent->aiflags &= ~AI_AUTOCAST_ACTIVE;
+    } else if (old.code == code) {
+        ent->autocast_code = 0;
+        ent->aiflags &= ~AI_AUTOCAST_ACTIVE;
     }
-#ifdef WC3_DEBUG_AUTOCAST
-    if (G_AutocastDebugLevel() >= 1) {
-        fprintf(stderr, "WC3_AUTOCAST toggle unit=%ld class=%.4s enabled=%d flags=0x%x idle_worker=%d abilities=%s\n",
-                g_edicts ? (long)(ent - g_edicts) : -1L, (LPCSTR)&ent->class_id,
-                enabled ? 1 : 0, ent->aiflags, G_UnitIsIdleWorker(ent) ? 1 : 0,
-                ent->data.UnitAbilities && ent->data.UnitAbilities->abilList ? ent->data.UnitAbilities->abilList : "<none>");
-    }
-#endif
     return true;
 }
 
+/* Dispatch the selected alias directly, including runtime-added abilities absent from UnitAbilities. */
 BOOL G_TryUnitAutocast(LPEDICT ent) {
-    LPCSTR abilities;
-
-    if (!ent || !(ent->aiflags & AI_AUTOCAST_ACTIVE) || !ent->data.UnitAbilities ||
-        !(abilities = ent->data.UnitAbilities->abilList)) {
-#ifdef WC3_DEBUG_AUTOCAST
-        if (G_AutocastDebugLevel() >= 2 && ent) {
-            fprintf(stderr, "WC3_AUTOCAST skip unit=%ld class=%.4s flags=0x%x abilities=%s\n",
-                    g_edicts ? (long)(ent - g_edicts) : -1L, (LPCSTR)&ent->class_id,
-                    ent->aiflags,
-                    ent->data.UnitAbilities && ent->data.UnitAbilities->abilList ? ent->data.UnitAbilities->abilList : "<none>");
-        }
-#endif
-        return false;
-    }
-#ifdef WC3_DEBUG_AUTOCAST
-    if (G_AutocastDebugLevel() >= 2) {
-        fprintf(stderr, "WC3_AUTOCAST try unit=%ld class=%.4s flags=0x%x abilities=%s\n",
-                g_edicts ? (long)(ent - g_edicts) : -1L, (LPCSTR)&ent->class_id,
-                ent->aiflags, abilities);
-    }
-#endif
-    PARSE_LIST(abilities, ability_name, parse_segment) {
-        ability_t const *ability = FindAbilityForCommand(ability_name);
-        abilityitem_t item = MAKE(abilityitem_t, .code = FS_SLKKey(ability_name), .ability = ability);
-        abilityCall_t call = MAKE(abilityCall_t, .item = &item);
-        BOOL is_on;
-        if (!ability || !(ability->flags & AB_AUTOCAST)) continue;
-        is_on = S_AbilityMessage(ent, A_AUTOCAST_ON, &call);
-#ifdef WC3_DEBUG_AUTOCAST
-        if (G_AutocastDebugLevel() >= 2) {
-            fprintf(stderr, "WC3_AUTOCAST ability unit=%ld code=%s on=%d\n",
-                    g_edicts ? (long)(ent - g_edicts) : -1L, ability_name, is_on ? 1 : 0);
-        }
-#endif
-        if (is_on && S_AbilityMessage(ent, A_AUTOCAST_ACQUIRE, &call)) {
-#ifdef WC3_DEBUG_AUTOCAST
-            if (G_AutocastDebugLevel() >= 1) {
-                fprintf(stderr, "WC3_AUTOCAST acquired unit=%ld code=%s\n",
-                        g_edicts ? (long)(ent - g_edicts) : -1L, ability_name);
-            }
-#endif
-            return true;
-        }
-    }
-#ifdef WC3_DEBUG_AUTOCAST
-    if (G_AutocastDebugLevel() >= 2) {
-        fprintf(stderr, "WC3_AUTOCAST no_target unit=%ld\n",
-                g_edicts ? (long)(ent - g_edicts) : -1L);
-    }
-#endif
-    return false;
+    if (!ent || !(ent->aiflags & AI_AUTOCAST_ACTIVE)) return false;
+    abilityitem_t item = S_AbilityItem(ent->autocast_code);
+    abilityCall_t call = MAKE(abilityCall_t, .item = &item);
+    return G_UnitAutocastIsOn(ent, item.code) && S_AbilityMessage(ent, A_AUTOCAST_ACQUIRE, &call);
 }
 
 DWORD FindAbilityIndex(LPCSTR classname) {

--- a/games/warcraft-3/game/skills/s_skills.h
+++ b/games/warcraft-3/game/skills/s_skills.h
@@ -18,7 +18,8 @@
     void NAME##_Execute(LPEDICT caster, spellTarget_t st, abilityitem_t const *spell)
 #define BZ_VALIDATED_SPELL_PROC(NAME, VALIDATE, EXECUTE) \
     BZ_ABILITY_PROC(C##NAME) { \
-        spellTarget_t target = call && call->target ? *call->target : MAKE(spellTarget_t, .type = SPELL_TARGET_NONE); \
+        spellTarget_t target = (msg == A_VALIDATE || msg == A_EXECUTE) && call && call->target ? \
+            *call->target : MAKE(spellTarget_t, .type = SPELL_TARGET_NONE); \
         switch (msg) { \
         case A_VALIDATE: return VALIDATE(ent, target, call ? call->item : NULL); \
         case A_EXECUTE: EXECUTE(ent, target, call ? call->item : NULL); return true; \
@@ -318,15 +319,13 @@ void S_SpellCursorSplat(LPEDICT clent, FLOAT radius);
 void S_SpellCodeString(DWORD code, LPSTR out);
 BOOL S_SpellIsChanneling(LPEDICT caster);
 void S_SpellCancelChannel(LPEDICT caster);
+LPEDICT S_SpellChannelThinker(LPEDICT caster, DWORD code);
+BOOL S_SpellChannelActive(LPEDICT thinker);
+void S_SpellEndChannel(LPEDICT thinker);
 
 /* Unified spell pipeline owns targeting and cast lifecycle; concrete procedures
  * receive validation and execution messages through the registry row. */
 void spell_cmd(LPEDICT clent);
 void spell_run_frame(LPEDICT ent);
-void SP_ability_item_attack_bonus(LPCSTR classname);
-void SP_ability_item_defense_bonus(LPCSTR classname);
-void SP_ability_item_life_bonus(LPCSTR classname);
-void SP_ability_item_mana_bonus(LPCSTR classname);
-void SP_ability_item_stat_bonus(LPCSTR classname);
 
 #endif

--- a/games/warcraft-3/game/skills/s_spell.c
+++ b/games/warcraft-3/game/skills/s_spell.c
@@ -67,6 +67,9 @@ BZ_ABILITY_PROC(CAbilitySimpleSpell) {
         spell_cmd(call->client);
         return true;
     case A_VALIDATE: return true;
+    case A_MOVE_LEAVE:
+        if (ent && ent->channel.code == call->item->code) S_SpellCancelChannel(ent);
+        return true;
     default:
         return false;
     }
@@ -418,9 +421,33 @@ void S_SpellCancelChannel(LPEDICT caster) {
         return;
     }
     caster->channel.code = 0;
-    if (caster->stand) {
-        caster->stand(caster);
-    }
+}
+
+/* A cast serial and owner incarnation prevent a retired thinker from following a recast or reused edict. */
+LPEDICT S_SpellChannelThinker(LPEDICT caster, DWORD code) {
+    LPEDICT ent = G_Spawn();
+    ent->owner = caster; ent->class_id = code;
+    ent->channel.serial = caster->channel.serial;
+    ent->channel.owner_spawn_time = caster->spawn_time;
+    return ent;
+}
+
+/* Each effect rechecks the caster before ticking, independently of edict iteration order. */
+BOOL S_SpellChannelActive(LPEDICT ent) {
+    LPEDICT caster = ent ? ent->owner : NULL;
+    if (!caster || !caster->inuse || caster->spawn_time != ent->channel.owner_spawn_time) return false;
+    spell_run_frame(caster);
+    return !M_IsDead(caster) && caster->channel.code == ent->class_id &&
+        caster->channel.serial == ent->channel.serial;
+}
+
+/* Ending an old thinker must never cancel a replacement order or a newer cast of the same spell. */
+void S_SpellEndChannel(LPEDICT ent) {
+    LPEDICT caster = ent->owner;
+    if (caster && caster->inuse && caster->spawn_time == ent->channel.owner_spawn_time &&
+        caster->channel.code == ent->class_id && caster->channel.serial == ent->channel.serial)
+        S_SpellCancelChannel(caster);
+    G_FreeEdict(ent);
 }
 
 /* ---- Unified Spell Pipeline ---- */
@@ -447,9 +474,7 @@ void spell_run_frame(LPEDICT ent) {
 
 /* Shared validation for spell spells: mana, cooldown, and optional range check. */
 static BOOL spell_validate(LPEDICT clent, LPEDICT caster, DWORD code, DWORD level, LPEDICT target, FLOAT range) {
-    if (!caster)
-        return false;
-    if (S_UnitPolymorphed(caster)) return false;
+    if (!S_SpellIsAliveTarget(caster) || caster->stunned || S_UnitPolymorphed(caster)) return false;
     if (S_UnitHasStatus(caster, MAKEFOURCC('B','N','s','i'))) {
         G_ShowCommandErrorText(clent, "Silenced.");
         return false;
@@ -471,7 +496,7 @@ static BOOL spell_validate(LPEDICT clent, LPEDICT caster, DWORD code, DWORD leve
 static BOOL spell_validate_point(spellPointValidateParams_t const *params) {
     if (!params || !params->caster || !params->point)
         return false;
-    if (S_UnitPolymorphed(params->caster)) return false;
+    if (!S_SpellIsAliveTarget(params->caster) || params->caster->stunned || S_UnitPolymorphed(params->caster)) return false;
     if (S_UnitHasStatus(params->caster, MAKEFOURCC('B','N','s','i'))) {
         G_ShowCommandErrorText(params->clent, "Silenced.");
         return false;
@@ -491,12 +516,15 @@ static BOOL spell_validate_point(spellPointValidateParams_t const *params) {
 
 /* Start channel: lock caster in place and record the origin for movement-cancel. */
 static void spell_begin_channel(LPEDICT caster, DWORD code) {
+    if (caster->stand) caster->stand(caster);
+    caster->channel.serial++;
     caster->channel.code = code;
     caster->channel.origin = caster->s.origin2;
 }
 
 /* Pre-execute common work: spend mana, start cooldown. */
 static void spell_commit(LPEDICT caster, DWORD code, DWORD level) {
+    S_SpellCancelChannel(caster);
     S_HumanBreakInvisibility(caster);
     S_SpellSpendMana(caster, code, level);
     S_SpellStartCooldown(caster, code, level);
@@ -579,7 +607,7 @@ static void spell_unit_target_approach_think(LPEDICT thinker) {
 
     /* Mana/cooldown can change while walking. Do not spend or fire the ability
      * unless it is still legal at the actual cast point. */
-    if (!S_SpellCooldownReady(caster, code) || !S_SpellCanPay(caster, code, level)) {
+    if (!spell_validate(NULL, caster, code, level, target, range)) {
         unit_stand(caster);
         G_FreeEdict(thinker);
         return;
@@ -683,6 +711,7 @@ static void spell_no_target_execute(LPEDICT clent) {
     if (!spell_message(caster, A_VALIDATE, &item, &st)) return;
 
     spell_commit(caster, code, level);
+    if (spell->flags & AB_CHANNEL) spell_begin_channel(caster, code);
     spell_publish_effect(caster, code, st);
     spell_message(caster, A_EXECUTE, &item, &st);
 }
@@ -697,10 +726,11 @@ BOOL S_CastNoTargetSpell(LPEDICT caster, DWORD code) {
     abilityitem_t item = { .code = code, .ability = spell };
     if (!spell || spell->target_type != SPELL_TARGET_NONE || !S_AbilityHasCommand(spell)) return false;
     level = S_SpellLevel(caster, code);
-    if (!S_SpellCooldownReady(caster, code) || !S_SpellCanPay(caster, code, level)) return false;
+    if (!spell_validate(NULL, caster, code, level, NULL, 0)) return false;
     if (!spell_message(caster, A_VALIDATE, &item, &target)) return false;
 
     spell_commit(caster, code, level);
+    if (spell->flags & AB_CHANNEL) spell_begin_channel(caster, code);
     spell_publish_effect(caster, code, target);
     spell_message(caster, A_EXECUTE, &item, &target);
     return true;
@@ -745,8 +775,8 @@ BOOL S_CastUnitTargetSpell(LPEDICT caster, DWORD code, LPEDICT unit) {
     abilityitem_t item = { .code = code, .ability = spell };
     if (!spell || spell->target_type != SPELL_TARGET_UNIT || !S_AbilityHasCommand(spell)) return false;
     level = S_SpellLevel(caster, code);
-    if (!S_SpellCooldownReady(caster, code) || !S_SpellCanPay(caster, code, level) ||
-        !S_SpellTargetInRange(caster, unit, S_SpellRange(code, level)) || !S_SpellAllowsTarget(code, caster, unit)) return false;
+    if (!spell_validate(NULL, caster, code, level, unit, S_SpellRange(code, level)) ||
+        !S_SpellAllowsTarget(code, caster, unit)) return false;
     if (!spell_message(caster, A_VALIDATE, &item, &target)) return false;
 
     spell_commit(caster, code, level);

--- a/games/warcraft-3/game/skills/s_stop.c
+++ b/games/warcraft-3/game/skills/s_stop.c
@@ -7,6 +7,8 @@ void order_stop(LPEDICT ent) {
     if (S_GoldMineWorkerIsInside(ent))
         return;
     G_ClearUnitOrderQueue(ent);
+    /* Channeling can retain the idle move, so Stop must cancel even without a move-leave notification. */
+    S_SpellCancelChannel(ent);
     ent->movement.attackmove_waypoint = NULL;
     ent->movement.patrol_a = NULL;
     ent->movement.patrol_b = NULL;

--- a/games/warcraft-3/game/skills/s_thunderbolt.c
+++ b/games/warcraft-3/game/skills/s_thunderbolt.c
@@ -24,8 +24,7 @@ static void thunderbolt_projectile_hit(LPEDICT missile) {
     LPEDICT caster = missile->owner;
 
     if (S_SpellIsAliveTarget(target)) {
-        S_SpellDamage(target, caster, missile->damage);
-        if (!M_IsDead(target)) {
+        if (S_SpellDamage(target, caster, missile->damage) && !M_IsDead(target)) {
             unit_addtimedstatus(target, ID_STUN_BUFF, 1, missile->wait);
         }
     }
@@ -38,7 +37,7 @@ static void thunderbolt_execute(LPEDICT caster, spellTarget_t st, abilityitem_t 
     DWORD level = S_SpellLevel(caster, code);
     LPCSTR art = G_AbilityEffectArt(code, WC3_EFFECT_MISSILE, 0);
     FLOAT speed = bolt_missile_speed(code);
-    FLOAT duration = S_SpellDuration(code, level, target->data.UnitBalance->level >= 5);
+    FLOAT duration = S_SpellDuration(code, level, G_UnitIsHero(target));
     LPEDICT missile;
 
     unit_setmove(caster, &spell_cast_move);
@@ -57,10 +56,11 @@ static void thunderbolt_execute(LPEDICT caster, spellTarget_t st, abilityitem_t 
 
 #define BZ_BOLT_PROC(NAME, SPEED) \
     BZ_ABILITY_PROC(C##NAME) { \
-        spellTarget_t target = call && call->target ? *call->target : MAKE(spellTarget_t, .type = SPELL_TARGET_NONE); \
         switch (msg) { \
         case A_INIT: if (call && call->classname) SPEED = ConfigNumber(call->classname, "Missilespeed"); return true; \
-        case A_EXECUTE: thunderbolt_execute(ent, target, call ? call->item : NULL); return true; \
+        case A_EXECUTE: \
+            if (!call || !call->item || !call->target) return false; \
+            thunderbolt_execute(ent, *call->target, call->item); return true; \
         default: return CAbilitySimpleSpell(ent, msg, call); \
         } \
     }

--- a/games/warcraft-3/game/tests/t_ability_dispatch.c
+++ b/games/warcraft-3/game/tests/t_ability_dispatch.c
@@ -1,0 +1,133 @@
+#ifdef BZ_TESTS
+#include "test.h"
+#include "../g_local.h"
+#include "../game/skills/s_skills.h"
+
+LPEDICT alloc_test_unit(DWORD class_id, FLOAT x, FLOAT y);
+void reset_entities(void);
+void setup_test_world(void);
+slkTestData_t *parse_slk_string(const char *slk_text);
+void free_slk_rows(slkTestData_t *rows);
+
+/* An object-data Heal alias must retain its authored amount and cost under autocast. */
+TEST(wc3_ability_dispatch, autocast_keeps_authored_alias) {
+    const char slk[] =
+        "ID;PWXL;N;EBB;Y4;X6\n"
+        "C;Y1;X1;K\"alias\"\nC;Y1;X2;K\"code\"\nC;Y1;X3;K\"targs\"\n"
+        "C;Y1;X4;K\"Cost1\"\nC;Y1;X5;K\"Rng1\"\nC;Y1;X6;K\"DataA1\"\n"
+        "C;Y2;X1;K\"Ahea\"\nC;Y2;X2;K\"Ahea\"\nC;Y2;X3;K\"air,ground,friend\"\n"
+        "C;Y2;X4;K\"5\"\nC;Y2;X5;K\"600\"\nC;Y2;X6;K\"25\"\n"
+        "C;Y3;X1;K\"A001\"\nC;Y3;X2;K\"Ahea\"\nC;Y3;X3;K\"air,ground,friend\"\n"
+        "C;Y3;X4;K\"13\"\nC;Y3;X5;K\"600\"\nC;Y3;X6;K\"37\"\n"
+        "C;Y4;X1;K\"A002\"\nC;Y4;X2;K\"Ahea\"\nC;Y4;X3;K\"air,ground,friend\"\n"
+        "C;Y4;X4;K\"23\"\nC;Y4;X5;K\"600\"\nC;Y4;X6;K\"89\"\nE\n";
+    UnitAbilities_t list = { .abilList = "A001,A002" };
+    slkTestData_t *rows = parse_slk_string(slk), *old = G_SetSLKRows("AbilityData", rows);
+    reset_entities();
+    setup_test_world();
+    LPEDICT caster = alloc_test_unit(MAKEFOURCC('h','p','r','i'), 0, 0);
+    LPEDICT target = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 50, 0);
+    caster->data.UnitAbilities = &list;
+    caster->mana.value = caster->mana.max_value = 200;
+    caster->s.player = target->s.player = 0;
+    caster->svflags |= SVF_MONSTER;
+    target->svflags |= SVF_MONSTER;
+    target->targtype = TARG_GROUND;
+    target->health.value = 100; target->health.max_value = 1000;
+    T_ASSERT(G_SetUnitAutocast(caster, FS_SLKKey("A001"), true));
+    T_ASSERT(G_TryUnitAutocast(caster));
+    T_FEQ(target->health.value, 137, 0.001f);
+    T_FEQ(caster->mana.value, 187, 0.001f);
+    T_ASSERT(G_UnitAutocastIsOn(caster, FS_SLKKey("A001")));
+    T_ASSERT(!G_UnitAutocastIsOn(caster, FS_SLKKey("A002")));
+    T_ASSERT(G_SetUnitAutocast(caster, FS_SLKKey("A001"), false));
+    T_ASSERT(!G_TryUnitAutocast(caster));
+    T_ASSERT(G_SetUnitAutocast(caster, FS_SLKKey("A002"), true));
+    T_ASSERT(G_TryUnitAutocast(caster));
+    T_FEQ(target->health.value, 226, 0.001f);
+    T_FEQ(caster->mana.value, 164, 0.001f);
+    T_ASSERT(G_ActorRemoveSkill(caster, FS_SLKKey("A002")));
+    T_EQ(caster->autocast_code, 0);
+    T_ASSERT(!G_TryUnitAutocast(caster));
+    T_ASSERT(!G_SetUnitAutocast(caster, FS_SLKKey("A002"), true));
+    T_ASSERT(G_ActorAddSkill(caster, FS_SLKKey("A002")));
+    T_ASSERT(G_SetUnitAutocast(caster, FS_SLKKey("A002"), true));
+    T_ASSERT(G_TryUnitAutocast(caster));
+    T_FEQ(target->health.value, 315, 0.001f);
+    G_SetSLKRows("AbilityData", old);
+    free_slk_rows(rows);
+}
+/* All Human boolean-message handlers and Repair must switch without leaking the old policy. */
+TEST(wc3_ability_dispatch, autocast_boolean_messages_switch_and_remove) {
+    const char slk[] =
+        "ID;PWXL;N;EBB;Y8;X2\nC;Y1;X1;K\"alias\"\nC;Y1;X2;K\"code\"\n"
+        "C;Y2;X1;K\"Ahea\"\nC;Y2;X2;K\"Ahea\"\n"
+        "C;Y3;X1;K\"Ainf\"\nC;Y3;X2;K\"Ainf\"\n"
+        "C;Y4;X1;K\"Aslo\"\nC;Y4;X2;K\"Aslo\"\n"
+        "C;Y5;X1;K\"Asps\"\nC;Y5;X2;K\"Asps\"\n"
+        "C;Y6;X1;K\"Arep\"\nC;Y6;X2;K\"Arep\"\n"
+        "C;Y7;X1;K\"Aren\"\nC;Y7;X2;K\"Aren\"\n"
+        "C;Y8;X1;K\"AEpa\"\nC;Y8;X2;K\"AEpa\"\nE\n";
+    slkTestData_t *rows = parse_slk_string(slk), *old = G_SetSLKRows("AbilityData", rows);
+    DWORD const codes[] = { MAKEFOURCC('A','h','e','a'), MAKEFOURCC('A','i','n','f'),
+        MAKEFOURCC('A','s','l','o'), MAKEFOURCC('A','s','p','s'),
+        MAKEFOURCC('A','r','e','p'), MAKEFOURCC('A','r','e','n') };
+    reset_entities(); setup_test_world();
+    LPEDICT caster = alloc_test_unit(MAKEFOURCC('h','p','r','i'), 0, 0);
+    UnitAbilities_t list = { .abilList = "" };
+    caster->data.UnitAbilities = &list;
+    FOR_LOOP(i, sizeof(codes) / sizeof(codes[0])) {
+        T_ASSERT(G_ActorAddSkill(caster, codes[i]));
+        T_ASSERT(G_SetUnitAutocast(caster, codes[i], true));
+        T_ASSERT(G_UnitAutocastIsOn(caster, codes[i]));
+        if (i) T_ASSERT(!G_UnitAutocastIsOn(caster, codes[i - 1]));
+    }
+    T_ASSERT(G_SetUnitAutocast(caster, codes[4], false));
+    T_ASSERT(G_UnitAutocastIsOn(caster, codes[5]));
+    T_ASSERT(G_ActorAddSkill(caster, FS_SLKKey("AEpa")));
+    T_ASSERT(!G_SetUnitAutocast(caster, FS_SLKKey("AEpa"), true));
+    T_ASSERT(G_UnitAutocastIsOn(caster, codes[5]));
+    T_ASSERT(G_ActorRemoveSkill(caster, codes[5]));
+    T_ASSERT(!(caster->aiflags & AI_AUTOCAST_ACTIVE));
+    T_ASSERT(!(caster->aiflags & AI_AUTOCAST_REPAIR));
+    T_EQ(caster->autocast_code, 0);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* Stock Shackles supplies separate caster/target buffs; cancellation must release only this cast's target. */
+TEST(wc3_ability_dispatch, shackles_locks_target_until_its_channel_ends) {
+    const char slk[] =
+        "ID;PWXL;N;EBB;Y2;X8\n"
+        "C;Y1;X1;K\"alias\"\nC;Y1;X2;K\"code\"\nC;Y1;X3;K\"targs\"\nC;Y1;X4;K\"Rng1\"\n"
+        "C;Y1;X5;K\"Dur1\"\nC;Y1;X6;K\"HeroDur1\"\nC;Y1;X7;K\"DataA1\"\nC;Y1;X8;K\"BuffID1\"\n"
+        "C;Y2;X1;K\"Amls\"\nC;Y2;X2;K\"Amls\"\nC;Y2;X3;K\"air,enemy\"\nC;Y2;X4;K\"800\"\n"
+        "C;Y2;X5;K\"10\"\nC;Y2;X6;K\"10\"\nC;Y2;X7;K\"30\"\nC;Y2;X8;K\"Bmlc,Bmlt\"\nE\n";
+    slkTestData_t *rows = parse_slk_string(slk), *old = G_SetSLKRows("AbilityData", rows);
+    UnitAbilities_t list = { .abilList = "Amls" };
+    reset_entities(); setup_test_world(); level.time = 1000;
+    ((LPMAPINFO)level.mapinfo)->players[0].playerType = kPlayerTypeHuman;
+    ((LPMAPINFO)level.mapinfo)->players[1].playerType = kPlayerTypeHuman;
+    LPEDICT caster = alloc_test_unit(MAKEFOURCC('h','p','r','i'), 0, 0);
+    LPEDICT target = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 100, 0), first = NULL, second = NULL;
+    caster->data.UnitAbilities = &list; caster->s.player = 0; target->s.player = 1;
+    caster->svflags |= SVF_MONSTER;
+    target->svflags |= SVF_MONSTER; target->targtype = TARG_AIR;
+    target->health.value = target->health.max_value = 1000;
+    T_ASSERT(S_CastUnitTargetSpell(caster, FS_SLKKey("Amls"), target));
+    FILTER_EDICTS(ent, ent->owner == caster && ent->think == human_ability_think) { first = ent; break; }
+    T_NOT_NULL(first);
+    T_ASSERT(!S_HumanCanAttack(target)); T_FEQ(S_HumanMoveFactor(target), 0, 0.001f);
+    T_ASSERT(!G_UnitStatusLevel(target, FS_SLKKey("Bmlc")));
+    T_ASSERT(S_CastUnitTargetSpell(caster, FS_SLKKey("Amls"), target));
+    FILTER_EDICTS(ent, ent != first && ent->owner == caster && ent->think == human_ability_think) {
+        second = ent; break;
+    }
+    T_NOT_NULL(second);
+    if (first) G_RunEntity(first);
+    T_ASSERT(S_SpellIsChanneling(caster)); T_ASSERT(!S_HumanCanAttack(target));
+    S_SpellCancelChannel(caster);
+    if (second) G_RunEntity(second);
+    T_ASSERT(S_HumanCanAttack(target)); T_FEQ(S_HumanMoveFactor(target), 1, 0.001f);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+#endif

--- a/games/warcraft-3/game/tests/t_ability_lifecycle.c
+++ b/games/warcraft-3/game/tests/t_ability_lifecycle.c
@@ -1,0 +1,512 @@
+#ifdef BZ_TESTS
+#include "test.h"
+#include "../g_local.h"
+#include "../game/skills/s_skills.h"
+
+LPEDICT alloc_test_unit(DWORD code, FLOAT x, FLOAT y);
+void reset_entities(void);
+void setup_test_world(void);
+slkTestData_t *parse_slk_string(const char *text);
+void free_slk_rows(slkTestData_t *rows);
+
+static UnitAbilities_t review_abilities = { .abilList = "AHfs,AHbz,AHdr,ANdr,AEtq,AHtb,AHre,AUfn,AHwe" };
+static char const review_slk[] =
+    "ID;PWXL;N;EBB;Y10;X15\n"
+    "C;Y1;X1;K\"alias\"\n"
+    "C;Y1;X2;K\"code\"\n"
+    "C;Y1;X3;K\"targs\"\n"
+    "C;Y1;X4;K\"Cost1\"\n"
+    "C;Y1;X5;K\"Rng1\"\n"
+    "C;Y1;X6;K\"Dur1\"\n"
+    "C;Y1;X7;K\"HeroDur1\"\n"
+    "C;Y1;X8;K\"Area1\"\n"
+    "C;Y1;X9;K\"DataA1\"\n"
+    "C;Y1;X10;K\"DataB1\"\n"
+    "C;Y1;X11;K\"DataC1\"\n"
+    "C;Y1;X12;K\"DataD1\"\n"
+    "C;Y1;X13;K\"DataE1\"\n"
+    "C;Y1;X14;K\"BuffID1\"\n"
+    "C;Y2;X1;K\"AHfs\"\n"
+    "C;Y2;X2;K\"AHfs\"\n"
+    "C;Y2;X3;K\"ground,enemy\"\n"
+    "C;Y2;X4;K\"0\"\n"
+    "C;Y2;X5;K\"800\"\n"
+    "C;Y2;X6;K\"9\"\n"
+    "C;Y2;X7;K\"2.67\"\n"
+    "C;Y2;X8;K\"200\"\n"
+    "C;Y2;X9;K\"15\"\n"
+    "C;Y2;X10;K\"0.33\"\n"
+    "C;Y2;X11;K\"4\"\n"
+    "C;Y2;X12;K\"1\"\n"
+    "C;Y2;X13;K\"0.75\"\n"
+    "C;Y2;X14;K\"BHfs\"\n"
+    "C;Y3;X1;K\"AHbz\"\n"
+    "C;Y3;X2;K\"AHbz\"\n"
+    "C;Y3;X3;K\"ground,enemy\"\n"
+    "C;Y3;X4;K\"0\"\n"
+    "C;Y3;X5;K\"800\"\n"
+    "C;Y3;X6;K\"0\"\n"
+    "C;Y3;X7;K\"0\"\n"
+    "C;Y3;X8;K\"200\"\n"
+    "C;Y3;X9;K\"6\"\n"
+    "C;Y3;X10;K\"30\"\n"
+    "C;Y3;X11;K\"6\"\n"
+    "C;Y3;X12;K\"0.5\"\n"
+    "C;Y3;X13;K\"0\"\n"
+    "C;Y3;X14;K\"BHbd,BHbz\"\n"
+    "C;Y4;X1;K\"AHdr\"\n"
+    "C;Y4;X2;K\"AHdr\"\n"
+    "C;Y4;X3;K\"air,ground,enemy,friend\"\n"
+    "C;Y4;X4;K\"0\"\n"
+    "C;Y4;X5;K\"600\"\n"
+    "C;Y4;X6;K\"6\"\n"
+    "C;Y4;X7;K\"6\"\n"
+    "C;Y4;X8;K\"800\"\n"
+    "C;Y4;X9;K\"0\"\n"
+    "C;Y4;X10;K\"15\"\n"
+    "C;Y4;X11;K\"1\"\n"
+    "C;Y4;X12;K\"0\"\n"
+    "C;Y4;X13;K\"30\"\n"
+    "C;Y4;X14;K\"\"\n"
+    "C;Y5;X1;K\"ANdr\"\n"
+    "C;Y5;X2;K\"AHdr\"\n"
+    "C;Y5;X3;K\"air,ground,enemy\"\n"
+    "C;Y5;X4;K\"0\"\n"
+    "C;Y5;X5;K\"500\"\n"
+    "C;Y5;X6;K\"8\"\n"
+    "C;Y5;X7;K\"8\"\n"
+    "C;Y5;X8;K\"800\"\n"
+    "C;Y5;X9;K\"30\"\n"
+    "C;Y5;X10;K\"0\"\n"
+    "C;Y5;X11;K\"1\"\n"
+    "C;Y5;X12;K\"0\"\n"
+    "C;Y5;X13;K\"0\"\n"
+    "C;Y5;X14;K\"\"\n"
+    "C;Y6;X1;K\"AEtq\"\n"
+    "C;Y6;X2;K\"AEtq\"\n"
+    "C;Y6;X3;K\"air,ground,friend\"\n"
+    "C;Y6;X4;K\"0\"\n"
+    "C;Y6;X5;K\"0\"\n"
+    "C;Y6;X6;K\"10\"\n"
+    "C;Y6;X7;K\"10\"\n"
+    "C;Y6;X8;K\"500\"\n"
+    "C;Y6;X9;K\"20\"\n"
+    "C;Y6;X10;K\"1\"\n"
+    "C;Y6;X11;K\"0\"\n"
+    "C;Y6;X12;K\"0\"\n"
+    "C;Y6;X13;K\"0\"\n"
+    "C;Y6;X14;K\"\"\n"
+    "C;Y7;X1;K\"AHtb\"\n"
+    "C;Y7;X2;K\"AHtb\"\n"
+    "C;Y7;X3;K\"air,ground,enemy\"\n"
+    "C;Y7;X4;K\"0\"\n"
+    "C;Y7;X5;K\"600\"\n"
+    "C;Y7;X6;K\"5\"\n"
+    "C;Y7;X7;K\"3\"\n"
+    "C;Y7;X8;K\"0\"\n"
+    "C;Y7;X9;K\"100\"\n"
+    "C;Y7;X10;K\"0\"\n"
+    "C;Y7;X11;K\"0\"\n"
+    "C;Y7;X12;K\"0\"\n"
+    "C;Y7;X13;K\"0\"\n"
+    "C;Y7;X14;K\"BPSE\"\n"
+    "C;Y8;X1;K\"AHre\"\n"
+    "C;Y8;X2;K\"AHre\"\n"
+    "C;Y8;X3;K\"ground,friend,dead\"\n"
+    "C;Y8;X4;K\"0\"\n"
+    "C;Y8;X5;K\"400\"\n"
+    "C;Y8;X6;K\"0\"\n"
+    "C;Y8;X7;K\"0\"\n"
+    "C;Y8;X8;K\"900\"\n"
+    "C;Y8;X9;K\"6\"\n"
+    "C;Y8;X10;K\"0\"\n"
+    "C;Y8;X11;K\"0\"\n"
+    "C;Y8;X12;K\"0\"\n"
+    "C;Y8;X13;K\"0\"\n"
+    "C;Y8;X14;K\"\"\n"
+    "C;Y9;X1;K\"AUfn\"\n"
+    "C;Y9;X2;K\"AUfn\"\n"
+    "C;Y9;X3;K\"air,ground,enemy\"\n"
+    "C;Y9;X4;K\"0\"\n"
+    "C;Y9;X5;K\"800\"\n"
+    "C;Y9;X6;K\"4\"\n"
+    "C;Y9;X7;K\"2\"\n"
+    "C;Y9;X8;K\"200\"\n"
+    "C;Y9;X9;K\"50\"\n"
+    "C;Y9;X10;K\"100\"\n"
+    "C;Y9;X11;K\"0\"\n"
+    "C;Y9;X12;K\"0\"\n"
+    "C;Y9;X13;K\"0\"\n"
+    "C;Y9;X14;K\"Bfro\"\n"
+    "C;Y10;X1;K\"AHwe\"\n"
+    "C;Y10;X2;K\"AHwe\"\n"
+    "C;Y10;X3;K\"\"\n"
+    "C;Y10;X4;K\"0\"\n"
+    "C;Y10;X5;K\"0\"\n"
+    "C;Y10;X6;K\"30\"\n"
+    "C;Y10;X7;K\"30\"\n"
+    "C;Y10;X8;K\"200\"\n"
+    "C;Y10;X9;K\"1\"\n"
+    "C;Y10;X10;K\"0\"\n"
+    "C;Y10;X11;K\"0\"\n"
+    "C;Y10;X12;K\"0\"\n"
+    "C;Y10;X13;K\"0\"\n"
+    "C;Y10;X14;K\"\"\n"
+    "C;Y1;X15;K\"Cast1\"\n"
+    "C;Y2;X15;K1.33\n"
+    "C;Y3;X15;K1\n"
+    "E\n"
+;
+
+/* Independent minimal units drive ordinary casting and the production thinker scheduler. */
+static LPEDICT review_unit(DWORD owner, FLOAT x) {
+    LPEDICT ent = alloc_test_unit(MAKEFOURCC('h','f','o','o'), x, 0);
+    ent->spawn_time = G_Time(); ent->svflags |= SVF_MONSTER; ent->s.player = owner; ent->targtype = TARG_GROUND;
+    ent->health.value = ent->health.max_value = 1000;
+    ent->mana.value = 100; ent->mana.max_value = 1000;
+    ent->stand = unit_stand; unit_stand(ent);
+    return ent;
+}
+
+static LPEDICT review_setup(void) {
+    reset_entities(); setup_test_world(); level.time = 1000;
+    ((LPMAPINFO)level.mapinfo)->players[0].playerType = kPlayerTypeHuman;
+    ((LPMAPINFO)level.mapinfo)->players[1].playerType = kPlayerTypeHuman;
+    LPEDICT caster = review_unit(0, 0);
+    caster->data.UnitAbilities = &review_abilities;
+    return caster;
+}
+
+static LPEDICT review_thinker(LPEDICT caster) {
+    FILTER_EDICTS(ent, ent->owner == caster && ent->think) return ent;
+    return NULL;
+}
+
+/* Stock AHfs starts burning promptly; DataA is damage per full-damage pulse, not a 15-second delay. */
+TEST(wc3_ability_lifecycle, flame_strike_stock_data_burns_within_two_seconds) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    BOOL cast = S_CastPointTargetSpell(caster, FS_SLKKey("AHfs"), &enemy->s.origin2);
+    LPEDICT thinker = review_thinker(caster);
+    level.time += 2000;
+    if (thinker) G_RunEntity(thinker);
+    FLOAT hp = enemy->health.value;
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+    T_ASSERT(cast); T_NOT_NULL(thinker); T_ASSERT(hp < 1000);
+}
+
+/* Once a flame pulse runs, another server frame must not count as another full burn tick. */
+TEST(wc3_ability_lifecycle, flame_strike_does_not_burn_every_server_frame) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    BOOL cast = S_CastPointTargetSpell(caster, FS_SLKKey("AHfs"), &enemy->s.origin2);
+    LPEDICT thinker = review_thinker(caster);
+    FLOAT hp = 0;
+    if (thinker) {
+        level.time = thinker->freetime; G_RunEntity(thinker); hp = enemy->health.value;
+        level.time += FRAMETIME; G_RunEntity(thinker);
+    }
+    FLOAT after = enemy->health.value;
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+    T_ASSERT(cast); T_NOT_NULL(thinker); T_FEQ(after, hp, .001f);
+}
+
+/* Stock Blizzard authors six waves and a zero Dur; zero must not truncate the cast to one second. */
+TEST(wc3_ability_lifecycle, blizzard_stock_zero_duration_keeps_all_six_waves) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    BOOL cast = S_CastPointTargetSpell(caster, FS_SLKKey("AHbz"), &enemy->s.origin2);
+    LPEDICT thinker = review_thinker(caster);
+    FOR_LOOP(i, 5) { level.time += 1000; if (thinker && thinker->inuse) G_RunEntity(thinker); }
+    FLOAT hp = enemy->health.value;
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+    T_ASSERT(cast); T_FEQ(hp, 820, .001f);
+}
+
+/* Cancelling the caster's channel must retire its pending resource transfer too. */
+TEST(wc3_ability_lifecycle, siphon_mana_stops_after_movement_cancel) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    BOOL cast = S_CastUnitTargetSpell(caster, FS_SLKKey("AHdr"), enemy);
+    LPEDICT thinker = review_thinker(caster);
+    caster->s.origin2.x += 10; spell_run_frame(caster);
+    DWORD channel = caster->channel.code;
+    level.time += 1000;
+    if (thinker) G_RunEntity(thinker);
+    FLOAT mana = enemy->mana.value;
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+    T_ASSERT(cast); T_EQ(channel, 0); T_FEQ(mana, 100, .001f);
+}
+
+/* ANdr's authored DataA drains life even when the target has no mana pool. */
+TEST(wc3_ability_lifecycle, life_drain_transfers_health_from_manaless_target) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    caster->health.value = 500; enemy->mana.value = enemy->mana.max_value = 0;
+    BOOL cast = S_CastUnitTargetSpell(caster, FS_SLKKey("ANdr"), enemy);
+    LPEDICT thinker = review_thinker(caster);
+    level.time += 1000;
+    if (thinker) G_RunEntity(thinker);
+    FLOAT hp = enemy->health.value, healed = caster->health.value;
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+    T_ASSERT(cast); T_FEQ(hp, 970, .001f); T_FEQ(healed, 530, .001f);
+}
+
+/* Tranquility is AB_CHANNEL even though it needs no target-selection click. */
+TEST(wc3_ability_lifecycle, no_target_tranquility_establishes_channel) {
+    LPEDICT caster = review_setup();
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    BOOL cast = S_CastNoTargetSpell(caster, FS_SLKKey("AEtq"));
+    DWORD channel = caster->channel.code;
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+    T_ASSERT(cast); T_EQ(channel, FS_SLKKey("AEtq"));
+}
+
+/* A launched bolt must not stun a target which becomes spell immune before impact. */
+TEST(wc3_ability_lifecycle, avatar_blocks_storm_bolt_stun_at_impact) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    BOOL cast = S_CastUnitTargetSpell(caster, FS_SLKKey("AHtb"), enemy);
+    LPEDICT missile = NULL;
+    FILTER_EDICTS(ent, ent->owner == caster && ent->movetype == MOVETYPE_FLYMISSILE) { missile = ent; break; }
+    unit_addtimedstatus(enemy, "BHav", 1, 10);
+    if (missile) missile->currentmove->endfunc(missile);
+    DWORD stun = G_UnitStatusLevel(enemy, FS_SLKKey("Bstu"));
+    FLOAT hp = enemy->health.value;
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+    T_ASSERT(cast); T_NOT_NULL(missile); T_FEQ(hp, 1000, .001f); T_EQ(stun, 0);
+}
+
+/* Resurrection's stock tooltip promises ordinary friendly corpses, not exclusively Heroes. */
+TEST(wc3_ability_lifecycle, resurrection_revives_friendly_footman) {
+    LPEDICT caster = review_setup(), ally = review_unit(0, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    ally->health.value = 0; ally->svflags |= SVF_DEADMONSTER;
+    BOOL cast = S_CastNoTargetSpell(caster, FS_SLKKey("AHre"));
+    FLOAT hp = ally->health.value;
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+    T_ASSERT(cast); T_ASSERT(hp > 0);
+}
+
+/* Frost Nova's range and target damage require a unit-target order. */
+TEST(wc3_ability_lifecycle, frost_nova_accepts_enemy_unit_target) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 500);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    BOOL cast = S_CastUnitTargetSpell(caster, FS_SLKKey("AUfn"), enemy);
+    FLOAT hp = enemy->health.value;
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+    T_ASSERT(cast); T_FEQ(hp, 850, .001f);
+}
+
+/* Serial ownership separates two casts of the same spell even when both thinkers still exist. */
+TEST(wc3_ability_lifecycle, recast_retires_old_thinker_without_cancelling_new_channel) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    T_ASSERT(S_CastUnitTargetSpell(caster, FS_SLKKey("AHdr"), enemy));
+    LPEDICT first = review_thinker(caster);
+    DWORD serial = caster->channel.serial;
+    T_ASSERT(S_CastUnitTargetSpell(caster, FS_SLKKey("AHdr"), enemy));
+    T_NE(caster->channel.serial, serial);
+    level.time += 1000; G_RunEntity(first);
+    T_ASSERT(!first->inuse); T_EQ(caster->channel.code, FS_SLKKey("AHdr")); T_FEQ(enemy->mana.value, 100, .001f);
+    LPEDICT next = review_thinker(caster);
+    T_NOT_NULL(next);
+    if (next) G_RunEntity(next);
+    T_FEQ(enemy->mana.value, 85, .001f);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* Stun can happen after cast commitment but before the caster's next own frame. */
+TEST(wc3_ability_lifecycle, stun_interrupts_blizzard_before_next_wave) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    T_ASSERT(S_CastPointTargetSpell(caster, FS_SLKKey("AHbz"), &enemy->s.origin2));
+    LPEDICT thinker = review_thinker(caster);
+    unit_addtimedstatus(caster, "Bstu", 1, 5); level.time += 1000; G_RunEntity(thinker);
+    T_FEQ(enemy->health.value, 970, .001f); T_ASSERT(!thinker->inuse); T_EQ(caster->channel.code, 0);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* The retired caster slot must not donate its old drain to a newly spawned unit. */
+TEST(wc3_ability_lifecycle, removed_caster_slot_cannot_own_old_drain) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    T_ASSERT(S_CastUnitTargetSpell(caster, FS_SLKKey("AHdr"), enemy));
+    LPEDICT thinker = review_thinker(caster);
+    G_FreeEdict(caster); level.time += 2000;
+    LPEDICT fresh = review_unit(0, 0);
+    T_ASSERT(fresh == caster);
+    fresh->channel.code = FS_SLKKey("AHdr"); fresh->channel.serial = thinker->channel.serial;
+    G_RunEntity(thinker);
+    T_ASSERT(!thinker->inuse); T_FEQ(enemy->mana.value, 100, .001f);
+    T_EQ(fresh->channel.code, FS_SLKKey("AHdr"));
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* The target's edict identity matters independently of the still-active caster and cast token. */
+TEST(wc3_ability_lifecycle, removed_target_slot_cannot_receive_old_drain) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    T_ASSERT(S_CastUnitTargetSpell(caster, FS_SLKKey("AHdr"), enemy));
+    LPEDICT thinker = review_thinker(caster);
+    G_FreeEdict(enemy); level.time += 2000;
+    LPEDICT fresh = review_unit(1, 100);
+    T_ASSERT(fresh == enemy); G_RunEntity(thinker);
+    T_ASSERT(!thinker->inuse); T_FEQ(fresh->mana.value, 100, .001f); T_EQ(caster->channel.code, 0);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* AHdr's authored friendly transfer rate and direction differ from enemy siphoning. */
+TEST(wc3_ability_lifecycle, siphon_sends_mana_to_allies_and_expires) {
+    LPEDICT caster = review_setup(), ally = review_unit(0, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    caster->mana.value = 500; ally->mana.value = 0;
+    T_ASSERT(S_CastUnitTargetSpell(caster, FS_SLKKey("AHdr"), ally));
+    LPEDICT thinker = review_thinker(caster);
+    FOR_LOOP(i, 6) { level.time += 1000; G_RunEntity(thinker); }
+    T_FEQ(caster->mana.value, 320, .001f); T_FEQ(ally->mana.value, 180, .001f);
+    T_ASSERT(!thinker->inuse); T_EQ(caster->channel.code, 0);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* Correcting the schema must preserve delayed startup, the reduced-damage phase, and final cleanup. */
+TEST(wc3_ability_lifecycle, flame_strike_obeys_authored_phase_intervals_and_expiry) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    T_ASSERT(S_CastPointTargetSpell(caster, FS_SLKKey("AHfs"), &enemy->s.origin2));
+    LPEDICT thinker = review_thinker(caster);
+    level.time = 2000; G_RunEntity(thinker); T_FEQ(enemy->health.value, 1000, .001f);
+    FOR_LOOP(i, 9) { level.time = 2330 + i * 330; G_RunEntity(thinker); }
+    T_FEQ(enemy->health.value, 865, .001f);
+    level.time = 5999; G_RunEntity(thinker); T_FEQ(enemy->health.value, 865, .001f);
+    level.time = 6000; G_RunEntity(thinker); T_FEQ(enemy->health.value, 861, .001f);
+    level.time = 11331; G_RunEntity(thinker); T_ASSERT(!thinker->inuse);
+    T_FEQ(enemy->health.value, 861, .001f);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* A targeted nova damages around its victim; nearby units do not receive the direct-target bonus. */
+TEST(wc3_ability_lifecycle, frost_nova_uses_victim_center_and_separate_direct_damage) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 500), near = review_unit(1, 550);
+    LPEDICT far = review_unit(1, 50), ally = review_unit(0, 550);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    T_ASSERT(S_CastUnitTargetSpell(caster, FS_SLKKey("AUfn"), enemy));
+    T_FEQ(enemy->health.value, 850, .001f); T_FEQ(near->health.value, 950, .001f);
+    T_FEQ(far->health.value, 1000, .001f); T_FEQ(ally->health.value, 1000, .001f);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* Ordinary corpses restore selection and the idle move instead of retaining their decay callback. */
+TEST(wc3_ability_lifecycle, resurrection_retires_death_state_and_rejects_empty_cast) {
+    LPEDICT caster = review_setup(), ally = review_unit(0, 100), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    T_ASSERT(!S_CastNoTargetSpell(caster, FS_SLKKey("AHre")));
+    unit_die(ally, enemy); ally->aiflags |= AI_HOLD_FRAME;
+    T_ASSERT(S_CastNoTargetSpell(caster, FS_SLKKey("AHre")));
+    T_FEQ(ally->health.value, ally->health.max_value, .001f);
+    T_ASSERT(!(ally->svflags & SVF_DEADMONSTER)); T_ASSERT(!(ally->s.flags & EF_NOT_SELECTABLE));
+    T_ASSERT(!(ally->aiflags & AI_HOLD_FRAME));
+    T_ASSERT(!S_CastNoTargetSpell(caster, FS_SLKKey("AHre")));
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* Saving a live drain preserves its owner/target pointers, callback, deadline and cast identity together. */
+TEST(wc3_ability_lifecycle, live_drain_continues_once_after_save_load) {
+    LPCSTR path = "/tmp/openwarcraft3-skill-drain-save.bin";
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    T_ASSERT(S_CastUnitTargetSpell(caster, FS_SLKKey("AHdr"), enemy));
+    LPEDICT thinker = review_thinker(caster);
+    T_ASSERT(WriteGame(path)); caster->channel.code = 0; thinker->think = NULL;
+    T_ASSERT(ReadGame(path));
+    level.time += 1000; G_RunEntity(thinker);
+    T_FEQ(enemy->mana.value, 85, .001f); T_EQ(caster->channel.code, FS_SLKKey("AHdr"));
+    G_RunEntity(thinker); T_FEQ(enemy->mana.value, 85, .001f);
+    remove(path); G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* The ROC Data11/Data12 spell schema and TFT DataA1/DataB1 schema must produce the same stock six waves. */
+TEST(wc3_ability_lifecycle, blizzard_roc_data_columns_keep_all_authored_waves) {
+    char roc[sizeof(review_slk)];
+    memcpy(roc, review_slk, sizeof(roc));
+    FOR_LOOP(i, 5) {
+        char field[] = "DataA1"; field[4] += i;
+        char *at = strstr(roc, field);
+        T_NOT_NULL(at);
+        if (at) { at[4] = '1'; at[5] = '1' + i; }
+    }
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(roc), *old = G_SetSLKRows("AbilityData", rows);
+    T_FEQ(S_SpellData(FS_SLKKey("AHbz"), 1, 1), 6, .001f);
+    T_ASSERT(S_CastPointTargetSpell(caster, FS_SLKKey("AHbz"), &enemy->s.origin2));
+    LPEDICT thinker = review_thinker(caster);
+    FOR_LOOP(i, 5) { level.time += 1000; G_RunEntity(thinker); }
+    T_FEQ(enemy->health.value, 820, .001f); T_ASSERT(!thinker->inuse);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* UnitBalance creep level is unrelated to Hero identity when selecting Storm Bolt's duration. */
+TEST(wc3_ability_lifecycle, storm_bolt_uses_hero_identity_for_stun_duration) {
+    LPEDICT caster = review_setup(), hero = review_unit(1, 100), creep = review_unit(1, 150);
+    UnitBalance_t balance = { .level = 8 }, hero_row = { .level = 1, .strength = 20 };
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    hero->class_id = MAKEFOURCC('H','p','a','l'); hero->data.UnitBalance = &hero_row; creep->data.UnitBalance = &balance;
+    T_ASSERT(G_UnitIsHero(hero)); T_ASSERT(!G_UnitIsHero(creep));
+    T_ASSERT(S_CastUnitTargetSpell(caster, FS_SLKKey("AHtb"), hero));
+    FILTER_EDICTS(ent, ent->owner == caster && ent->movetype == MOVETYPE_FLYMISSILE) {
+        T_FEQ(ent->wait, 3, .001f); ent->currentmove->endfunc(ent);
+    }
+    T_ASSERT(S_CastUnitTargetSpell(caster, FS_SLKKey("AHtb"), creep));
+    FILTER_EDICTS(ent, ent->owner == caster && ent->movetype == MOVETYPE_FLYMISSILE) T_FEQ(ent->wait, 5, .001f);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* Fractional authored intervals accumulate on scheduled deadlines instead of rounding each tick up to FRAMETIME. */
+TEST(wc3_ability_lifecycle, flame_strike_fractional_interval_keeps_cadence_on_server_frames) {
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+    T_ASSERT(S_CastPointTargetSpell(caster, FS_SLKKey("AHfs"), &enemy->s.origin2));
+    LPEDICT thinker = review_thinker(caster);
+    while (level.time < 5000) { level.time += FRAMETIME; G_RunEntity(thinker); }
+    T_FEQ(enemy->health.value, 865, .001f); T_EQ(thinker->freetime, 6000);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* Replacement orders interrupt at dispatch, even before a Move changes coordinates or an Attack swings. */
+TEST(wc3_ability_lifecycle, stop_move_and_attack_retire_channel_before_motion) {
+    LPCSTR orders[] = { "stop", "move", "attack" };
+    FOR_LOOP(i, 3) {
+        LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+        slkTestData_t *rows = parse_slk_string(review_slk), *old = G_SetSLKRows("AbilityData", rows);
+        caster->unitinfo.MoveSpeed = 300; caster->movetype = MOVETYPE_STEP;
+        caster->attack1.range = 600; caster->attack1.damageBase = 10; caster->attack1.cooldown = 1;
+        T_ASSERT(S_CastUnitTargetSpell(caster, FS_SLKKey("AHdr"), enemy));
+        LPEDICT thinker = review_thinker(caster);
+        if (i == 0) T_ASSERT(unit_issueimmediateorder(caster, orders[i]));
+        else if (i == 1) T_ASSERT(unit_issueorder(caster, orders[i], &MAKE(VECTOR2, .x = 300)));
+        else T_ASSERT(unit_issuetargetorder(caster, orders[i], enemy));
+        umove_t const *move = caster->currentmove;
+        T_EQ(caster->channel.code, 0); T_FEQ(caster->s.origin2.x, 0, .001f);
+        level.time += 1000; G_RunEntity(thinker);
+        T_ASSERT(!thinker->inuse); T_FEQ(enemy->mana.value, 100, .001f); T_ASSERT(caster->currentmove == move);
+        G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+    }
+}
+
+/* Multiple authored pulses can fit in one server frame; the patch preserves them instead of clamping the interval. */
+TEST(wc3_ability_lifecycle, flame_strike_custom_interval_can_tick_twice_per_frame) {
+    char slk[sizeof(review_slk)];
+    memcpy(slk, review_slk, sizeof(slk));
+    char *interval = strstr(slk, "0.33");
+    T_NOT_NULL(interval);
+    if (interval) memcpy(interval, "0.05", 4);
+    LPEDICT caster = review_setup(), enemy = review_unit(1, 100);
+    slkTestData_t *rows = parse_slk_string(slk), *old = G_SetSLKRows("AbilityData", rows);
+    T_ASSERT(S_CastPointTargetSpell(caster, FS_SLKKey("AHfs"), &enemy->s.origin2));
+    LPEDICT thinker = review_thinker(caster);
+    level.time = 2300; G_RunEntity(thinker); T_FEQ(enemy->health.value, 1000, .001f);
+    level.time = 2400; G_RunEntity(thinker); T_FEQ(enemy->health.value, 970, .001f);
+    level.time = 2500; G_RunEntity(thinker); T_FEQ(enemy->health.value, 940, .001f);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+#endif

--- a/games/warcraft-3/game/tests/t_building.c
+++ b/games/warcraft-3/game/tests/t_building.c
@@ -2011,15 +2011,15 @@ TEST(wc3_building, repair_autocast_toggle_is_unit_state) {
     repair = FindAbilityForCommand("Aren");
 
     T_NOT_NULL(repair);
-    T_ASSERT(!G_UnitAutocastIsOn(worker, repair));
-    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    T_ASSERT(!G_UnitAutocastIsOn(worker, FS_SLKKey(repair->classname)));
+    T_ASSERT(G_SetUnitAutocast(worker, FS_SLKKey(repair->classname), true));
     T_ASSERT(worker->aiflags & AI_AUTOCAST_REPAIR);
     T_ASSERT(worker->aiflags & AI_AUTOCAST_ACTIVE);
-    T_ASSERT(G_UnitAutocastIsOn(worker, repair));
-    T_ASSERT(G_SetUnitAutocast(worker, repair, false));
+    T_ASSERT(G_UnitAutocastIsOn(worker, FS_SLKKey(repair->classname)));
+    T_ASSERT(G_SetUnitAutocast(worker, FS_SLKKey(repair->classname), false));
     T_ASSERT(!(worker->aiflags & AI_AUTOCAST_REPAIR));
     T_ASSERT(!(worker->aiflags & AI_AUTOCAST_ACTIVE));
-    T_ASSERT(!G_UnitAutocastIsOn(worker, repair));
+    T_ASSERT(!G_UnitAutocastIsOn(worker, FS_SLKKey(repair->classname)));
 
     building_restore_repair_data(old_abilities, rows);
 }
@@ -2038,10 +2038,10 @@ TEST(wc3_building, repairon_and_repairoff_immediate_orders_toggle_without_starti
 
     T_NOT_NULL(repair);
     T_ASSERT(unit_issueimmediateorder(worker, "repairon"));
-    T_ASSERT(G_UnitAutocastIsOn(worker, repair));
+    T_ASSERT(G_UnitAutocastIsOn(worker, FS_SLKKey(repair->classname)));
     T_NULL(worker->build);
     T_ASSERT(unit_issueimmediateorder(worker, "repairoff"));
-    T_ASSERT(!G_UnitAutocastIsOn(worker, repair));
+    T_ASSERT(!G_UnitAutocastIsOn(worker, FS_SLKKey(repair->classname)));
     T_NULL(worker->build);
 
     building_restore_repair_data(old_abilities, rows);
@@ -2065,7 +2065,7 @@ TEST(wc3_building, repair_command_button_exposes_autocast_secondary_command) {
     T_STREQ(button.alternate, "autocast Arep");
     T_EQ(button.alternate_active, 0);
 
-    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    T_ASSERT(G_SetUnitAutocast(worker, FS_SLKKey(repair->classname), true));
     T_ASSERT(G_BuildCommandButton(worker, "Arep", false, 0, &button));
     T_STREQ(button.alternate, "autocast Arep");
     T_EQ(button.alternate_active, 1);
@@ -2100,7 +2100,7 @@ TEST(wc3_building, repair_autocast_chooses_nearest_valid_damaged_building) {
     repair = FindAbilityForCommand("Aren");
 
     T_NOT_NULL(repair);
-    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    T_ASSERT(G_SetUnitAutocast(worker, FS_SLKKey(repair->classname), true));
     T_ASSERT(G_TryUnitAutocast(worker));
     T_ASSERT(worker->build == near_building);
     T_ASSERT(worker->build != far_building);
@@ -2131,7 +2131,7 @@ TEST(wc3_building, repair_autocast_uses_collision_aware_nearest_valid_distance) 
     repair = FindAbilityForCommand("Aren");
 
     T_NOT_NULL(repair);
-    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    T_ASSERT(G_SetUnitAutocast(worker, FS_SLKKey(repair->classname), true));
     /* Center distance is 410 (> uacq 400), but edge distance is only 330.
      * Warsmash expands from the caster collision rectangle and compares unit
      * edge distance, so the nearby building remains a valid acquisition. */
@@ -2166,7 +2166,7 @@ TEST(wc3_building, moving_away_while_repairing_preserves_replacement_goal) {
     repair = FindAbilityForCommand("Aren");
 
     T_NOT_NULL(repair);
-    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    T_ASSERT(G_SetUnitAutocast(worker, FS_SLKKey(repair->classname), true));
     T_ASSERT(S_OrderRepair(worker, building, MAKEFOURCC('A','r','e','n')));
     T_ASSERT(worker->build == building);
     T_NE(worker->buildwork.ability, 0);
@@ -2216,7 +2216,7 @@ TEST(wc3_building, idle_acquisition_prefers_auto_repair_over_auto_attack) {
     repair = FindAbilityForCommand("Aren");
 
     T_NOT_NULL(repair);
-    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    T_ASSERT(G_SetUnitAutocast(worker, FS_SLKKey(repair->classname), true));
     stagger = (DWORD)(worker - g_edicts) % 300;
     level.time = (300 - stagger) % 300;
     ai_stand(worker);
@@ -2281,7 +2281,7 @@ TEST(wc3_building, repair_autocast_ignores_full_health_nearer_building) {
     repair = FindAbilityForCommand("Aren");
 
     T_NOT_NULL(repair);
-    T_ASSERT(G_SetUnitAutocast(worker, repair, true));
+    T_ASSERT(G_SetUnitAutocast(worker, FS_SLKKey(repair->classname), true));
     T_ASSERT(G_TryUnitAutocast(worker));
     T_ASSERT(worker->build == damaged_building);
 

--- a/games/warcraft-3/game/tests/t_combat.c
+++ b/games/warcraft-3/game/tests/t_combat.c
@@ -301,6 +301,7 @@ TEST(wc3_combat, tdamage_lethal_resets_attacker_to_stand) {
     LPEDICT attacker = make_combat_unit(MAKEFOURCC('h','p','e','a'), 250.0f, 50.0f, 0.0f);
     _die_call_count  = 0;
 
+    order_attack(attacker, target);
     T_Damage(target, attacker, 100);
 
     /* After a kill the attacker's move should be the stand animation. */

--- a/games/warcraft-3/game/tests/t_game.c
+++ b/games/warcraft-3/game/tests/t_game.c
@@ -2831,6 +2831,10 @@ SAVE_INT_FIELD_TEST(field_peons_inside_round_trip, peonsinside, 5)
 SAVE_INT_FIELD_TEST(field_ai_flags_round_trip, aiflags, 0x55)
 SAVE_INT_FIELD_TEST(field_damage_round_trip, damage, 99)
 SAVE_INT_FIELD_TEST(field_autocast_code_round_trip, autocast_code, MAKEFOURCC('A', 'h', 'e', 'a'))
+SAVE_INT_FIELD_TEST(field_channel_code_round_trip, channel.code, MAKEFOURCC('A', 'H', 'd', 'r'))
+SAVE_INT_FIELD_TEST(field_channel_serial_round_trip, channel.serial, 7)
+SAVE_INT_FIELD_TEST(field_channel_owner_spawn_round_trip, channel.owner_spawn_time, 200)
+SAVE_INT_FIELD_TEST(field_channel_target_spawn_round_trip, channel.target_spawn_time, 300)
 SAVE_INT_FIELD_TEST(field_avatar_level_round_trip, avatar.level, 2)
 SAVE_INT_FIELD_TEST(field_avatar_damage_round_trip, avatar.damage, 31)
 SAVE_FLOAT_FIELD_TEST(field_avatar_armor_round_trip, avatar.armor, 7.0f)
@@ -2886,6 +2890,20 @@ TEST(wc3_save, field_origin_round_trip) {
     T_ASSERT(WriteGame(filename)); unit->s.origin = (VECTOR3){ 0 }; T_ASSERT(ReadGame(filename));
     T_FEQ(unit->s.origin.x, 12.5f, 0.001f); T_FEQ(unit->s.origin.y, 34.5f, 0.001f);
     T_FEQ(unit->s.origin.z, 56.5f, 0.001f); remove(filename);
+}
+
+/* Movement cancellation must compare against the saved cast position after restoring a live channel. */
+TEST(wc3_save, field_channel_origin_round_trip) {
+    LPCSTR filename = "/tmp/openwarcraft3-wc3-save-channel-origin.bin";
+    field_t const *desc = find_save_field("channel.origin");
+    reset_entities();
+    LPEDICT unit = alloc_test_unit(MAKEFOURCC('h', 'p', 'e', 'a'), 0, 0);
+    T_NOT_NULL(desc);
+    if (desc) T_EQ(desc->type, F_VECTOR);
+    unit->channel.origin = (VECTOR2){ 12.5f, 34.5f };
+    T_ASSERT(WriteGame(filename)); unit->channel.origin = (VECTOR2){0}; T_ASSERT(ReadGame(filename));
+    T_FEQ(unit->channel.origin.x, 12.5f, 0.001f); T_FEQ(unit->channel.origin.y, 34.5f, 0.001f);
+    remove(filename);
 }
 
 TEST(wc3_save, field_vertex_tint_round_trip) {

--- a/games/warcraft-3/game/tests/t_item_lifecycle.c
+++ b/games/warcraft-3/game/tests/t_item_lifecycle.c
@@ -1,0 +1,141 @@
+#ifdef BZ_TESTS
+#include "test.h"
+#include "../g_local.h"
+#include "../skills/s_skills.h"
+
+LPEDICT alloc_test_unit(DWORD class_id, FLOAT x, FLOAT y);
+void setup_test_world(void);
+slkTestData_t *parse_slk_string(const char *text);
+void free_slk_rows(slkTestData_t *rows);
+
+/* Distinct stock aliases stack and reverse after reload without depending on a family-wide cache. */
+TEST(wc3_item_lifecycle, passive_item_alias_applies_authored_attack_bonus) {
+    const char slk[] =
+        "ID;PWXL;N;EBB;Y6;X3\n"
+        "C;Y1;X1;K\"alias\"\nC;Y1;X2;K\"code\"\nC;Y1;X3;K\"DataA1\"\n"
+        "C;Y2;X1;K\"AIat\"\nC;Y2;X2;K\"AIat\"\nC;Y2;X3;K\"3\"\n"
+        "C;Y3;X1;K\"AItg\"\nC;Y3;X2;K\"AIat\"\nC;Y3;X3;K\"1\"\n"
+        "C;Y4;X1;K\"AInv\"\nC;Y4;X2;K\"AInv\"\nC;Y4;X3;K\"6\"\n"
+        "C;Y5;X1;K\"AIt6\"\nC;Y5;X2;K\"AIat\"\nC;Y5;X3;K\"6\"\n"
+        "C;Y6;X1;K\"AId1\"\nC;Y6;X2;K\"AIde\"\nC;Y6;X3;K\"1\"\nE\n";
+    const char items[] =
+        "ID;PWXL;N;EBB;Y4;X2\n"
+        "C;Y1;X1;K\"itemID\"\nC;Y1;X2;K\"abilList\"\n"
+        "C;Y2;X1;K\"ratf\"\nC;Y2;X2;K\"AItg\"\n"
+        "C;Y3;X1;K\"rde2\"\nC;Y3;X2;K\"AIt6\"\n"
+        "C;Y4;X1;K\"spro\"\nC;Y4;X2;K\"AId1\"\nE\n";
+    LPCSTR path = "/tmp/openwarcraft3-item-alias-save.bin";
+    DWORD codes[] = { MAKEFOURCC('r','a','t','f'), MAKEFOURCC('r','d','e','2'), MAKEFOURCC('s','p','r','o') };
+    slkTestData_t *rows = parse_slk_string(slk), *old = G_SetSLKRows("AbilityData", rows);
+    slkTestData_t *idata = parse_slk_string(items), *olditem = G_SetSLKRows("ItemData", idata);
+    setup_test_world();
+    LPEDICT unit = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 0, 0);
+    unit->attack1.temporaryDamageBonus = unit->attack2.temporaryDamageBonus = 0;
+    unit->temporary_armor_bonus = 0;
+    FOR_LOOP(i, 3) {
+        LPEDICT item = alloc_test_unit(codes[i], 32, 0);
+        item->targtype = TARG_ITEM;
+        item->item.in_world = true;
+        item->item.inventory_slot = -1;
+        T_ASSERT(G_AddItemToSlot(unit, item, i));
+    }
+    T_FEQ(unit->attack1.temporaryDamageBonus, 7, 0.001f);
+    T_FEQ(unit->attack2.temporaryDamageBonus, 7, 0.001f);
+    T_FEQ(unit->temporary_armor_bonus, 1, 0.001f);
+    DWORD index = unit->s.number;
+    T_ASSERT(WriteGame(path));
+    T_ASSERT(ReadGame(path));
+    unit = g_edicts + index;
+    T_FEQ(unit->attack1.temporaryDamageBonus, 7, 0.001f);
+    T_FEQ(unit->temporary_armor_bonus, 1, 0.001f);
+    T_ASSERT(G_DropItem(unit, 1));
+    T_FEQ(unit->attack1.temporaryDamageBonus, 1, 0.001f);
+    T_FEQ(unit->attack2.temporaryDamageBonus, 1, 0.001f);
+    T_ASSERT(G_DropItem(unit, 2));
+    T_FEQ(unit->temporary_armor_bonus, 0, 0.001f);
+    T_ASSERT(G_DropItem(unit, 0));
+    T_FEQ(unit->attack1.temporaryDamageBonus, 0, 0.001f);
+    T_FEQ(unit->attack2.temporaryDamageBonus, 0, 0.001f);
+    remove(path);
+    G_SetSLKRows("ItemData", olditem); free_slk_rows(idata);
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* All three tomes and their passive equivalents use Agility/Intelligence/Strength data order. */
+TEST(wc3_item_lifecycle, strength_tome_modifies_strength) {
+    const char slk[] =
+        "ID;PWXL;N;EBB;Y7;X5\n"
+        "C;Y1;X1;K\"alias\"\nC;Y1;X2;K\"code\"\nC;Y1;X3;K\"DataA1\"\n"
+        "C;Y1;X4;K\"DataB1\"\nC;Y1;X5;K\"DataC1\"\n"
+        "C;Y2;X1;K\"AIsm\"\nC;Y2;X2;K\"AIsm\"\nC;Y2;X5;K\"1\"\n"
+        "C;Y3;X1;K\"AIam\"\nC;Y3;X2;K\"AIam\"\nC;Y3;X3;K\"1\"\n"
+        "C;Y4;X1;K\"AIim\"\nC;Y4;X2;K\"AIim\"\nC;Y4;X4;K\"1\"\n"
+        "C;Y5;X1;K\"AIs1\"\nC;Y5;X2;K\"AIab\"\nC;Y5;X5;K\"1\"\n"
+        "C;Y6;X1;K\"AIa1\"\nC;Y6;X2;K\"AIab\"\nC;Y6;X3;K\"1\"\n"
+        "C;Y7;X1;K\"AIi1\"\nC;Y7;X2;K\"AIab\"\nC;Y7;X4;K\"1\"\nE\n";
+    DWORD codes[][2] = {
+        { MAKEFOURCC('A','I','s','m'), MAKEFOURCC('A','I','s','1') },
+        { MAKEFOURCC('A','I','a','m'), MAKEFOURCC('A','I','a','1') },
+        { MAKEFOURCC('A','I','i','m'), MAKEFOURCC('A','I','i','1') },
+    };
+    slkTestData_t *rows = parse_slk_string(slk), *old = G_SetSLKRows("AbilityData", rows);
+    setup_test_world();
+    LPEDICT unit = alloc_test_unit(MAKEFOURCC('H','p','a','l'), 0, 0);
+    LPEDICT clent = g_edicts;
+    unit->s.player = 0;
+    G_SelectEntity(clent->client, unit);
+    FOR_LOOP(i, 3) {
+        unit->hero.str = unit->hero.agi = unit->hero.intel = 10;
+        clent->client->menu.ability_code = codes[i][0];
+        abilityitem_t item = S_AbilityItem(codes[i][0]);
+        abilityCall_t call = { .item = &item, .client = clent };
+        T_ASSERT(S_AbilityMessage(clent, A_ITEM_USE, &call));
+        T_EQ(unit->hero.str, 10 + (i == 0));
+        T_EQ(unit->hero.agi, 10 + (i == 1));
+        T_EQ(unit->hero.intel, 10 + (i == 2));
+        item = S_AbilityItem(codes[i][1]);
+        T_ASSERT(S_AbilityMessage(unit, A_ITEM_ADD, &call));
+        T_EQ(unit->hero.str, 10 + 2 * (i == 0));
+        T_EQ(unit->hero.agi, 10 + 2 * (i == 1));
+        T_EQ(unit->hero.intel, 10 + 2 * (i == 2));
+        T_ASSERT(S_AbilityMessage(unit, A_ITEM_REMOVE, &call));
+        T_EQ(unit->hero.str, 10 + (i == 0));
+        T_EQ(unit->hero.agi, 10 + (i == 1));
+        T_EQ(unit->hero.intel, 10 + (i == 2));
+    }
+    G_SetSLKRows("AbilityData", old); free_slk_rows(rows);
+}
+
+/* A regeneration aura uses owner+goalentity too; natural sleep must remove only its own art. */
+TEST(wc3_item_lifecycle, waking_creep_preserves_regeneration_overlay) {
+    setup_test_world();
+    LPEDICT creep = alloc_test_unit(MAKEFOURCC('h','f','o','o'), 0, 0);
+    creep->s.player = PLAYER_NEUTRAL_AGGRESSIVE;
+    creep->svflags |= SVF_MONSTER;
+    creep->sleep.can_sleep = true;
+    creep->stand = unit_stand;
+    unit_stand(creep);
+    G_SetTimeOfDay(game.constants.duskTimeGameHours);
+    G_UpdateTimeOfDay();
+    LPEDICT effect = G_Spawn();
+    effect->owner = effect->goalentity = creep;
+    effect->summon_ability = MAKEFOURCC('A','o','a','r');
+    FOR_LOOP(i, 3) {
+        ai_stand(creep);
+        T_ASSERT(G_UnitIsSleeping(creep));
+        LPEDICT sleep = NULL;
+        FOR_LOOP(j, globals.num_edicts)
+            if (g_edicts[j].inuse && g_edicts[j].owner == creep &&
+                g_edicts[j].summon_ability == MAKEFOURCC('A','C','s','p')) sleep = g_edicts + j;
+        T_NOT_NULL(sleep);
+        if (i == 0) G_UnitWakeUp(creep);
+        else if (i == 1) unit_stand(creep);
+        else G_UnitSetCanSleep(creep, false);
+        T_ASSERT(!G_UnitIsSleeping(creep));
+        T_ASSERT(effect->inuse && effect->goalentity == creep);
+        T_ASSERT(sleep && (!sleep->inuse || sleep->goalentity != creep));
+    }
+    G_SetTimeOfDay(12.0f);
+    G_UpdateTimeOfDay();
+}
+#endif

--- a/games/warcraft-3/game/tests/t_order_lifecycle.c
+++ b/games/warcraft-3/game/tests/t_order_lifecycle.c
@@ -1,0 +1,188 @@
+#ifdef BZ_TESTS
+#include "shared/test.h"
+#include "../skills/s_skills.h"
+
+LPEDICT alloc_test_unit(DWORD class_id, FLOAT x, FLOAT y);
+void setup_test_world(void);
+void order_attack(LPEDICT self, LPEDICT target);
+void T_Damage(LPEDICT target, LPEDICT attacker, int damage);
+void SV_Physics_Toss(LPEDICT ent);
+void unit_build(LPEDICT self, DWORD class_id);
+void attack_melee_cooldown(LPEDICT self);
+void ai_train_build(LPEDICT self);
+static slkTestData_t *building_install_repair_data(slkTestData_t **rows_out);
+static void building_restore_repair_data(slkTestData_t *old, slkTestData_t *rows);
+
+/* Keep production order, acquisition, and death entry points active in this review fixture. */
+static LPEDICT review_order_unit(FLOAT x, DWORD owner) {
+    LPEDICT ent = alloc_test_unit(MAKEFOURCC('h','f','o','o'), x, 0);
+    ((LPMAPINFO)level.mapinfo)->players[owner].playerType = kPlayerTypeHuman;
+    ent->s.player = owner;
+    ent->svflags |= SVF_MONSTER;
+    ent->movetype = MOVETYPE_STEP;
+    ent->stand = unit_stand;
+    ent->die = unit_die;
+    ent->unitinfo.MoveSpeed = 300;
+    ent->attack1.range = 30;
+    ent->attack1.cooldown = 1;
+    ent->attack1.damageBase = 10;
+    ent->runtime.acquisition_range = 600;
+    unit_stand(ent);
+    gi.LinkEntity(ent);
+    return ent;
+}
+
+TEST(wc3_order_lifecycle, hold_position_does_not_chase_acquired_enemy) {
+    setup_test_world();
+    LPEDICT unit = review_order_unit(0, 0), enemy = review_order_unit(300, 1);
+    T_ASSERT(S_HoldPosition(unit));
+    level.time = 300 - (DWORD)(unit - g_edicts) % 300;
+    unit->currentmove->think(unit);
+    T_ASSERT(unit->goalentity == enemy);
+    T_ASSERT(unit->movement.holding_position);
+    unit->currentmove->think(unit);
+    T_FEQ(unit->s.origin.x, 0, 0.001f);
+}
+
+TEST(wc3_order_lifecycle, hold_attacks_in_range_then_stays_when_enemy_leaves) {
+    setup_test_world();
+    LPEDICT unit = review_order_unit(0, 0), enemy = review_order_unit(20, 1);
+    T_ASSERT(S_HoldPosition(unit));
+    level.time = 300 - (DWORD)(unit - g_edicts) % 300;
+    unit->currentmove->think(unit);
+    unit->currentmove->think(unit);
+    T_STREQ(unit->currentmove->animation, "attack");
+    enemy->s.origin.x = 300;
+    attack_melee_cooldown(unit);
+    unit->currentmove->think(unit);
+    unit->currentmove->think(unit);
+    T_FEQ(unit->s.origin.x, 0, 0.001f);
+    T_ASSERT(unit->movement.holding_position);
+    T_STREQ(unit->currentmove->animation, "stand");
+}
+
+TEST(wc3_order_lifecycle, delayed_kill_preserves_new_move_order) {
+    setup_test_world();
+    LPEDICT unit = review_order_unit(0, 0), enemy = review_order_unit(300, 1);
+    VECTOR2 point = {600, 0};
+    T_ASSERT(unit_issuetargetorder(unit, "attack", enemy));
+    LPEDICT missile = G_Spawn();
+    missile->owner = unit;
+    missile->goalentity = enemy;
+    missile->velocity = 10000;
+    missile->damage = 10000;
+    T_ASSERT(unit_issueorder(unit, "move", &point));
+    T_ASSERT(G_IssueUnitPointOrder(unit, "move", &MAKE(VECTOR2, .x = 800), true, 0, 0));
+    umove_t const *move = unit->currentmove;
+    /* A projectile resolves damage after its owner has already accepted Move. */
+    SV_Physics_Toss(missile);
+    T_ASSERT(M_IsDead(enemy));
+    T_ASSERT(unit->currentmove == move);
+    T_EQ(G_UnitQueuedOrderCount(unit), 1);
+}
+
+TEST(wc3_order_lifecycle, explicit_attack_replaces_persistent_follow) {
+    setup_test_world();
+    LPEDICT unit = review_order_unit(0, 0), ally = review_order_unit(500, 0);
+    LPEDICT enemy = review_order_unit(300, 1);
+    T_ASSERT(unit_issuetargetorder(unit, "move", ally));
+    T_ASSERT(unit->movement.follow_target == ally);
+    G_SetHealth(enemy, 0);
+    T_ASSERT(!unit_issuetargetorder(unit, "attack", enemy));
+    T_ASSERT(unit->movement.follow_target == ally);
+    T_ASSERT(unit->goalentity == ally);
+    G_SetHealth(enemy, enemy->health.max_value);
+    T_ASSERT(unit_issuetargetorder(unit, "attack", enemy));
+    T_Damage(enemy, unit, (int)enemy->health.value);
+    T_NULL(unit->movement.follow_target);
+}
+
+TEST(wc3_order_lifecycle, queued_attack_preserves_follow_until_follow_completes) {
+    setup_test_world();
+    LPEDICT unit = review_order_unit(0, 0), ally = review_order_unit(500, 0);
+    LPEDICT enemy = review_order_unit(300, 1);
+    T_ASSERT(unit_issuetargetorder(unit, "move", ally));
+    T_ASSERT(G_IssueUnitTargetOrder(unit, "attack", enemy, true, 0));
+    T_ASSERT(unit->movement.follow_target == ally);
+    T_ASSERT(unit->goalentity == ally);
+    T_EQ(G_UnitQueuedOrderCount(unit), 1);
+    G_SetHealth(ally, 0);
+    unit->currentmove->think(unit);
+    T_ASSERT(unit->goalentity == enemy);
+    T_NULL(unit->movement.follow_target);
+    T_EQ(G_UnitQueuedOrderCount(unit), 0);
+    T_Damage(enemy, unit, (int)enemy->health.value);
+    T_STREQ(unit->currentmove->animation, "stand");
+}
+
+TEST(wc3_order_lifecycle, auto_attack_resumes_patrol_but_smart_attack_replaces_it) {
+    setup_test_world();
+    LPEDICT unit = review_order_unit(0, 0), first = review_order_unit(300, 1);
+    LPEDICT second = review_order_unit(400, 1);
+    order_patrol(unit, Waypoint_add(&MAKE(VECTOR2, .x = 600)));
+    LPEDICT patrol = unit->movement.patrol_target;
+    order_attack(unit, first);
+    T_Damage(first, unit, (int)first->health.value);
+    T_ASSERT(unit->goalentity == patrol);
+    T_ASSERT(unit->currentmove->proc == CAbilityPatrol);
+    T_ASSERT(unit_issuetargetorder(unit, "smart", second));
+    T_ASSERT(unit->goalentity == second);
+    T_ASSERT(unit->currentmove->proc == CAbilityAttack);
+    T_Damage(second, unit, (int)second->health.value);
+    T_NULL(unit->movement.patrol_a);
+    T_NULL(unit->movement.patrol_b);
+    T_NULL(unit->movement.patrol_target);
+    T_STREQ(unit->currentmove->animation, "stand");
+}
+
+TEST(wc3_order_lifecycle, animationless_melee_kill_preserves_resumed_follow) {
+    setup_test_world();
+    LPEDICT unit = review_order_unit(0, 0), ally = review_order_unit(500, 0);
+    LPEDICT enemy = review_order_unit(20, 1);
+    T_ASSERT(unit_issuetargetorder(unit, "move", ally));
+    unit->attack1.damagePoint = (FLOAT)FRAMETIME / 1000.0f;
+    G_SetHealth(enemy, 1);
+    order_attack(unit, enemy);
+    unit->currentmove->think(unit);
+    unit->currentmove->think(unit);
+    T_ASSERT(M_IsDead(enemy));
+    T_ASSERT(unit->goalentity == ally);
+    T_ASSERT(unit->currentmove->proc == CAbilityMove);
+}
+
+TEST(wc3_order_lifecycle, finishing_repair_preserves_production_queue) {
+    setup_test_world();
+    slkTestData_t *rows, *old = building_install_repair_data(&rows);
+    LPEDICT worker = review_order_unit(0, 0);
+    LPEDICT building = alloc_test_unit(MAKEFOURCC('h','b','a','r'), 0, 0);
+    UnitAbilities_t abilities = { .abilList = "Arep" };
+    worker->data.UnitAbilities = &abilities;
+    building->stand = unit_stand;
+    building->svflags |= SVF_MONSTER;
+    UnitBalance_t balance = *building->data.UnitBalance;
+    balance.reptm = 10;
+    building->data.UnitBalance = &balance;
+    game.clients[0].ps.stats[PLAYERSTATE_RESOURCE_GOLD] = 1000;
+    game.clients[0].ps.stats[PLAYERSTATE_RESOURCE_LUMBER] = 1000;
+    game.clients[0].ps.stats[PLAYERSTATE_RESOURCE_FOOD_CAP] = 100;
+    unit_build(building, MAKEFOURCC('h','f','o','o'));
+    LPEDICT queued = building->build;
+    T_NOT_NULL(queued);
+    UnitBalance_t trainee = *queued->data.UnitBalance;
+    trainee.buildTime = 20;
+    queued->data.UnitBalance = &trainee;
+    queued->health.max_value = 420;
+    queued->health.value = 0;
+    queued->stand = unit_stand;
+    building->health.value = building->health.max_value - 0.001f;
+    T_ASSERT(S_OrderRepair(worker, building, 0));
+    worker->currentmove->think(worker);
+    building_restore_repair_data(old, rows);
+    T_FEQ(building->health.value, building->health.max_value, 0.0001f);
+    T_ASSERT(building->build == queued);
+    T_ASSERT(building->currentmove->proc == CAbilityTrain);
+    FLOAT progress = queued->health.value;
+    ai_train_build(building);
+    T_ASSERT(queued->health.value > progress);
+}
+#endif

--- a/games/warcraft-3/game/tests/t_spell.c
+++ b/games/warcraft-3/game/tests/t_spell.c
@@ -942,7 +942,7 @@ TEST(wc3_spell, requested_neutral_hero_abilities_have_contracts) {
 	T_ASSERT(mana_shield->flags & AB_PASSIVE);
 	T_ASSERT(brawler->flags & AB_PASSIVE);
 	T_ASSERT(cleave->flags & AB_PASSIVE);
-	T_EQ((int)revive->target_type, (int)SPELL_TARGET_POINT);
+	T_EQ((int)revive->target_type, (int)SPELL_TARGET_NONE);
 	T_EQ((int)breath->target_type, (int)SPELL_TARGET_POINT);
 	T_EQ((int)haze->target_type, (int)SPELL_TARGET_UNIT);
 	T_EQ((int)doom->target_type, (int)SPELL_TARGET_UNIT);
@@ -1202,7 +1202,9 @@ TEST(wc3_spell, death_and_decay_uses_percentage_damage_and_enemy_filter) {
 	((LPMAPINFO)level.mapinfo)->players[0].playerType = kPlayerTypeHuman;
 	((LPMAPINFO)level.mapinfo)->players[1].playerType = kPlayerTypeHuman;
 	memset(level.alliances, 0, sizeof(level.alliances));
-	test_execute_code(caster, "AUdd", st);
+    UnitAbilities_t abilities = { .abilList = "AUdd" };
+    caster->data.UnitAbilities = &abilities;
+    T_ASSERT(S_CastPointTargetSpell(caster, FS_SLKKey("AUdd"), &st.point));
 	thinker = &globals.edicts[thinker_slot];
 	T_FEQ(enemy->health.value, 96.0f, 0.01f);
 	T_FEQ(caster->health.value, 250.0f, 0.01f);


### PR DESCRIPTION
Implemented WC3 abilities could crash when enabling autocast, overwrite newer orders, discard production during Repair, and apply the wrong spell or item data. This change fixes the reproduced failures and adds permanent lifecycle regressions.

- Preserve authored autocast aliases and decode ability-message union payloads only for their message type. Handle policy switching, removal, and unsupported-policy rollback.
- Keep Hold Position stationary; preserve newer orders after projectile impacts; distinguish explicit Attack/Smart from automatic Follow/Patrol interruption; preserve production when Repair finishes.
- Correct Flame Strike timing/data, Blizzard wave count, health versus mana drain, Frost Nova targeting, ordinary-corpse Resurrection, and Storm Bolt immunity/duration. Channel identity and cleanup cover Stop, movement, stun, repeated casts, entity reuse, and save/load. Shackles applies and releases the target lock correctly.
- Apply item bonuses by authored alias, correct tome/attribute columns, and restrict creep-sleep effect cleanup to its own overlay.

Validation: 37 new behavior tests plus five save-schema tests. `make test` passes all 3,228 test invocations / 65,585 assertions, including 1,174 WC3 tests in each of ROC and TFT mode. `make build` passes without compiler warnings. Registry audit is unchanged at 193 registered TFT class IDs.

Compatibility: channel identity changes bump the WC3 save format to version 21; older saves are rejected. Existing documented partial spell/race implementations and visual parity remain outside this fix. The ability-verification document records the contracts, source-data evidence, and remaining limits.
